### PR TITLE
Add capability-authorized account deletion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4907,6 +4907,7 @@ dependencies = [
  "ipld-core",
  "js-sys",
  "rand 0.9.5",
+ "serde",
  "serde-wasm-bindgen",
  "serde_ipld_dagcbor",
  "sha2 0.10.9",

--- a/docs/plans/2026-08-19-account-and-space-deletion-design.md
+++ b/docs/plans/2026-08-19-account-and-space-deletion-design.md
@@ -1,0 +1,137 @@
+# Account and hosted-space deletion design
+
+**Status:** implemented in `feat/delete-account`; pending review and deployment
+
+## Goal
+
+Let a person permanently delete a Tonk account from `tonk-ui` or
+`tonk-cli`. Deletion removes every space that account created from Tonk's
+hosted services, leaves spaces created by other accounts intact, removes the
+account's service-side personal data, and frees its email for a future account.
+Tonk does not claim to erase replicas held by other devices or providers.
+
+## Authority
+
+Deleting a hosted space is authorized by an explicit UCAN capability minted by
+the space at creation time:
+
+- subject: the space DID;
+- ability: exactly `/space/delete`;
+- issuer: the space DID;
+- audience: the creator's account root DID.
+
+The access service accepts a deletion only when a fresh account-root-signed
+invocation presents that exact grant. It rejects broad grants, indirect member
+chains, device-signed invocations, onward delegation, and a target other than
+the invocation subject.
+
+This exact-shape rule is necessary because existing operational ownership and
+invite delegations use an empty command prefix, which otherwise covers every
+future command. `consumer.provider` remains a discovery, billing, and
+consistency index; it is not deletion authority.
+
+At provisioning, the access service records the CID of the deletion grant on
+the consumer. A submitted grant must both verify cryptographically and match
+the registered CID.
+
+## Existing spaces
+
+An account may upgrade a pre-feature space when it presents the original,
+direct `space -> account-root` ownership delegation. The access service checks
+that direct proof and binds the space to a deletion grant for that owner. An
+invite-derived or otherwise indirect member chain cannot upgrade a space.
+
+The upgrade is idempotent. A space whose direct ownership proof is unavailable
+is reported as not deletable; there is no administrative authorization
+fallback.
+
+## Hosted-space deletion
+
+Deletion is a service lifecycle operation distinct from today's local
+`tonk spot rm` and Hub removal.
+
+For one space, the access service:
+
+1. verifies the exact deletion capability and fresh root invocation;
+2. atomically marks the consumer `deleting` before removing content, so stale
+   replicas cannot repopulate it;
+3. denies all subsequent storage authorization for the deleted consumer;
+4. deletes every R2 object under the `{space DID}/` prefix, including branch
+   heads, archive blocks, and blobs;
+5. clears the mutable provider association while retaining the immutable owner
+   inventory and non-personal denial marker needed to prevent resurrection; and
+6. returns an idempotent deletion receipt.
+
+The initiating client then removes its local replica. Other devices' local
+replicas are outside Tonk service deletion and may remain, but cannot upload to
+the deleted Tonk consumer.
+
+Short invite links are content-addressed rather than space-indexed today. They
+are not included in the space prefix purge and remain only until their existing
+bounded expiry. Product copy therefore promises deletion of hosted space
+content, not every derived redirect object.
+
+## Account deletion
+
+Account deletion is an ordered, retryable client orchestration rather than a
+cross-service transaction:
+
+1. Tonk obtains a device-authorized deletion inventory from the access service
+   and account backups from the account service. Each
+   candidate must still present its registered deletion capability before the
+   access service purges it. Joined spaces have no such capability and are not
+   candidates for hosted-content deletion.
+2. One passkey ceremony creates root-signed invocations for the exact reviewed
+   space set, access-customer finalization, and account-service deletion.
+3. Tonk submits each space invocation. The access service refuses customer
+   finalization while any owned hosted space is not deleted.
+4. The access service purges the account repository consumer and removes the
+   customer row and its email-bearing control
+   data. Its deleted-consumer denial markers no longer retain the provider DID.
+5. The account service deletes R2 chain backups and spot-head indexes, then
+   atomically deletes dependent link requests and devices,
+   matching email codes, and finally the account row. Removing the account row
+   frees the normalized email and root DID for a new account.
+6. The initiating client clears its local account attachment and reports an
+   exact receipt. Local space data is removed only on that initiating device.
+
+If a service step fails, repeating the reviewed operation resumes from the
+service state: deleted spaces are idempotent, an already-removed access
+customer is accepted, and account-service object deletion can be retried. The
+account service does not currently persist a global `deleting` state, so other
+account mutations are not blocked during a partial cross-service attempt. The
+product flow orders account-row/email removal last, after access-service
+cleanup; the account-service endpoint itself does not independently verify an
+access-service receipt.
+
+## Product safeguards
+
+The UI and CLI show the same consequences before starting:
+
+- every Tonk-hosted space created by the account becomes unavailable to all
+  members;
+- spaces created by other accounts remain hosted;
+- Tonk cannot erase replicas held on other devices or independent providers;
+- account deletion cannot be undone; and
+- the email may be used to create a new, empty account after completion.
+
+The UI requires typing the normalized account email, checking a consequences
+acknowledgement, accepting a final native confirmation, and completing a
+passkey ceremony. `tonk account delete` only opens that browser review; it has
+no direct or non-interactive deletion flag. `tonk account spots delete
+<SUBJECT>` opens the same safeguards scoped to one owned space and leaves the
+account and all other spaces intact.
+
+## Failure and compatibility boundaries
+
+- New account-backed space creation mints and retains the deletion grant.
+  Backup and registration failures are surfaced by the existing creation or
+  reconciliation path; later reconciliation retries registration.
+- Legacy account/spot backup JSON remains readable; new deletion metadata is
+  optional and versioned.
+- Deleted consumers are denied before R2 cleanup begins, making retries safe.
+- A newly created account may reuse a deleted email. It creates a new passkey
+  by default and therefore a new root DID; if a caller deliberately reuses an
+  old root, old deleted-space denial markers still cannot grant content back.
+- Revocation records required to reject old credentials are security records,
+  not user content, and may be retained without email or account association.

--- a/docs/plans/2026-08-19-account-and-space-deletion-plan.md
+++ b/docs/plans/2026-08-19-account-and-space-deletion-plan.md
@@ -1,0 +1,65 @@
+# Account and hosted-space deletion implementation record
+
+**Status:** implementation and local verification complete; review pending
+
+## Delivered behavior
+
+- New account-backed spaces receive an exact direct
+  `space -> account-root /space/delete` grant while the space signer is
+  available. The grant is retained with account backup metadata.
+- Existing spaces are upgraded only from their original single-proof direct
+  broad `space -> account-root` delegation. Indirect member chains are refused.
+- The access service registers the proof CID and mode, changes a consumer to
+  `deleting` before object removal, denies subsequent storage access, purges
+  its `{space DID}/` object prefix, and finalizes an idempotent `deleted`
+  marker.
+- Access-service customer inventory uses immutable owner metadata only to find
+  candidates. Each space still requires its registered cryptographic deletion
+  proof. Customer finalization is root-signed and is refused until every owned
+  hosted space is deleted.
+- The account service accepts only a fresh root-signed `/account/delete`
+  invocation whose confirmed email matches. It deletes the account backup
+  namespace, then removes link requests, devices, matching email codes, and the
+  account row in dependent-first order. Removing the row frees the normalized
+  email for a new account.
+- The browser account dashboard presents an exact service-backed review,
+  separates owned and joined spaces, blocks if authority is unavailable,
+  requires typed email, a consequences checkbox, final confirmation, and one
+  passkey ceremony.
+- `tonk account delete` opens the guarded browser account-deletion review.
+  `tonk account spots delete <SUBJECT>` opens the same flow for one owned
+  hosted space and preserves the account and every other space. Neither CLI
+  command deletes directly or offers an automation bypass.
+
+## Retry and lifecycle boundaries
+
+- Hosted-space deletion is denial-first and idempotent. A failed object purge
+  leaves the consumer denied in `deleting`; submitting the same root-authorized
+  operation retries it.
+- The browser composes space deletion, access-customer cleanup, account-service
+  cleanup, and local unlink in that order. A retry tolerates spaces already
+  deleted and an access customer already removed.
+- There is no account-service-wide persisted `deleting` state in this change.
+  The browser order keeps email/account-row deletion last, but the
+  account-service endpoint does not independently attest access-service
+  completion.
+- Local cleanup affects only the initiating device. Tonk makes no claim to
+  erase replicas already held on other devices or independent providers.
+- Existing content-addressed short invite redirects are not indexed by space;
+  they retain their existing bounded expiry rather than being included in the
+  hosted space prefix purge.
+
+## Verification checklist
+
+- [x] `cargo fmt --all -- --check`
+- [x] `cargo test -p tonk-account`
+- [x] `cargo test -p tonk-account-service --features helpers`
+- [x] `cargo test -p tonk-access-service --features helpers`
+- [x] `cargo test -p tonk-cli`
+- [x] `cargo test -p tonk-worker-api`
+- [x] native checks for changed crates
+- [x] wasm checks for `tonk-access-service`, `tonk-account-service`,
+      `tonk-worker`, `tonk-ui`, and `tonk-identity`
+- [x] `NEXTEST_TEST_THREADS=4 nix develop path:. -c test:web:debug`
+- [x] `cargo clippy` for the changed native crates
+- [x] `git diff --check`

--- a/rust/tonk-access-service/migrations/0002_deletion.sql
+++ b/rust/tonk-access-service/migrations/0002_deletion.sql
@@ -1,0 +1,14 @@
+-- Capability-authorized hosted-space deletion lifecycle. The provider is
+-- billing/discovery metadata only; destructive authority is the registered
+-- direct delegation CID and its verification mode.
+ALTER TABLE consumer ADD COLUMN deletion_grant_cid TEXT;
+ALTER TABLE consumer ADD COLUMN deletion_grant_kind TEXT
+  CHECK (deletion_grant_kind IN ('exact', 'legacy-direct'));
+ALTER TABLE consumer ADD COLUMN deletion_state TEXT NOT NULL DEFAULT 'active'
+  CHECK (deletion_state IN ('active', 'deleting', 'deleted'));
+ALTER TABLE consumer ADD COLUMN deleted_at INTEGER;
+-- Immutable creator/provider identity used only to enumerate deletion work.
+-- Authorization still comes exclusively from the registered proof.
+ALTER TABLE consumer ADD COLUMN owner TEXT;
+UPDATE consumer SET owner = provider WHERE owner IS NULL;
+CREATE INDEX consumer_owner ON consumer(owner);

--- a/rust/tonk-access-service/src/deletion.rs
+++ b/rust/tonk-access-service/src/deletion.rs
@@ -1,0 +1,785 @@
+//! Capability-authorized, denial-first hosted-space deletion.
+
+use async_trait::async_trait;
+use dialog_credentials::Ed25519KeyResolver;
+use dialog_ucan_core::subject::Subject;
+use dialog_ucan_core::{Container, Delegation, Invocation, InvocationChain};
+use dialog_varsig::Did;
+use dialog_varsig::algorithm::eddsa::Ed25519Signature;
+use serde::{Deserialize, Serialize};
+
+use crate::store::{Consumer, ConsumerDeletionState, DeletionGrantKind, Store};
+
+/// Exact destructive command recognized at the UCAN endpoint.
+pub const COMMAND: [&str; 2] = ["space", "delete"];
+/// Root-authenticated inventory command used before a destructive ceremony.
+pub const CUSTOMER_PLAN_COMMAND: [&str; 3] = ["customer", "deletion", "plan"];
+/// Root-authenticated access-service customer finalization command.
+pub const CUSTOMER_DELETE_COMMAND: [&str; 2] = ["customer", "delete"];
+
+/// Successful, idempotent hosted-space deletion receipt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Receipt {
+    pub space: Did,
+    pub state: String,
+    pub deleted_at: u64,
+}
+
+/// One hosted space the access service associates with the deleting account.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HostedSpace {
+    pub space: String,
+    pub deletion_ready: bool,
+    pub deletion_kind: Option<String>,
+    pub deletion_state: String,
+}
+
+/// Authoritative access-service inventory. `owner` discovers candidates; it
+/// never substitutes for each row's registered destructive proof.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomerDeletionPlan {
+    pub customer: String,
+    pub spaces: Vec<HostedSpace>,
+}
+
+/// Successful removal of access-service customer state and its email.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomerDeletionReceipt {
+    pub customer: String,
+    pub state: String,
+}
+
+/// Stable deletion refusal returned by Worker and native helper routes.
+#[derive(Debug, thiserror::Error, Serialize)]
+#[serde(tag = "code")]
+pub enum Error {
+    #[error("deletion invocation is malformed: {0}")]
+    Malformed(String),
+    #[error("deletion invocation failed cryptographic verification: {0}")]
+    Unauthorized(String),
+    #[error("the hosted space has no registered deletion authority")]
+    NotRegistered,
+    #[error("the invocation does not present the registered deletion proof")]
+    WrongGrant,
+    #[error("registered deletion authority does not have the required direct shape")]
+    Forbidden,
+    #[error("hosted-space deletion is temporarily incomplete: {0}")]
+    Incomplete(String),
+    #[error("owned hosted spaces must be deleted first: {0:?}")]
+    OwnedSpacesRemain(Vec<String>),
+    #[error("hosted-space deletion failed internally: {0}")]
+    Internal(String),
+}
+
+impl Error {
+    pub fn status(&self) -> u16 {
+        match self {
+            Self::Malformed(_) => 400,
+            Self::Unauthorized(_) => 401,
+            Self::NotRegistered => 404,
+            Self::WrongGrant | Self::Forbidden => 403,
+            Self::Incomplete(_) => 503,
+            Self::OwnedSpacesRemain(_) => 409,
+            Self::Internal(_) => 500,
+        }
+    }
+}
+
+/// Storage namespace removal, abstracted so lifecycle behavior is unit-testable.
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+pub trait SpacePurger {
+    async fn purge(&self, prefix: &str) -> Result<(), String>;
+}
+
+/// Return true only for the exact destructive command.
+pub fn is_deletion(container: &[u8]) -> bool {
+    let Ok(tokens) = Container::from_bytes(container).map(Container::into_tokens) else {
+        return false;
+    };
+    let Some(first) = tokens.first() else {
+        return false;
+    };
+    let Ok(invocation) = serde_ipld_dagcbor::from_slice::<Invocation<Ed25519Signature>>(first)
+    else {
+        return false;
+    };
+    invocation.command().0 == COMMAND.map(str::to_string)
+}
+
+/// Whether a container names either root-authenticated customer deletion command.
+pub fn is_customer_deletion(container: &[u8]) -> bool {
+    command(container).is_some_and(|command| {
+        command == CUSTOMER_PLAN_COMMAND.map(str::to_string)
+            || command == CUSTOMER_DELETE_COMMAND.map(str::to_string)
+    })
+}
+
+fn command(container: &[u8]) -> Option<Vec<String>> {
+    let tokens = Container::from_bytes(container).ok()?.into_tokens();
+    let invocation =
+        serde_ipld_dagcbor::from_slice::<Invocation<Ed25519Signature>>(tokens.first()?).ok()?;
+    Some(invocation.command().0.clone())
+}
+
+/// Parsed command for the thin HTTP adapter; authority is never inferred here.
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn command_for_handler(container: &[u8]) -> Vec<String> {
+    command(container).unwrap_or_default()
+}
+
+/// Parsed command for the native HTTP adapter.
+#[cfg(all(feature = "helpers", not(target_arch = "wasm32")))]
+pub(crate) fn command_for_native_handler(container: &[u8]) -> Vec<String> {
+    command(container).unwrap_or_default()
+}
+
+/// Subject named before authorization, used only to locate the row whose
+/// registered proof is then checked cryptographically.
+pub fn subject(container: &[u8]) -> Option<Did> {
+    InvocationChain::try_from(container)
+        .ok()
+        .map(|chain| chain.subject().clone())
+}
+
+/// Delete one hosted space. State flips to deleting before object removal,
+/// so stale replicas cannot resurrect a partial purge.
+pub async fn delete<S: Store, P: SpacePurger>(
+    store: &S,
+    purger: &P,
+    container: &[u8],
+    now: u64,
+) -> Result<Receipt, Error> {
+    let space = subject(container).ok_or_else(|| Error::Malformed("missing subject".into()))?;
+    let consumer = store
+        .consumer(space.as_str())
+        .await
+        .map_err(|error| Error::Internal(error.to_string()))?
+        .ok_or(Error::NotRegistered)?;
+    verify(container, &consumer, now).await?;
+
+    if consumer.deletion_state == ConsumerDeletionState::Deleted {
+        return Ok(receipt(&space, consumer.deleted_at.unwrap_or_default()));
+    }
+    if consumer.deletion_state == ConsumerDeletionState::Active {
+        let cid = consumer
+            .deletion_grant_cid
+            .as_deref()
+            .ok_or(Error::NotRegistered)?;
+        if !store
+            .mark_consumer_deleting(space.as_str(), cid)
+            .await
+            .map_err(|error| Error::Internal(error.to_string()))?
+        {
+            let current = store
+                .consumer(space.as_str())
+                .await
+                .map_err(|error| Error::Internal(error.to_string()))?
+                .ok_or(Error::NotRegistered)?;
+            if current.deletion_state == ConsumerDeletionState::Deleted {
+                return Ok(receipt(&space, current.deleted_at.unwrap_or_default()));
+            }
+            if current.deletion_state != ConsumerDeletionState::Deleting {
+                return Err(Error::Internal(
+                    "could not enter deletion denial state".into(),
+                ));
+            }
+        }
+    }
+
+    purger
+        .purge(&format!("{space}/"))
+        .await
+        .map_err(Error::Incomplete)?;
+    if !store
+        .finish_consumer_deletion(space.as_str(), now)
+        .await
+        .map_err(|error| Error::Internal(error.to_string()))?
+    {
+        let current = store
+            .consumer(space.as_str())
+            .await
+            .map_err(|error| Error::Internal(error.to_string()))?
+            .ok_or(Error::NotRegistered)?;
+        if current.deletion_state != ConsumerDeletionState::Deleted {
+            return Err(Error::Internal("could not finalize deletion state".into()));
+        }
+        return Ok(receipt(&space, current.deleted_at.unwrap_or_default()));
+    }
+    Ok(receipt(&space, now))
+}
+
+/// List every non-account consumer originally associated with this customer.
+pub async fn customer_plan<S: Store>(
+    store: &S,
+    container: &[u8],
+    now: u64,
+) -> Result<CustomerDeletionPlan, Error> {
+    let customer =
+        verify_customer_command(store, container, &CUSTOMER_PLAN_COMMAND, now, true).await?;
+    let spaces = store
+        .consumers_by_owner(customer.as_str())
+        .await
+        .map_err(|error| Error::Internal(error.to_string()))?
+        .into_iter()
+        .filter(|consumer| consumer.did != customer)
+        .map(|consumer| HostedSpace {
+            space: consumer.did,
+            deletion_ready: consumer.deletion_grant_cid.is_some()
+                && consumer.deletion_grant_kind.is_some(),
+            deletion_kind: consumer
+                .deletion_grant_kind
+                .map(|kind| kind.as_str().to_string()),
+            deletion_state: consumer.deletion_state.as_str().to_string(),
+        })
+        .collect();
+    Ok(CustomerDeletionPlan { customer, spaces })
+}
+
+/// Purge the account space and remove access-service customer state only after
+/// every other owned hosted space has completed its capability-authorized purge.
+pub async fn delete_customer<S: Store, P: SpacePurger>(
+    store: &S,
+    purger: &P,
+    container: &[u8],
+    now: u64,
+) -> Result<CustomerDeletionReceipt, Error> {
+    let customer =
+        verify_customer_command(store, container, &CUSTOMER_DELETE_COMMAND, now, false).await?;
+    let remaining: Vec<_> = store
+        .consumers_by_owner(&customer)
+        .await
+        .map_err(|error| Error::Internal(error.to_string()))?
+        .into_iter()
+        .filter(|consumer| {
+            consumer.did != customer && consumer.deletion_state != ConsumerDeletionState::Deleted
+        })
+        .map(|consumer| consumer.did)
+        .collect();
+    if !remaining.is_empty() {
+        return Err(Error::OwnedSpacesRemain(remaining));
+    }
+
+    let self_consumer = store
+        .consumer(&customer)
+        .await
+        .map_err(|error| Error::Internal(error.to_string()))?
+        .ok_or(Error::NotRegistered)?;
+    if self_consumer.deletion_state == ConsumerDeletionState::Active
+        && !store
+            .mark_self_consumer_deleting(&customer)
+            .await
+            .map_err(|error| Error::Internal(error.to_string()))?
+    {
+        return Err(Error::Internal(
+            "could not deny the account-space consumer".into(),
+        ));
+    }
+    purger
+        .purge(&format!("{customer}/"))
+        .await
+        .map_err(Error::Incomplete)?;
+    if !store
+        .delete_customer(&customer)
+        .await
+        .map_err(|error| Error::Internal(error.to_string()))?
+    {
+        return Err(Error::Internal(
+            "could not remove access-service customer state".into(),
+        ));
+    }
+    let _ = now;
+    Ok(CustomerDeletionReceipt {
+        customer,
+        state: "deleted".into(),
+    })
+}
+
+async fn verify_customer_command<S: Store, const N: usize>(
+    store: &S,
+    container: &[u8],
+    expected: &[&str; N],
+    now: u64,
+    allow_device: bool,
+) -> Result<String, Error> {
+    let chain = InvocationChain::try_from(container)
+        .map_err(|error| Error::Malformed(error.to_string()))?;
+    chain
+        .verify(&Ed25519KeyResolver)
+        .await
+        .map_err(|error| Error::Unauthorized(error.to_string()))?;
+    if chain.command().0 != expected.map(str::to_string) {
+        return Err(Error::Forbidden);
+    }
+    let expiration = chain
+        .invocation
+        .expiration()
+        .ok_or_else(|| Error::Unauthorized("invocation must expire".into()))?;
+    if expiration.to_unix() < now {
+        return Err(Error::Unauthorized("invocation has expired".into()));
+    }
+    let customer = chain.subject().to_string();
+    if store
+        .customer(&customer)
+        .await
+        .map_err(|error| Error::Internal(error.to_string()))?
+        .is_none()
+    {
+        return Err(Error::NotRegistered);
+    }
+    if chain.issuer() == chain.subject() {
+        if !chain.proofs().is_empty() {
+            return Err(Error::Forbidden);
+        }
+    } else {
+        if !allow_device || chain.proofs().len() != 1 {
+            return Err(Error::Forbidden);
+        }
+        let cid = chain.proofs()[0].to_string();
+        let proof = deposited_proof(container, &cid)?;
+        let customer_did: Did = customer.parse().map_err(|_| Error::Forbidden)?;
+        if proof.issuer() != &customer_did
+            || proof.audience() != chain.issuer()
+            || proof.subject() != &Subject::Any
+            || !proof.command().0.is_empty()
+        {
+            return Err(Error::Forbidden);
+        }
+    }
+    Ok(customer)
+}
+
+fn receipt(space: &Did, deleted_at: u64) -> Receipt {
+    Receipt {
+        space: space.clone(),
+        state: "deleted".to_string(),
+        deleted_at,
+    }
+}
+
+async fn verify(container: &[u8], consumer: &Consumer, now: u64) -> Result<(), Error> {
+    let chain = InvocationChain::try_from(container)
+        .map_err(|error| Error::Malformed(error.to_string()))?;
+    chain
+        .verify(&Ed25519KeyResolver)
+        .await
+        .map_err(|error| Error::Unauthorized(error.to_string()))?;
+    let space: Did = consumer
+        .did
+        .parse()
+        .map_err(|_| Error::Internal("stored consumer DID is invalid".into()))?;
+    if chain.subject() != &space || chain.command().0 != COMMAND.map(str::to_string) {
+        return Err(Error::Forbidden);
+    }
+    let expiration = chain
+        .invocation
+        .expiration()
+        .ok_or_else(|| Error::Unauthorized("invocation must expire".into()))?;
+    if expiration.to_unix() < now {
+        return Err(Error::Unauthorized("invocation has expired".into()));
+    }
+    if chain.proofs().len() != 1 {
+        return Err(Error::Forbidden);
+    }
+    let registered = consumer
+        .deletion_grant_cid
+        .as_deref()
+        .ok_or(Error::NotRegistered)?;
+    if chain.proofs()[0].to_string() != registered {
+        return Err(Error::WrongGrant);
+    }
+    let proof = deposited_proof(container, registered)?;
+    if proof.issuer() != &space
+        || proof.audience() != chain.issuer()
+        || proof.subject() != &Subject::Specific(space)
+    {
+        return Err(Error::Forbidden);
+    }
+    match consumer.deletion_grant_kind.ok_or(Error::NotRegistered)? {
+        DeletionGrantKind::Exact if proof.command().0 == COMMAND.map(str::to_string) => Ok(()),
+        DeletionGrantKind::LegacyDirect if proof.command().0.is_empty() => Ok(()),
+        _ => Err(Error::Forbidden),
+    }
+}
+
+fn deposited_proof(
+    container: &[u8],
+    registered: &str,
+) -> Result<Delegation<Ed25519Signature>, Error> {
+    Container::from_bytes(container)
+        .map_err(|error| Error::Malformed(error.to_string()))?
+        .into_tokens()
+        .into_iter()
+        .skip(1)
+        .filter_map(|bytes| {
+            serde_ipld_dagcbor::from_slice::<Delegation<Ed25519Signature>>(&bytes).ok()
+        })
+        .find(|proof| proof.to_cid().to_string() == registered)
+        .ok_or(Error::WrongGrant)
+}
+
+/// Production R2 namespace purger.
+#[cfg(target_arch = "wasm32")]
+pub struct R2SpacePurger(worker::Bucket);
+
+#[cfg(target_arch = "wasm32")]
+impl R2SpacePurger {
+    pub fn new(bucket: worker::Bucket) -> Self {
+        Self(bucket)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+#[async_trait(?Send)]
+impl SpacePurger for R2SpacePurger {
+    async fn purge(&self, prefix: &str) -> Result<(), String> {
+        loop {
+            let listed = self
+                .0
+                .list()
+                .prefix(prefix.to_string())
+                .limit(1000)
+                .execute()
+                .await
+                .map_err(|error| error.to_string())?;
+            let keys: Vec<String> = listed
+                .objects()
+                .into_iter()
+                .map(|object| object.key())
+                .collect();
+            if keys.is_empty() {
+                return Ok(());
+            }
+            self.0
+                .delete_multiple(keys)
+                .await
+                .map_err(|error| error.to_string())?;
+        }
+    }
+}
+
+/// S3-compatible purger used by the native helper service.
+#[cfg(all(feature = "helpers", not(target_arch = "wasm32")))]
+pub struct NativeSpacePurger {
+    address: dialog_remote_s3::Address,
+    credential: dialog_remote_s3::s3::S3Credential,
+}
+
+#[cfg(all(feature = "helpers", not(target_arch = "wasm32")))]
+impl NativeSpacePurger {
+    pub fn new(
+        address: dialog_remote_s3::Address,
+        credential: dialog_remote_s3::s3::S3Credential,
+    ) -> Self {
+        Self {
+            address,
+            credential,
+        }
+    }
+
+    async fn send(
+        &self,
+        request: dialog_remote_s3::request::S3Request,
+    ) -> Result<reqwest::Response, String> {
+        let permit = request
+            .attest(self.credential.clone())
+            .redeem(&self.address)
+            .await
+            .map_err(|error| error.to_string())?;
+        permit
+            .send()
+            .await
+            .map_err(|error| error.to_string())?
+            .error_for_status()
+            .map_err(|error| error.to_string())
+    }
+}
+
+#[cfg(all(feature = "helpers", not(target_arch = "wasm32")))]
+#[async_trait]
+impl SpacePurger for NativeSpacePurger {
+    async fn purge(&self, prefix: &str) -> Result<(), String> {
+        loop {
+            let response = self
+                .send(dialog_remote_s3::request::S3Request {
+                    method: "GET".to_string(),
+                    path: "/".to_string(),
+                    params: Some(vec![
+                        ("list-type".to_string(), "2".to_string()),
+                        ("prefix".to_string(), prefix.to_string()),
+                        ("max-keys".to_string(), "1000".to_string()),
+                    ]),
+                    ..Default::default()
+                })
+                .await?;
+            let xml = response.text().await.map_err(|error| error.to_string())?;
+            let keys = xml_values(&xml, "Key");
+            if keys.is_empty() {
+                return Ok(());
+            }
+            for key in keys {
+                self.send(dialog_remote_s3::request::S3Request {
+                    method: "DELETE".to_string(),
+                    path: key,
+                    ..Default::default()
+                })
+                .await?;
+            }
+        }
+    }
+}
+
+#[cfg(all(feature = "helpers", not(target_arch = "wasm32")))]
+fn xml_values(xml: &str, element: &str) -> Vec<String> {
+    let open = format!("<{element}>");
+    let close = format!("</{element}>");
+    let mut values = Vec::new();
+    let mut remaining = xml;
+    while let Some(start) = remaining.find(&open) {
+        let value = &remaining[start + open.len()..];
+        let Some(end) = value.find(&close) else {
+            break;
+        };
+        values.push(value[..end].to_string());
+        remaining = &value[end + close.len()..];
+    }
+    values
+}
+
+#[cfg(all(test, not(target_arch = "wasm32"), feature = "helpers"))]
+mod tests {
+    use std::sync::Mutex;
+
+    use dialog_credentials::Ed25519Signer;
+    use dialog_ucan_core::InvocationBuilder;
+    use dialog_ucan_core::time::timestamp::Timestamp;
+    use dialog_varsig::Principal as _;
+    use tonk_account::deletion::{build_deletion_invocation, mint_deletion_grant};
+
+    use super::*;
+    use crate::store::sqlite::SqliteStore;
+    use crate::store::{SIGNUP_PLAN, Store};
+
+    struct FlakyPurger {
+        fail_once: Mutex<bool>,
+        prefixes: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl SpacePurger for FlakyPurger {
+        async fn purge(&self, prefix: &str) -> Result<(), String> {
+            self.prefixes.lock().unwrap().push(prefix.to_string());
+            let mut fail = self.fail_once.lock().unwrap();
+            if *fail {
+                *fail = false;
+                return Err("injected R2 failure".to_string());
+            }
+            Ok(())
+        }
+    }
+
+    fn now() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    async fn root_container(root: Ed25519Signer, command: &[&str]) -> Vec<u8> {
+        let did = root.did();
+        let invocation = InvocationBuilder::new()
+            .issuer(root)
+            .audience(&did)
+            .subject(&did)
+            .command(
+                command
+                    .iter()
+                    .map(|segment| (*segment).to_string())
+                    .collect(),
+            )
+            .proofs(vec![])
+            .issue_now()
+            .expiration(Timestamp::five_minutes_from_now())
+            .try_build()
+            .await
+            .unwrap();
+        InvocationChain::new(invocation, Default::default())
+            .to_bytes()
+            .unwrap()
+    }
+
+    struct RecordingPurger(Mutex<Vec<String>>);
+
+    #[async_trait]
+    impl SpacePurger for RecordingPurger {
+        async fn purge(&self, prefix: &str) -> Result<(), String> {
+            self.0.lock().unwrap().push(prefix.to_string());
+            Ok(())
+        }
+    }
+
+    #[dialog_common::test]
+    async fn denial_precedes_purge_and_retry_finishes_idempotently() {
+        let store = SqliteStore::in_memory().unwrap();
+        let root = Ed25519Signer::import(&[71; 32]).await.unwrap();
+        let space = Ed25519Signer::import(&[72; 32]).await.unwrap();
+        let grant = mint_deletion_grant(&space, &root.did()).await.unwrap();
+        let cid = grant.proof_cids()[0].to_string();
+        let at = now();
+        store
+            .enroll_customer(
+                root.did().as_str(),
+                "owner@example.com",
+                b"access",
+                SIGNUP_PLAN,
+                at,
+            )
+            .await
+            .unwrap();
+        store
+            .add_consumer(
+                space.did().as_str(),
+                root.did().as_str(),
+                at,
+                Some(&cid),
+                Some(DeletionGrantKind::Exact),
+            )
+            .await
+            .unwrap();
+        let invocation = build_deletion_invocation(root.clone(), &grant)
+            .await
+            .unwrap();
+        let purger = FlakyPurger {
+            fail_once: Mutex::new(true),
+            prefixes: Mutex::new(Vec::new()),
+        };
+
+        assert!(matches!(
+            delete(&store, &purger, &invocation, at + 1).await,
+            Err(Error::Incomplete(_))
+        ));
+        let denied = store.consumer(space.did().as_str()).await.unwrap().unwrap();
+        assert_eq!(denied.deletion_state, ConsumerDeletionState::Deleting);
+        assert_eq!(denied.provider.as_deref(), Some(root.did().as_str()));
+
+        let receipt = delete(&store, &purger, &invocation, at + 2).await.unwrap();
+        assert_eq!(receipt.space, space.did());
+        let deleted = store.consumer(space.did().as_str()).await.unwrap().unwrap();
+        assert_eq!(deleted.deletion_state, ConsumerDeletionState::Deleted);
+        assert!(deleted.provider.is_none());
+
+        let replay = delete(&store, &purger, &invocation, at + 3).await.unwrap();
+        assert_eq!(replay.deleted_at, receipt.deleted_at);
+        assert_eq!(
+            purger.prefixes.lock().unwrap().as_slice(),
+            &[format!("{}/", space.did()), format!("{}/", space.did())]
+        );
+    }
+
+    #[dialog_common::test]
+    async fn customer_finalization_requires_every_owned_space_then_removes_email_state() {
+        let store = SqliteStore::in_memory().unwrap();
+        let root = Ed25519Signer::import(&[81; 32]).await.unwrap();
+        let space = Ed25519Signer::import(&[82; 32]).await.unwrap();
+        let at = now();
+        store
+            .enroll_customer(
+                root.did().as_str(),
+                "delete@example.com",
+                b"access",
+                SIGNUP_PLAN,
+                at,
+            )
+            .await
+            .unwrap();
+        let grant = mint_deletion_grant(&space, &root.did()).await.unwrap();
+        store
+            .add_consumer(
+                space.did().as_str(),
+                root.did().as_str(),
+                at,
+                Some(&grant.proof_cids()[0].to_string()),
+                Some(DeletionGrantKind::Exact),
+            )
+            .await
+            .unwrap();
+        let device = Ed25519Signer::import(&[83; 32]).await.unwrap();
+        let link = tonk_identity::delegation::mint_device_delegation(root.clone(), &device.did())
+            .await
+            .unwrap();
+        let plan_invocation = tonk_identity::request::build_device_invocation(
+            device,
+            &link,
+            CUSTOMER_PLAN_COMMAND.map(str::to_string).to_vec(),
+            Default::default(),
+        )
+        .await
+        .unwrap();
+        let plan = customer_plan(&store, &plan_invocation, at).await.unwrap();
+        assert_eq!(plan.spaces.len(), 1);
+        assert_eq!(plan.spaces[0].space, space.did().to_string());
+        assert!(plan.spaces[0].deletion_ready);
+
+        let customer_invocation = root_container(root.clone(), &CUSTOMER_DELETE_COMMAND).await;
+        let purger = RecordingPurger(Mutex::new(Vec::new()));
+        assert!(matches!(
+            delete_customer(&store, &purger, &customer_invocation, at + 1).await,
+            Err(Error::OwnedSpacesRemain(spaces)) if spaces == vec![space.did().to_string()]
+        ));
+        assert!(store.customer(root.did().as_str()).await.unwrap().is_some());
+
+        let space_invocation = build_deletion_invocation(root.clone(), &grant)
+            .await
+            .unwrap();
+        delete(&store, &purger, &space_invocation, at + 2)
+            .await
+            .unwrap();
+        let receipt = delete_customer(&store, &purger, &customer_invocation, at + 3)
+            .await
+            .unwrap();
+        assert_eq!(receipt.customer, root.did().to_string());
+        assert!(store.customer(root.did().as_str()).await.unwrap().is_none());
+        assert!(
+            store
+                .consumers_by_owner(root.did().as_str())
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        let denial = store.consumer(space.did().as_str()).await.unwrap().unwrap();
+        assert_eq!(denial.deletion_state, ConsumerDeletionState::Deleted);
+        assert!(denial.provider.is_none());
+        assert!(denial.owner.is_none());
+        assert!(denial.deletion_grant_cid.is_none());
+        assert!(denial.deletion_grant_kind.is_none());
+        assert!(
+            !store
+                .add_consumer(
+                    space.did().as_str(),
+                    root.did().as_str(),
+                    at + 4,
+                    Some(&grant.proof_cids()[0].to_string()),
+                    Some(DeletionGrantKind::Exact),
+                )
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            store
+                .consumer(space.did().as_str())
+                .await
+                .unwrap()
+                .unwrap()
+                .deletion_state,
+            ConsumerDeletionState::Deleted
+        );
+        assert_eq!(
+            purger.0.lock().unwrap().as_slice(),
+            &[format!("{}/", space.did()), format!("{}/", root.did())]
+        );
+    }
+}

--- a/rust/tonk-access-service/src/handlers.rs
+++ b/rust/tonk-access-service/src/handlers.rs
@@ -1,6 +1,7 @@
 //! HTTP request handlers.
 
 pub mod config;
+pub mod deletion;
 pub mod health;
 pub mod info;
 pub mod registration;

--- a/rust/tonk-access-service/src/handlers/deletion.rs
+++ b/rust/tonk-access-service/src/handlers/deletion.rs
@@ -1,0 +1,37 @@
+//! Worker adapter for hosted-space deletion.
+
+#[cfg(target_arch = "wasm32")]
+pub async fn handle(body: &[u8], env: &worker::Env) -> worker::Result<worker::Response> {
+    let store = crate::store::d1::D1Store::new(env.d1("CONTROL")?);
+    let purger = crate::deletion::R2SpacePurger::new(env.bucket("BUCKET")?);
+    let now = worker::Date::now().as_millis() / 1_000;
+    match crate::deletion::delete(&store, &purger, body, now).await {
+        Ok(receipt) => worker::Response::from_json(&receipt),
+        Err(error) => worker::Response::from_json(&serde_json::json!({ "error": error }))
+            .map(|response| response.with_status(error.status())),
+    }
+}
+
+/// Handle root-authenticated customer inventory and finalization commands.
+#[cfg(target_arch = "wasm32")]
+pub async fn handle_customer(body: &[u8], env: &worker::Env) -> worker::Result<worker::Response> {
+    let store = crate::store::d1::D1Store::new(env.d1("CONTROL")?);
+    let purger = crate::deletion::R2SpacePurger::new(env.bucket("BUCKET")?);
+    let now = worker::Date::now().as_millis() / 1_000;
+    let result = if crate::deletion::command_for_handler(body)
+        == crate::deletion::CUSTOMER_PLAN_COMMAND.map(str::to_string)
+    {
+        crate::deletion::customer_plan(&store, body, now)
+            .await
+            .map(|plan| serde_json::to_value(plan).expect("plan serializes"))
+    } else {
+        crate::deletion::delete_customer(&store, &purger, body, now)
+            .await
+            .map(|receipt| serde_json::to_value(receipt).expect("receipt serializes"))
+    };
+    match result {
+        Ok(receipt) => worker::Response::from_json(&receipt),
+        Err(error) => worker::Response::from_json(&serde_json::json!({ "error": error }))
+            .map(|response| response.with_status(error.status())),
+    }
+}

--- a/rust/tonk-access-service/src/handlers/ucan.rs
+++ b/rust/tonk-access-service/src/handlers/ucan.rs
@@ -58,6 +58,18 @@ pub async fn serve(mut req: Request, env: Env, ctx: Context) -> Result<Response>
     // metered: those invocations are once-per-account ceremonies, not
     // billable operations.
     #[cfg(target_arch = "wasm32")]
+    if crate::deletion::is_deletion(&body_bytes) {
+        return crate::handlers::deletion::handle(&body_bytes, &env)
+            .await
+            .map(with_cors_headers);
+    }
+    #[cfg(target_arch = "wasm32")]
+    if crate::deletion::is_customer_deletion(&body_bytes) {
+        return crate::handlers::deletion::handle_customer(&body_bytes, &env)
+            .await
+            .map(with_cors_headers);
+    }
+    #[cfg(target_arch = "wasm32")]
     if registration_command(&body_bytes).is_some() {
         return handle_registration(&body_bytes, &req, &env)
             .await
@@ -130,6 +142,8 @@ async fn presign(body_bytes: &[u8], env: &Env) -> std::result::Result<(Response,
     // presign the screen cannot clear is refused.
     #[cfg(target_arch = "wasm32")]
     screen_credentials(body_bytes, env).await?;
+    #[cfg(target_arch = "wasm32")]
+    screen_consumer_state(body_bytes, env).await?;
 
     // Write permits carry the declared size as a signed Content-Length,
     // which is the exact byte figure metering records.
@@ -149,6 +163,26 @@ async fn presign(body_bytes: &[u8], env: &Env) -> std::result::Result<(Response,
             (r.with_headers(headers), bytes)
         })
         .map_err(|e| Refusal::unclassified(format!("response error: {e}")))
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn screen_consumer_state(body_bytes: &[u8], env: &Env) -> std::result::Result<(), Refusal> {
+    use crate::store::{ConsumerDeletionState, Store, d1::D1Store};
+
+    let Some(subject) = crate::deletion::subject(body_bytes) else {
+        return Ok(());
+    };
+    let store = D1Store::new(env.d1("CONTROL").map_err(|_| unavailable())?);
+    match store
+        .consumer(subject.as_str())
+        .await
+        .map_err(|_| unavailable())?
+    {
+        Some(consumer) if consumer.deletion_state != ConsumerDeletionState::Active => {
+            Err(AuthorizeError::Revoked { subject }.into())
+        }
+        _ => Ok(()),
+    }
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/rust/tonk-access-service/src/helpers/server.rs
+++ b/rust/tonk-access-service/src/helpers/server.rs
@@ -59,6 +59,7 @@ struct RegistrationState {
     sender: AnnouncedEmail,
     service: Ed25519Signer,
     origin: String,
+    purger: crate::deletion::NativeSpacePurger,
 }
 
 /// Captures activation emails and announces them on stdout, so a human
@@ -102,6 +103,7 @@ impl AccessServer {
         let credential = S3Credential::new(access_key, secret_key);
 
         // Create UcanAuthorizer - the core of our service
+        let purger = crate::deletion::NativeSpacePurger::new(address.clone(), credential.clone());
         let authorizer = Arc::new(RwLock::new(UcanAuthorizer::new(address, Some(credential))));
 
         let listener = TcpListener::bind("127.0.0.1:0").await?;
@@ -142,6 +144,7 @@ impl AccessServer {
             // Activation links open on the page origin, which behind a
             // dev proxy is not this server's own address.
             origin: public_origin.unwrap_or_else(|| endpoint.clone()),
+            purger,
         });
 
         let shortcuts: Shortcuts = Arc::new(RwLock::new(HashMap::new()));
@@ -393,6 +396,69 @@ async fn handle_request(
 
     // Registration commands ride the same endpoint; anything else falls
     // through to the presign path untouched. Mirrors the Worker handler.
+    if crate::deletion::is_deletion(&body_bytes) {
+        let response = match crate::deletion::delete(
+            &registration.store,
+            &registration.purger,
+            &body_bytes,
+            unix_now(),
+        )
+        .await
+        {
+            Ok(receipt) => Response::builder()
+                .status(StatusCode::OK)
+                .header(CONTENT_TYPE, "application/json")
+                .body(Full::new(Bytes::from(
+                    serde_json::to_vec(&receipt).expect("deletion receipt serializes"),
+                )))
+                .unwrap(),
+            Err(error) => Response::builder()
+                .status(error.status())
+                .header(CONTENT_TYPE, "application/json")
+                .body(Full::new(Bytes::from(
+                    serde_json::to_vec(&serde_json::json!({ "error": error }))
+                        .expect("deletion refusal serializes"),
+                )))
+                .unwrap(),
+        };
+        return Ok(cors_response(response));
+    }
+    if crate::deletion::is_customer_deletion(&body_bytes) {
+        let response = if crate::deletion::command_for_native_handler(&body_bytes)
+            == crate::deletion::CUSTOMER_PLAN_COMMAND.map(str::to_string)
+        {
+            match crate::deletion::customer_plan(&registration.store, &body_bytes, unix_now()).await
+            {
+                Ok(plan) => Response::builder()
+                    .status(StatusCode::OK)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Full::new(Bytes::from(
+                        serde_json::to_vec(&plan).expect("deletion plan serializes"),
+                    )))
+                    .unwrap(),
+                Err(error) => deletion_error_response(error),
+            }
+        } else {
+            match crate::deletion::delete_customer(
+                &registration.store,
+                &registration.purger,
+                &body_bytes,
+                unix_now(),
+            )
+            .await
+            {
+                Ok(receipt) => Response::builder()
+                    .status(StatusCode::OK)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Full::new(Bytes::from(
+                        serde_json::to_vec(&receipt).expect("deletion receipt serializes"),
+                    )))
+                    .unwrap(),
+                Err(error) => deletion_error_response(error),
+            }
+        };
+        return Ok(cors_response(response));
+    }
     if registration_command(&body_bytes).is_some() {
         let env = Registration {
             store: &registration.store,
@@ -426,6 +492,34 @@ async fn handle_request(
     // Authorize the UCAN container using UcanAuthorizer
     let authorizer = authorizer.read().await;
     let outcome = authorizer.authorize(&body_bytes).await;
+    if outcome.is_ok()
+        && let Some(subject) = crate::deletion::subject(&body_bytes)
+    {
+        use crate::store::{ConsumerDeletionState, Store};
+        match registration.store.consumer(subject.as_str()).await {
+            Ok(Some(consumer)) if consumer.deletion_state != ConsumerDeletionState::Active => {
+                return Ok(cors_response(
+                    Response::builder()
+                        .status(StatusCode::FORBIDDEN)
+                        .body(Full::new(Bytes::from(
+                            "Authorization failed: hosted space is deleting or deleted",
+                        )))
+                        .unwrap(),
+                ));
+            }
+            Err(error) => {
+                return Ok(cors_response(
+                    Response::builder()
+                        .status(StatusCode::SERVICE_UNAVAILABLE)
+                        .body(Full::new(Bytes::from(format!(
+                            "consumer deletion state unavailable: {error}"
+                        ))))
+                        .unwrap(),
+                ));
+            }
+            _ => {}
+        }
+    }
     // Metering mirrors the worker: permits and attributable denials are
     // recorded, infra failures and unparseable containers are not.
     let metered = match &outcome {
@@ -490,6 +584,19 @@ fn unix_now() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .expect("system clock is past the epoch")
         .as_secs()
+}
+
+fn deletion_error_response(
+    error: crate::deletion::Error,
+) -> Response<http_body_util::Full<bytes::Bytes>> {
+    Response::builder()
+        .status(error.status())
+        .header(CONTENT_TYPE, "application/json")
+        .body(http_body_util::Full::new(bytes::Bytes::from(
+            serde_json::to_vec(&serde_json::json!({ "error": error }))
+                .expect("deletion refusal serializes"),
+        )))
+        .unwrap()
 }
 
 /// PUT /@ → validate and store a shortcut target, mirroring the

--- a/rust/tonk-access-service/src/lib.rs
+++ b/rust/tonk-access-service/src/lib.rs
@@ -42,6 +42,7 @@ use worker::*;
 /// mid-load, roughly doubling the requests a cold load pays for.
 pub(crate) const PREFLIGHT_MAX_AGE: &str = "86400";
 
+pub mod deletion;
 pub mod email;
 mod error;
 #[cfg(any(target_arch = "wasm32", test))]

--- a/rust/tonk-access-service/src/registration.rs
+++ b/rust/tonk-access-service/src/registration.rs
@@ -39,7 +39,7 @@ use tonk_account::customer::{
 };
 
 use crate::email::EmailSender;
-use crate::store::{SIGNUP_PLAN, Store, StoreError};
+use crate::store::{DeletionGrantKind, SIGNUP_PLAN, Store, StoreError};
 
 /// The command path segments of [`Enroll`], as they appear in an
 /// invocation. Pinned to the capability-derived ability by a test.
@@ -328,9 +328,30 @@ impl<S: Store, E: EmailSender> Registration<'_, S, E> {
         let consent = self.deposited_delegation(&effect.consent.to_string())?;
         self.verify_consent(&consent.delegation, &effect.consumer, &provider)
             .await?;
+        let deletion = match effect.deletion {
+            Some(cid) => {
+                let grant = self.deposited_delegation(&cid.to_string())?;
+                self.verify_exact_deletion_grant(&grant.delegation, &effect.consumer, &provider)
+                    .await?;
+                Some((cid.to_string(), DeletionGrantKind::Exact))
+            }
+            None if is_direct_legacy_owner(&consent.delegation, &effect.consumer, &provider) => {
+                Some((
+                    consent.delegation.to_cid().to_string(),
+                    DeletionGrantKind::LegacyDirect,
+                ))
+            }
+            None => None,
+        };
         if !self
             .store
-            .add_consumer(effect.consumer.as_str(), provider.as_str(), self.now)
+            .add_consumer(
+                effect.consumer.as_str(),
+                provider.as_str(),
+                self.now,
+                deletion.as_ref().map(|(cid, _)| cid.as_str()),
+                deletion.as_ref().map(|(_, kind)| *kind),
+            )
             .await
             .map_err(internal)?
         {
@@ -339,7 +360,32 @@ impl<S: Store, E: EmailSender> Registration<'_, S, E> {
         Ok(ConsumerReceipt {
             consumer: effect.consumer,
             provider,
+            deletion_ready: deletion.is_some(),
         })
+    }
+
+    async fn verify_exact_deletion_grant(
+        &self,
+        grant: &Delegation<Ed25519Signature>,
+        consumer: &Did,
+        provider: &Did,
+    ) -> Result<(), RegistrationError> {
+        if grant.issuer() != consumer
+            || grant.audience() != provider
+            || grant.subject() != &DelegatedSubject::Specific(consumer.clone())
+            || grant.command().0 != ["space".to_string(), "delete".to_string()]
+        {
+            return Err(RegistrationError::Forbidden {
+                message: "deletion authority must be an exact direct space-to-customer /space/delete grant".to_string(),
+            });
+        }
+        self.check_window(grant)?;
+        grant
+            .verify_signature(&Ed25519KeyResolver)
+            .await
+            .map_err(|err| RegistrationError::Unauthorized {
+                message: format!("deletion grant failed to verify: {err}"),
+            })
     }
 
     /// Validate the deposited consent: the consumer's own delegation to
@@ -663,6 +709,17 @@ impl<S: Store, E: EmailSender> Registration<'_, S, E> {
         }
         Ok(())
     }
+}
+
+fn is_direct_legacy_owner(
+    consent: &Delegation<Ed25519Signature>,
+    consumer: &Did,
+    provider: &Did,
+) -> bool {
+    consent.issuer() == consumer
+        && consent.audience() == provider
+        && consent.subject() == &DelegatedSubject::Specific(consumer.clone())
+        && consent.command().0.is_empty()
 }
 
 // [`Store`] and [`EmailSender`] are declared through the same dual

--- a/rust/tonk-access-service/src/store.rs
+++ b/rust/tonk-access-service/src/store.rs
@@ -66,8 +66,75 @@ pub struct Consumer {
     pub did: String,
     /// The customer paying for this consumer; null means not servable.
     pub provider: Option<String>,
+    /// Original account provider, retained after hosted deletion for inventory.
+    pub owner: Option<String>,
     /// Registration time as a unix timestamp in seconds.
     pub registered: u64,
+    /// CID of the direct proof registered for destructive authority.
+    pub deletion_grant_cid: Option<String>,
+    /// Whether the CID names a purpose-built grant or a legacy owner proof.
+    pub deletion_grant_kind: Option<DeletionGrantKind>,
+    /// Denial-first hosted deletion lifecycle.
+    pub deletion_state: ConsumerDeletionState,
+    /// Completed deletion time, when any.
+    pub deleted_at: Option<u64>,
+}
+
+/// Verification rule attached to a registered deletion proof.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeletionGrantKind {
+    /// Exact direct `/space/delete` grant minted at creation.
+    Exact,
+    /// One-time upgrade from an original direct broad owner delegation.
+    LegacyDirect,
+}
+
+impl DeletionGrantKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Exact => "exact",
+            Self::LegacyDirect => "legacy-direct",
+        }
+    }
+
+    pub fn parse(value: &str) -> Result<Self, StoreError> {
+        match value {
+            "exact" => Ok(Self::Exact),
+            "legacy-direct" => Ok(Self::LegacyDirect),
+            other => Err(StoreError::Internal(format!(
+                "unknown deletion grant kind: {other}"
+            ))),
+        }
+    }
+}
+
+/// Whether a consumer still accepts storage operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConsumerDeletionState {
+    Active,
+    Deleting,
+    Deleted,
+}
+
+impl ConsumerDeletionState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Deleting => "deleting",
+            Self::Deleted => "deleted",
+        }
+    }
+
+    pub fn parse(value: &str) -> Result<Self, StoreError> {
+        match value {
+            "active" => Ok(Self::Active),
+            "deleting" => Ok(Self::Deleting),
+            "deleted" => Ok(Self::Deleted),
+            other => Err(StoreError::Internal(format!(
+                "unknown consumer deletion state: {other}"
+            ))),
+        }
+    }
 }
 
 /// Storage operations registration needs. Declared through the dual
@@ -82,6 +149,10 @@ pub trait Store {
 
     /// Look up a consumer by DID.
     async fn consumer(&self, did: &str) -> Result<Option<Consumer>, StoreError>;
+
+    /// List every consumer originally provided by one account, including
+    /// deleted rows whose live provider has been cleared.
+    async fn consumers_by_owner(&self, owner: &str) -> Result<Vec<Consumer>, StoreError>;
 
     /// Atomically write a new customer row together with its self-provided
     /// account consumer. Two steps would leave a window in which a
@@ -102,7 +173,31 @@ pub trait Store {
     /// Provision `did` as a consumer under `provider`. Idempotent for the
     /// same provider; answers false when a different customer already
     /// provides it, which the caller reports as a conflict.
-    async fn add_consumer(&self, did: &str, provider: &str, now: u64) -> Result<bool, StoreError>;
+    async fn add_consumer(
+        &self,
+        did: &str,
+        provider: &str,
+        now: u64,
+        deletion_grant_cid: Option<&str>,
+        deletion_grant_kind: Option<DeletionGrantKind>,
+    ) -> Result<bool, StoreError>;
+
+    /// Atomically deny future storage operations before object removal.
+    async fn mark_consumer_deleting(
+        &self,
+        did: &str,
+        deletion_grant_cid: &str,
+    ) -> Result<bool, StoreError>;
+
+    /// Finalize a denied consumer after its entire object prefix is empty.
+    async fn finish_consumer_deletion(&self, did: &str, now: u64) -> Result<bool, StoreError>;
+
+    /// Deny the customer's own account-space consumer after root authorization.
+    async fn mark_self_consumer_deleting(&self, did: &str) -> Result<bool, StoreError>;
+
+    /// Remove the self consumer and customer row only when all other owned
+    /// consumers are already deleted. Returns whether the customer was removed.
+    async fn delete_customer(&self, did: &str) -> Result<bool, StoreError>;
 
     /// Promote a `Registered` customer to `Active`, recording the
     /// activation time, terms acceptance, and cycle anchor. Returns false
@@ -125,7 +220,15 @@ SELECT did, email, status, plan, verified, terms_version
 "#;
 
 pub const SELECT_CONSUMER: &str = r#"
-SELECT did, provider, registered FROM consumer WHERE did = ?1
+SELECT did, provider, owner, registered, deletion_grant_cid, deletion_grant_kind,
+       deletion_state, deleted_at
+  FROM consumer WHERE did = ?1
+"#;
+
+pub const SELECT_CONSUMERS_BY_OWNER: &str = r#"
+SELECT did, provider, owner, registered, deletion_grant_cid, deletion_grant_kind,
+       deletion_state, deleted_at
+  FROM consumer WHERE owner = ?1 ORDER BY registered, did
 "#;
 
 pub const INSERT_CUSTOMER: &str = r#"
@@ -137,8 +240,8 @@ VALUES (?1, ?2, 'Registered', ?3, ?4, ?5)
 /// customer provides it. `ON CONFLICT DO NOTHING` keeps re-enrollment
 /// idempotent when the consumer row survived an earlier attempt.
 pub const INSERT_SELF_CONSUMER: &str = r#"
-INSERT INTO consumer (did, provider, registered)
-VALUES (?1, ?1, ?2)
+INSERT INTO consumer (did, provider, owner, registered)
+VALUES (?1, ?1, ?1, ?2)
 ON CONFLICT (did) DO NOTHING
 "#;
 
@@ -146,10 +249,22 @@ ON CONFLICT (did) DO NOTHING
 /// customer re-runs the update, while a consumer someone else provides
 /// matches no row and changes nothing.
 pub const ADD_CONSUMER: &str = r#"
-INSERT INTO consumer (did, provider, registered)
-VALUES (?1, ?2, ?3)
-ON CONFLICT (did) DO UPDATE SET provider = excluded.provider
-WHERE consumer.provider IS NULL OR consumer.provider = excluded.provider
+INSERT INTO consumer (did, provider, owner, registered, deletion_grant_cid, deletion_grant_kind)
+VALUES (?1, ?2, ?2, ?3, ?4, ?5)
+ON CONFLICT (did) DO UPDATE SET
+  provider = excluded.provider,
+  deletion_grant_cid = CASE
+    WHEN excluded.deletion_grant_kind = 'exact' THEN excluded.deletion_grant_cid
+    WHEN consumer.deletion_grant_cid IS NULL THEN excluded.deletion_grant_cid
+    ELSE consumer.deletion_grant_cid
+  END,
+  deletion_grant_kind = CASE
+    WHEN excluded.deletion_grant_kind = 'exact' THEN excluded.deletion_grant_kind
+    WHEN consumer.deletion_grant_kind IS NULL THEN excluded.deletion_grant_kind
+    ELSE consumer.deletion_grant_kind
+  END
+WHERE (consumer.provider IS NULL OR consumer.provider = excluded.provider)
+  AND consumer.deletion_state = 'active'
 "#;
 
 pub const UPDATE_REGISTERED_EMAIL: &str = r#"
@@ -164,6 +279,51 @@ UPDATE customer
        terms_accepted_at = ?2,
        cycle_anchor = ?2
  WHERE did = ?1 AND status = 'Registered'
+"#;
+
+pub const MARK_CONSUMER_DELETING: &str = r#"
+UPDATE consumer SET deletion_state = 'deleting'
+ WHERE did = ?1
+   AND deletion_grant_cid = ?2
+   AND deletion_state = 'active'
+"#;
+
+pub const FINISH_CONSUMER_DELETION: &str = r#"
+UPDATE consumer
+   SET deletion_state = 'deleted', deleted_at = ?2, provider = NULL
+ WHERE did = ?1 AND deletion_state = 'deleting'
+"#;
+
+pub const MARK_SELF_CONSUMER_DELETING: &str = r#"
+UPDATE consumer SET deletion_state = 'deleting'
+ WHERE did = ?1 AND owner = ?1 AND deletion_state = 'active'
+"#;
+
+/// Detach completed denial markers from the deleted customer while retaining
+/// the minimum state that prevents a stale replica from provisioning the same
+/// space again.
+pub const ANONYMIZE_DELETED_CONSUMERS: &str = r#"
+UPDATE consumer
+   SET provider = NULL,
+       owner = NULL,
+       deletion_grant_cid = NULL,
+       deletion_grant_kind = NULL
+ WHERE owner = ?1
+   AND did <> ?1
+   AND deletion_state = 'deleted'
+"#;
+
+pub const DELETE_SELF_CONSUMER: &str = r#"
+DELETE FROM consumer
+ WHERE did = ?1
+   AND owner = ?1
+   AND deletion_state IN ('deleting', 'deleted')
+"#;
+
+pub const DELETE_CUSTOMER: &str = r#"
+DELETE FROM customer
+ WHERE did = ?1
+   AND NOT EXISTS (SELECT 1 FROM consumer WHERE owner = ?1)
 "#;
 
 pub mod ingest;

--- a/rust/tonk-access-service/src/store/d1.rs
+++ b/rust/tonk-access-service/src/store/d1.rs
@@ -13,8 +13,11 @@ use worker::d1::D1Database;
 use worker::wasm_bindgen::JsValue;
 
 use crate::store::{
-    ACTIVATE_CUSTOMER, ADD_CONSUMER, Consumer, Customer, INSERT_CUSTOMER, INSERT_SELF_CONSUMER,
-    SELECT_CONSUMER, SELECT_CUSTOMER, Store, StoreError, UPDATE_REGISTERED_EMAIL, parse_status,
+    ACTIVATE_CUSTOMER, ADD_CONSUMER, ANONYMIZE_DELETED_CONSUMERS, Consumer, ConsumerDeletionState,
+    Customer, DELETE_CUSTOMER, DELETE_SELF_CONSUMER, DeletionGrantKind, FINISH_CONSUMER_DELETION,
+    INSERT_CUSTOMER, INSERT_SELF_CONSUMER, MARK_CONSUMER_DELETING, MARK_SELF_CONSUMER_DELETING,
+    SELECT_CONSUMER, SELECT_CONSUMERS_BY_OWNER, SELECT_CUSTOMER, Store, StoreError,
+    UPDATE_REGISTERED_EMAIL, parse_status,
 };
 
 /// Cloudflare D1-backed [`Store`], for production use.
@@ -71,16 +74,32 @@ impl TryFrom<CustomerRowD1> for Customer {
 struct ConsumerRowD1 {
     did: String,
     provider: Option<String>,
+    owner: Option<String>,
     registered: f64,
+    deletion_grant_cid: Option<String>,
+    deletion_grant_kind: Option<String>,
+    deletion_state: String,
+    deleted_at: Option<f64>,
 }
 
-impl From<ConsumerRowD1> for Consumer {
-    fn from(row: ConsumerRowD1) -> Self {
-        Consumer {
+impl TryFrom<ConsumerRowD1> for Consumer {
+    type Error = StoreError;
+
+    fn try_from(row: ConsumerRowD1) -> Result<Self, Self::Error> {
+        Ok(Consumer {
             did: row.did,
             provider: row.provider,
+            owner: row.owner,
             registered: row.registered as u64,
-        }
+            deletion_grant_cid: row.deletion_grant_cid,
+            deletion_grant_kind: row
+                .deletion_grant_kind
+                .as_deref()
+                .map(DeletionGrantKind::parse)
+                .transpose()?,
+            deletion_state: ConsumerDeletionState::parse(&row.deletion_state)?,
+            deleted_at: row.deleted_at.map(|value| value as u64),
+        })
     }
 }
 
@@ -107,7 +126,24 @@ impl Store for D1Store {
             .first(None)
             .await
             .map_err(map_err)?;
-        Ok(row.map(Consumer::from))
+        row.map(Consumer::try_from).transpose()
+    }
+
+    async fn consumers_by_owner(&self, owner: &str) -> Result<Vec<Consumer>, StoreError> {
+        let result = self
+            .0
+            .prepare(SELECT_CONSUMERS_BY_OWNER)
+            .bind(&[JsValue::from(owner)])
+            .map_err(map_err)?
+            .all()
+            .await
+            .map_err(map_err)?;
+        result
+            .results::<ConsumerRowD1>()
+            .map_err(map_err)?
+            .into_iter()
+            .map(Consumer::try_from)
+            .collect()
     }
 
     async fn enroll_customer(
@@ -156,7 +192,14 @@ impl Store for D1Store {
         Ok(changed_rows(&result) > 0)
     }
 
-    async fn add_consumer(&self, did: &str, provider: &str, now: u64) -> Result<bool, StoreError> {
+    async fn add_consumer(
+        &self,
+        did: &str,
+        provider: &str,
+        now: u64,
+        deletion_grant_cid: Option<&str>,
+        deletion_grant_kind: Option<DeletionGrantKind>,
+    ) -> Result<bool, StoreError> {
         let result = self
             .0
             .prepare(ADD_CONSUMER)
@@ -164,12 +207,80 @@ impl Store for D1Store {
                 JsValue::from(did),
                 JsValue::from(provider),
                 JsValue::from_f64(now as f64),
+                deletion_grant_cid.map_or(JsValue::NULL, JsValue::from),
+                deletion_grant_kind
+                    .map(DeletionGrantKind::as_str)
+                    .map_or(JsValue::NULL, JsValue::from),
             ])
             .map_err(map_err)?
             .run()
             .await
             .map_err(map_err)?;
         Ok(changed_rows(&result) > 0)
+    }
+
+    async fn mark_consumer_deleting(
+        &self,
+        did: &str,
+        deletion_grant_cid: &str,
+    ) -> Result<bool, StoreError> {
+        let result = self
+            .0
+            .prepare(MARK_CONSUMER_DELETING)
+            .bind(&[JsValue::from(did), JsValue::from(deletion_grant_cid)])
+            .map_err(map_err)?
+            .run()
+            .await
+            .map_err(map_err)?;
+        Ok(changed_rows(&result) > 0)
+    }
+
+    async fn finish_consumer_deletion(&self, did: &str, now: u64) -> Result<bool, StoreError> {
+        let result = self
+            .0
+            .prepare(FINISH_CONSUMER_DELETION)
+            .bind(&[JsValue::from(did), JsValue::from_f64(now as f64)])
+            .map_err(map_err)?
+            .run()
+            .await
+            .map_err(map_err)?;
+        Ok(changed_rows(&result) > 0)
+    }
+
+    async fn mark_self_consumer_deleting(&self, did: &str) -> Result<bool, StoreError> {
+        let result = self
+            .0
+            .prepare(MARK_SELF_CONSUMER_DELETING)
+            .bind(&[JsValue::from(did)])
+            .map_err(map_err)?
+            .run()
+            .await
+            .map_err(map_err)?;
+        Ok(changed_rows(&result) > 0)
+    }
+
+    async fn delete_customer(&self, did: &str) -> Result<bool, StoreError> {
+        let anonymize = self
+            .0
+            .prepare(ANONYMIZE_DELETED_CONSUMERS)
+            .bind(&[JsValue::from(did)])
+            .map_err(map_err)?;
+        let self_consumer = self
+            .0
+            .prepare(DELETE_SELF_CONSUMER)
+            .bind(&[JsValue::from(did)])
+            .map_err(map_err)?;
+        let customer = self
+            .0
+            .prepare(DELETE_CUSTOMER)
+            .bind(&[JsValue::from(did)])
+            .map_err(map_err)?;
+        let results = self
+            .0
+            .batch(vec![anonymize, self_consumer, customer])
+            .await
+            .map_err(map_err)?;
+        Ok(results.last().map(changed_rows).unwrap_or_default() == 1)
     }
 
     async fn activate_customer(

--- a/rust/tonk-access-service/src/store/sqlite.rs
+++ b/rust/tonk-access-service/src/store/sqlite.rs
@@ -8,8 +8,11 @@ use async_trait::async_trait;
 use rusqlite::{Connection, OptionalExtension, params};
 
 use super::{
-    ACTIVATE_CUSTOMER, ADD_CONSUMER, Consumer, Customer, INSERT_CUSTOMER, INSERT_SELF_CONSUMER,
-    SELECT_CONSUMER, SELECT_CUSTOMER, Store, StoreError, UPDATE_REGISTERED_EMAIL, parse_status,
+    ACTIVATE_CUSTOMER, ADD_CONSUMER, ANONYMIZE_DELETED_CONSUMERS, Consumer, ConsumerDeletionState,
+    Customer, DELETE_CUSTOMER, DELETE_SELF_CONSUMER, DeletionGrantKind, FINISH_CONSUMER_DELETION,
+    INSERT_CUSTOMER, INSERT_SELF_CONSUMER, MARK_CONSUMER_DELETING, MARK_SELF_CONSUMER_DELETING,
+    SELECT_CONSUMER, SELECT_CONSUMERS_BY_OWNER, SELECT_CUSTOMER, Store, StoreError,
+    UPDATE_REGISTERED_EMAIL, parse_status,
 };
 
 /// Native `rusqlite`-backed [`Store`], for tests and local development.
@@ -35,13 +38,20 @@ impl SqliteStore {
     fn prepare(conn: Connection) -> Result<Self, StoreError> {
         conn.pragma_update(None, "foreign_keys", "ON")
             .map_err(map_err)?;
-        let version: i64 = conn
+        let mut version: i64 = conn
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .map_err(map_err)?;
         if version == 0 {
             conn.execute_batch(include_str!("../../migrations/0001_control.sql"))
                 .map_err(map_err)?;
             conn.pragma_update(None, "user_version", 1)
+                .map_err(map_err)?;
+            version = 1;
+        }
+        if version < 2 {
+            conn.execute_batch(include_str!("../../migrations/0002_deletion.sql"))
+                .map_err(map_err)?;
+            conn.pragma_update(None, "user_version", 2)
                 .map_err(map_err)?;
         }
         Ok(Self(Mutex::new(conn)))
@@ -96,15 +106,73 @@ impl Store for SqliteStore {
 
     async fn consumer(&self, did: &str) -> Result<Option<Consumer>, StoreError> {
         let conn = self.0.lock().expect("store mutex poisoned");
-        conn.query_row(SELECT_CONSUMER, params![did], |row| {
+        let row = conn
+            .query_row(SELECT_CONSUMER, params![did], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                    row.get::<_, Option<String>>(5)?,
+                    row.get::<_, String>(6)?,
+                    row.get::<_, Option<i64>>(7)?,
+                ))
+            })
+            .optional()
+            .map_err(map_err)?;
+        row.map(
+            |(did, provider, owner, registered, cid, kind, state, deleted_at)| {
+                Ok(Consumer {
+                    did,
+                    provider,
+                    owner,
+                    registered: registered as u64,
+                    deletion_grant_cid: cid,
+                    deletion_grant_kind: kind
+                        .as_deref()
+                        .map(DeletionGrantKind::parse)
+                        .transpose()?,
+                    deletion_state: ConsumerDeletionState::parse(&state)?,
+                    deleted_at: deleted_at.map(|value| value as u64),
+                })
+            },
+        )
+        .transpose()
+    }
+
+    async fn consumers_by_owner(&self, owner: &str) -> Result<Vec<Consumer>, StoreError> {
+        let conn = self.0.lock().expect("store mutex poisoned");
+        let mut statement = conn.prepare(SELECT_CONSUMERS_BY_OWNER).map_err(map_err)?;
+        let rows = statement
+            .query_map(params![owner], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                    row.get::<_, Option<String>>(5)?,
+                    row.get::<_, String>(6)?,
+                    row.get::<_, Option<i64>>(7)?,
+                ))
+            })
+            .map_err(map_err)?;
+        rows.map(|row| {
+            let (did, provider, owner, registered, cid, kind, state, deleted_at) =
+                row.map_err(map_err)?;
             Ok(Consumer {
-                did: row.get(0)?,
-                provider: row.get(1)?,
-                registered: row.get::<_, i64>(2)? as u64,
+                did,
+                provider,
+                owner,
+                registered: registered as u64,
+                deletion_grant_cid: cid,
+                deletion_grant_kind: kind.as_deref().map(DeletionGrantKind::parse).transpose()?,
+                deletion_state: ConsumerDeletionState::parse(&state)?,
+                deleted_at: deleted_at.map(|value| value as u64),
             })
         })
-        .optional()
-        .map_err(map_err)
+        .collect()
     }
 
     async fn enroll_customer(
@@ -135,12 +203,68 @@ impl Store for SqliteStore {
         Ok(changed > 0)
     }
 
-    async fn add_consumer(&self, did: &str, provider: &str, now: u64) -> Result<bool, StoreError> {
+    async fn add_consumer(
+        &self,
+        did: &str,
+        provider: &str,
+        now: u64,
+        deletion_grant_cid: Option<&str>,
+        deletion_grant_kind: Option<DeletionGrantKind>,
+    ) -> Result<bool, StoreError> {
         let conn = self.0.lock().expect("store mutex poisoned");
         let changed = conn
-            .execute(ADD_CONSUMER, params![did, provider, now as i64])
+            .execute(
+                ADD_CONSUMER,
+                params![
+                    did,
+                    provider,
+                    now as i64,
+                    deletion_grant_cid,
+                    deletion_grant_kind.map(DeletionGrantKind::as_str)
+                ],
+            )
             .map_err(map_err)?;
         Ok(changed > 0)
+    }
+
+    async fn mark_consumer_deleting(
+        &self,
+        did: &str,
+        deletion_grant_cid: &str,
+    ) -> Result<bool, StoreError> {
+        let conn = self.0.lock().expect("store mutex poisoned");
+        let changed = conn
+            .execute(MARK_CONSUMER_DELETING, params![did, deletion_grant_cid])
+            .map_err(map_err)?;
+        Ok(changed > 0)
+    }
+
+    async fn finish_consumer_deletion(&self, did: &str, now: u64) -> Result<bool, StoreError> {
+        let conn = self.0.lock().expect("store mutex poisoned");
+        let changed = conn
+            .execute(FINISH_CONSUMER_DELETION, params![did, now as i64])
+            .map_err(map_err)?;
+        Ok(changed > 0)
+    }
+
+    async fn mark_self_consumer_deleting(&self, did: &str) -> Result<bool, StoreError> {
+        let conn = self.0.lock().expect("store mutex poisoned");
+        Ok(conn
+            .execute(MARK_SELF_CONSUMER_DELETING, params![did])
+            .map_err(map_err)?
+            > 0)
+    }
+
+    async fn delete_customer(&self, did: &str) -> Result<bool, StoreError> {
+        let mut conn = self.0.lock().expect("store mutex poisoned");
+        let tx = conn.transaction().map_err(map_err)?;
+        tx.execute(ANONYMIZE_DELETED_CONSUMERS, params![did])
+            .map_err(map_err)?;
+        tx.execute(DELETE_SELF_CONSUMER, params![did])
+            .map_err(map_err)?;
+        let changed = tx.execute(DELETE_CUSTOMER, params![did]).map_err(map_err)?;
+        tx.commit().map_err(map_err)?;
+        Ok(changed == 1)
     }
 
     async fn activate_customer(

--- a/rust/tonk-access-service/tests/registration.rs
+++ b/rust/tonk-access-service/tests/registration.rs
@@ -25,8 +25,8 @@ use dialog_varsig::{Did, Principal};
 use tonk_access_service::email::CapturedEmail;
 use tonk_access_service::helpers::AccessServiceAddress;
 use tonk_access_service::registration::{Answer, Registration, SIGNUP_TERMS};
-use tonk_access_service::store::Store;
 use tonk_access_service::store::sqlite::SqliteStore;
+use tonk_access_service::store::{DeletionGrantKind, Store};
 use tonk_account::customer::{Receipt, RegistrationError, deposit_scopes};
 
 /// Current time as unix seconds.
@@ -457,6 +457,15 @@ async fn add_container(
     space: &Ed25519Signer,
     consent_to: &Did,
 ) -> Vec<u8> {
+    add_container_with_deletion(customer, space, consent_to, false).await
+}
+
+async fn add_container_with_deletion(
+    customer: &Ed25519Signer,
+    space: &Ed25519Signer,
+    consent_to: &Did,
+    carry_exact_deletion_grant: bool,
+) -> Vec<u8> {
     let consent = DelegationBuilder::new()
         .issuer(space.clone())
         .audience(consent_to)
@@ -465,27 +474,48 @@ async fn add_container(
         .try_build()
         .await
         .expect("consent delegation");
+    let deletion = if carry_exact_deletion_grant {
+        Some(
+            DelegationBuilder::new()
+                .issuer(space.clone())
+                .audience(consent_to)
+                .subject(DelegatedSubject::Specific(space.did()))
+                .command(vec!["space".to_string(), "delete".to_string()])
+                .try_build()
+                .await
+                .expect("deletion delegation"),
+        )
+    } else {
+        None
+    };
+    let mut arguments = BTreeMap::from([
+        (
+            "consumer".to_string(),
+            Promised::String(space.did().to_string()),
+        ),
+        ("consent".to_string(), Promised::Link(consent.to_cid())),
+    ]);
+    if let Some(deletion) = &deletion {
+        arguments.insert("deletion".to_string(), Promised::Link(deletion.to_cid()));
+    }
     let invocation = InvocationBuilder::new()
         .issuer(customer.clone())
         .audience(&customer.did())
         .subject(&customer.did())
         .command(vec!["provider".to_string(), "add".to_string()])
-        .arguments(BTreeMap::from([
-            (
-                "consumer".to_string(),
-                Promised::String(space.did().to_string()),
-            ),
-            ("consent".to_string(), Promised::Link(consent.to_cid())),
-        ]))
+        .arguments(arguments)
         .proofs(vec![])
         .expiration(Timestamp::five_minutes_from_now())
         .try_build()
         .await
         .expect("add invocation");
-    let tokens = vec![
+    let mut tokens = vec![
         serde_ipld_dagcbor::to_vec(&invocation).expect("invocation encodes"),
         consent.encoded().to_vec(),
     ];
+    if let Some(deletion) = deletion {
+        tokens.push(deletion.encoded().to_vec());
+    }
     Container::new(tokens)
         .to_bytes()
         .expect("container encodes")
@@ -515,10 +545,49 @@ async fn it_provisions_a_consumer_with_the_spaces_consent() -> anyhow::Result<()
         .unwrap()
         .expect("the consumer row exists");
     assert_eq!(consumer.provider.as_deref(), Some(customer.did().as_str()));
+    assert_eq!(
+        consumer.deletion_grant_kind,
+        Some(DeletionGrantKind::LegacyDirect),
+        "an existing direct owner proof is upgraded once"
+    );
+    assert!(consumer.deletion_grant_cid.is_some());
 
     // Re-provisioning under the same customer is a no-op success.
     let container = add_container(&customer, &space, &customer.did()).await;
     assert!(fixture.registration(&container).handle().await.is_ok());
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_registers_the_exact_delete_grant_for_new_spaces() -> anyhow::Result<()> {
+    let fixture = Fixture::new().await;
+    let customer = Ed25519Signer::generate().await?;
+    let space = Ed25519Signer::generate().await?;
+    let container = enroll_container(&customer, &fixture.service.did(), "alice@example.com").await;
+    fixture.registration(&container).handle().await.unwrap();
+
+    let legacy = add_container(&customer, &space, &customer.did()).await;
+    fixture.registration(&legacy).handle().await.unwrap();
+    assert_eq!(
+        fixture
+            .store
+            .consumer(space.did().as_str())
+            .await?
+            .expect("legacy consumer row")
+            .deletion_grant_kind,
+        Some(DeletionGrantKind::LegacyDirect)
+    );
+
+    let container = add_container_with_deletion(&customer, &space, &customer.did(), true).await;
+    fixture.registration(&container).handle().await.unwrap();
+
+    let consumer = fixture
+        .store
+        .consumer(space.did().as_str())
+        .await?
+        .expect("consumer row");
+    assert_eq!(consumer.deletion_grant_kind, Some(DeletionGrantKind::Exact));
+    assert!(consumer.deletion_grant_cid.is_some());
     Ok(())
 }
 

--- a/rust/tonk-account-service/src/chains.rs
+++ b/rust/tonk-account-service/src/chains.rs
@@ -70,6 +70,10 @@ pub trait ChainStore {
         root_did: &str,
         slot: SpotHeadSlot,
     ) -> Result<Vec<(String, String)>, ChainError>;
+
+    /// Permanently remove every immutable chain and mutable spot head in an
+    /// account root's namespace.
+    async fn delete_namespace(&self, root_did: &str) -> Result<(), ChainError>;
 }
 
 #[cfg(any(test, feature = "helpers"))]
@@ -181,6 +185,20 @@ mod memory {
                 .collect();
             heads.sort();
             Ok(heads)
+        }
+
+        async fn delete_namespace(&self, root_did: &str) -> Result<(), ChainError> {
+            let mut store = self
+                .0
+                .lock()
+                .map_err(|_| ChainError::Internal("chain store lock poisoned".to_string()))?;
+            let blob_prefix = format!("{root_did}/");
+            store.blobs.retain(|key, _| !key.starts_with(&blob_prefix));
+            for slot in [SpotHeadSlot::Named, SpotHeadSlot::Unnamed] {
+                let head_prefix = format!("{}/{root_did}/", slot.as_str());
+                store.heads.retain(|key, _| !key.starts_with(&head_prefix));
+            }
+            Ok(())
         }
     }
 }

--- a/rust/tonk-account-service/src/chains/r2.rs
+++ b/rust/tonk-account-service/src/chains/r2.rs
@@ -156,4 +156,36 @@ impl ChainStore for R2ChainStore {
         }
         Ok(heads)
     }
+
+    async fn delete_namespace(&self, root_did: &str) -> Result<(), ChainError> {
+        for prefix in [
+            format!("chains/{root_did}/"),
+            format!("spot-heads/named/{root_did}/"),
+            format!("spot-heads/unnamed/{root_did}/"),
+        ] {
+            loop {
+                let listed = self
+                    .0
+                    .list()
+                    .prefix(prefix.clone())
+                    .limit(1000)
+                    .execute()
+                    .await
+                    .map_err(|error| ChainError::Internal(error.to_string()))?;
+                let keys: Vec<_> = listed
+                    .objects()
+                    .into_iter()
+                    .map(|object| object.key())
+                    .collect();
+                if keys.is_empty() {
+                    break;
+                }
+                self.0
+                    .delete_multiple(keys)
+                    .await
+                    .map_err(|error| ChainError::Internal(error.to_string()))?;
+            }
+        }
+        Ok(())
+    }
 }

--- a/rust/tonk-account-service/src/core.rs
+++ b/rust/tonk-account-service/src/core.rs
@@ -13,6 +13,7 @@ pub mod accounts;
 pub mod backup;
 pub mod codes;
 pub mod delegation;
+pub mod deletion;
 pub mod descriptor;
 pub mod devices;
 pub mod links;

--- a/rust/tonk-account-service/src/core/backup.rs
+++ b/rust/tonk-account-service/src/core/backup.rs
@@ -111,6 +111,7 @@ fn summary(
         remote_url: backup.remote_url.clone(),
         revocation_url: backup.revocation_url.clone(),
         ambiguous,
+        deletion_ready: backup.deletion_grant_hex.is_some(),
     }
 }
 
@@ -204,6 +205,7 @@ pub async fn list_account_spots<C: ChainStore>(
                 remote_url: None,
                 revocation_url: None,
                 ambiguous: true,
+                deletion_ready: false,
             });
         } else {
             rows.push(summary(first, subject, Some(first_key.clone()), false));
@@ -286,6 +288,10 @@ mod tests {
         ) -> Result<Vec<(String, String)>, ChainError> {
             self.inner.list_spot_heads(root_did, slot).await
         }
+
+        async fn delete_namespace(&self, root_did: &str) -> Result<(), ChainError> {
+            self.inner.delete_namespace(root_did).await
+        }
     }
 
     fn account(id: i64, root_did: &str) -> Account {
@@ -319,6 +325,7 @@ mod tests {
         let chain = DelegationChain::new(delegation);
         let artifact = AccountSpotBackup {
             chain_hex: hex::encode(chain.to_bytes().unwrap()),
+            deletion_grant_hex: None,
             remote_url: Some(remote.to_string()),
             revocation_url: None,
             name: name.map(str::to_string),
@@ -329,6 +336,7 @@ mod tests {
     fn artifact(chain: &DelegationChain) -> Vec<u8> {
         serde_json::to_vec(&AccountSpotBackup {
             chain_hex: hex::encode(chain.to_bytes().unwrap()),
+            deletion_grant_hex: None,
             remote_url: Some("https://access.example/".to_string()),
             revocation_url: None,
             name: Some("garden".to_string()),
@@ -433,6 +441,7 @@ mod tests {
                     .to_bytes()
                     .unwrap(),
             ),
+            deletion_grant_hex: None,
             remote_url: Some("https://access.example/".to_string()),
             revocation_url: None,
             name: Some("garden".to_string()),

--- a/rust/tonk-account-service/src/core/deletion.rs
+++ b/rust/tonk-account-service/src/core/deletion.rs
@@ -1,0 +1,166 @@
+//! Permanent account-service removal.
+
+use serde::Serialize;
+
+use crate::chains::ChainStore;
+use crate::store::Store;
+
+use super::CeremonyError;
+
+/// Successful removal from the account service.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountDeletionReceipt {
+    /// Root DID whose account-service namespace was removed.
+    pub root_did: String,
+    /// Verified email released for a future account.
+    pub email: String,
+}
+
+/// Delete all account-service objects and rows after exact email confirmation.
+///
+/// Object storage goes first. If that fails, the D1 identity remains and the
+/// root can retry. The dependent-row D1 removal is one transaction/batch.
+pub async fn delete_account<S: Store, C: ChainStore>(
+    store: &S,
+    chains: &C,
+    root_did: &str,
+    confirmed_email: &str,
+) -> Result<AccountDeletionReceipt, CeremonyError> {
+    let account = store
+        .account_by_root(root_did)
+        .await?
+        .ok_or_else(|| CeremonyError::Unauthorized("unknown account".to_string()))?;
+    if confirmed_email.trim().to_lowercase() != account.email {
+        return Err(CeremonyError::Forbidden(
+            "email confirmation does not match this account".to_string(),
+        ));
+    }
+
+    chains.delete_namespace(root_did).await?;
+    if !store.delete_account(account.id, &account.email).await? {
+        return Err(CeremonyError::Internal(
+            "account disappeared while deletion was finalizing".to_string(),
+        ));
+    }
+    Ok(AccountDeletionReceipt {
+        root_did: root_did.to_string(),
+        email: account.email,
+    })
+}
+
+#[cfg(all(test, feature = "helpers", not(target_arch = "wasm32")))]
+mod tests {
+    use crate::chains::{ChainStore, MemoryChainStore, SpotHeadSlot};
+    use crate::store::sqlite::SqliteStore;
+    use crate::store::{CodeRow, Device, DeviceStatus, LinkRequest, Store};
+
+    async fn populated() -> (SqliteStore, MemoryChainStore, String, i64) {
+        let store = SqliteStore::in_memory().unwrap();
+        let chains = MemoryChainStore::default();
+        let root = "did:key:z6Mktest-root".to_string();
+        let account_id = store
+            .create_account("owner@example.com", &root, "credential", 1)
+            .await
+            .unwrap();
+        store
+            .insert_device(&Device {
+                id: 0,
+                account_id,
+                device_did: "did:key:z6Mktest-device".into(),
+                attachment_id: "attachment".into(),
+                delegation_cid: "bafkdelegation".into(),
+                delegation_hex: "aa".into(),
+                name: "laptop".into(),
+                status: DeviceStatus::Active,
+                created_at: 1,
+            })
+            .await
+            .unwrap();
+        store
+            .put_link(&LinkRequest {
+                token_hash: "link".into(),
+                device_did: "did:key:z6Mkpending".into(),
+                device_name: "phone".into(),
+                account_id: None,
+                attachment_id: None,
+                delegation_cid: None,
+                delegation_hex: None,
+                descriptor_hex: None,
+                created_at: 1,
+                expires_at: 2,
+                completed_at: None,
+                consumed_at: None,
+                activated_at: None,
+                cancelled_at: None,
+            })
+            .await
+            .unwrap();
+        store
+            .put_code(&CodeRow {
+                email: "owner@example.com".into(),
+                code_hash: "hash".into(),
+                created_at: 1,
+                expires_at: 2,
+                attempts: 0,
+            })
+            .await
+            .unwrap();
+        chains.put(&root, "delegation", b"chain").await.unwrap();
+        chains
+            .put_spot_head(&root, "subject", SpotHeadSlot::Named, "blob")
+            .await
+            .unwrap();
+        (store, chains, root, account_id)
+    }
+
+    #[dialog_common::test]
+    async fn exact_email_confirmation_is_required_without_mutation() {
+        let (store, chains, root, account_id) = populated().await;
+
+        let error = super::delete_account(&store, &chains, &root, "wrong@example.com")
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, crate::core::CeremonyError::Forbidden(_)));
+        assert!(store.account_by_root(&root).await.unwrap().is_some());
+        assert_eq!(store.devices(account_id).await.unwrap().len(), 1);
+        assert_eq!(chains.list(&root).await.unwrap(), vec!["delegation"]);
+    }
+
+    #[dialog_common::test]
+    async fn it_removes_account_objects_dependents_and_email_for_reuse() {
+        let (store, chains, root, account_id) = populated().await;
+
+        let receipt = super::delete_account(&store, &chains, &root, "owner@example.com")
+            .await
+            .unwrap();
+
+        assert_eq!(receipt.root_did, root);
+        assert_eq!(receipt.email, "owner@example.com");
+        assert!(store.account_by_root(&root).await.unwrap().is_none());
+        assert!(
+            store
+                .account_by_email("owner@example.com")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(store.devices(account_id).await.unwrap().is_empty());
+        assert!(store.code("owner@example.com").await.unwrap().is_none());
+        assert!(chains.list(&root).await.unwrap().is_empty());
+        assert!(
+            chains
+                .list_spot_heads(&root, SpotHeadSlot::Named)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            store
+                .create_account("owner@example.com", "did:key:z6Mknew", "new", 3)
+                .await
+                .is_ok()
+        );
+    }
+}

--- a/rust/tonk-account-service/src/handlers/accounts.rs
+++ b/rust/tonk-account-service/src/handlers/accounts.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 
 use crate::auth::{authorize, authorize_root, optional_passkey_metadata, required_string};
 use crate::core::accounts::{CreateAccount, create_account, preflight_account};
+use crate::core::deletion::delete_account;
 use crate::error::{ErrorCode, ServiceError};
 use crate::handlers::{build_store, ceremony_error, read_body, with_cors_headers};
 use crate::store::Store;
@@ -13,6 +14,35 @@ use crate::store::Store;
 /// `OPTIONS /accounts` → CORS preflight.
 pub async fn handle_options(_req: Request, _ctx: RouteContext<()>) -> Result<Response> {
     Ok(with_cors_headers(Response::empty()?.with_status(204)))
+}
+
+/// `POST /account/delete` → permanently remove account-service state.
+pub async fn handle_delete(mut req: Request, ctx: RouteContext<()>) -> Result<Response> {
+    let response = match handle_delete_inner(&mut req, &ctx).await {
+        Ok(response) => response,
+        Err(err) => err.to_response()?,
+    };
+    Ok(with_cors_headers(response))
+}
+
+async fn handle_delete_inner(
+    req: &mut Request,
+    ctx: &RouteContext<()>,
+) -> std::result::Result<Response, ServiceError> {
+    let body = read_body(req).await?;
+    let caller = authorize_root(&body, &["account", "delete"])
+        .await
+        .map_err(ceremony_error)?;
+    let confirmed_email =
+        required_string(&caller.arguments, "confirmedEmail").map_err(ceremony_error)?;
+    let store = build_store(ctx)?;
+    let chains = crate::handlers::build_chains(ctx)?;
+    let receipt = delete_account(&store, &chains, &caller.root_did, &confirmed_email)
+        .await
+        .map_err(ceremony_error)?;
+    Response::from_json(&receipt).map_err(|error| {
+        ServiceError::new(ErrorCode::InternalError, format!("response error: {error}"))
+    })
 }
 
 #[derive(Deserialize)]

--- a/rust/tonk-account-service/src/helpers/server.rs
+++ b/rust/tonk-account-service/src/helpers/server.rs
@@ -32,6 +32,7 @@ use crate::chains::MemoryChainStore;
 use crate::core::accounts::{CreateAccount, create_account, preflight_account};
 use crate::core::backup::{get_chain, list_account_spots, list_chains, put_chain_and_index_spot};
 use crate::core::codes::{generate_code, request_code};
+use crate::core::deletion::delete_account;
 use crate::core::descriptor::establish_descriptor;
 use crate::core::devices::{
     DeviceView, detach_device, list_devices, register_device, revoke_device,
@@ -145,6 +146,7 @@ async fn handle_request(
         (Method::POST, "/accounts") => accounts_route(req, &backends).await,
         (Method::POST, "/accounts/preflight") => accounts_preflight_route(req, &backends).await,
         (Method::POST, "/account/summary") => account_summary_route(req, &backends).await,
+        (Method::POST, "/account/delete") => account_delete_route(req, &backends).await,
         (Method::POST, "/revocations") => revocations_route(req, &backends).await,
         (Method::POST, "/account/repository/establish") => {
             repository_establish_route(req, &backends).await
@@ -173,6 +175,28 @@ async fn handle_request(
         Ok(response) => response,
         Err(err) => error_response(err),
     }))
+}
+
+/// `POST /account/delete` → root-authorized permanent account removal.
+async fn account_delete_route(
+    req: Request<Incoming>,
+    backends: &Backends,
+) -> Result<Response<Full<Bytes>>, ServiceError> {
+    let body = body_bytes(req).await?;
+    let caller = authorize_root(&body, &["account", "delete"])
+        .await
+        .map_err(ceremony_error)?;
+    let confirmed_email =
+        required_string(&caller.arguments, "confirmedEmail").map_err(ceremony_error)?;
+    let receipt = delete_account(
+        &backends.store,
+        &backends.chains,
+        &caller.root_did,
+        &confirmed_email,
+    )
+    .await
+    .map_err(ceremony_error)?;
+    Ok(json_response(StatusCode::OK, &receipt))
 }
 
 /// `POST /account/summary` → verified account facts for an active device.

--- a/rust/tonk-account-service/src/lib.rs
+++ b/rust/tonk-account-service/src/lib.rs
@@ -37,6 +37,8 @@ async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         .options_async("/accounts/preflight", handlers::accounts::handle_options)
         .post_async("/account/summary", handlers::accounts::handle_summary)
         .options_async("/account/summary", handlers::accounts::handle_options)
+        .post_async("/account/delete", handlers::accounts::handle_delete)
+        .options_async("/account/delete", handlers::accounts::handle_options)
         .post_async("/revocations", handlers::revocations::handle)
         .options_async("/revocations", handlers::revocations::handle_options)
         .post_async(

--- a/rust/tonk-account-service/src/store.rs
+++ b/rust/tonk-account-service/src/store.rs
@@ -281,6 +281,10 @@ pub trait Store {
     /// [`crate::core::accounts::create_account`].
     async fn account_by_email(&self, email: &str) -> Result<Option<Account>, StoreError>;
 
+    /// Atomically remove dependent links and devices, any pending code for
+    /// the verified email, and finally the account row itself.
+    async fn delete_account(&self, account_id: i64, email: &str) -> Result<bool, StoreError>;
+
     /// Atomically create a new account, register its first device, and consume
     /// the email's verified code.
     ///
@@ -417,6 +421,13 @@ pub const SELECT_REPOSITORY_DESCRIPTOR: &str =
 /// SQL: look up an account by email address.
 pub const SELECT_ACCOUNT_BY_EMAIL: &str = "SELECT id, email, root_did, credential_id, \
     repository_descriptor, passkey_created_at, passkey_created_on, created_at FROM accounts WHERE email = ?1";
+
+/// SQL: delete pending links selected by this account before its row.
+pub const DELETE_ACCOUNT_LINKS: &str = "DELETE FROM link_requests WHERE account_id = ?1";
+/// SQL: delete every device generation before its account row.
+pub const DELETE_ACCOUNT_DEVICES: &str = "DELETE FROM devices WHERE account_id = ?1";
+/// SQL: delete the account row after all foreign-key dependents.
+pub const DELETE_ACCOUNT: &str = "DELETE FROM accounts WHERE id = ?1 AND email = ?2";
 
 /// SQL: register a device under an account.
 pub const INSERT_DEVICE: &str = "INSERT INTO devices (account_id, device_did, attachment_id, delegation_cid, delegation_hex, name, status, created_at) \

--- a/rust/tonk-account-service/src/store/d1.rs
+++ b/rust/tonk-account-service/src/store/d1.rs
@@ -13,12 +13,13 @@ use worker::d1::D1Database;
 use worker::wasm_bindgen::JsValue;
 
 use crate::store::{
-    Account, ActivateOutcome, BUMP_ATTEMPTS, COMPLETE_LINK, CONSUME_LINK, CodeRow, DELETE_CODE,
-    DetachStoreOutcome, Device, DeviceStatus, ESTABLISH_REPOSITORY_DESCRIPTOR, INSERT_ACCOUNT,
-    INSERT_ACCOUNT_WITH_DESCRIPTOR, INSERT_DEVICE, INSERT_DEVICE_FOR_NEW_ACCOUNT, INSERT_LINK,
-    LinkCompletion, LinkRequest, NewAccount, NewDevice, SELECT_ACCOUNT_BY_EMAIL,
-    SELECT_ACCOUNT_BY_ROOT, SELECT_ACTIVE_DEVICE_BY_DID, SELECT_ATTACHMENT, SELECT_CODE,
-    SELECT_DEVICE_FOR_ACCOUNT, SELECT_DEVICES_BY_ACCOUNT, SELECT_LINK, SELECT_LINK_BY_ATTACHMENT,
+    Account, ActivateOutcome, BUMP_ATTEMPTS, COMPLETE_LINK, CONSUME_LINK, CodeRow, DELETE_ACCOUNT,
+    DELETE_ACCOUNT_DEVICES, DELETE_ACCOUNT_LINKS, DELETE_CODE, DetachStoreOutcome, Device,
+    DeviceStatus, ESTABLISH_REPOSITORY_DESCRIPTOR, INSERT_ACCOUNT, INSERT_ACCOUNT_WITH_DESCRIPTOR,
+    INSERT_DEVICE, INSERT_DEVICE_FOR_NEW_ACCOUNT, INSERT_LINK, LinkCompletion, LinkRequest,
+    NewAccount, NewDevice, SELECT_ACCOUNT_BY_EMAIL, SELECT_ACCOUNT_BY_ROOT,
+    SELECT_ACTIVE_DEVICE_BY_DID, SELECT_ATTACHMENT, SELECT_CODE, SELECT_DEVICE_FOR_ACCOUNT,
+    SELECT_DEVICES_BY_ACCOUNT, SELECT_LINK, SELECT_LINK_BY_ATTACHMENT,
     SELECT_REPOSITORY_DESCRIPTOR, Store, StoreError, UPDATE_DEVICE_REVOKE,
     UPDATE_DEVICE_REVOKE_BY_CID, UPSERT_CODE,
 };
@@ -331,6 +332,41 @@ impl Store for D1Store {
             .await
             .map_err(map_err)?;
         Ok(row.map(Account::from))
+    }
+
+    async fn delete_account(&self, account_id: i64, email: &str) -> Result<bool, StoreError> {
+        let id = JsValue::from_f64(account_id as f64);
+        let links = self
+            .0
+            .prepare(DELETE_ACCOUNT_LINKS)
+            .bind(&[id.clone()])
+            .map_err(map_err)?;
+        let devices = self
+            .0
+            .prepare(DELETE_ACCOUNT_DEVICES)
+            .bind(&[id.clone()])
+            .map_err(map_err)?;
+        let code = self
+            .0
+            .prepare(DELETE_CODE)
+            .bind(&[JsValue::from(email)])
+            .map_err(map_err)?;
+        let account = self
+            .0
+            .prepare(DELETE_ACCOUNT)
+            .bind(&[id, JsValue::from(email)])
+            .map_err(map_err)?;
+        let results = self
+            .0
+            .batch(vec![links, devices, code, account])
+            .await
+            .map_err(map_err)?;
+        Ok(results
+            .last()
+            .and_then(|result| result.meta().ok().flatten())
+            .and_then(|meta| meta.changes)
+            .unwrap_or(0)
+            == 1)
     }
 
     async fn establish_repository_descriptor(

--- a/rust/tonk-account-service/src/store/sqlite.rs
+++ b/rust/tonk-account-service/src/store/sqlite.rs
@@ -7,14 +7,14 @@ use std::sync::Mutex;
 use rusqlite::{Connection, OptionalExtension, params};
 
 use super::{
-    Account, ActivateOutcome, BUMP_ATTEMPTS, COMPLETE_LINK, CONSUME_LINK, CodeRow, DELETE_CODE,
-    DetachStoreOutcome, Device, DeviceStatus, ESTABLISH_REPOSITORY_DESCRIPTOR, INSERT_ACCOUNT,
-    INSERT_ACCOUNT_WITH_DESCRIPTOR, INSERT_DEVICE, INSERT_LINK, LinkCompletion, LinkRequest,
-    NewAccount, NewDevice, SELECT_ACCOUNT_BY_EMAIL, SELECT_ACCOUNT_BY_ROOT,
-    SELECT_ACTIVE_DEVICE_BY_DID, SELECT_ATTACHMENT, SELECT_CODE, SELECT_DEVICE_FOR_ACCOUNT,
-    SELECT_DEVICES_BY_ACCOUNT, SELECT_LINK, SELECT_LINK_BY_ATTACHMENT,
-    SELECT_REPOSITORY_DESCRIPTOR, Store, StoreError, UPDATE_DEVICE_REVOKE,
-    UPDATE_DEVICE_REVOKE_BY_CID, UPSERT_CODE,
+    Account, ActivateOutcome, BUMP_ATTEMPTS, COMPLETE_LINK, CONSUME_LINK, CodeRow, DELETE_ACCOUNT,
+    DELETE_ACCOUNT_DEVICES, DELETE_ACCOUNT_LINKS, DELETE_CODE, DetachStoreOutcome, Device,
+    DeviceStatus, ESTABLISH_REPOSITORY_DESCRIPTOR, INSERT_ACCOUNT, INSERT_ACCOUNT_WITH_DESCRIPTOR,
+    INSERT_DEVICE, INSERT_LINK, LinkCompletion, LinkRequest, NewAccount, NewDevice,
+    SELECT_ACCOUNT_BY_EMAIL, SELECT_ACCOUNT_BY_ROOT, SELECT_ACTIVE_DEVICE_BY_DID,
+    SELECT_ATTACHMENT, SELECT_CODE, SELECT_DEVICE_FOR_ACCOUNT, SELECT_DEVICES_BY_ACCOUNT,
+    SELECT_LINK, SELECT_LINK_BY_ATTACHMENT, SELECT_REPOSITORY_DESCRIPTOR, Store, StoreError,
+    UPDATE_DEVICE_REVOKE, UPDATE_DEVICE_REVOKE_BY_CID, UPSERT_CODE,
 };
 
 /// Native `rusqlite`-backed [`Store`], for tests and local development.
@@ -283,6 +283,21 @@ impl Store for SqliteStore {
         })
         .optional()
         .map_err(map_err)
+    }
+
+    async fn delete_account(&self, account_id: i64, email: &str) -> Result<bool, StoreError> {
+        let mut conn = self.0.lock().expect("store mutex poisoned");
+        let tx = conn.transaction().map_err(map_err)?;
+        tx.execute(DELETE_ACCOUNT_LINKS, params![account_id])
+            .map_err(map_err)?;
+        tx.execute(DELETE_ACCOUNT_DEVICES, params![account_id])
+            .map_err(map_err)?;
+        tx.execute(DELETE_CODE, params![email]).map_err(map_err)?;
+        let changed = tx
+            .execute(DELETE_ACCOUNT, params![account_id, email])
+            .map_err(map_err)?;
+        tx.commit().map_err(map_err)?;
+        Ok(changed == 1)
     }
 
     async fn establish_repository_descriptor(

--- a/rust/tonk-account-service/tests/service.rs
+++ b/rust/tonk-account-service/tests/service.rs
@@ -38,6 +38,7 @@ async fn spot_backup(root: &Did, name: Option<&str>, remote: &str) -> Vec<u8> {
     let chain = DelegationChain::new(delegation);
     serde_json::to_vec(&AccountSpotBackup {
         chain_hex: hex::encode(chain.to_bytes().unwrap()),
+        deletion_grant_hex: None,
         remote_url: Some(remote.to_string()),
         revocation_url: None,
         name: name.map(str::to_string),
@@ -127,6 +128,51 @@ async fn account_creation(email: &str) -> Vec<u8> {
     .await
     .unwrap();
     hex::decode(ceremony.invocation_hex).unwrap()
+}
+
+async fn account_deletion(email: &str) -> Vec<u8> {
+    let root = tonk_identity::derive::derive_root_signer(&ROOT_PRF)
+        .await
+        .unwrap();
+    let ceremony = tonk_identity::ceremony::delete_account(root, email.to_string())
+        .await
+        .unwrap();
+    hex::decode(ceremony.invocation_hex).unwrap()
+}
+
+#[dialog_common::test]
+async fn it_deletes_account_state_and_releases_the_email_over_http() {
+    let server = AccountServer::start().await;
+    let client = reqwest::Client::new();
+    let email = "delete-me@example.com";
+
+    client
+        .post(format!("{}/accounts", server.endpoint))
+        .body(account_creation(email).await)
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+    let deleted = client
+        .post(format!("{}/account/delete", server.endpoint))
+        .body(account_deletion(email).await)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(deleted.status(), 200);
+    let receipt: serde_json::Value = deleted.json().await.unwrap();
+    assert_eq!(receipt["email"], email);
+
+    let recreated = client
+        .post(format!("{}/accounts", server.endpoint))
+        .body(account_creation(email).await)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(recreated.status(), 201);
+
+    server.stop().await;
 }
 
 #[dialog_common::test]

--- a/rust/tonk-account/src/backup.rs
+++ b/rust/tonk-account/src/backup.rs
@@ -5,6 +5,8 @@
 pub const SPACE_ROOT_SITE_PREFIX: &str = "tonk-space-root-v1/";
 /// Credential prefix for account-root-specific reusable space authority.
 pub const SPACE_ROOT_SITE_V2_PREFIX: &str = "tonk-space-root-v2/";
+/// Credential prefix for exact hosted-space deletion grants.
+pub const SPACE_DELETE_SITE_V1_PREFIX: &str = "tonk-space-delete-v1/";
 
 /// Credential key for one repository's prefix ending at one exact account root.
 pub fn space_root_site(
@@ -12,6 +14,14 @@ pub fn space_root_site(
     account_root: &dialog_varsig::Did,
 ) -> String {
     format!("{SPACE_ROOT_SITE_V2_PREFIX}{repository_did}/{account_root}")
+}
+
+/// Credential key for one space's deletion grant to one exact account root.
+pub fn space_delete_site(
+    repository_did: &dialog_varsig::Did,
+    account_root: &dialog_varsig::Did,
+) -> String {
+    format!("{SPACE_DELETE_SITE_V1_PREFIX}{repository_did}/{account_root}")
 }
 /// Credential site holding the content key of the last account backup a
 /// native client successfully uploaded for a repository subject.
@@ -26,6 +36,9 @@ pub const ACCOUNT_SPOTS_CAPABILITY_V1: &str = "v1";
 pub struct AccountSpotBackup {
     /// Hex-encoded [`dialog_ucan_core::DelegationChain`] bytes.
     pub chain_hex: String,
+    /// Exact direct `space -> account-root /space/delete` grant, when ready.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deletion_grant_hex: Option<String>,
     /// Access-service URL used to synchronize the spot.
     pub remote_url: Option<String>,
     /// Immutable invitation-revocation relay URL.
@@ -52,6 +65,9 @@ pub struct AccountSpotSummary {
     pub revocation_url: Option<String>,
     /// Whether conflicting unindexed artifacts prevent safe selection.
     pub ambiguous: bool,
+    /// Whether exact hosted-space deletion authority is retained.
+    #[serde(default)]
+    pub deletion_ready: bool,
 }
 
 /// A decoded and verified reusable account spot backup.
@@ -61,6 +77,8 @@ pub struct ValidatedAccountSpot {
     pub subject: dialog_varsig::Did,
     /// Exact verified root-ending delegation chain.
     pub chain: dialog_ucan_core::DelegationChain,
+    /// Exact hosted-space deletion grant, when the backup carries one.
+    pub deletion_grant: Option<dialog_ucan_core::DelegationChain>,
 }
 
 /// Stable validation failures for account spot artifacts.
@@ -102,6 +120,10 @@ pub enum AccountSpotBackupError {
     /// The revocation relay metadata was malformed.
     #[error("backup revocation URL is invalid: {0}")]
     InvalidRevocationUrl(String),
+    /// The optional deletion grant was malformed or did not belong to this
+    /// space and account root.
+    #[error("backup deletion grant is invalid: {0}")]
+    InvalidDeletionGrant(String),
 }
 
 impl AccountSpotBackup {
@@ -182,7 +204,28 @@ impl AccountSpotBackup {
                 .map_err(|error| AccountSpotBackupError::InvalidRevocationUrl(error.to_string()))?;
         }
 
-        Ok(ValidatedAccountSpot { subject, chain })
+        let deletion_grant = match &self.deletion_grant_hex {
+            Some(encoded) => {
+                let bytes = hex::decode(encoded).map_err(|error| {
+                    AccountSpotBackupError::InvalidDeletionGrant(error.to_string())
+                })?;
+                Some(
+                    crate::deletion::validate_deletion_grant(&bytes, &subject, account_root)
+                        .await
+                        .map_err(|error| {
+                            AccountSpotBackupError::InvalidDeletionGrant(error.to_string())
+                        })?
+                        .chain,
+                )
+            }
+            None => None,
+        };
+
+        Ok(ValidatedAccountSpot {
+            subject,
+            chain,
+            deletion_grant,
+        })
     }
 }
 
@@ -199,17 +242,25 @@ mod tests {
         }"#;
         let decoded: AccountSpotBackup = serde_json::from_str(legacy).unwrap();
         assert_eq!(decoded.name, None);
+        assert_eq!(decoded.deletion_grant_hex, None);
 
         let named = AccountSpotBackup {
             chain_hex: "00ff".to_string(),
+            deletion_grant_hex: Some("aabb".to_string()),
             remote_url: Some("https://access.example/ucan/".to_string()),
             revocation_url: Some("https://artifacts.example/revocations/".to_string()),
             name: Some("garden".to_string()),
         };
         let value = serde_json::to_value(&named).unwrap();
         let object = value.as_object().unwrap();
-        assert_eq!(object.len(), 4);
-        for key in ["chain_hex", "remote_url", "revocation_url", "name"] {
+        assert_eq!(object.len(), 5);
+        for key in [
+            "chain_hex",
+            "deletion_grant_hex",
+            "remote_url",
+            "revocation_url",
+            "name",
+        ] {
             assert!(object.contains_key(key), "missing {key}: {object:?}");
         }
 
@@ -220,11 +271,13 @@ mod tests {
             remote_url: named.remote_url,
             revocation_url: named.revocation_url,
             ambiguous: false,
+            deletion_ready: true,
         };
         let summary = serde_json::to_value(summary).unwrap();
         assert!(summary.get("remoteUrl").is_some());
         assert!(summary.get("revocationUrl").is_some());
         assert!(summary.get("remote_url").is_none());
+        assert_eq!(summary["deletionReady"], true);
     }
 
     async fn signer(seed: u8) -> dialog_credentials::Ed25519Signer {
@@ -255,6 +308,7 @@ mod tests {
     fn artifact(chain: &dialog_ucan_core::DelegationChain) -> AccountSpotBackup {
         AccountSpotBackup {
             chain_hex: hex::encode(chain.to_bytes().unwrap()),
+            deletion_grant_hex: None,
             remote_url: Some("https://access.example/ucan/".to_string()),
             revocation_url: Some("https://artifacts.example/revocations/".to_string()),
             name: Some("garden".to_string()),
@@ -355,6 +409,31 @@ mod tests {
         ] {
             assert!(invalid.validate_for(&account).await.is_err());
         }
+    }
+
+    #[dialog_common::test]
+    async fn it_validates_an_optional_exact_deletion_grant() {
+        use dialog_varsig::Principal as _;
+
+        let space = signer(7).await;
+        let account = signer(8).await.did();
+        let chain = space_chain(space.clone(), &account, &space.did()).await;
+        let deletion = crate::deletion::mint_deletion_grant(&space, &account)
+            .await
+            .unwrap();
+        let mut backup = artifact(&chain);
+        backup.deletion_grant_hex = Some(hex::encode(deletion.to_bytes().unwrap()));
+
+        let validated = backup.validate_for(&account).await.unwrap();
+
+        assert_eq!(validated.deletion_grant.unwrap(), deletion);
+
+        let broad = space_chain(space, &account, &validated.subject).await;
+        backup.deletion_grant_hex = Some(hex::encode(broad.to_bytes().unwrap()));
+        assert!(matches!(
+            backup.validate_for(&account).await,
+            Err(AccountSpotBackupError::InvalidDeletionGrant(_))
+        ));
     }
 
     #[dialog_common::test]

--- a/rust/tonk-account/src/customer.rs
+++ b/rust/tonk-account/src/customer.rs
@@ -112,6 +112,11 @@ pub struct Add {
     /// container. It must root at the consumer and be issued to the
     /// invoking customer, granting `/consumer/provision` or broader.
     pub consent: Cid,
+    /// Exact direct `/space/delete` grant, when the creator minted one.
+    /// Legacy clients omit this and may be upgraded from their direct broad
+    /// owner proof by the service.
+    #[serde(default)]
+    pub deletion: Option<Cid>,
 }
 
 impl Effect for Add {
@@ -146,6 +151,9 @@ pub struct ConsumerReceipt {
     pub consumer: Did,
     /// The customer now providing it.
     pub provider: Did,
+    /// Whether the service registered cryptographic deletion authority.
+    #[serde(default)]
+    pub deletion_ready: bool,
 }
 
 /// Customer lifecycle state, as stored and as answered on the wire.
@@ -276,6 +284,7 @@ mod tests {
         let add: Capability<Add> = subject().attenuate(Provider).invoke(Add {
             consumer: did!("key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"),
             consent: Cid::default(),
+            deletion: None,
         });
         assert_eq!(add.ability(), "/provider/add");
 

--- a/rust/tonk-account/src/deletion.rs
+++ b/rust/tonk-account/src/deletion.rs
@@ -1,0 +1,496 @@
+//! Capability contracts for irreversible hosted-space deletion.
+
+use std::collections::HashMap;
+
+use dialog_ucan_core::subject::Subject;
+use dialog_ucan_core::time::timestamp::Timestamp;
+use dialog_ucan_core::{DelegationChain, InvocationBuilder, InvocationChain};
+use dialog_varsig::Did;
+
+/// The only command an irreversible hosted-space deletion grant may carry.
+pub const SPACE_DELETE_COMMAND: [&str; 2] = ["space", "delete"];
+
+/// A verified, direct grant from one space to its creator account.
+#[derive(Debug)]
+pub struct SpaceDeletionGrant {
+    /// Repository subject this grant permits deleting.
+    pub space: Did,
+    /// Account root that may exercise the grant.
+    pub owner: Did,
+    /// Human-readable exact ability, useful in receipts and diagnostics.
+    pub command: &'static str,
+    /// CID of the exact delegation the access service registers.
+    pub cid: String,
+    /// Verified one-proof chain, retained for invocation construction.
+    pub chain: DelegationChain,
+}
+
+/// Stable reasons a candidate deletion grant is not creator authority.
+#[derive(Debug, thiserror::Error)]
+pub enum SpaceDeletionGrantError {
+    /// Bytes did not decode as a delegation chain.
+    #[error("deletion grant container is invalid: {0}")]
+    InvalidChain(String),
+    /// The grant must contain exactly one direct proof.
+    #[error("deletion grant must be one direct space-to-account proof")]
+    Indirect,
+    /// The proof issuer was not the repository being deleted.
+    #[error("deletion grant was not issued by the space")]
+    WrongIssuer,
+    /// The proof subject was not the repository being deleted.
+    #[error("deletion grant is not scoped to the space")]
+    WrongSubject,
+    /// The proof audience was not the creator account root.
+    #[error("deletion grant was not issued to this account")]
+    WrongOwner,
+    /// Broad grants are deliberately insufficient for destructive authority.
+    #[error("deletion grant must carry exactly /space/delete")]
+    WrongCommand,
+    /// The grant signature did not verify against its space DID.
+    #[error("deletion grant signature is invalid: {0}")]
+    InvalidSignature(String),
+    /// The grant is expired or not active yet.
+    #[error("deletion grant is not currently valid: {0}")]
+    NotCurrentlyValid(String),
+}
+
+/// Failure to construct the root-signed deletion invocation.
+#[derive(Debug, thiserror::Error)]
+pub enum DeletionInvocationError {
+    #[error("deletion grant is invalid: {0}")]
+    Grant(#[from] SpaceDeletionGrantError),
+    #[error("deletion invocation signer is not the deletion-grant owner")]
+    WrongRoot,
+    #[error("failed to sign deletion invocation: {0}")]
+    Build(String),
+    #[error("failed to encode deletion invocation: {0}")]
+    Encode(String),
+}
+
+/// Mint the non-expiring exact deletion grant while the space signer exists.
+pub async fn mint_deletion_grant(
+    space: &dialog_credentials::Ed25519Signer,
+    owner: &Did,
+) -> Result<DelegationChain, dialog_ucan_core::delegation::builder::BuildError> {
+    use dialog_ucan_core::DelegationBuilder;
+    use dialog_varsig::Principal as _;
+
+    let space_did = space.did();
+    let delegation = DelegationBuilder::new()
+        .issuer(space.clone())
+        .audience(owner)
+        .subject(Subject::Specific(space_did))
+        .command(
+            SPACE_DELETE_COMMAND
+                .iter()
+                .map(ToString::to_string)
+                .collect(),
+        )
+        .try_build()
+        .await?;
+    Ok(DelegationChain::new(delegation))
+}
+
+/// Build a short-lived root-signed deletion invocation. Calling this is a
+/// passkey/root ceremony; ordinary device authority is deliberately
+/// insufficient for irreversible deletion.
+pub async fn build_deletion_invocation(
+    root: dialog_credentials::Ed25519Signer,
+    deletion_grant: &DelegationChain,
+) -> Result<Vec<u8>, DeletionInvocationError> {
+    use dialog_varsig::Principal as _;
+
+    let space = deletion_grant.issuer().clone();
+    let owner = deletion_grant.audience().clone();
+    validate_deletion_grant(
+        &deletion_grant
+            .to_bytes()
+            .map_err(|error| DeletionInvocationError::Encode(error.to_string()))?,
+        &space,
+        &owner,
+    )
+    .await?;
+
+    if root.did() != owner {
+        return Err(DeletionInvocationError::WrongRoot);
+    }
+    let grant_cid = *deletion_grant
+        .proof_cids()
+        .first()
+        .ok_or(DeletionInvocationError::Grant(
+            SpaceDeletionGrantError::Indirect,
+        ))?;
+    let invocation = InvocationBuilder::new()
+        .issuer(root)
+        .audience(&space)
+        .subject(&space)
+        .command(
+            SPACE_DELETE_COMMAND
+                .iter()
+                .map(ToString::to_string)
+                .collect(),
+        )
+        .proofs(vec![grant_cid])
+        .expiration(Timestamp::five_minutes_from_now())
+        .try_build()
+        .await
+        .map_err(|error| DeletionInvocationError::Build(error.to_string()))?;
+    let proofs: HashMap<_, _> = deletion_grant.export().collect();
+    InvocationChain::new(invocation, proofs)
+        .to_bytes()
+        .map_err(|error| DeletionInvocationError::Encode(error.to_string()))
+}
+
+/// Build the one-time compatibility invocation for an original direct broad
+/// `space -> account-root` proof. Services may accept this only when that
+/// exact proof CID was registered as `legacy-direct`; indirect invite chains
+/// are always refused.
+pub async fn build_legacy_deletion_invocation(
+    root: dialog_credentials::Ed25519Signer,
+    direct_owner_chain: &DelegationChain,
+) -> Result<Vec<u8>, DeletionInvocationError> {
+    use dialog_varsig::Principal as _;
+
+    let mut proofs = direct_owner_chain.proofs();
+    let proof = proofs.next().ok_or(DeletionInvocationError::Grant(
+        SpaceDeletionGrantError::Indirect,
+    ))?;
+    if proofs.next().is_some() {
+        return Err(SpaceDeletionGrantError::Indirect.into());
+    }
+    let space = proof.issuer().clone();
+    if proof.subject() != &Subject::Specific(space.clone()) {
+        return Err(SpaceDeletionGrantError::WrongSubject.into());
+    }
+    if proof.audience() != &root.did() {
+        return Err(DeletionInvocationError::WrongRoot);
+    }
+    if !proof.command().0.is_empty() {
+        return Err(SpaceDeletionGrantError::WrongCommand.into());
+    }
+    proof
+        .verify_signature(&dialog_credentials::Ed25519KeyResolver)
+        .await
+        .map_err(|error| SpaceDeletionGrantError::InvalidSignature(error.to_string()))?;
+    dialog_ucan_core::time::TimeRange::new(proof.not_before(), proof.expiration())
+        .check(&dialog_ucan_core::time::Timestamp::now())
+        .map_err(|error| SpaceDeletionGrantError::NotCurrentlyValid(error.to_string()))?;
+    let cid = proof.to_cid();
+    drop(proofs);
+    let invocation = InvocationBuilder::new()
+        .issuer(root)
+        .audience(&space)
+        .subject(&space)
+        .command(SPACE_DELETE_COMMAND.map(str::to_string).to_vec())
+        .proofs(vec![cid])
+        .expiration(Timestamp::five_minutes_from_now())
+        .try_build()
+        .await
+        .map_err(|error| DeletionInvocationError::Build(error.to_string()))?;
+    InvocationChain::new(invocation, direct_owner_chain.export().collect())
+        .to_bytes()
+        .map_err(|error| DeletionInvocationError::Encode(error.to_string()))
+}
+
+/// Validate exact creator authority for deleting `space`.
+///
+/// Ordinary Tonk ownership and invite chains historically grant the empty
+/// command prefix. That broad operational authority must not silently acquire
+/// a newly introduced destructive power, so this validator requires one
+/// direct proof carrying exactly `/space/delete`.
+pub async fn validate_deletion_grant(
+    bytes: &[u8],
+    space: &Did,
+    owner: &Did,
+) -> Result<SpaceDeletionGrant, SpaceDeletionGrantError> {
+    let chain = DelegationChain::try_from(bytes)
+        .map_err(|error| SpaceDeletionGrantError::InvalidChain(error.to_string()))?;
+    let mut proofs = chain.proofs();
+    let proof = proofs.next().ok_or(SpaceDeletionGrantError::Indirect)?;
+    if proofs.next().is_some() {
+        return Err(SpaceDeletionGrantError::Indirect);
+    }
+    if proof.issuer() != space {
+        return Err(SpaceDeletionGrantError::WrongIssuer);
+    }
+    if proof.subject() != &Subject::Specific(space.clone()) {
+        return Err(SpaceDeletionGrantError::WrongSubject);
+    }
+    if proof.audience() != owner {
+        return Err(SpaceDeletionGrantError::WrongOwner);
+    }
+    let expected: Vec<String> = SPACE_DELETE_COMMAND
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+    if proof.command().0 != expected {
+        return Err(SpaceDeletionGrantError::WrongCommand);
+    }
+    proof
+        .verify_signature(&dialog_credentials::Ed25519KeyResolver)
+        .await
+        .map_err(|error| SpaceDeletionGrantError::InvalidSignature(error.to_string()))?;
+    dialog_ucan_core::time::TimeRange::new(proof.not_before(), proof.expiration())
+        .check(&dialog_ucan_core::time::Timestamp::now())
+        .map_err(|error| SpaceDeletionGrantError::NotCurrentlyValid(error.to_string()))?;
+    let cid = proof.to_cid().to_string();
+    drop(proofs);
+
+    Ok(SpaceDeletionGrant {
+        space: space.clone(),
+        owner: owner.clone(),
+        command: "/space/delete",
+        cid,
+        chain,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use dialog_credentials::Ed25519Signer;
+    use dialog_ucan_core::subject::Subject;
+    use dialog_ucan_core::time::Timestamp;
+    use dialog_ucan_core::{Delegation, DelegationBuilder, DelegationChain};
+    use dialog_varsig::Principal as _;
+    use dialog_varsig::eddsa::Ed25519Signature;
+
+    use super::{
+        SPACE_DELETE_COMMAND, SpaceDeletionGrantError, mint_deletion_grant, validate_deletion_grant,
+    };
+
+    async fn signer(seed: u8) -> Ed25519Signer {
+        Ed25519Signer::import(&[seed; 32]).await.unwrap()
+    }
+
+    async fn grant(
+        issuer: Ed25519Signer,
+        audience: &dialog_varsig::Did,
+        subject: Subject,
+        command: &[&str],
+        expiration: Option<Timestamp>,
+    ) -> Delegation<Ed25519Signature> {
+        let builder = DelegationBuilder::new()
+            .issuer(issuer)
+            .audience(audience)
+            .subject(subject)
+            .command(command.iter().map(ToString::to_string).collect());
+        match expiration {
+            Some(expiration) => builder.expiration(expiration).try_build().await.unwrap(),
+            None => builder.try_build().await.unwrap(),
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_accepts_only_an_exact_direct_space_delete_grant() {
+        let space = signer(41).await;
+        let owner = signer(42).await;
+        let delegation = grant(
+            space.clone(),
+            &owner.did(),
+            Subject::Specific(space.did()),
+            &SPACE_DELETE_COMMAND,
+            None,
+        )
+        .await;
+        let bytes = DelegationChain::new(delegation).to_bytes().unwrap();
+
+        let validated = validate_deletion_grant(&bytes, &space.did(), &owner.did())
+            .await
+            .unwrap();
+
+        assert_eq!(validated.space, space.did());
+        assert_eq!(validated.owner, owner.did());
+        assert_eq!(validated.command, "/space/delete");
+    }
+
+    #[dialog_common::test]
+    async fn it_mints_the_exact_direct_grant() {
+        let space = signer(43).await;
+        let owner = signer(44).await;
+
+        let chain = mint_deletion_grant(&space, &owner.did()).await.unwrap();
+        let bytes = chain.to_bytes().unwrap();
+        let validated = validate_deletion_grant(&bytes, &space.did(), &owner.did())
+            .await
+            .unwrap();
+
+        assert_eq!(validated.cid, chain.proof_cids()[0].to_string());
+    }
+
+    #[dialog_common::test]
+    async fn it_builds_a_root_invocation_from_the_exact_space_grant() {
+        let space = signer(45).await;
+        let root = signer(46).await;
+        let grant = mint_deletion_grant(&space, &root.did()).await.unwrap();
+
+        let bytes = super::build_deletion_invocation(root, &grant)
+            .await
+            .unwrap();
+        let invocation = dialog_ucan_core::InvocationChain::try_from(bytes.as_slice()).unwrap();
+        invocation
+            .verify(&dialog_credentials::Ed25519KeyResolver)
+            .await
+            .unwrap();
+
+        assert_eq!(invocation.subject(), &space.did());
+        assert_eq!(invocation.command().0, ["space", "delete"]);
+        assert_eq!(invocation.proofs().len(), 1);
+    }
+
+    #[dialog_common::test]
+    async fn legacy_upgrade_builds_only_from_the_original_direct_broad_proof() {
+        let space = signer(47).await;
+        let root = signer(48).await;
+        let broad = grant(
+            space.clone(),
+            &root.did(),
+            Subject::Specific(space.did()),
+            &[],
+            None,
+        )
+        .await;
+        let chain = DelegationChain::new(broad);
+
+        let bytes = super::build_legacy_deletion_invocation(root, &chain)
+            .await
+            .unwrap();
+        let invocation = dialog_ucan_core::InvocationChain::try_from(bytes.as_slice()).unwrap();
+        invocation
+            .verify(&dialog_credentials::Ed25519KeyResolver)
+            .await
+            .unwrap();
+        assert_eq!(invocation.subject(), &space.did());
+        assert_eq!(invocation.command().0, ["space", "delete"]);
+        assert_eq!(invocation.proofs(), chain.proof_cids());
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_broad_indirect_or_misdirected_grants() {
+        let space = signer(51).await;
+        let owner = signer(52).await;
+        let member = signer(53).await;
+        let other = signer(54).await;
+        let space_did = space.did();
+        let owner_did = owner.did();
+
+        let broad = grant(
+            space.clone(),
+            &owner_did,
+            Subject::Specific(space_did.clone()),
+            &[],
+            None,
+        )
+        .await;
+        assert!(matches!(
+            validate_deletion_grant(
+                &DelegationChain::new(broad).to_bytes().unwrap(),
+                &space_did,
+                &owner_did,
+            )
+            .await,
+            Err(SpaceDeletionGrantError::WrongCommand)
+        ));
+
+        let first = grant(
+            space.clone(),
+            &member.did(),
+            Subject::Specific(space_did.clone()),
+            &SPACE_DELETE_COMMAND,
+            None,
+        )
+        .await;
+        let second = grant(
+            member,
+            &owner_did,
+            Subject::Specific(space_did.clone()),
+            &SPACE_DELETE_COMMAND,
+            None,
+        )
+        .await;
+        let indirect = DelegationChain::new(first).push(second).unwrap();
+        assert!(matches!(
+            validate_deletion_grant(&indirect.to_bytes().unwrap(), &space_did, &owner_did,).await,
+            Err(SpaceDeletionGrantError::Indirect)
+        ));
+
+        for (candidate, expected) in [
+            (
+                grant(
+                    other.clone(),
+                    &owner_did,
+                    Subject::Specific(space_did.clone()),
+                    &SPACE_DELETE_COMMAND,
+                    None,
+                )
+                .await,
+                "issuer",
+            ),
+            (
+                grant(
+                    space.clone(),
+                    &owner_did,
+                    Subject::Specific(other.did()),
+                    &SPACE_DELETE_COMMAND,
+                    None,
+                )
+                .await,
+                "subject",
+            ),
+            (
+                grant(
+                    space.clone(),
+                    &other.did(),
+                    Subject::Specific(space_did.clone()),
+                    &SPACE_DELETE_COMMAND,
+                    None,
+                )
+                .await,
+                "owner",
+            ),
+        ] {
+            let error = validate_deletion_grant(
+                &DelegationChain::new(candidate).to_bytes().unwrap(),
+                &space_did,
+                &owner_did,
+            )
+            .await
+            .unwrap_err();
+            assert!(
+                matches!(
+                    (&error, expected),
+                    (SpaceDeletionGrantError::WrongIssuer, "issuer")
+                        | (SpaceDeletionGrantError::WrongSubject, "subject")
+                        | (SpaceDeletionGrantError::WrongOwner, "owner")
+                ),
+                "unexpected {expected} error: {error}"
+            );
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_an_expired_delete_grant() {
+        use dialog_ucan_core::time::timestamp::{Duration, SystemTime};
+
+        let space = signer(61).await;
+        let owner = signer(62).await;
+        let expired_at = Timestamp::new(SystemTime::now() - Duration::from_secs(60)).unwrap();
+        let expired = grant(
+            space.clone(),
+            &owner.did(),
+            Subject::Specific(space.did()),
+            &SPACE_DELETE_COMMAND,
+            Some(expired_at),
+        )
+        .await;
+
+        assert!(matches!(
+            validate_deletion_grant(
+                &DelegationChain::new(expired).to_bytes().unwrap(),
+                &space.did(),
+                &owner.did(),
+            )
+            .await,
+            Err(SpaceDeletionGrantError::NotCurrentlyValid(_))
+        ));
+    }
+}

--- a/rust/tonk-account/src/lib.rs
+++ b/rust/tonk-account/src/lib.rs
@@ -10,6 +10,8 @@ pub mod backup;
 pub mod customer;
 /// Retaining space authority into the account repository.
 pub mod delegations;
+/// Capability contracts for irreversible hosted-space deletion.
+pub mod deletion;
 mod descriptor;
 /// Canonical device-signed account attachment detach intents.
 pub mod detach;

--- a/rust/tonk-cli/src/account.rs
+++ b/rust/tonk-cli/src/account.rs
@@ -20,6 +20,47 @@ pub const DEFAULT_ACCOUNT_PAGE: &str = "https://tonk.network/account";
 /// Production link ceremony page: it reads `?audience=` and `?callback=`
 /// and posts the grant back to the waiting CLI.
 pub const DEFAULT_LINK_PAGE: &str = "https://tonk.network/account/link";
+
+/// Open the browser's passkey-protected, review-first account deletion flow.
+pub async fn open_deletion(
+    profile: &Profile,
+    account_url: &str,
+    open_browser: bool,
+) -> Result<String> {
+    let status = status(profile).await?;
+    if !matches!(status, AccountStatus::Registered { .. }) {
+        bail!("no account is linked to this profile");
+    }
+    let url = format!("{}#delete-account", account_url.trim_end_matches('/'));
+    if open_browser && webbrowser::open(&url).is_err() {
+        bail!("could not open the account deletion page; open {url}");
+    }
+    Ok(url)
+}
+
+/// Open the browser's passkey-protected review for deleting one owned space.
+pub async fn open_space_deletion(
+    profile: &Profile,
+    account_url: &str,
+    subject: &str,
+    open_browser: bool,
+) -> Result<String> {
+    let status = status(profile).await?;
+    if !matches!(status, AccountStatus::Registered { .. }) {
+        bail!("no account is linked to this profile");
+    }
+    subject
+        .parse::<Did>()
+        .context("space subject is not a valid DID")?;
+    let mut url = Url::parse(account_url).context("account page URL is invalid")?;
+    url.query_pairs_mut().append_pair("delete-space", subject);
+    url.set_fragment(Some("delete-account"));
+    let url = url.to_string();
+    if open_browser && webbrowser::open(&url).is_err() {
+        bail!("could not open the space deletion page; open {url}");
+    }
+    Ok(url)
+}
 /// Credential-store key for optional provider attachment metadata.
 pub const ACCOUNT_LINK_SITE: &str = tonk_account::ACCOUNT_PROVIDER_CREDENTIAL_SITE;
 

--- a/rust/tonk-cli/src/account_spots.rs
+++ b/rust/tonk-cli/src/account_spots.rs
@@ -7,11 +7,12 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, bail};
 use dialog_operator::Profile;
 use dialog_query::{Output as _, Query, Term};
+use dialog_ucan_core::DelegationChain;
 use dialog_ucan_core::promise::Promised;
 use dialog_varsig::Did;
 use tonk_account::backup::{
     ACCOUNT_SPOT_BACKUP_MARKER_PREFIX, ACCOUNT_SPOTS_CAPABILITY_HEADER,
-    ACCOUNT_SPOTS_CAPABILITY_V1, AccountSpotBackup, AccountSpotSummary,
+    ACCOUNT_SPOTS_CAPABILITY_V1, AccountSpotBackup, AccountSpotSummary, space_delete_site,
 };
 use tonk_schema::RepositoryName;
 use tonk_schema::prelude::DidExt as _;
@@ -34,6 +35,8 @@ pub struct AccountSpotRow {
     pub ambiguous: bool,
     /// Whether the selected artifact carries a usable sync remote.
     pub pullable: bool,
+    /// Whether the account holds exact hosted deletion authority.
+    pub deletion_ready: bool,
 }
 
 /// Result of pulling one account spot.
@@ -158,6 +161,7 @@ fn legacy_rows(artifacts: Vec<(String, AccountSpotBackup, Did)>) -> Vec<AccountS
                     remote_url: None,
                     revocation_url: None,
                     ambiguous: true,
+                    deletion_ready: false,
                 }
             } else {
                 AccountSpotSummary {
@@ -167,6 +171,7 @@ fn legacy_rows(artifacts: Vec<(String, AccountSpotBackup, Did)>) -> Vec<AccountS
                     remote_url: first.remote_url.clone(),
                     revocation_url: first.revocation_url.clone(),
                     ambiguous: false,
+                    deletion_ready: first.deletion_grant_hex.is_some(),
                 }
             }
         })
@@ -286,6 +291,7 @@ pub async fn list(profile: &Profile, store: &SpotStore) -> Result<Vec<AccountSpo
             subject: summary.subject,
             remote_name: summary.name,
             ambiguous: summary.ambiguous,
+            deletion_ready: summary.deletion_ready,
         })
         .collect();
     rows.sort_by(|left, right| left.subject.cmp(&right.subject));
@@ -405,11 +411,26 @@ pub async fn pull(
         .remote_url
         .as_deref()
         .context("account spot backup has no usable sync remote")?;
+    let deletion_grant_bytes = validated
+        .deletion_grant
+        .as_ref()
+        .map(DelegationChain::to_bytes)
+        .transpose()
+        .context("failed to serialize restored deletion grant")?;
 
     let mut fresh_target = FreshPullTarget::new(target.clone());
     let site = crate::site::mount_delegated_at(&target, validated.chain, site_config(profile))
         .await
         .context("failed to mount account spot")?;
+    if let Some(bytes) = deletion_grant_bytes {
+        site.profile
+            .credential()
+            .site(space_delete_site(&requested, &connection.root_did))
+            .save(bytes)
+            .perform(site.operator.local())
+            .await
+            .context("failed to retain the restored deletion grant")?;
+    }
     remote::add_with_revocation(
         &site,
         DEFAULT_REMOTE,
@@ -508,13 +529,28 @@ async fn back_up_site_with_connection(
         .subject()
         .cloned()
         .context("account-root prefix has no repository subject")?;
+    let deletion_grant = crate::site::deletion_grant(site, &connection.root_did).await?;
     let artifact = AccountSpotBackup {
         chain_hex: hex::encode(chain.to_bytes()?),
+        deletion_grant_hex: deletion_grant
+            .as_ref()
+            .map(|grant| grant.to_bytes())
+            .transpose()?
+            .map(hex::encode),
         remote_url: Some(remote.endpoint),
         revocation_url: remote.revocation_url,
         name: Some(name),
     };
     artifact.validate_for(&connection.root_did).await?;
+    // Re-provision even when the immutable backup itself is unchanged. This
+    // installs exact grants for new spaces and narrowly tags an original
+    // direct broad owner proof as `legacy-direct`; indirect joined chains are
+    // refused and remain non-destructive.
+    if let Err(error) =
+        crate::customer::provision(&site.profile, &subject, &chain, deletion_grant.as_ref()).await
+    {
+        eprintln!("warning: deletion-authority upgrade skipped: {error:#}");
+    }
     let bytes = serde_json::to_vec(&artifact)?;
     let content_key = blake3::hash(&bytes).to_hex().to_string();
     if marker(site, &subject).await?.as_deref() == Some(content_key.as_bytes()) {
@@ -678,6 +714,7 @@ mod tests {
             .unwrap();
         let first = AccountSpotBackup {
             chain_hex: "aa".to_string(),
+            deletion_grant_hex: None,
             remote_url: Some("https://one.example/".to_string()),
             revocation_url: None,
             name: None,

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -540,6 +540,26 @@ enum AccountCommand {
     /// device. Use `tonk account revoke <DID>` to revoke a device instead.
     Logout,
 
+    /// Review and permanently delete this account in the browser
+    ///
+    /// This does not delete immediately. The browser shows the exact owned
+    /// spaces, requires the verified email, a consequences checkbox, a final
+    /// confirmation, and the account passkey. Joined spaces are left intact;
+    /// copies already replicated to other devices cannot be erased by Tonk.
+    Delete {
+        /// Browser account page that runs the deletion ceremony.
+        #[arg(
+            long,
+            value_name = "URL",
+            default_value = account::DEFAULT_ACCOUNT_PAGE,
+            hide = true
+        )]
+        account_url: String,
+        /// Print the review URL without asking the OS to open it.
+        #[arg(long)]
+        no_open: bool,
+    },
+
     /// List or pull the spots backed up under this account
     Spots {
         #[command(subcommand)]
@@ -604,6 +624,27 @@ enum AccountSpotsCommand {
         /// Explicit local spot slug.
         #[arg(long, value_name = "SLUG")]
         name: Option<String>,
+    },
+    /// Review and permanently delete one owned hosted space
+    ///
+    /// This opens the browser for an exact-scope review, typed-email
+    /// confirmation, final warning, and account-passkey authorization. The
+    /// account and every other space remain.
+    Delete {
+        /// Full repository subject DID.
+        #[arg(value_name = "SUBJECT")]
+        subject: String,
+        /// Browser account page that runs the deletion ceremony.
+        #[arg(
+            long,
+            value_name = "URL",
+            default_value = account::DEFAULT_ACCOUNT_PAGE,
+            hide = true
+        )]
+        account_url: String,
+        /// Print the review URL without asking the OS to open it.
+        #[arg(long)]
+        no_open: bool,
     },
 }
 
@@ -915,9 +956,11 @@ fn descriptor(command: &Command) -> (&'static str, Option<&'static str>) {
                 AccountCommand::Status => "status",
                 AccountCommand::Link { .. } => "link",
                 AccountCommand::Logout => "logout",
+                AccountCommand::Delete { .. } => "delete",
                 AccountCommand::Spots { command } => match command {
                     None | Some(AccountSpotsCommand::List) => "spots-list",
                     Some(AccountSpotsCommand::Pull { .. }) => "spots-pull",
+                    Some(AccountSpotsCommand::Delete { .. }) => "spots-delete",
                 },
                 AccountCommand::Migrate => "migrate",
                 AccountCommand::Devices { .. } => "devices",
@@ -1401,6 +1444,19 @@ async fn account_op(command: AccountCommand) -> ExitCode {
             }
             Err(error) => print_failure(error),
         },
+        AccountCommand::Delete {
+            account_url,
+            no_open,
+        } => match account::open_deletion(&profile, &account_url, !no_open).await {
+            Ok(url) => {
+                println!("Review permanent account deletion in your browser:\n{url}");
+                println!(
+                    "No data has been deleted yet. The browser will list owned spaces, leave joined spaces intact, and require your email plus passkey."
+                );
+                ExitCode::Success
+            }
+            Err(error) => print_failure(error),
+        },
         AccountCommand::Spots { command } => {
             let store = match tonk_cli::spot::SpotStore::open() {
                 Ok(store) => store,
@@ -1449,6 +1505,22 @@ async fn account_op(command: AccountCommand) -> ExitCode {
                         Err(error) => print_failure(error),
                     }
                 }
+                AccountSpotsCommand::Delete {
+                    subject,
+                    account_url,
+                    no_open,
+                } => match account::open_space_deletion(&profile, &account_url, &subject, !no_open)
+                    .await
+                {
+                    Ok(url) => {
+                        println!("Review permanent deletion of {subject} in your browser:\n{url}");
+                        println!(
+                            "No data has been deleted yet. Your account and every other space will remain; the browser requires your email, explicit confirmation, and passkey."
+                        );
+                        ExitCode::Success
+                    }
+                    Err(error) => print_failure(error),
+                },
             }
         }
         AccountCommand::Devices { service_url } => {
@@ -3186,6 +3258,18 @@ mod account_spots_parser_tests {
     }
 
     #[test]
+    fn account_delete_is_a_browser_review_not_an_immediate_flag() {
+        let cli = Cli::try_parse_from(["tonk", "account", "delete", "--no-open"]).unwrap();
+        let Some(Command::Account {
+            command: AccountCommand::Delete { no_open, .. },
+        }) = cli.command
+        else {
+            panic!("expected account delete");
+        };
+        assert!(no_open);
+    }
+
+    #[test]
     fn account_logout_is_a_no_argument_account_operation() {
         let cli = Cli::try_parse_from(["tonk", "account", "logout"]).unwrap();
         let command = cli.command.as_ref().expect("account command");
@@ -3233,5 +3317,26 @@ mod account_spots_parser_tests {
         };
         assert_eq!(subject, did);
         assert_eq!(name.as_deref(), Some("garden"));
+    }
+
+    #[test]
+    fn account_spots_delete_requires_an_exact_subject_and_browser_review() {
+        let did = "did:key:z6MkgMn9hDxTd2saBSAouyTpPLWUmzrVTXfS1N5yB4TjJ3qL";
+        let cli =
+            Cli::try_parse_from(["tonk", "account", "spots", "delete", did, "--no-open"]).unwrap();
+        let Some(Command::Account {
+            command:
+                AccountCommand::Spots {
+                    command:
+                        Some(AccountSpotsCommand::Delete {
+                            subject, no_open, ..
+                        }),
+                },
+        }) = cli.command
+        else {
+            panic!("expected account spots delete");
+        };
+        assert_eq!(subject, did);
+        assert!(no_open);
     }
 }

--- a/rust/tonk-cli/src/customer.rs
+++ b/rust/tonk-cli/src/customer.rs
@@ -63,6 +63,7 @@ pub async fn provision(
     profile: &Profile,
     consumer: &Did,
     consent: &dialog_ucan_core::DelegationChain,
+    deletion_grant: Option<&dialog_ucan_core::DelegationChain>,
 ) -> Result<()> {
     let connection = crate::account::optional_connection(profile)
         .await?
@@ -70,11 +71,12 @@ pub async fn provision(
     let origin = access_origin(profile)
         .await?
         .context("the account has no repository descriptor to locate its service by")?;
-    let body = tonk_identity::request::build_provider_add_invocation(
+    let body = tonk_identity::request::build_provider_add_invocation_with_deletion(
         profile.signer().signer().clone(),
         &connection.link,
         consumer,
         consent,
+        deletion_grant,
     )
     .await?;
     let response = reqwest::Client::new()

--- a/rust/tonk-cli/src/site.rs
+++ b/rust/tonk-cli/src/site.rs
@@ -28,7 +28,9 @@ use dialog_ucan_core::DelegationChain;
 use dialog_ucan_core::time::Timestamp;
 use dialog_ucan_core::time::timestamp::{Duration, SystemTime};
 use dialog_varsig::{Did, Principal};
-use tonk_account::backup::{AccountSpotBackup, SPACE_ROOT_SITE_PREFIX, space_root_site};
+use tonk_account::backup::{
+    AccountSpotBackup, SPACE_ROOT_SITE_PREFIX, space_delete_site, space_root_site,
+};
 
 /// The standard-library notation document seeded into a freshly
 /// created repository: the built-in concepts, views, commands, and
@@ -391,6 +393,23 @@ async fn bootstrap_repository(
         .await
         .context("failed to persist repo→root delegation")?;
 
+    let deletion_grant = tonk_account::deletion::mint_deletion_grant(
+        signer_repo.credential().signer(),
+        &durable_did,
+    )
+    .await
+    .context("failed to mint exact space deletion grant")?;
+    let deletion_grant_bytes = deletion_grant
+        .to_bytes()
+        .context("failed to serialize exact space deletion grant")?;
+    profile
+        .credential()
+        .site(space_delete_site(&signer_repo.did(), &durable_did))
+        .save(deletion_grant_bytes)
+        .perform(operator)
+        .await
+        .context("failed to persist exact space deletion grant")?;
+
     profile
         .access()
         .save(UcanDelegation(prefix.clone()))
@@ -412,7 +431,10 @@ async fn bootstrap_repository(
     // The billing half of the same act: provision the new space as a
     // consumer of the access service, depositing the powerline as its
     // consent. Non-fatal for the same reason retain is.
-    if let Err(error) = crate::customer::provision(profile, &signer_repo.did(), &prefix).await {
+    if let Err(error) =
+        crate::customer::provision(profile, &signer_repo.did(), &prefix, Some(&deletion_grant))
+            .await
+    {
         eprintln!("warning: space not provisioned with the sync service: {error:#}");
     }
 
@@ -484,6 +506,7 @@ async fn mount_delegated_inner(
         .context("failed to serialize delegated authority")?;
     let reusable = AccountSpotBackup {
         chain_hex: hex::encode(&chain_bytes),
+        deletion_grant_hex: None,
         remote_url: None,
         revocation_url: None,
         name: None,
@@ -560,10 +583,33 @@ pub async fn account_root_prefix(site: &TonkSite, account_root: &Did) -> Result<
     .await
 }
 
+/// Load this device's exact hosted-space deletion grant, when one was minted
+/// while the repository signer was available.
+pub async fn deletion_grant(
+    site: &TonkSite,
+    account_root: &Did,
+) -> Result<Option<DelegationChain>> {
+    let subject = site.repository.did();
+    let Some(bytes) = optional_credential(
+        &site.profile,
+        site.operator.local(),
+        space_delete_site(&subject, account_root),
+    )
+    .await?
+    else {
+        return Ok(None);
+    };
+    let validated = tonk_account::deletion::validate_deletion_grant(&bytes, &subject, account_root)
+        .await
+        .context("stored deletion grant is invalid")?;
+    Ok(Some(validated.chain))
+}
+
 /// Decode a stored prefix artifact for `account_root`.
 async fn validate_prefix(bytes: Vec<u8>, account_root: &Did) -> Result<DelegationChain> {
     Ok(AccountSpotBackup {
         chain_hex: hex::encode(bytes),
+        deletion_grant_hex: None,
         remote_url: None,
         revocation_url: None,
         name: None,

--- a/rust/tonk-cli/tests/account_spots.rs
+++ b/rust/tonk-cli/tests/account_spots.rs
@@ -350,6 +350,7 @@ async fn pull_requires_a_backed_inventory_row_and_returns_an_adopted_site() -> R
     fixture
         .put(&tonk_account::backup::AccountSpotBackup {
             chain_hex: hex::encode(adopted_prefix.to_bytes()?),
+            deletion_grant_hex: None,
             remote_url: Some("http://127.0.0.1:9/ucan/".to_string()),
             revocation_url: None,
             name: Some("adopted".to_string()),
@@ -441,6 +442,7 @@ async fn pull_from_a_live_access_service_syncs_the_canonical_unbound_site(
     fixture
         .put(&tonk_account::backup::AccountSpotBackup {
             chain_hex: hex::encode(prefix.to_bytes()?),
+            deletion_grant_hex: None,
             remote_url: Some(env.access_service_url.clone()),
             revocation_url: None,
             name: Some("garden".to_string()),
@@ -622,6 +624,13 @@ async fn backup_reconciles_owned_joined_recovered_and_newly_remote_sites() -> Re
         Some("synced-owned"),
         "synced RepositoryName takes precedence over the registry alias"
     );
+    assert!(
+        rows.iter()
+            .find(|row| row.subject == owned.repository.did().to_string())
+            .unwrap()
+            .deletion_ready,
+        "a newly owned space backup carries its exact deletion grant"
+    );
     assert_eq!(
         rows.iter()
             .find(|row| row.subject == joined_subject.to_string())
@@ -630,6 +639,14 @@ async fn backup_reconciles_owned_joined_recovered_and_newly_remote_sites() -> Re
             .as_deref(),
         Some("joined-alias"),
         "an unnamed repository falls back to its registry name"
+    );
+    assert!(
+        !rows
+            .iter()
+            .find(|row| row.subject == joined_subject.to_string())
+            .unwrap()
+            .deletion_ready,
+        "a joined space must not acquire deletion authority"
     );
     assert_eq!(
         rows.iter()

--- a/rust/tonk-cli/tests/common.rs
+++ b/rust/tonk-cli/tests/common.rs
@@ -200,6 +200,7 @@ impl AccountFixture {
         let chain = DelegationChain::new(delegation);
         let backup = tonk_account::backup::AccountSpotBackup {
             chain_hex: hex::encode(chain.to_bytes()?),
+            deletion_grant_hex: None,
             remote_url: remote_url.map(str::to_string),
             revocation_url: None,
             name: name.map(str::to_string),

--- a/rust/tonk-cli/tests/site.rs
+++ b/rust/tonk-cli/tests/site.rs
@@ -1237,7 +1237,7 @@ mod when_mounting_account_authority {
     use dialog_ucan_core::subject::Subject;
     use dialog_ucan_core::{DelegationBuilder, DelegationChain};
     use dialog_varsig::Principal as _;
-    use tonk_account::backup::space_root_site;
+    use tonk_account::backup::{space_delete_site, space_root_site};
     use tonk_cli::site::{self, TonkSite};
     use tonk_schema::{Invitation, InvitedVia, MemberName, MemberRole, Membership};
 
@@ -1268,6 +1268,26 @@ mod when_mounting_account_authority {
             .try_build()
             .await?;
         Ok((subject, DelegationChain::new(delegation)))
+    }
+
+    #[dialog_common::test]
+    async fn it_retains_an_exact_delete_grant_for_a_new_owned_space() -> Result<()> {
+        let test = common::TestSite::new().await?;
+        let root = local_root(&test.site).await?;
+        let subject = test.site.repository.did();
+        let bytes = test
+            .site
+            .profile
+            .credential()
+            .site(space_delete_site(&subject, &root))
+            .load::<Vec<u8>>()
+            .perform(&test.site.operator)
+            .await?;
+
+        let validated =
+            tonk_account::deletion::validate_deletion_grant(&bytes, &subject, &root).await?;
+        assert_eq!(validated.command, "/space/delete");
+        Ok(())
     }
 
     #[dialog_common::test]

--- a/rust/tonk-identity/Cargo.toml
+++ b/rust/tonk-identity/Cargo.toml
@@ -25,6 +25,7 @@ getrandom_0_3 = { workspace = true }
 js-sys = { workspace = true }
 rand = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
+serde = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 web-sys = { workspace = true, features = [

--- a/rust/tonk-identity/src/ceremony.rs
+++ b/rust/tonk-identity/src/ceremony.rs
@@ -199,6 +199,36 @@ async fn build(
     })
 }
 
+/// Sign the permanent account-service deletion request with the passkey root.
+/// The verified email is repeated as a signed, human-readable confirmation.
+pub async fn delete_account(
+    root: Ed25519Signer,
+    confirmed_email: String,
+) -> Result<AccountCeremony> {
+    build(
+        root,
+        vec!["account".into(), "delete".into()],
+        strings([("confirmedEmail", confirmed_email)]),
+        String::new(),
+        String::new(),
+        None,
+    )
+    .await
+}
+
+/// Sign access-service customer finalization with the passkey root.
+pub async fn delete_access_customer(root: Ed25519Signer) -> Result<AccountCeremony> {
+    build(
+        root,
+        vec!["customer".into(), "delete".into()],
+        BTreeMap::new(),
+        String::new(),
+        String::new(),
+        None,
+    )
+    .await
+}
+
 /// Sign a witnessed revocation with the passkey-derived root.
 ///
 /// The root must be an issuer in the path prefix through the target. The

--- a/rust/tonk-identity/src/install.rs
+++ b/rust/tonk-identity/src/install.rs
@@ -111,6 +111,128 @@ async fn sign_revocation(input: JsValue) -> Result<JsValue, JsValue> {
     Ok(result.into())
 }
 
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DeletionProofInput {
+    kind: String,
+    proof_hex: String,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PrepareAccountDeletionInput {
+    expected_root: String,
+    confirmed_email: String,
+    proofs: Vec<DeletionProofInput>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PrepareSpaceDeletionInput {
+    expected_root: String,
+    proof: DeletionProofInput,
+}
+
+async fn prepare_space_deletion(input: JsValue) -> Result<JsValue, JsValue> {
+    use dialog_ucan_core::DelegationChain;
+    use dialog_varsig::Principal as _;
+
+    let input: PrepareSpaceDeletionInput = serde_wasm_bindgen::from_value(input)
+        .map_err(|_| JsValue::from_str("malformed space deletion input"))?;
+    let evaluated = crate::passkey::evaluate_passkey().await.map_err(js_error)?;
+    let prf = evaluated
+        .prf_output
+        .ok_or_else(|| JsValue::from_str("the authenticator returned no PRF output"))?;
+    let root = crate::derive::derive_root_signer(&prf)
+        .await
+        .map_err(js_error)?;
+    if root.did().to_string() != input.expected_root {
+        return Err(JsValue::from_str(
+            "the evaluated passkey does not match the space owner",
+        ));
+    }
+    let bytes = hex::decode(&input.proof.proof_hex)
+        .map_err(|error| JsValue::from_str(&format!("invalid deletion proof hex: {error}")))?;
+    let proof = DelegationChain::try_from(bytes.as_slice())
+        .map_err(|error| JsValue::from_str(&format!("invalid deletion proof: {error}")))?;
+    let invocation = match input.proof.kind.as_str() {
+        "exact" => tonk_account::deletion::build_deletion_invocation(root, &proof).await,
+        "legacy-direct" => {
+            tonk_account::deletion::build_legacy_deletion_invocation(root, &proof).await
+        }
+        _ => return Err(JsValue::from_str("unknown deletion proof kind")),
+    }
+    .map_err(|error| JsValue::from_str(&error.to_string()))?;
+    let result = Object::new();
+    Reflect::set(
+        &result,
+        &"invocationHex".into(),
+        &hex::encode(invocation).into(),
+    )?;
+    Ok(result.into())
+}
+
+/// One user-verifying passkey ceremony signs every destructive request in an
+/// already-reviewed plan. Proof shape is revalidated before the prompt result
+/// can be turned into an invocation.
+async fn prepare_account_deletion(input: JsValue) -> Result<JsValue, JsValue> {
+    use dialog_ucan_core::DelegationChain;
+    use dialog_varsig::Principal as _;
+
+    let input: PrepareAccountDeletionInput = serde_wasm_bindgen::from_value(input)
+        .map_err(|_| JsValue::from_str("malformed account deletion input"))?;
+    let evaluated = crate::passkey::evaluate_passkey().await.map_err(js_error)?;
+    let prf = evaluated
+        .prf_output
+        .ok_or_else(|| JsValue::from_str("the authenticator returned no PRF output"))?;
+    let root = crate::derive::derive_root_signer(&prf)
+        .await
+        .map_err(js_error)?;
+    if root.did().to_string() != input.expected_root {
+        return Err(JsValue::from_str(
+            "the evaluated passkey does not match the account being deleted",
+        ));
+    }
+
+    let space_invocations = js_sys::Array::new();
+    for candidate in input.proofs {
+        let bytes = hex::decode(&candidate.proof_hex)
+            .map_err(|error| JsValue::from_str(&format!("invalid deletion proof hex: {error}")))?;
+        let proof = DelegationChain::try_from(bytes.as_slice())
+            .map_err(|error| JsValue::from_str(&format!("invalid deletion proof: {error}")))?;
+        let invocation = match candidate.kind.as_str() {
+            "exact" => {
+                tonk_account::deletion::build_deletion_invocation(root.clone(), &proof).await
+            }
+            "legacy-direct" => {
+                tonk_account::deletion::build_legacy_deletion_invocation(root.clone(), &proof).await
+            }
+            _ => return Err(JsValue::from_str("unknown deletion proof kind")),
+        }
+        .map_err(|error| JsValue::from_str(&error.to_string()))?;
+        space_invocations.push(&JsValue::from_str(&hex::encode(invocation)));
+    }
+    let customer = crate::ceremony::delete_access_customer(root.clone())
+        .await
+        .map_err(js_error)?;
+    let account = crate::ceremony::delete_account(root, input.confirmed_email)
+        .await
+        .map_err(js_error)?;
+    let result = Object::new();
+    Reflect::set(&result, &"spaceInvocationsHex".into(), &space_invocations)?;
+    Reflect::set(
+        &result,
+        &"customerInvocationHex".into(),
+        &customer.invocation_hex.into(),
+    )?;
+    Reflect::set(
+        &result,
+        &"accountInvocationHex".into(),
+        &account.invocation_hex.into(),
+    )?;
+    Ok(result.into())
+}
+
 fn root_result(ceremony: crate::ceremony::RootCeremony) -> Result<JsValue, JsValue> {
     let result = Object::new();
     Reflect::set(&result, &"rootDid".into(), &ceremony.root_did.into())?;
@@ -552,6 +674,26 @@ pub fn install() {
     );
     sign_revocation.forget();
 
+    let prepare_deletion = Closure::<dyn FnMut(JsValue) -> Promise>::new(|input: JsValue| {
+        future_to_promise(prepare_account_deletion(input))
+    });
+    let _ = Reflect::set(
+        &identity,
+        &"prepareAccountDeletion".into(),
+        prepare_deletion.as_ref().unchecked_ref(),
+    );
+    prepare_deletion.forget();
+
+    let prepare_space_deletion = Closure::<dyn FnMut(JsValue) -> Promise>::new(|input: JsValue| {
+        future_to_promise(prepare_space_deletion(input))
+    });
+    let _ = Reflect::set(
+        &identity,
+        &"prepareSpaceDeletion".into(),
+        prepare_space_deletion.as_ref().unchecked_ref(),
+    );
+    prepare_space_deletion.forget();
+
     let _ = Reflect::set(&window, &"tonkIdentity".into(), &identity.into());
 }
 
@@ -650,6 +792,8 @@ mod tests {
             "linkDevice",
             "establishAccountRepository",
             "completeLink",
+            "prepareAccountDeletion",
+            "prepareSpaceDeletion",
         ] {
             let function = Reflect::get(&identity, &name.into()).unwrap();
             assert!(function.is_function(), "{name} must be a function");

--- a/rust/tonk-identity/src/request.rs
+++ b/rust/tonk-identity/src/request.rs
@@ -173,17 +173,35 @@ pub async fn build_provider_add_invocation(
     consumer: &Did,
     consent: &DelegationChain,
 ) -> Result<Vec<u8>> {
+    build_provider_add_invocation_with_deletion(device, link, consumer, consent, None).await
+}
+
+/// Build `/provider/add` while depositing the creator's exact deletion grant.
+pub async fn build_provider_add_invocation_with_deletion(
+    device: Ed25519Signer,
+    link: &DelegationChain,
+    consumer: &Did,
+    consent: &DelegationChain,
+    deletion_grant: Option<&DelegationChain>,
+) -> Result<Vec<u8>> {
     let head = consent
         .proofs()
         .next()
         .context("the consent chain carries no delegation")?;
-    let arguments = BTreeMap::from([
+    let mut arguments = BTreeMap::from([
         (
             "consumer".to_string(),
             Promised::String(consumer.to_string()),
         ),
         ("consent".to_string(), Promised::Link(head.to_cid())),
     ]);
+    if let Some(deletion_grant) = deletion_grant {
+        let deletion = deletion_grant
+            .proofs()
+            .next()
+            .context("the deletion grant carries no delegation")?;
+        arguments.insert("deletion".to_string(), Promised::Link(deletion.to_cid()));
+    }
     let invocation = build_device_invocation(
         device,
         link,
@@ -196,6 +214,11 @@ pub async fn build_provider_add_invocation(
         .into_tokens();
     for delegation in consent.proofs() {
         tokens.push(delegation.encoded().to_vec());
+    }
+    if let Some(deletion_grant) = deletion_grant {
+        for delegation in deletion_grant.proofs() {
+            tokens.push(delegation.encoded().to_vec());
+        }
     }
     Container::new(tokens)
         .to_bytes()

--- a/rust/tonk-ui/src/account.css
+++ b/rust/tonk-ui/src/account.css
@@ -484,6 +484,58 @@ tonk-account {
     border-top: 1px solid var(--account-divider);
 }
 
+.account__danger {
+    border: 1px solid color-mix(in oklab, var(--wa-color-danger-fill-loud, #d9363e) 48%, transparent);
+}
+
+.account__button--danger {
+    margin-top: 18px;
+    background: var(--wa-color-danger-fill-loud, #c92f38);
+    color: white;
+}
+
+.account__delete-review {
+    display: grid;
+    gap: 14px;
+    margin-top: 20px;
+    padding-top: 20px;
+    border-top: 1px solid var(--account-divider);
+}
+
+.account__delete-spaces {
+    margin: 0;
+    padding-left: 22px;
+    color: var(--account-ink);
+    font-size: 14px;
+    line-height: 1.55;
+}
+
+.account__delete-confirm {
+    display: grid;
+    gap: 8px;
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.account__delete-confirm input {
+    min-height: 44px;
+    padding: 10px 12px;
+    border: 1px solid var(--account-divider);
+    background: var(--account-field);
+    color: var(--account-ink);
+    font: inherit;
+}
+
+.account__delete-check {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: start;
+    gap: 10px;
+    color: var(--account-muted);
+    font-size: 14px;
+    line-height: 1.5;
+}
+
 @media (prefers-color-scheme: dark) {
     tonk-account {
         --account-shadow: 0 0 0 1px rgb(255 255 255 / 8%);

--- a/rust/tonk-ui/src/account.html
+++ b/rust/tonk-ui/src/account.html
@@ -123,6 +123,29 @@
       </div>
       <button id="account-unlink" class="account__button account__button--secondary account__button--compact" type="button">Sign out</button>
     </section>
+
+    <section id="delete-account" class="account__section account__danger" aria-labelledby="account-delete-title">
+      <div class="account__section-heading">
+        <h2 id="account-delete-title">Delete account permanently</h2>
+        <p id="account-delete-description">This is not sign out. Tonk will permanently delete the hosted content for every space this account created, account backups, device registrations, and the account record. Your email will be released so you can create a new account later.</p>
+        <p id="account-delete-boundary">Spaces created by other people will not be deleted. Tonk cannot erase copies that other devices have already replicated.</p>
+      </div>
+      <button id="account-delete-review" class="account__button account__button--danger" type="button">Review permanent deletion</button>
+      <div id="account-delete-review-panel" class="account__delete-review" hidden>
+        <p id="account-delete-scope"></p>
+        <ul id="account-delete-spaces" class="account__delete-spaces"></ul>
+        <p id="account-delete-blocked" class="account__error" hidden></p>
+        <label class="account__delete-confirm">
+          Type your account email to confirm
+          <input id="account-delete-email" name="Account email" type="email" autocomplete="off">
+        </label>
+        <label class="account__delete-check">
+          <input id="account-delete-understood" type="checkbox">
+          <span id="account-delete-understood-label">I understand that owned spaces and account data will be permanently deleted from Tonk services and cannot be recovered by Tonk.</span>
+        </label>
+        <button id="account-delete-submit" class="account__button account__button--danger" type="button">Delete owned spaces and account</button>
+      </div>
+    </section>
   </div>
 
   <p id="account-working" class="account__hint" role="status" aria-live="polite">Checking this browser…</p>

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -8,18 +8,24 @@ use wasm_bindgen_futures::spawn_local;
 use web_sys::{HtmlButtonElement, HtmlElement, HtmlInputElement, window};
 
 use tonk_account::{AccountStateStatus, handoff::ResolvedLink};
-use tonk_worker_api::{AccountStatus, RevocationProjection, RevokeDeviceAcknowledgement};
+use tonk_worker_api::{
+    AccountDeletionPlan, AccountDeletionRequest, AccountSpaceDeletionRequest, AccountStatus,
+    RevocationProjection, RevokeDeviceAcknowledgement,
+};
 
 use crate::identity_bridge::{
-    CeremonyOutput, CreateAccountInput, CreateFreshAccountInput, EstablishRepositoryInput,
-    LinkDeviceInput, RevocationOutput, SignRevocationInput, complete_link, create_account,
-    create_fresh_account, establish_account_repository, link_device, sign_revocation,
+    CeremonyOutput, CreateAccountInput, CreateFreshAccountInput, DeletionProofInput,
+    EstablishRepositoryInput, LinkDeviceInput, PrepareAccountDeletionInput,
+    PrepareSpaceDeletionInput, RevocationOutput, SignRevocationInput, complete_link,
+    create_account, create_fresh_account, establish_account_repository, link_device,
+    prepare_account_deletion, prepare_space_deletion, sign_revocation,
 };
 
 const STYLE_ID: &str = "tonk-account-styles";
 const HANDOFF: &str = "__tonkCliHandoff";
 /// Where a pending callback authorization's `(audience, callback)` is parked.
 const CALLBACK: &str = "__tonkCliCallback";
+const DELETION_PLAN: &str = "__tonkAccountDeletionPlan";
 
 /// The top-document account element. WebAuthn must not run in sealed guests.
 #[derive(Default)]
@@ -145,6 +151,8 @@ fn set_busy(host: &HtmlElement, busy: bool, status: &str) {
         "#account-handoff-submit",
         "#account-setup-submit",
         "#account-unlink",
+        "#account-delete-review",
+        "#account-delete-submit",
         "#account-add-profile",
         "#account-use-different-account",
     ] {
@@ -268,6 +276,161 @@ fn set_text(host: &HtmlElement, selector: &str, value: &str) {
     if let Ok(Some(element)) = host.query_selector(selector) {
         element.set_text_content(Some(value));
     }
+}
+
+fn requested_space_deletion() -> Option<String> {
+    let href = window()?.location().href().ok()?;
+    url::Url::parse(&href)
+        .ok()?
+        .query_pairs()
+        .find_map(|(name, value)| (name == "delete-space").then(|| value.into_owned()))
+        .filter(|value| !value.is_empty())
+}
+
+fn configure_deletion_entry(host: &HtmlElement) {
+    if requested_space_deletion().is_none() {
+        return;
+    }
+    set_text(
+        host,
+        "#account-delete-title",
+        "Delete owned space permanently",
+    );
+    set_text(
+        host,
+        "#account-delete-description",
+        "This deletes one selected space's hosted content from Tonk services. Your account and every other space remain.",
+    );
+    set_text(
+        host,
+        "#account-delete-boundary",
+        "Tonk cannot erase copies that other devices have already replicated.",
+    );
+    set_text(
+        host,
+        "#account-delete-review",
+        "Review selected space deletion",
+    );
+    set_text(
+        host,
+        "#account-delete-understood-label",
+        "I understand that this owned space's hosted content will be permanently deleted from Tonk services and cannot be recovered by Tonk.",
+    );
+}
+
+fn render_deletion_plan(host: &HtmlElement, plan: &AccountDeletionPlan) -> Result<(), String> {
+    let panel = host
+        .query_selector("#account-delete-review-panel")
+        .ok()
+        .flatten()
+        .ok_or_else(|| "missing deletion review panel".to_string())?;
+    let _ = panel.remove_attribute("hidden");
+    let requested = requested_space_deletion();
+    let visible: Vec<_> = plan
+        .spaces
+        .iter()
+        .filter(|space| {
+            requested
+                .as_deref()
+                .is_none_or(|subject| space.subject == subject)
+        })
+        .collect();
+    if let Some(subject) = requested.as_deref()
+        && visible.is_empty()
+    {
+        return Err(format!(
+            "{subject} is not an owned hosted space for this account"
+        ));
+    }
+    set_text(
+        host,
+        "#account-delete-title",
+        if requested.is_some() {
+            "Delete owned space permanently"
+        } else {
+            "Delete account permanently"
+        },
+    );
+    set_text(
+        host,
+        "#account-delete-submit",
+        if requested.is_some() {
+            "Delete selected owned space"
+        } else {
+            "Delete owned spaces and account"
+        },
+    );
+    set_text(
+        host,
+        "#account-delete-scope",
+        &if requested.is_some() {
+            format!(
+                "This will permanently delete the selected owned hosted space. {} joined space{} will be left intact.",
+                plan.joined_spaces,
+                if plan.joined_spaces == 1 { "" } else { "s" },
+            )
+        } else {
+            format!(
+                "{} owned hosted space{} will be deleted. {} joined space{} will be left intact.",
+                plan.spaces.len(),
+                if plan.spaces.len() == 1 { "" } else { "s" },
+                plan.joined_spaces,
+                if plan.joined_spaces == 1 { "" } else { "s" },
+            )
+        },
+    );
+    let list = host
+        .query_selector("#account-delete-spaces")
+        .ok()
+        .flatten()
+        .ok_or_else(|| "missing deletion space list".to_string())?;
+    list.set_inner_html("");
+    let document = window()
+        .and_then(|window| window.document())
+        .ok_or_else(|| "document is unavailable".to_string())?;
+    for space in &visible {
+        let item = document
+            .create_element("li")
+            .map_err(|_| "could not render deletion space".to_string())?;
+        let label = space.name.as_deref().unwrap_or(&space.subject);
+        item.set_text_content(Some(&format!("{label} — {}", space.state)));
+        let _ = list.append_child(&item);
+    }
+    if visible.is_empty() {
+        let item = document
+            .create_element("li")
+            .map_err(|_| "could not render empty deletion plan".to_string())?;
+        item.set_text_content(Some("No owned hosted spaces"));
+        let _ = list.append_child(&item);
+    }
+    if let Ok(Some(blocked)) = host.query_selector("#account-delete-blocked") {
+        let blocked_visible: Vec<_> = plan
+            .blocked_spaces
+            .iter()
+            .filter(|space| {
+                requested
+                    .as_deref()
+                    .is_none_or(|subject| space.as_str() == subject)
+            })
+            .cloned()
+            .collect();
+        if blocked_visible.is_empty() {
+            let _ = blocked.set_attribute("hidden", "");
+            blocked.set_text_content(None);
+        } else {
+            blocked.set_text_content(Some(&format!(
+                "Deletion is blocked because Tonk cannot recover deletion authority for: {}",
+                blocked_visible.join(", ")
+            )));
+            let _ = blocked.remove_attribute("hidden");
+        }
+    }
+    let value = serde_wasm_bindgen::to_value(plan)
+        .map_err(|_| "could not retain deletion plan".to_string())?;
+    Reflect::set(host.as_ref(), &DELETION_PLAN.into(), &value)
+        .map_err(|_| "could not retain deletion plan".to_string())?;
+    focus_input(host, "#account-delete-email");
+    Ok(())
 }
 
 fn render_summary(host: &HtmlElement, summary: &tonk_worker_api::AccountSummary) {
@@ -1305,6 +1468,7 @@ fn bind_return_links(host: &HtmlElement) {
 fn bind(host: &HtmlElement) {
     prevent_form_navigation(host);
     bind_return_links(host);
+    configure_deletion_entry(host);
     on_click(host, "#account-choose-create", |host| {
         clear_error(&host);
         set_mode(&host, "create");
@@ -1615,6 +1779,209 @@ fn bind(host: &HtmlElement) {
                 Err(error) => {
                     set_busy(&host, false, "");
                     show_error(&host, error.to_string());
+                }
+            }
+        });
+    });
+
+    on_click(host, "#account-delete-review", |host| {
+        clear_error(&host);
+        set_busy(&host, true, "Loading the permanent deletion scope…");
+        spawn_local(async move {
+            match crate::api::account_deletion_plan().await {
+                Ok(plan) => {
+                    set_busy(&host, false, "");
+                    if let Err(error) = render_deletion_plan(&host, &plan) {
+                        show_error(&host, error);
+                    }
+                }
+                Err(error) => {
+                    set_busy(&host, false, "");
+                    show_error(&host, error.to_string());
+                }
+            }
+        });
+    });
+
+    on_click(host, "#account-delete-submit", |host| {
+        clear_error(&host);
+        let plan = Reflect::get(host.as_ref(), &DELETION_PLAN.into())
+            .ok()
+            .and_then(|value| serde_wasm_bindgen::from_value::<AccountDeletionPlan>(value).ok());
+        let Some(plan) = plan else {
+            return show_error(&host, "Review the current deletion scope first.");
+        };
+        let requested = requested_space_deletion();
+        let blocked = plan.blocked_spaces.iter().any(|space| {
+            requested
+                .as_deref()
+                .is_none_or(|subject| space.as_str() == subject)
+        });
+        if blocked {
+            return show_error(
+                &host,
+                if requested.is_some() {
+                    "This space cannot be deleted because Tonk cannot recover its registered deletion authority."
+                } else {
+                    "Account deletion is blocked until every owned hosted space has recoverable deletion authority."
+                },
+            );
+        }
+        let confirmed_email = match input(&host, "#account-delete-email") {
+            Ok(email) if email == plan.email => email,
+            Ok(_) => {
+                return show_error(&host, "The confirmation email does not match this account.");
+            }
+            Err(error) => return show_error(&host, error),
+        };
+        let understood = host
+            .query_selector("#account-delete-understood")
+            .ok()
+            .flatten()
+            .and_then(|element| element.dyn_into::<HtmlInputElement>().ok())
+            .is_some_and(|input| input.checked());
+        if !understood {
+            return show_error(
+                &host,
+                "Confirm that you understand the permanent consequences.",
+            );
+        }
+        let destructive: Vec<_> = plan
+            .spaces
+            .iter()
+            .filter(|space| {
+                space.state != "deleted"
+                    && requested
+                        .as_deref()
+                        .is_none_or(|subject| space.subject == subject)
+            })
+            .cloned()
+            .collect();
+        if requested.is_some() && destructive.len() != 1 {
+            return show_error(&host, "The selected owned space is already deleted.");
+        }
+        let final_confirmation = if requested.is_some() {
+            format!(
+                "Permanently delete {} and its hosted content from Tonk services?\n\nYour account and every other space will remain. Copies already replicated to other devices cannot be erased by Tonk. This cannot be undone.",
+                destructive[0]
+                    .name
+                    .as_deref()
+                    .unwrap_or(&destructive[0].subject),
+            )
+        } else {
+            format!(
+                "Permanently delete {} owned space{}, their hosted content from Tonk services, all account backups, and the account for {}?\n\nJoined spaces will not be deleted. Copies already replicated to other devices cannot be erased by Tonk. This cannot be undone.",
+                destructive.len(),
+                if destructive.len() == 1 { "" } else { "s" },
+                plan.email,
+            )
+        };
+        if !window()
+            .and_then(|window| window.confirm_with_message(&final_confirmation).ok())
+            .unwrap_or(false)
+        {
+            return;
+        }
+        set_busy(&host, true, "Waiting for your passkey…");
+        spawn_local(async move {
+            let result = async {
+                if requested.is_some() {
+                    let space = &destructive[0];
+                    let proof = DeletionProofInput {
+                        kind: space.proof_kind.clone().ok_or_else(|| {
+                            format!("{} has no registered deletion proof kind", space.subject)
+                        })?,
+                        proof_hex: space.proof_hex.clone().ok_or_else(|| {
+                            format!("{} has no recoverable deletion proof", space.subject)
+                        })?,
+                    };
+                    let prepared = prepare_space_deletion(PrepareSpaceDeletionInput {
+                        expected_root: plan.root_did.clone(),
+                        proof,
+                    })
+                    .await
+                    .map_err(|error| error.to_string())?;
+                    let deleted = crate::api::delete_owned_space(&AccountSpaceDeletionRequest {
+                        subject: space.subject.clone(),
+                        invocation_hex: prepared.invocation_hex,
+                    })
+                    .await
+                    .map_err(|error| error.to_string())?;
+                    return Ok::<_, String>((Some(deleted.subject), None));
+                }
+                let proofs = destructive
+                    .iter()
+                    .map(|space| {
+                        Ok(DeletionProofInput {
+                            kind: space.proof_kind.clone().ok_or_else(|| {
+                                format!("{} has no registered deletion proof kind", space.subject)
+                            })?,
+                            proof_hex: space.proof_hex.clone().ok_or_else(|| {
+                                format!("{} has no recoverable deletion proof", space.subject)
+                            })?,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, String>>()?;
+                let prepared = prepare_account_deletion(PrepareAccountDeletionInput {
+                    expected_root: plan.root_did.clone(),
+                    confirmed_email,
+                    proofs,
+                })
+                .await
+                .map_err(|error| error.to_string())?;
+                if prepared.space_invocations_hex.len() != destructive.len() {
+                    return Err("the passkey ceremony returned an incomplete deletion set".into());
+                }
+                let spaces = destructive
+                    .iter()
+                    .zip(prepared.space_invocations_hex)
+                    .map(|(space, invocation_hex)| AccountSpaceDeletionRequest {
+                        subject: space.subject.clone(),
+                        invocation_hex,
+                    })
+                    .collect();
+                let deleted = crate::api::delete_account(&AccountDeletionRequest {
+                    spaces,
+                    customer_invocation_hex: prepared.customer_invocation_hex,
+                    account_invocation_hex: prepared.account_invocation_hex,
+                })
+                .await
+                .map_err(|error| error.to_string())?;
+                Ok((None, Some(deleted)))
+            }
+            .await;
+            match result {
+                Ok((Some(subject), None)) => {
+                    let _ = window().map(|window| {
+                        window.alert_with_message(&format!(
+                            "Owned space {subject} deleted from Tonk services. Your account and other spaces remain. Tonk cannot erase copies already replicated to other devices."
+                        ))
+                    });
+                    if let Some(window) = window() {
+                        let _ = window.location().set_href("/account");
+                    }
+                }
+                Ok((None, Some(result))) => {
+                    let _ = window().map(|window| {
+                        window.alert_with_message(&format!(
+                            "Account deleted. {} owned space{} removed from Tonk services; {} joined space{} left intact.",
+                            result.deleted_spaces,
+                            if result.deleted_spaces == 1 { "" } else { "s" },
+                            result.retained_joined_spaces,
+                            if result.retained_joined_spaces == 1 { "" } else { "s" },
+                        ))
+                    });
+                    if let Some(window) = window() {
+                        let _ = window.location().set_href("/account");
+                    }
+                }
+                Ok(_) => {
+                    set_busy(&host, false, "");
+                    show_error(&host, "the deletion result was incomplete");
+                }
+                Err(error) => {
+                    set_busy(&host, false, "");
+                    show_error(&host, error);
                 }
             }
         });
@@ -2055,6 +2422,10 @@ mod tests {
             "#account-add-profile",
             ".account__passkey",
             ".account__signout",
+            "#account-delete-review",
+            "#account-delete-submit",
+            "#account-delete-email",
+            "#account-delete-understood",
         ] {
             assert!(
                 dashboard.query_selector(selector).unwrap().is_some(),
@@ -2072,6 +2443,9 @@ mod tests {
         assert!(copy.contains("device, browser profile, or password manager"));
         assert!(copy.contains("do not tell Tonk which passkey manager currently stores it"));
         assert!(copy.contains("syncing will stop until you sign in again"));
+        assert!(copy.contains("This is not sign out"));
+        assert!(copy.contains("Spaces created by other people will not be deleted"));
+        assert!(copy.contains("cannot erase copies that other devices have already replicated"));
         for technical in ["authority", "grant", "relink required"] {
             assert!(
                 !copy.contains(technical),

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -2,9 +2,10 @@ use reqwest::StatusCode;
 use serde::Deserialize;
 use tonk_account::handoff::{LinkSecretRequest, ResolvedLink};
 use tonk_worker_api::{
-    AccountDevice, AccountLinkRequest, AccountRepositoryEstablishRequest, AccountStatus,
-    AccountSummary, ActivateProfileRequest, EvaluateResponse, IdentifyResponse, JoinRequest,
-    JoinResponse, MembershipResponse, ProfilesResponse, QueryResponse, RepositoryInfo,
+    AccountDeletionPlan, AccountDeletionRequest, AccountDeletionResult, AccountDevice,
+    AccountLinkRequest, AccountRepositoryEstablishRequest, AccountStatus, AccountSummary,
+    ActivateProfileRequest, EvaluateResponse, HostedSpaceDeletionResult, IdentifyResponse,
+    JoinRequest, JoinResponse, MembershipResponse, ProfilesResponse, QueryResponse, RepositoryInfo,
     RevokeDeviceAcknowledgement, RevokeDeviceRequest, RootStatus, SaveRootRequest, SyncResponse,
     SyncStatusResponse,
 };
@@ -802,6 +803,69 @@ pub async fn unlink_account() -> Result<AccountStatus, TonkUiError> {
         let text = response.text().await.unwrap_or_default();
         Err(TonkUiError::ApiError(format!(
             "DELETE /api/account returned {status}: {text}"
+        )))
+    }
+}
+
+/// Load the exact, service-authoritative destructive scope for review.
+pub async fn account_deletion_plan() -> Result<AccountDeletionPlan, TonkUiError> {
+    tonk_host::ready::wait().await;
+    let response = reqwest::Client::new()
+        .get(format!("{}/api/account/deletion/plan", origin()))
+        .send()
+        .await
+        .map_err(into_api_error)?;
+    if response.status().is_success() {
+        response.json().await.map_err(into_api_error)
+    } else {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        Err(TonkUiError::ApiError(format!(
+            "GET /api/account/deletion/plan returned {status}: {text}"
+        )))
+    }
+}
+
+/// Execute the root-signed destructive plan in service-safe order.
+pub async fn delete_account(
+    request: &AccountDeletionRequest,
+) -> Result<AccountDeletionResult, TonkUiError> {
+    tonk_host::ready::wait().await;
+    let response = reqwest::Client::new()
+        .post(format!("{}/api/account/delete", origin()))
+        .json(request)
+        .send()
+        .await
+        .map_err(into_api_error)?;
+    if response.status().is_success() {
+        response.json().await.map_err(into_api_error)
+    } else {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        Err(TonkUiError::ApiError(format!(
+            "POST /api/account/delete returned {status}: {text}"
+        )))
+    }
+}
+
+/// Permanently delete one owned hosted space without deleting the account.
+pub async fn delete_owned_space(
+    request: &tonk_worker_api::AccountSpaceDeletionRequest,
+) -> Result<HostedSpaceDeletionResult, TonkUiError> {
+    tonk_host::ready::wait().await;
+    let response = reqwest::Client::new()
+        .post(format!("{}/api/account/spaces/delete", origin()))
+        .json(request)
+        .send()
+        .await
+        .map_err(into_api_error)?;
+    if response.status().is_success() {
+        response.json().await.map_err(into_api_error)
+    } else {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        Err(TonkUiError::ApiError(format!(
+            "POST /api/account/spaces/delete returned {status}: {text}"
         )))
     }
 }

--- a/rust/tonk-ui/src/identity_bridge.rs
+++ b/rust/tonk-ui/src/identity_bridge.rs
@@ -151,6 +151,42 @@ pub(crate) struct RevocationOutput {
     pub revocation_hex: String,
 }
 
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DeletionProofInput {
+    pub kind: String,
+    pub proof_hex: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PrepareAccountDeletionInput {
+    pub expected_root: String,
+    pub confirmed_email: String,
+    pub proofs: Vec<DeletionProofInput>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PreparedAccountDeletion {
+    pub space_invocations_hex: Vec<String>,
+    pub customer_invocation_hex: String,
+    pub account_invocation_hex: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PrepareSpaceDeletionInput {
+    pub expected_root: String,
+    pub proof: DeletionProofInput,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PreparedSpaceDeletion {
+    pub invocation_hex: String,
+}
+
 /// Stable failures produced at the JavaScript identity boundary.
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 pub(crate) enum IdentityBridgeError {
@@ -298,6 +334,18 @@ pub(crate) async fn sign_revocation(
     input: SignRevocationInput,
 ) -> Result<RevocationOutput, IdentityBridgeError> {
     call("signRevocation", input).await
+}
+
+pub(crate) async fn prepare_account_deletion(
+    input: PrepareAccountDeletionInput,
+) -> Result<PreparedAccountDeletion, IdentityBridgeError> {
+    call("prepareAccountDeletion", input).await
+}
+
+pub(crate) async fn prepare_space_deletion(
+    input: PrepareSpaceDeletionInput,
+) -> Result<PreparedSpaceDeletion, IdentityBridgeError> {
+    call("prepareSpaceDeletion", input).await
 }
 
 #[cfg(test)]

--- a/rust/tonk-worker-api/src/account.rs
+++ b/rust/tonk-worker-api/src/account.rs
@@ -17,6 +17,79 @@ pub struct AccountSummary {
     pub passkey: Option<PasskeyMetadata>,
 }
 
+/// One hosted space associated with an account deletion review.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountDeletionSpace {
+    /// Repository subject to be permanently purged from Tonk services.
+    pub subject: String,
+    /// Best available account backup name.
+    pub name: Option<String>,
+    /// Access-service lifecycle state.
+    pub state: String,
+    /// Registered proof mode (`exact` or narrowly upgraded `legacy-direct`).
+    pub proof_kind: Option<String>,
+    /// Exact public proof bytes the passkey ceremony must present.
+    pub proof_hex: Option<String>,
+}
+
+/// Reviewable destructive scope loaded before asking for a passkey.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountDeletionPlan {
+    /// Account root that must sign every destructive request.
+    pub root_did: String,
+    /// Verified email the user must type exactly.
+    pub email: String,
+    /// Hosted spaces originally provided by this account.
+    pub spaces: Vec<AccountDeletionSpace>,
+    /// Owned subjects lacking retrievable registered proof material.
+    pub blocked_spaces: Vec<String>,
+    /// Backed-up spaces absent from the owned service inventory; these are
+    /// joined spaces and are not deleted.
+    pub joined_spaces: usize,
+}
+
+/// One root-signed space purge bound to its reviewed subject.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountSpaceDeletionRequest {
+    /// Reviewed repository subject.
+    pub subject: String,
+    /// Hex-encoded root-signed `/space/delete` invocation.
+    pub invocation_hex: String,
+}
+
+/// Prepared destructive invocations returned by one passkey ceremony.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountDeletionRequest {
+    /// One invocation for every active/deleting owned hosted space.
+    pub spaces: Vec<AccountSpaceDeletionRequest>,
+    /// Root-signed access-customer finalization invocation.
+    pub customer_invocation_hex: String,
+    /// Root-signed account-service deletion invocation.
+    pub account_invocation_hex: String,
+}
+
+/// Completed service-account deletion result.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountDeletionResult {
+    /// Number of owned hosted spaces whose purge was confirmed.
+    pub deleted_spaces: usize,
+    /// Joined spaces deliberately left intact locally and on their owners' services.
+    pub retained_joined_spaces: usize,
+}
+
+/// Receipt for deleting one owned hosted space without deleting its account.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HostedSpaceDeletionResult {
+    /// Repository subject removed from Tonk services.
+    pub subject: String,
+}
+
 /// Attach provider services to an already persisted local root, naming the
 /// account repository this root owns.
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/rust/tonk-worker-api/src/lib.rs
+++ b/rust/tonk-worker-api/src/lib.rs
@@ -29,9 +29,11 @@ pub mod share;
 mod sync;
 
 pub use account::{
-    AccountConvergenceReport, AccountDevice, AccountDisplayNameRequest, AccountDisplayNameResponse,
-    AccountLinkRequest, AccountRepositoryEstablishRequest, AccountStatus, AccountSummary,
-    RevocationProjection, RevokeDeviceAcknowledgement, RevokeDeviceRequest,
+    AccountConvergenceReport, AccountDeletionPlan, AccountDeletionRequest, AccountDeletionResult,
+    AccountDeletionSpace, AccountDevice, AccountDisplayNameRequest, AccountDisplayNameResponse,
+    AccountLinkRequest, AccountRepositoryEstablishRequest, AccountSpaceDeletionRequest,
+    AccountStatus, AccountSummary, HostedSpaceDeletionResult, RevocationProjection,
+    RevokeDeviceAcknowledgement, RevokeDeviceRequest,
 };
 pub use claim::{ClaimResponse, QueryResponse};
 pub use conclusion::{Conclusion, Frame};

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -21,6 +21,7 @@ mod claim;
 pub use claim::{AssertPath, AssertResponse, ClaimQuery, ClaimResponse, QueryResponse};
 
 mod account;
+mod account_deletion;
 mod customer;
 
 pub(crate) mod account_state;
@@ -235,6 +236,12 @@ pub fn api_router_from_state(state: AppState) -> (Router, Arc<LspHub>) {
             get(identity::get).post(identity::save),
         )
         .route("/api/account", get(account::get).delete(account::unlink))
+        .route("/api/account/deletion/plan", get(account_deletion::plan))
+        .route("/api/account/delete", post(account_deletion::delete))
+        .route(
+            "/api/account/spaces/delete",
+            post(account_deletion::delete_space),
+        )
         .route("/api/account/attach", post(account::link))
         .route("/api/account/display-name", post(account::set_display_name))
         .route(

--- a/rust/tonk-worker/src/router/account_backup.rs
+++ b/rust/tonk-worker/src/router/account_backup.rs
@@ -191,31 +191,37 @@ pub(crate) async fn get_backed_up_spot(
 }
 
 /// Build, sign, and upload one immutable backup artifact.
-async fn run_backup(
-    device: Ed25519Signer,
-    link: DelegationChain,
-    service: String,
+struct BackupArtifactInput {
     chain: DelegationChain,
     deletion_grant: Option<DelegationChain>,
     remote_url: Option<String>,
     revocation_url: Option<String>,
     name: Option<String>,
+}
+
+async fn run_backup(
+    device: Ed25519Signer,
+    link: DelegationChain,
+    service: String,
+    input: BackupArtifactInput,
 ) -> Result<(), TonkWorkerError> {
-    let chain_bytes = chain
+    let chain_bytes = input
+        .chain
         .to_bytes()
         .map_err(|error| TonkWorkerError::Internal(format!("serialize claimed chain: {error}")))?;
     let artifact = AccountSpotBackup {
         chain_hex: hex::encode(chain_bytes),
-        deletion_grant_hex: deletion_grant
+        deletion_grant_hex: input
+            .deletion_grant
             .map(|grant| grant.to_bytes())
             .transpose()
             .map_err(|error| {
                 TonkWorkerError::Internal(format!("serialize deletion grant: {error}"))
             })?
             .map(hex::encode),
-        remote_url,
-        revocation_url,
-        name,
+        remote_url: input.remote_url,
+        revocation_url: input.revocation_url,
+        name: input.name,
     };
     artifact
         .validate_for(link.issuer())
@@ -272,11 +278,13 @@ async fn dispatch_backup(
         device,
         link,
         service,
-        chain,
-        deletion_grant,
-        remote_url,
-        revocation_url,
-        name,
+        BackupArtifactInput {
+            chain,
+            deletion_grant,
+            remote_url,
+            revocation_url,
+            name,
+        },
     )
     .await
     .map_err(|error| TonkWorkerError::Internal(format!("{context} backup failed: {error}")))

--- a/rust/tonk-worker/src/router/account_backup.rs
+++ b/rust/tonk-worker/src/router/account_backup.rs
@@ -143,6 +143,7 @@ async fn legacy_inventory(
                 remote_url: None,
                 revocation_url: None,
                 ambiguous: true,
+                deletion_ready: false,
             });
         } else {
             rows.push(AccountSpotSummary {
@@ -152,6 +153,7 @@ async fn legacy_inventory(
                 remote_url: first.remote_url.clone(),
                 revocation_url: first.revocation_url.clone(),
                 ambiguous: false,
+                deletion_ready: first.deletion_grant_hex.is_some(),
             });
         }
     }
@@ -194,6 +196,7 @@ async fn run_backup(
     link: DelegationChain,
     service: String,
     chain: DelegationChain,
+    deletion_grant: Option<DelegationChain>,
     remote_url: Option<String>,
     revocation_url: Option<String>,
     name: Option<String>,
@@ -203,6 +206,13 @@ async fn run_backup(
         .map_err(|error| TonkWorkerError::Internal(format!("serialize claimed chain: {error}")))?;
     let artifact = AccountSpotBackup {
         chain_hex: hex::encode(chain_bytes),
+        deletion_grant_hex: deletion_grant
+            .map(|grant| grant.to_bytes())
+            .transpose()
+            .map_err(|error| {
+                TonkWorkerError::Internal(format!("serialize deletion grant: {error}"))
+            })?
+            .map(hex::encode),
         remote_url,
         revocation_url,
         name,
@@ -242,12 +252,28 @@ async fn dispatch_backup(
     let Some(service) = account_service_url(tonk).await else {
         return Ok(());
     };
+    let subject = chain.subject().ok_or_else(|| {
+        TonkWorkerError::Internal("backup chain has no repository subject".to_string())
+    })?;
+    let deletion_grant =
+        crate::router::repository::space_deletion_grant(tonk, subject, link.issuer()).await?;
+    // Re-provision during every backup sweep. This upgrades an original
+    // direct legacy owner proof to the access service's narrowly tagged
+    // `legacy-direct` deletion mode, or installs the exact creation grant.
+    // Indirect joined-space chains are refused by the service and remain
+    // ordinary backups; discovery never grants destructive authority.
+    if let Err(error) =
+        super::customer::provision_consumer(tonk, subject, &chain, deletion_grant.as_ref()).await
+    {
+        log!("{context} deletion-authority upgrade skipped: {error}");
+    }
     let device = tonk.profile.signer().signer().clone();
     run_backup(
         device,
         link,
         service,
         chain,
+        deletion_grant,
         remote_url,
         revocation_url,
         name,
@@ -521,7 +547,12 @@ mod tests {
             let tonk = state.read().await;
             crate::router::identity::root_did(&tonk).await.unwrap()
         };
-        assert_eq!(artifact.validate_for(&root).await.unwrap().subject, subject);
+        let validated = artifact.validate_for(&root).await.unwrap();
+        assert_eq!(validated.subject, subject);
+        assert!(
+            validated.deletion_grant.is_some(),
+            "a worker-created owned space backup carries its exact deletion grant"
+        );
     }
 
     #[dialog_common::test]

--- a/rust/tonk-worker/src/router/account_deletion.rs
+++ b/rust/tonk-worker/src/router/account_deletion.rs
@@ -1,0 +1,318 @@
+//! Reviewable, root-authorized account deletion orchestration.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use axum::{
+    Json,
+    extract::{Extension, State},
+};
+use axum_wasm_macros::wasm_compat;
+use dialog_ucan_core::InvocationChain;
+use serde::Deserialize;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use tokio::sync::oneshot;
+use tonk_worker_api::{
+    AccountDeletionPlan, AccountDeletionRequest, AccountDeletionResult, AccountDeletionSpace,
+    AccountSpaceDeletionRequest, HostedSpaceDeletionResult,
+};
+use url::Url;
+
+use super::AppState;
+use crate::TonkWorkerError;
+use crate::axum::RequestOrigin;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AccessPlan {
+    customer: String,
+    spaces: Vec<AccessSpace>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AccessSpace {
+    space: String,
+    deletion_ready: bool,
+    deletion_kind: Option<String>,
+    deletion_state: String,
+}
+
+async fn load_plan(
+    state: &crate::worker::TonkState,
+    origin: &Url,
+) -> Result<AccountDeletionPlan, TonkWorkerError> {
+    let link = super::account::account_link(state).await.ok_or_else(|| {
+        TonkWorkerError::NotFound("this profile is not linked to an account".into())
+    })?;
+    let root_did = link.issuer().to_string();
+    let email = super::account_devices::account_summary(state)
+        .await?
+        .email
+        .ok_or_else(|| TonkWorkerError::Conflict("the account has no verified email".into()))?;
+    let device = state.profile.signer().signer().clone();
+    let inventory_invocation = tonk_identity::request::build_device_invocation(
+        device.clone(),
+        &link,
+        vec!["customer".into(), "deletion".into(), "plan".into()],
+        BTreeMap::new(),
+    )
+    .await
+    .map_err(|error| TonkWorkerError::Internal(format!("build deletion inventory: {error}")))?;
+    let ucan = origin
+        .join("ucan/")
+        .map_err(|error| TonkWorkerError::Internal(format!("access endpoint: {error}")))?;
+    let access: AccessPlan = match super::http::post_cbor(&ucan, &inventory_invocation).await {
+        Ok(response) => serde_json::from_slice(&response.body).map_err(|error| {
+            TonkWorkerError::Internal(format!("access deletion inventory is invalid: {error}"))
+        })?,
+        Err(super::http::HttpError::Upstream(failure)) if failure.status == 404 => AccessPlan {
+            customer: root_did.clone(),
+            spaces: Vec::new(),
+        },
+        Err(error) => return Err(error.into()),
+    };
+    if access.customer != root_did {
+        return Err(TonkWorkerError::Forbidden(
+            "access deletion inventory belongs to another account".into(),
+        ));
+    }
+
+    let account_service = super::account_backup::account_service_url(state)
+        .await
+        .ok_or_else(|| TonkWorkerError::Conflict("no account service is attached".into()))?;
+    let summaries =
+        super::account_backup::list_backed_up_spots(&device, &link, &account_service).await?;
+    let summary_by_subject: BTreeMap<_, _> = summaries
+        .iter()
+        .map(|summary| (summary.subject.as_str(), summary))
+        .collect();
+    let owned: BTreeSet<_> = access
+        .spaces
+        .iter()
+        .map(|space| space.space.as_str())
+        .collect();
+    let joined_spaces = summaries
+        .iter()
+        .filter(|summary| !owned.contains(summary.subject.as_str()))
+        .count();
+
+    let mut spaces = Vec::with_capacity(access.spaces.len());
+    let mut blocked_spaces = Vec::new();
+    for hosted in access.spaces {
+        let mut name = None;
+        let mut proof_hex = None;
+        if hosted.deletion_state != "deleted"
+            && let Some(summary) = summary_by_subject.get(hosted.space.as_str())
+        {
+            name = summary.name.clone();
+            if let Some(key) = &summary.key {
+                let artifact = super::account_backup::get_backed_up_spot(
+                    &device,
+                    &link,
+                    &account_service,
+                    key,
+                )
+                .await?;
+                let validated = artifact
+                    .validate_for(link.issuer())
+                    .await
+                    .map_err(|error| {
+                        TonkWorkerError::Conflict(format!(
+                            "account backup for {} is not deletion-safe: {error}",
+                            hosted.space
+                        ))
+                    })?;
+                proof_hex = match hosted.deletion_kind.as_deref() {
+                    Some("exact") => artifact.deletion_grant_hex,
+                    Some("legacy-direct") => Some(artifact.chain_hex),
+                    _ => None,
+                };
+                if validated.subject.to_string() != hosted.space {
+                    proof_hex = None;
+                }
+            }
+        }
+        if hosted.deletion_state != "deleted" && (!hosted.deletion_ready || proof_hex.is_none()) {
+            blocked_spaces.push(hosted.space.clone());
+        }
+        spaces.push(AccountDeletionSpace {
+            subject: hosted.space,
+            name,
+            state: hosted.deletion_state,
+            proof_kind: hosted.deletion_kind,
+            proof_hex,
+        });
+    }
+    Ok(AccountDeletionPlan {
+        root_did,
+        email,
+        spaces,
+        blocked_spaces,
+        joined_spaces,
+    })
+}
+
+/// GET `/api/account/deletion/plan` returns the exact destructive scope.
+#[wasm_compat]
+pub async fn plan(
+    State(state): State<AppState>,
+    Extension(origin): Extension<RequestOrigin>,
+) -> Result<Json<AccountDeletionPlan>, TonkWorkerError> {
+    let state = state.read().await;
+    Ok(Json(load_plan(&state, origin.url()).await?))
+}
+
+fn invocation_subject(encoded: &str) -> Result<String, TonkWorkerError> {
+    let bytes = hex::decode(encoded)
+        .map_err(|error| TonkWorkerError::Router(format!("invalid invocation hex: {error}")))?;
+    let chain = InvocationChain::try_from(bytes.as_slice()).map_err(|error| {
+        TonkWorkerError::Router(format!("invalid deletion invocation: {error}"))
+    })?;
+    Ok(chain.subject().to_string())
+}
+
+/// POST `/api/account/spaces/delete` deletes one reviewed owned hosted space
+/// while leaving the account and every other space intact.
+#[wasm_compat]
+pub async fn delete_space(
+    State(state): State<AppState>,
+    Extension(origin): Extension<RequestOrigin>,
+    Json(request): Json<AccountSpaceDeletionRequest>,
+) -> Result<Json<HostedSpaceDeletionResult>, TonkWorkerError> {
+    let current = {
+        let state = state.read().await;
+        load_plan(&state, origin.url()).await?
+    };
+    let selected = current
+        .spaces
+        .iter()
+        .find(|space| space.subject == request.subject)
+        .ok_or_else(|| TonkWorkerError::Forbidden("space is not owned by this account".into()))?;
+    if selected.state == "deleted" {
+        return Ok(Json(HostedSpaceDeletionResult {
+            subject: request.subject,
+        }));
+    }
+    if selected.proof_hex.is_none()
+        || current
+            .blocked_spaces
+            .iter()
+            .any(|space| space == &request.subject)
+        || invocation_subject(&request.invocation_hex)? != request.subject
+    {
+        return Err(TonkWorkerError::Forbidden(
+            "space deletion does not match recoverable registered authority".into(),
+        ));
+    }
+    let ucan = origin
+        .url()
+        .join("ucan/")
+        .map_err(|error| TonkWorkerError::Internal(format!("access endpoint: {error}")))?;
+    let bytes = hex::decode(&request.invocation_hex)
+        .map_err(|error| TonkWorkerError::Router(format!("invalid invocation hex: {error}")))?;
+    super::http::post_cbor(&ucan, &bytes).await?;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    {
+        let subject = request.subject.parse().map_err(|error| {
+            TonkWorkerError::Internal(format!("reviewed space DID became invalid: {error}"))
+        })?;
+        super::repository::remove_space_inner(&state, &subject).await?;
+    }
+    Ok(Json(HostedSpaceDeletionResult {
+        subject: request.subject,
+    }))
+}
+
+/// POST `/api/account/delete` executes a previously reviewed passkey ceremony.
+#[wasm_compat]
+pub async fn delete(
+    State(state): State<AppState>,
+    Extension(origin): Extension<RequestOrigin>,
+    Json(request): Json<AccountDeletionRequest>,
+) -> Result<Json<AccountDeletionResult>, TonkWorkerError> {
+    let current = {
+        let state = state.read().await;
+        load_plan(&state, origin.url()).await?
+    };
+    if !current.blocked_spaces.is_empty() {
+        return Err(TonkWorkerError::Conflict(format!(
+            "deletion proof is unavailable for: {}",
+            current.blocked_spaces.join(", ")
+        )));
+    }
+    let required: BTreeSet<_> = current
+        .spaces
+        .iter()
+        .filter(|space| space.state != "deleted")
+        .map(|space| space.subject.clone())
+        .collect();
+    let supplied: BTreeSet<_> = request
+        .spaces
+        .iter()
+        .map(|space| space.subject.clone())
+        .collect();
+    let subjects_match = request.spaces.iter().all(|space| {
+        invocation_subject(&space.invocation_hex).is_ok_and(|subject| subject == space.subject)
+    });
+    if supplied != required || !subjects_match {
+        return Err(TonkWorkerError::Forbidden(
+            "prepared deletion invocations do not match the reviewed space set".into(),
+        ));
+    }
+
+    let ucan = origin
+        .url()
+        .join("ucan/")
+        .map_err(|error| TonkWorkerError::Internal(format!("access endpoint: {error}")))?;
+    for space in &request.spaces {
+        let bytes = hex::decode(&space.invocation_hex)
+            .map_err(|error| TonkWorkerError::Router(format!("invalid invocation hex: {error}")))?;
+        super::http::post_cbor(&ucan, &bytes).await?;
+    }
+    let customer = hex::decode(&request.customer_invocation_hex).map_err(|error| {
+        TonkWorkerError::Router(format!("invalid customer deletion invocation: {error}"))
+    })?;
+    match super::http::post_cbor(&ucan, &customer).await {
+        Ok(_) => {}
+        Err(super::http::HttpError::Upstream(failure)) if failure.status == 404 => {
+            // A previous attempt may have completed access-service cleanup
+            // before the account-service call failed. Continue that retry.
+        }
+        Err(error) => return Err(error.into()),
+    }
+
+    let account_service = {
+        let state = state.read().await;
+        super::account_backup::account_service_url(&state)
+            .await
+            .ok_or_else(|| TonkWorkerError::Conflict("no account service is attached".into()))?
+    };
+    let account_endpoint = Url::parse(&format!(
+        "{}/account/delete",
+        account_service.trim_end_matches('/')
+    ))
+    .map_err(|error| TonkWorkerError::Internal(format!("account deletion endpoint: {error}")))?;
+    let account = hex::decode(&request.account_invocation_hex).map_err(|error| {
+        TonkWorkerError::Router(format!("invalid account deletion invocation: {error}"))
+    })?;
+    super::http::post_cbor(&account_endpoint, &account).await?;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    for space in &request.spaces {
+        let subject = space.subject.parse().map_err(|error| {
+            TonkWorkerError::Internal(format!("reviewed space DID became invalid: {error}"))
+        })?;
+        super::repository::remove_space_inner(&state, &subject).await?;
+    }
+    {
+        let current_state = state.read().await;
+        super::customer::clear_customer(&current_state).await?;
+    }
+    let _ = super::account::unlink(State(state.clone())).await?;
+
+    Ok(Json(AccountDeletionResult {
+        deleted_spaces: request.spaces.len(),
+        retained_joined_spaces: current.joined_spaces,
+    }))
+}

--- a/rust/tonk-worker/src/router/customer.rs
+++ b/rust/tonk-worker/src/router/customer.rs
@@ -202,18 +202,25 @@ pub(crate) async fn provision_consumer(
     state: &crate::worker::TonkState,
     consumer: &dialog_varsig::Did,
     consent: &dialog_ucan_core::DelegationChain,
+    deletion_grant: Option<&dialog_ucan_core::DelegationChain>,
 ) -> Result<(), TonkWorkerError> {
-    use tonk_identity::request::build_provider_add_invocation;
+    use tonk_identity::request::build_provider_add_invocation_with_deletion;
 
     let link = super::account::account_link(state).await.ok_or_else(|| {
         TonkWorkerError::NotFound("this profile is not linked to an account".to_string())
     })?;
     let device = state.profile.signer().signer().clone();
-    let body = build_provider_add_invocation(device, &link, consumer, consent)
-        .await
-        .map_err(|error| {
-            TonkWorkerError::Internal(format!("failed to build the add invocation: {error}"))
-        })?;
+    let body = build_provider_add_invocation_with_deletion(
+        device,
+        &link,
+        consumer,
+        consent,
+        deletion_grant,
+    )
+    .await
+    .map_err(|error| {
+        TonkWorkerError::Internal(format!("failed to build the add invocation: {error}"))
+    })?;
     let origin = service_origin()?;
     match post_cbor(&ucan_endpoint(&origin)?, &body).await {
         Ok(_) => Ok(()),
@@ -320,5 +327,20 @@ async fn save_customer(
         .await
         .map_err(|error| {
             TonkWorkerError::Internal(format!("failed to save the customer record: {error}"))
+        })
+}
+
+pub(crate) async fn clear_customer(
+    state: &crate::worker::TonkState,
+) -> Result<(), TonkWorkerError> {
+    state
+        .profile
+        .credential()
+        .site(CUSTOMER_CREDENTIAL_SITE)
+        .save(Vec::<u8>::new())
+        .perform(&state.operator)
+        .await
+        .map_err(|error| {
+            TonkWorkerError::Internal(format!("failed to clear the customer record: {error}"))
         })
 }

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -27,7 +27,7 @@ use dialog_varsig::{Did, Principal};
 use serde::{Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
-use tonk_account::backup::SPACE_ROOT_SITE_PREFIX;
+use tonk_account::backup::{SPACE_ROOT_SITE_PREFIX, space_delete_site};
 use tonk_common::log;
 use tonk_schema::prelude::DidExt as _;
 use tonk_schema::{
@@ -1794,7 +1794,10 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for RemoveSpaceHa
 /// chrome in the Hub, and deleting the profile's own storage would take
 /// every space with it.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-async fn remove_space_inner(state: &AppState, subject: &Did) -> Result<(), RepositoryError> {
+pub(crate) async fn remove_space_inner(
+    state: &AppState,
+    subject: &Did,
+) -> Result<(), RepositoryError> {
     {
         let tonk = state.write().await;
         if let Err(error) = require_real_space(&tonk, subject).await
@@ -2676,7 +2679,7 @@ pub async fn create_repository(
     let delegation = repository
         .access()
         .claim(&repository)
-        .delegate(owner)
+        .delegate(owner.clone())
         .perform(&tonk.operator)
         .await
         .map_err(|e| {
@@ -2684,6 +2687,14 @@ pub async fn create_repository(
         })?;
 
     let prefix = delegation.into_chain();
+
+    let deletion_grant = mint_and_persist_space_deletion_grant(
+        tonk,
+        repository.credential().signer(),
+        &repository.did(),
+        &owner,
+    )
+    .await?;
     tonk.profile
         .access()
         .save(UcanDelegation(prefix.clone()))
@@ -2700,7 +2711,9 @@ pub async fn create_repository(
     // consumer of the access service, depositing the powerline as its
     // consent. Best effort for the same reason retain is — a space is
     // usable the moment its delegations exist locally.
-    if let Err(error) = super::customer::provision_consumer(tonk, &repository.did(), &prefix).await
+    if let Err(error) =
+        super::customer::provision_consumer(tonk, &repository.did(), &prefix, Some(&deletion_grant))
+            .await
     {
         log!("consumer provisioning skipped: {error}");
     }
@@ -2736,6 +2749,63 @@ pub async fn create_repository(
     .await?;
 
     Ok(repository)
+}
+
+async fn mint_and_persist_space_deletion_grant(
+    tonk: &TonkState,
+    signer: &Ed25519Signer,
+    subject: &Did,
+    owner: &Did,
+) -> Result<DelegationChain, RepositoryError> {
+    let grant = tonk_account::deletion::mint_deletion_grant(signer, owner)
+        .await
+        .map_err(|error| {
+            RepositoryError::Internal(format!("Failed to mint space deletion grant: {error}"))
+        })?;
+    let bytes = grant.to_bytes().map_err(|error| {
+        RepositoryError::Internal(format!("Failed to serialize space deletion grant: {error}"))
+    })?;
+    tonk.profile
+        .credential()
+        .site(space_delete_site(subject, owner))
+        .save(bytes)
+        .perform(&tonk.operator)
+        .await
+        .map_err(|error| {
+            RepositoryError::Internal(format!("Failed to persist space deletion grant: {error}"))
+        })?;
+    Ok(grant)
+}
+
+/// Load and validate the exact deletion grant retained for one account root.
+pub(crate) async fn space_deletion_grant(
+    tonk: &TonkState,
+    subject: &Did,
+    owner: &Did,
+) -> Result<Option<DelegationChain>, TonkWorkerError> {
+    let bytes = match tonk
+        .profile
+        .credential()
+        .site(space_delete_site(subject, owner))
+        .load::<Vec<u8>>()
+        .perform(&tonk.operator)
+        .await
+    {
+        Ok(bytes) if bytes.is_empty() => return Ok(None),
+        Ok(bytes) => bytes,
+        Err(error) if crate::credential::is_missing(&error) => return Ok(None),
+        Err(error) => {
+            return Err(TonkWorkerError::Internal(format!(
+                "failed to load space deletion grant: {error}"
+            )));
+        }
+    };
+    tonk_account::deletion::validate_deletion_grant(&bytes, subject, owner)
+        .await
+        .map(|validated| Some(validated.chain))
+        .map_err(|error| {
+            TonkWorkerError::Internal(format!("stored space deletion grant is invalid: {error}"))
+        })
 }
 
 /// Load the exact provider-neutral `space → root` prefix persisted at creation.
@@ -2853,8 +2923,32 @@ pub(crate) async fn adopt_profile_spaces(tonk: &TonkState) {
         } else {
             continue;
         };
+        let mut deletion_grant = space_deletion_grant(tonk, &subject, &root.root_did)
+            .await
+            .ok()
+            .flatten();
+        if deletion_grant.is_none()
+            && let Some(access) = repository.try_access()
+        {
+            match mint_and_persist_space_deletion_grant(
+                tonk,
+                access.signer().signer(),
+                &subject,
+                &root.root_did,
+            )
+            .await
+            {
+                Ok(grant) => deletion_grant = Some(grant),
+                Err(error) => {
+                    log!("adopted space '{subject}' deletion grant did not persist: {error}")
+                }
+            }
+        }
         super::account_state::retain_space_delegation(tonk, &chain).await;
-        if let Err(error) = super::customer::provision_consumer(tonk, &subject, &chain).await {
+        if let Err(error) =
+            super::customer::provision_consumer(tonk, &subject, &chain, deletion_grant.as_ref())
+                .await
+        {
             log!("adopted space '{subject}' provisioning skipped: {error}");
         }
     }

--- a/rust/tonk-worker/src/router/restore.rs
+++ b/rust/tonk-worker/src/router/restore.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use dialog_ucan::UcanDelegation;
 use dialog_ucan_core::DelegationChain;
-use tonk_account::backup::{AccountSpotSummary, SPACE_ROOT_SITE_PREFIX};
+use tonk_account::backup::{AccountSpotSummary, SPACE_ROOT_SITE_PREFIX, space_delete_site};
 use tonk_common::log;
 
 use crate::router::account_backup::{
@@ -88,6 +88,14 @@ async fn restore_one(
     let prefix_bytes = validated.chain.to_bytes().map_err(|error| {
         crate::TonkWorkerError::Internal(format!("serialize restored delegation: {error}"))
     })?;
+    let deletion_grant_bytes = validated
+        .deletion_grant
+        .as_ref()
+        .map(DelegationChain::to_bytes)
+        .transpose()
+        .map_err(|error| {
+            crate::TonkWorkerError::Internal(format!("serialize restored deletion grant: {error}"))
+        })?;
     tonk.profile
         .access()
         .save(UcanDelegation(validated.chain))
@@ -105,6 +113,19 @@ async fn restore_one(
         .map_err(|error| {
             crate::TonkWorkerError::Internal(format!("persist restored delegation: {error}"))
         })?;
+    if let Some(bytes) = deletion_grant_bytes {
+        tonk.profile
+            .credential()
+            .site(space_delete_site(&expected, link.issuer()))
+            .save(bytes)
+            .perform(&tonk.operator)
+            .await
+            .map_err(|error| {
+                crate::TonkWorkerError::Internal(format!(
+                    "persist restored deletion grant: {error}"
+                ))
+            })?;
+    }
 
     // The synced content branch remains authoritative for membership,
     // roles, names, invitations, and provenance.
@@ -149,6 +170,7 @@ mod tests {
             .unwrap();
         let backup = AccountSpotBackup {
             chain_hex: hex::encode(DelegationChain::new(delegation).to_bytes().unwrap()),
+            deletion_grant_hex: None,
             remote_url: Some("https://sync.example.test/ucan/".to_string()),
             revocation_url: Some("https://relay.example.test/revocations/".to_string()),
             name: name.map(str::to_string),
@@ -220,6 +242,7 @@ mod tests {
                 remote_url: None,
                 revocation_url: None,
                 ambiguous: true,
+                deletion_ready: false,
             },
             AccountSpotSummary {
                 subject: bad_subject.to_string(),
@@ -228,6 +251,7 @@ mod tests {
                 remote_url: Some("https://sync.example.test/ucan/".to_string()),
                 revocation_url: None,
                 ambiguous: false,
+                deletion_ready: false,
             },
             AccountSpotSummary {
                 subject: legacy_subject.to_string(),
@@ -236,6 +260,7 @@ mod tests {
                 remote_url: Some("https://sync.example.test/ucan/".to_string()),
                 revocation_url: None,
                 ambiguous: false,
+                deletion_ready: false,
             },
             AccountSpotSummary {
                 subject: good_subject.to_string(),
@@ -244,6 +269,7 @@ mod tests {
                 remote_url: Some("https://sync.example.test/ucan/".to_string()),
                 revocation_url: None,
                 ambiguous: false,
+                deletion_ready: false,
             },
         ];
         let _inventory = install_inventory(&rows, &[b"bad artifact".to_vec(), legacy, good]);


### PR DESCRIPTION
## Summary

- issue exact `/space/delete` UCAN capabilities to creators and safely upgrade legacy direct owners
- add review-first single-space and whole-account deletion flows to the UI and CLI
- denial-first purge owned hosted spaces, remove account-service state in dependent order, and release D1 email uniqueness for reuse
- retain anonymized deletion markers so deleted space DIDs cannot be reprovisioned

## Safety boundaries

- joined spaces are left intact and are never treated as owned authorization
- destructive invocations require the account root/passkey; inventory metadata is discovery-only
- the UI requires exact review, typed email, consequence acknowledgement, and final confirmation
- deletion removes Tonk-hosted data and initiating-device state; it cannot erase replicas already held by other devices or providers
- existing short invite redirects are not space-indexed and expire under their existing bounded TTL

## Verification

- `NEXTEST_TEST_THREADS=4 nix develop path:. -c test:web:debug` (1307 passed, 1 skipped)
- `cargo test -p tonk-cli -- --test-threads=4`
- `cargo test -p tonk-account -p tonk-worker-api`
- `cargo test -p tonk-account-service --features helpers`
- `cargo test -p tonk-access-service --features helpers`
- Wasm checks for access service, account service, worker, UI, and identity
- `cargo fmt --all -- --check`, clippy, and diff checks

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on implementing account and hosted-space deletion features, enhancing the management of deletion grants, and updating the associated APIs and database structures to support these functionalities.

### Detailed summary
- Added `deletion` modules in various services.
- Introduced new API endpoints for account and space deletion.
- Implemented deletion grant handling in account provisioning.
- Updated database schemas to support deletion states and grants.
- Enhanced UI components for account deletion confirmation.
- Added tests for deletion functionalities and scenarios.

> The following files were skipped due to too many changes: `rust/tonk-access-service/tests/registration.rs`, `rust/tonk-access-service/src/store/d1.rs`, `rust/tonk-access-service/src/helpers/server.rs`, `rust/tonk-account-service/src/core/deletion.rs`, `rust/tonk-cli/src/bin/tonk.rs`, `rust/tonk-worker/src/router/repository.rs`, `rust/tonk-access-service/src/store/sqlite.rs`, `rust/tonk-identity/src/install.rs`, `rust/tonk-account/src/backup.rs`, `docs/plans/2026-08-19-account-and-space-deletion-design.md`, `rust/tonk-access-service/src/store.rs`, `rust/tonk-worker/src/router/account_deletion.rs`, `rust/tonk-ui/src/account.rs`, `rust/tonk-account/src/deletion.rs`, `rust/tonk-access-service/src/deletion.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->