### PR TITLE
feat(cli): synthesize branch behavior as notation via tonk schema

### DIFF
--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -109,16 +109,35 @@ enum Command {
     ///
     /// Every named attribute and concept, or just one concept's
     /// subset when `<CONCEPT>` is given. The human field/type view
-    /// lives in `tonk assert <concept> --help`.
+    /// lives in `tonk assert <concept> --help`. Selector flags
+    /// widen or narrow the document: `--rules` and `--views` add
+    /// (or, without `--concepts`, select only) those sections;
+    /// `--all` emits everything the branch's behavior comprises.
     #[command(
-        after_help = "Examples:\n  tonk schema\n  tonk schema task\n  tonk schema > schema.notation"
+        after_help = "Examples:\n  tonk schema\n  tonk schema task\n  tonk schema --rules\n  tonk schema --all > behavior.notation"
     )]
     Schema {
         /// Optional concept name — emit only that concept's
         /// `concept!:` block plus the `attribute!:` declarations
         /// it references.
-        #[arg(value_name = "CONCEPT")]
+        #[arg(value_name = "CONCEPT", conflicts_with_all = ["concepts", "rules", "views", "all"])]
         concept: Option<String>,
+        /// Emit attribute and concept declarations (the default
+        /// section; state explicitly when combining with other
+        /// selectors).
+        #[arg(long)]
+        concepts: bool,
+        /// Emit installed rules — inductive and deductive — as
+        /// `rule!:` blocks.
+        #[arg(long)]
+        rules: bool,
+        /// Emit view instances as `view!:` blocks.
+        #[arg(long)]
+        views: bool,
+        /// Emit everything: attributes + concepts, rules, and
+        /// views, in an order that re-evaluates cleanly.
+        #[arg(long, conflicts_with_all = ["concepts", "rules", "views"])]
+        all: bool,
     },
 
     /// Report how local main relates to its upstream and its current hash
@@ -1046,7 +1065,24 @@ async fn main() {
         Command::Account { command } => account_op(command).await,
         Command::Eval(args) => eval(args, spot.as_deref()).await,
         Command::Guide { topic, item } => print_guide(topic.as_deref(), item.as_deref()),
-        Command::Schema { concept } => print_schema(concept, spot.as_deref()).await,
+        Command::Schema {
+            concept,
+            concepts,
+            rules,
+            views,
+            all,
+        } => {
+            // No selector means the classic document (attributes +
+            // concepts); any selector narrows to exactly the named
+            // sections; `--all` is every section.
+            let selected = concepts || rules || views;
+            let sections = SchemaSections {
+                concepts: all || concepts || !selected,
+                rules: all || rules,
+                views: all || views,
+            };
+            print_schema(concept, sections, spot.as_deref()).await
+        }
         Command::Query {
             concept,
             entity,
@@ -2942,7 +2978,18 @@ fn print_view_row(out: &mut impl std::io::Write, row: &ViewSummary) -> std::io::
     writeln!(out, "{}\t{}\t{}", name, row.entity, row.body_bytes)
 }
 
-async fn print_schema(concept: Option<String>, spot: Option<&str>) -> ExitCode {
+/// Section selectors for `tonk schema`, resolved from the flags.
+struct SchemaSections {
+    concepts: bool,
+    rules: bool,
+    views: bool,
+}
+
+async fn print_schema(
+    concept: Option<String>,
+    sections: SchemaSections,
+    spot: Option<&str>,
+) -> ExitCode {
     let (_, site) = match open_selected(spot).await {
         Ok(opened) => opened,
         Err(code) => return code,
@@ -2955,10 +3002,32 @@ async fn print_schema(concept: Option<String>, spot: Option<&str>) -> ExitCode {
                 return err.exit_code();
             }
         },
-        None => match schema::render(&site).await {
-            Ok(text) => text,
-            Err(err) => return print_failure(err),
-        },
+        None => {
+            // Section order matters: rules reference concepts and
+            // views reference both, so a document with every
+            // section re-evaluates top to bottom on a fresh
+            // branch.
+            let mut rendered = String::new();
+            if sections.concepts {
+                match schema::render(&site).await {
+                    Ok(text) => rendered.push_str(&text),
+                    Err(err) => return print_failure(err),
+                }
+            }
+            if sections.rules {
+                match schema::render_rules(&site).await {
+                    Ok(text) => rendered.push_str(&text),
+                    Err(err) => return print_failure(err),
+                }
+            }
+            if sections.views {
+                match schema::render_views(&site).await {
+                    Ok(text) => rendered.push_str(&text),
+                    Err(err) => return print_failure(err),
+                }
+            }
+            rendered
+        }
     };
     let mut stdout = std::io::stdout().lock();
     if let Err(e) = stdout.write_all(rendered.as_bytes()) {

--- a/rust/tonk-cli/src/schema.rs
+++ b/rust/tonk-cli/src/schema.rs
@@ -7,28 +7,20 @@
 //!    (named or not). For each, a separate lookup against
 //!    `db.name/referent` recovers the bookmark name where one
 //!    exists.
-//! 2. The built-in `concept` concept enumerates every concept
-//!    *with* a name claim — the concept-of-concept descriptor
-//!    requires a `name` field, so anonymous concepts fall through.
-//!    Each row's `source` is the JSON-encoded
+//! 2. The built-in `concept` concept enumerates every concept —
+//!    named or not. Each row's `source` is the JSON-encoded
 //!    [`ConceptDescriptor`], deserialized to recover the full
-//!    `with:` map.
+//!    `with:`/`maybe:` maps and the concept description (the
+//!    query layer folds the `db.meta/description` claim into the
+//!    synthesised descriptor). The `transient` field decides the
+//!    head: transient concepts re-emit as `command!:`, which the
+//!    analyzer derives to the same entity as `concept!:` +
+//!    `transient:`.
 //!
-//! Anonymous attribute and concept emission is intentionally
-//! out of scope — the typical workflow names everything via
-//! bookmark form, and adding the URI-binding round-trip path
-//! would multiply the test surface for a corner case we haven't
-//! seen in real schemas yet.
-//!
-//! Known fidelity gap: `db.meta/description` claims on
-//! *concepts* are not surfaced. The dialog query engine's
-//! anonymous-concept dispatch path (which the `concept:` head
-//! lands on) only binds `this`, `name`, and a synthesised
-//! `source`; reconstructed descriptors set `description: None`.
-//! Concept descriptions are optional in the analyzer, so the
-//! emitted schema still re-submits cleanly — only the prose is
-//! lost. Attribute descriptions round-trip because the
-//! `attribute:` query returns the underlying claim directly.
+//! A concept whose stored entity differs from its descriptor's
+//! content address (a pinned `this:`, e.g. `tonk:view`) re-emits
+//! the pin; anonymous concepts emit without an anchor and rely on
+//! the pin or the content address for identity.
 
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Write as _;
@@ -36,11 +28,14 @@ use std::fmt::Write as _;
 use anyhow::{Context, Result, anyhow};
 use dialog_artifacts::Entity;
 use dialog_query::{
-    AttributeQuery, Cardinality, ConceptDescriptor, Output as _, Term, Type, attribute,
+    AttributeQuery, Cardinality, ConceptDescriptor, ConceptFieldDescriptor, Output as _, Term,
+    Type, attribute,
 };
 use serde_json::Value as Json;
 use tonk_evaluator::evaluate::{QueryMatchBlock, SyntaxEvaluateExt};
 use tonk_notation::parse;
+use tonk_schema::rule::{DeductiveRule, InductiveRule, Rule};
+use tonk_schema::rule_notation;
 
 use crate::output::EvaluateResponse;
 
@@ -91,8 +86,12 @@ pub async fn list_concepts(site: &TonkSite) -> Result<Vec<ConceptSummary>> {
     let infos = enumerate_concepts(site).await?;
     Ok(infos
         .into_iter()
-        .map(|info| ConceptSummary {
-            name: info.name,
+        .filter_map(|info| {
+            let name = info.name.clone()?;
+            Some((name, info))
+        })
+        .map(|(name, info)| ConceptSummary {
+            name,
             entity: info.entity,
             description: info.description,
             fields: info
@@ -149,6 +148,35 @@ pub async fn render(site: &TonkSite) -> Result<String> {
     Ok(out)
 }
 
+/// Render every rule installed on the branch — inductive and
+/// deductive — as `rule!:` notation, appended after the schema the
+/// rules' concept references resolve against.
+///
+/// A rule that cannot be expressed in notation (a `reduce` fold, a
+/// foreign body, a concept with no published name) is emitted as a
+/// comment naming the rule entity and the reason, so the document
+/// stays honest about what it dropped.
+pub async fn render_rules(site: &TonkSite) -> Result<String> {
+    let rules = enumerate_rules(site).await?;
+    let mut names = BranchNames::load(site).await?;
+    let mut out = String::new();
+    for (entity, rule) in &rules {
+        match rule_notation::render_rule(rule, &mut names) {
+            Ok(block) => {
+                out.push_str(&block);
+                out.push('\n');
+            }
+            Err(reason) => {
+                let _ = writeln!(
+                    out,
+                    "# rule {entity}: not expressible in notation: {reason}\n"
+                );
+            }
+        }
+    }
+    Ok(out)
+}
+
 /// Render one named concept's schema subset — the `attribute!:`
 /// declarations it references followed by its `concept!:` block —
 /// in the same re-submittable notation as [`render`]. Returns
@@ -156,7 +184,7 @@ pub async fn render(site: &TonkSite) -> Result<String> {
 pub async fn render_one(site: &TonkSite, name: &str) -> Result<Option<String>> {
     let attrs = enumerate_attributes(site).await?;
     let concepts = enumerate_concepts(site).await?;
-    let Some(concept) = concepts.iter().find(|c| c.name == name) else {
+    let Some(concept) = concepts.iter().find(|c| c.name.as_deref() == Some(name)) else {
         return Ok(None);
     };
     let uri_to_name: HashMap<String, String> = attrs
@@ -198,20 +226,22 @@ struct AttributeInfo {
     description: String,
 }
 
-/// A single named concept's schema — fields, types, cardinalities,
+/// A single concept's schema — fields, types, cardinalities,
 /// and description — as read off the branch.
 #[derive(Debug)]
 pub struct ConceptInfo {
-    /// Bookmark name. Required — anonymous concepts aren't yet
-    /// surfaced.
-    pub name: String,
+    /// Bookmark name, when one is published.
+    pub name: Option<String>,
     /// Entity identifier of the concept descriptor.
     pub entity: String,
     /// `db.meta/description` when present.
     pub description: Option<String>,
     /// Decoded descriptor — the source of truth for the rendered
-    /// `with:` map.
+    /// `with:`/`maybe:` maps.
     pub descriptor: ConceptDescriptor,
+    /// `dialog.concept/transient` marker — `true` means this is a
+    /// command and re-emits as `command!:`.
+    pub transient: bool,
 }
 
 /// Find a single user-defined concept by its bookmark name,
@@ -222,7 +252,7 @@ pub async fn find_concept(site: &TonkSite, name: &str) -> Result<Option<ConceptI
     Ok(enumerate_concepts(site)
         .await?
         .into_iter()
-        .find(|c| c.name == name))
+        .find(|c| c.name.as_deref() == Some(name)))
 }
 
 // ---------------------------------------------------------------- //
@@ -249,9 +279,19 @@ async fn enumerate_attributes(site: &TonkSite) -> Result<Vec<AttributeInfo>> {
             .this
             .parse()
             .with_context(|| format!("attribute row had unparseable entity: {}", row.this))?;
+        let the = take_string(&row.fields, "id");
+        // Runtime-owned vocabulary (`dialog.*` replica bindings,
+        // `db.*` schema bookkeeping) is regenerated by the
+        // destination branch and often carries no description,
+        // which a re-submitted `attribute!:` block must have.
+        // Concepts referencing one of these render it inline from
+        // their own descriptor instead.
+        if the.starts_with("dialog.") || the.starts_with("db.") {
+            continue;
+        }
         out.push(AttributeInfo {
             name: names.get(&entity).cloned(),
-            the: take_string(&row.fields, "id"),
+            the,
             type_name: take_string(&row.fields, "type"),
             cardinality: take_string(&row.fields, "cardinality"),
             description: take_string(&row.fields, "description"),
@@ -319,16 +359,28 @@ async fn name_claims_by_entity(site: &TonkSite) -> Result<HashMap<Entity, String
 
 async fn enumerate_concepts(site: &TonkSite) -> Result<Vec<ConceptInfo>> {
     const QUERY: &str = r#"concept:
-  this:        ?c
-  concept:     ?cc
-  name:        ?name
-  description: ?desc
-  source:      ?source
+  this:      ?c
+  concept:   ?cc
+  name:      ?name
+  source:    ?source
+  transient: ?transient
 "#;
     let response = run_query(site, QUERY).await?;
     let block = expect_block(&response, "concept")?;
+    // Built-in concepts are folded into the query results from the
+    // registry; recognize them by their well-known entities rather
+    // than a name list, so a registry addition can't leak into the
+    // rendered document (the `command` sentinel once did).
+    let builtin_entities: std::collections::HashSet<String> =
+        tonk_schema::builtin::concept_registry()
+            .iter()
+            .map(|(_, definition)| definition.entity.to_string())
+            .collect();
     let mut out: Vec<ConceptInfo> = Vec::with_capacity(block.results.len());
     for row in &block.results {
+        if builtin_entities.contains(&row.this) {
+            continue;
+        }
         let source = match row.fields.get("source") {
             Some(Json::String(s)) => s.clone(),
             _ => continue, // skip rows lacking a parsable source
@@ -340,30 +392,272 @@ async fn enumerate_concepts(site: &TonkSite) -> Result<Vec<ConceptInfo>> {
             )
         })?;
         let name = match row.fields.get("name") {
-            Some(Json::String(s)) => s.clone(),
-            _ => continue,
+            Some(Json::String(s)) => Some(s.clone()),
+            _ => None,
         };
         // Built-in concepts are baked into the analyzer's
         // registry — every branch already resolves them without
         // needing them in the document. Skipping them keeps the
         // emitted schema portable to a fresh branch (no
         // duplicate-shadow attempts) and short.
-        if is_builtin_concept(&name) {
+        if let Some(name) = &name
+            && is_builtin_concept(name)
+        {
             continue;
         }
-        let description = match row.fields.get("description") {
-            Some(Json::String(s)) if !s.is_empty() => Some(s.clone()),
-            _ => None,
-        };
+        let transient = matches!(row.fields.get("transient"), Some(Json::Bool(true)));
+        // The query layer folds the concept's `db.meta/description`
+        // claim into the synthesised descriptor, so the descriptor
+        // is the read path for it.
+        let description = descriptor
+            .description()
+            .filter(|d| !d.is_empty())
+            .map(str::to_owned);
         out.push(ConceptInfo {
             name,
             entity: row.this.to_string(),
             description,
             descriptor,
+            transient,
         });
     }
-    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out.sort_by(|a, b| match (&a.name, &b.name) {
+        // Named concepts first (alphabetical), anonymous after
+        // (by entity), matching the attribute ordering.
+        (Some(x), Some(y)) => x.cmp(y),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => a.entity.cmp(&b.entity),
+    });
     Ok(out)
+}
+
+/// Render every view instance on the branch as `view!:` blocks.
+///
+/// A view is ordinary data — three claims of the stdlib `view`
+/// concept (`model`, `display`) — so unlike concepts and rules it
+/// needs no descriptor reconstruction, just enumeration. The
+/// stored `this` is emitted verbatim: most stdlib views pin
+/// entities like `id:tonk:blank/view` that an anchor-derived
+/// `id:{anchor}` would silently move.
+pub async fn render_views(site: &TonkSite) -> Result<String> {
+    const QUERY: &str = r#"view:
+  this:    ?v
+  model:   ?model
+  display: ?display
+"#;
+    let response = run_query(site, QUERY).await?;
+    let block = expect_block(&response, "view")?;
+    let names = name_claims_by_entity(site).await?;
+
+    let mut views: Vec<(String, Option<String>, String, String)> = Vec::new();
+    for row in &block.results {
+        let model = take_string(&row.fields, "model");
+        let display = take_string(&row.fields, "display");
+        let name = row
+            .this
+            .parse::<Entity>()
+            .ok()
+            .and_then(|entity| names.get(&entity).cloned());
+        views.push((row.this.clone(), name, model, display));
+    }
+    // Named views first (alphabetical), anonymous after (by
+    // entity), matching the attribute and concept ordering.
+    views.sort_by(|a, b| match (&a.1, &b.1) {
+        (Some(x), Some(y)) => x.cmp(y),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => a.0.cmp(&b.0),
+    });
+
+    let mut out = String::new();
+    for (this, name, model, display) in &views {
+        match name {
+            Some(name) => {
+                let _ = writeln!(out, "view!: &{name}");
+            }
+            None => out.push_str("view!:\n"),
+        }
+        let _ = writeln!(out, "  this: {this}");
+        let _ = writeln!(out, "  model: {model}");
+        out.push_str("  display: |\n");
+        for line in display.lines() {
+            let _ = writeln!(out, "    {line}");
+        }
+        out.push('\n');
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------- //
+// Rule enumeration                                                 //
+// ---------------------------------------------------------------- //
+
+/// Read every rule stored on the branch, both kinds, sorted by
+/// entity for stable output.
+///
+/// This is the seam a dialog-native enumeration API will replace:
+/// it sweeps the `dialog.rule/source` claims directly and decodes
+/// each canonical body, verifying the content address the way
+/// dialog's own readers do — an entry whose body does not hash
+/// back to its entity is inert and skipped.
+pub async fn enumerate_rules(site: &TonkSite) -> Result<Vec<(Entity, Rule)>> {
+    let the: attribute::The = "dialog.rule/source"
+        .parse()
+        .expect("`dialog.rule/source` is a valid attribute URI");
+    let session = site.branch().await?;
+    let claims: Vec<dialog_query::Claim> = session
+        .handle()
+        .query()
+        .select(AttributeQuery::new(
+            Term::from(the),
+            Term::<Entity>::var("of"),
+            Term::<Vec<u8>>::var("is").into(),
+            Term::<attribute::Cause>::blank(),
+            None,
+        ))
+        .perform(&site.operator)
+        .try_vec()
+        .await
+        .map_err(|e| anyhow!("dialog.rule/source query failed: {e:?}"))?;
+
+    let mut out: Vec<(Entity, Rule)> = Vec::with_capacity(claims.len());
+    for claim in claims {
+        let dialog_artifacts::Value::Bytes(source) = claim.is else {
+            continue;
+        };
+        // The two kinds share the source attribute; the decoded
+        // descriptor's head field decides which one this is.
+        let rule = if let Ok(rule) = InductiveRule::decode(&source) {
+            Rule::Inductive(rule)
+        } else if let Ok(rule) = DeductiveRule::decode(&source) {
+            Rule::Deductive(rule)
+        } else {
+            continue;
+        };
+        let verified = match &rule {
+            Rule::Inductive(rule) => rule.this() == claim.of,
+            Rule::Deductive(rule) => rule.this() == claim.of,
+        };
+        if !verified {
+            continue;
+        }
+        out.push((claim.of, rule));
+    }
+    out.sort_by_key(|(entity, _)| entity.to_string());
+    Ok(out)
+}
+
+/// Concept-name table for rule rendering: the branch's published
+/// concepts plus the analyzer's built-in registry, matched by
+/// descriptor serde form as [`rule_notation::ConceptNames`]
+/// requires.
+struct BranchNames {
+    entries: Vec<(Json, String)>,
+}
+
+impl BranchNames {
+    async fn load(site: &TonkSite) -> Result<Self> {
+        let mut entries = Vec::new();
+        for concept in enumerate_concepts(site).await? {
+            let Some(name) = concept.name else {
+                continue;
+            };
+            entries.push((serde_json::to_value(&concept.descriptor)?, name));
+        }
+        for (name, definition) in tonk_schema::builtin::concept_registry() {
+            entries.push((
+                serde_json::to_value(definition.descriptor.concept())?,
+                (*name).to_string(),
+            ));
+        }
+        Ok(Self { entries })
+    }
+}
+
+impl rule_notation::ConceptNames for BranchNames {
+    fn reference(
+        &mut self,
+        descriptor: &ConceptDescriptor,
+    ) -> Result<String, rule_notation::RenderRuleError> {
+        let form = serde_json::to_value(descriptor)
+            .map_err(|e| rule_notation::RenderRuleError::Serialize(e.to_string()))?;
+        // Exact serde-form match first.
+        if let Some((_, name)) = self
+            .entries
+            .iter()
+            .find(|(candidate, _)| *candidate == form)
+        {
+            return Ok(name.clone());
+        }
+        // Analysis narrows an embedded descriptor to the fields
+        // the premise actually binds, so a rule that uses a
+        // subset of a concept's fields embeds a subset
+        // descriptor. Re-analysis re-narrows the same way from
+        // the same `where:` keys, so a name resolves when
+        // exactly one concept subsumes the narrowed form: every
+        // narrowed field present with a structurally identical
+        // field descriptor. Descriptions are ignored — an
+        // attribute's description is one global claim, so prose
+        // captured at rule-authoring time can drift from what the
+        // branch now says; refusing such a rule would trade its
+        // behavior away to preserve prose. A drift-affected rule
+        // re-derives under a new content address with the
+        // branch's current metadata.
+        // Several concepts can subsume the same narrowed form
+        // (`invitation` ⊂ `tonk/agent-invite` share four
+        // attributes); the tightest fit — fewest fields, then
+        // name for determinism — is the reference the narrowing
+        // most plausibly came from.
+        let mut matches: Vec<(usize, &String)> = self
+            .entries
+            .iter()
+            .filter(|(candidate, _)| subsumes(candidate, &form))
+            .map(|(candidate, name)| {
+                let fields = candidate
+                    .get("with")
+                    .and_then(Json::as_object)
+                    .map(|with| with.len())
+                    .unwrap_or(usize::MAX);
+                (fields, name)
+            })
+            .collect();
+        matches.sort();
+        match matches.first() {
+            Some((_, name)) => Ok((*name).clone()),
+            None => Err(rule_notation::RenderRuleError::UnresolvedConcept {
+                concept: form.to_string(),
+            }),
+        }
+    }
+}
+
+/// `true` when the `full` concept descriptor (serde form) subsumes
+/// the `narrowed` one: every narrowed field present in full with a
+/// field descriptor identical up to descriptions.
+fn subsumes(full: &Json, narrowed: &Json) -> bool {
+    let (Some(Json::Object(full_with)), Some(Json::Object(narrowed_with))) =
+        (full.get("with"), narrowed.get("with"))
+    else {
+        return false;
+    };
+    !narrowed_with.is_empty()
+        && narrowed_with.iter().all(|(field, descriptor)| {
+            full_with.get(field).is_some_and(|candidate| {
+                sans_description(candidate) == sans_description(descriptor)
+            })
+        })
+}
+
+/// A field descriptor's serde form with the description removed —
+/// the structural part that must match exactly for a name
+/// reference to be sound.
+fn sans_description(descriptor: &Json) -> Json {
+    let mut stripped = descriptor.clone();
+    if let Some(map) = stripped.as_object_mut() {
+        map.remove("description");
+    }
+    stripped
 }
 
 /// Built-in concept names hard-coded in
@@ -413,43 +707,83 @@ fn render_attribute(out: &mut String, attr: &AttributeInfo) {
 }
 
 fn render_concept(out: &mut String, concept: &ConceptInfo, uri_to_name: &HashMap<String, String>) {
-    let _ = writeln!(out, "concept!: &{name}", name = concept.name);
+    // A transient concept is a command; `command!:` derives the
+    // same entity as `concept!:` + `transient:`, so the clearer
+    // keyword is safe to prefer.
+    let keyword = if concept.transient {
+        "command!"
+    } else {
+        "concept!"
+    };
+    match &concept.name {
+        Some(name) => {
+            let _ = writeln!(out, "{keyword}: &{name}");
+        }
+        None => {
+            let _ = writeln!(out, "{keyword}:");
+        }
+    }
+    // A stored entity that differs from the descriptor's content
+    // address was pinned at authoring time (`this: tonk:view`);
+    // re-emit the pin so re-evaluation lands on the same entity.
+    if concept.entity != concept.descriptor.this().to_string() {
+        let _ = writeln!(out, "  this: {}", concept.entity);
+    }
     if let Some(desc) = &concept.description {
         let _ = writeln!(out, "  description: {}", quote_string(desc));
     }
-    out.push_str("  with:\n");
-    for (field, attr_descriptor) in concept.descriptor.with().iter() {
-        let uri = attr_descriptor.the().to_string();
-        match uri_to_name.get(&uri) {
-            // Named — use the bare-symbol reference; the
-            // analyzer resolves it through the published name
-            // table on the branch.
-            Some(name) => {
-                let _ = writeln!(out, "    {field}: {name}");
-            }
-            // Anonymous — emit the inline definition so the
-            // re-submitted document carries enough information to
-            // reconstruct the attribute. Uses `the:` URI plus the
-            // type and cardinality.
-            None => {
-                let _ = writeln!(out, "    {field}:");
-                let _ = writeln!(out, "      the:         {uri}");
-                if let Some(t) = attr_descriptor.content_type() {
-                    let _ = writeln!(out, "      as:          {}", type_to_notation(&t));
-                }
-                let card = match attr_descriptor.cardinality() {
-                    Cardinality::One => "one",
-                    Cardinality::Many => "many",
-                };
-                let _ = writeln!(out, "      cardinality: {card}");
-                let desc = attr_descriptor.description();
-                if !desc.is_empty() {
-                    let _ = writeln!(out, "      description: {}", quote_string(desc));
-                }
-            }
+    let (required, optional): (Vec<_>, Vec<_>) = concept
+        .descriptor
+        .with()
+        .iter()
+        .partition(|(_, descriptor)| !descriptor.is_optional());
+    for (block, fields) in [("with", required), ("maybe", optional)] {
+        if fields.is_empty() {
+            continue;
+        }
+        let _ = writeln!(out, "  {block}:");
+        for (field, attr_descriptor) in fields {
+            render_concept_field(out, field, attr_descriptor, uri_to_name);
         }
     }
     out.push('\n');
+}
+
+fn render_concept_field(
+    out: &mut String,
+    field: &str,
+    attr_descriptor: &ConceptFieldDescriptor,
+    uri_to_name: &HashMap<String, String>,
+) {
+    let uri = attr_descriptor.the().to_string();
+    match uri_to_name.get(&uri) {
+        // Named — use the bare-symbol reference; the
+        // analyzer resolves it through the published name
+        // table on the branch.
+        Some(name) => {
+            let _ = writeln!(out, "    {field}: {name}");
+        }
+        // Anonymous — emit the inline definition so the
+        // re-submitted document carries enough information to
+        // reconstruct the attribute. Uses `the:` URI plus the
+        // type and cardinality.
+        None => {
+            let _ = writeln!(out, "    {field}:");
+            let _ = writeln!(out, "      the:         {uri}");
+            if let Some(t) = attr_descriptor.content_type() {
+                let _ = writeln!(out, "      as:          {}", type_to_notation(&t));
+            }
+            let card = match attr_descriptor.cardinality() {
+                Cardinality::One => "one",
+                Cardinality::Many => "many",
+            };
+            let _ = writeln!(out, "      cardinality: {card}");
+            let desc = attr_descriptor.description();
+            if !desc.is_empty() {
+                let _ = writeln!(out, "      description: {}", quote_string(desc));
+            }
+        }
+    }
 }
 
 /// Map a dialog `Type` onto the string accepted by the analyzer

--- a/rust/tonk-cli/tests/notation.rs
+++ b/rust/tonk-cli/tests/notation.rs
@@ -368,17 +368,170 @@ mod when_introspecting_the_schema {
 
     use crate::common::{self, ATTRIBUTE_DECL, CONCEPT_DECL};
 
-    // TODO(post-#447): re-port `tonk_cli::schema::render` to the new
-    // analyzer model. After the head/this/anchor rewrite, the
-    // built-in `attribute:` query no longer surfaces standalone
-    // attribute entities the same way, and the `as:` value
-    // capitalisation needs to round-trip through `text` /
-    // `boolean` / etc. instead of `Text` / `Boolean`. The
-    // re-submittability contract this test pins is still a
-    // load-bearing property — leave the test in place but
-    // ignored so the next pass can flip it back on.
+    /// The full behavior round trip: schema + rules + views
+    /// synthesized off one branch must re-evaluate on a fresh
+    /// branch and synthesize identically there. Rule identity is
+    /// checked by entity — the entity is the content address of
+    /// the canonical body, so set equality is byte equality.
     #[dialog_common::test]
-    #[ignore = "schema render needs a separate port to the post-#447 analyzer model"]
+    async fn it_round_trips_behavior_through_notation() -> Result<()> {
+        let test = common::TestSite::new().await?;
+        test.eval_inline(
+            r#"
+attribute!: &rt-tag
+  description: "round-trip tag"
+  the:         xyz.tonk.rt/tag
+  as:          text
+  cardinality: one
+
+attribute!: &rt-echo
+  description: "round-trip echo"
+  the:         xyz.tonk.rt/echo
+  as:          text
+  cardinality: one
+
+command!: &rt-ping
+  description: "round-trip ping"
+  with:
+    tag: rt-tag
+
+concept!: &rt-pong
+  this: tonk:rt-pong
+  description: "round-trip pong"
+  with:
+    echo: rt-echo
+
+rule!:
+  assert!: rt-pong
+  when:
+    - assert: rt-ping
+      where:
+        this: ?this
+        tag: ?echo
+
+view!: &rt-pong-view
+  this: id:rt-pong/view
+  model: tonk:rt-pong
+  display: |
+    <div>{echo}</div>
+"#,
+        )
+        .await?;
+
+        let concepts = schema::render(&test.site).await?;
+        let rules = schema::render_rules(&test.site).await?;
+        let views = schema::render_views(&test.site).await?;
+        assert!(rules.contains("rule!:"), "{rules}");
+        assert!(rules.contains("assert!: rt-pong"), "{rules}");
+        assert!(rules.contains("assert: rt-ping"), "{rules}");
+        assert!(
+            views.contains("view!: &rt-pong-view\n  this: id:rt-pong/view"),
+            "{views}"
+        );
+
+        assert!(
+            !rules.contains("not expressible"),
+            "every stored rule should render:\n{rules}"
+        );
+
+        let fresh = common::TestSite::new().await?;
+        let outcome = fresh
+            .eval_inline(&format!("{concepts}{rules}{views}"))
+            .await?;
+        assert!(outcome.committed, "replay should commit");
+
+        // The authored rule must survive the round trip
+        // byte-identically — the entity is the content address of
+        // the canonical body, so membership is byte equality.
+        // (Stdlib rules whose embedded attribute descriptions
+        // drifted from the branch's current claims legitimately
+        // re-derive under new addresses, so full set equality is
+        // not the contract.)
+        let rt_rule: Vec<String> = schema::enumerate_rules(&test.site)
+            .await?
+            .into_iter()
+            .filter_map(|(entity, rule)| {
+                let tonk_schema::rule::Rule::Inductive(rule) = rule else {
+                    return None;
+                };
+                serde_json::to_string(&rule.descriptor())
+                    .ok()?
+                    .contains("xyz.tonk.rt/echo")
+                    .then(|| entity.to_string())
+            })
+            .collect();
+        assert_eq!(rt_rule.len(), 1, "the authored rule should be stored");
+        let replayed: std::collections::HashSet<String> = schema::enumerate_rules(&fresh.site)
+            .await?
+            .into_iter()
+            .map(|(entity, _)| entity.to_string())
+            .collect();
+        assert!(
+            replayed.contains(&rt_rule[0]),
+            "rule {} must survive the round trip byte-identically",
+            rt_rule[0]
+        );
+
+        assert_eq!(concepts, schema::render(&fresh.site).await?);
+        assert_eq!(views, schema::render_views(&fresh.site).await?);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_renders_commands_descriptions_and_optional_fields() -> Result<()> {
+        let test = common::TestSite::new().await?;
+        test.eval_inline(
+            r#"
+attribute!: &ping-tag
+  description: "ping tag"
+  the:         xyz.tonk.test/ping-tag
+  as:          text
+  cardinality: one
+
+attribute!: &ping-note
+  description: "ping note"
+  the:         xyz.tonk.test/ping-note
+  as:          text
+  cardinality: one
+
+command!: &ping
+  description: "a ping command"
+  with:
+    tag: ping-tag
+  maybe:
+    note: ping-note
+
+concept!: &pinned
+  this: tonk:test/pinned
+  description: "a pinned concept"
+  with:
+    tag: ping-tag
+"#,
+        )
+        .await?;
+
+        let rendered = schema::render(&test.site).await?;
+        for marker in [
+            // The transient marker decides the head keyword; the
+            // `command!:` form derives the same entity, so
+            // commandness survives a replay.
+            "command!: &ping",
+            "description: \"a ping command\"",
+            "  maybe:\n    note: ping-note",
+            // Pinned concepts re-emit their `this:` so replay
+            // lands on the authored entity, not the content
+            // address.
+            "concept!: &pinned\n  this: tonk:test/pinned",
+        ] {
+            assert!(
+                rendered.contains(marker),
+                "expected `{marker}` in schema:\n{rendered}",
+            );
+        }
+        Ok(())
+    }
+
+    #[dialog_common::test]
     async fn it_emits_a_re_submittable_notation_document() -> Result<()> {
         let test = common::TestSite::new().await?;
         test.eval_inline(ATTRIBUTE_DECL).await?;

--- a/rust/tonk-cli/tests/schema_read.rs
+++ b/rust/tonk-cli/tests/schema_read.rs
@@ -19,7 +19,7 @@ mod when_reading_a_concepts_schema {
         let info = tonk_cli::schema::find_concept(&test.site, "task")
             .await?
             .expect("task concept should be found");
-        assert_eq!(info.name, "task");
+        assert_eq!(info.name.as_deref(), Some("task"));
         let fields: Vec<&str> = info.descriptor.with().iter().map(|(f, _)| f).collect();
         assert!(
             fields.contains(&"title"),

--- a/rust/tonk-schema/src/lib.rs
+++ b/rust/tonk-schema/src/lib.rs
@@ -54,6 +54,8 @@ pub mod rule_query;
 
 pub mod rule;
 
+pub mod rule_notation;
+
 pub mod builtin;
 
 pub mod query;

--- a/rust/tonk-schema/src/rule_notation.rs
+++ b/rust/tonk-schema/src/rule_notation.rs
@@ -1,0 +1,698 @@
+//! Render a stored dialog rule back into `rule!:` notation.
+//!
+//! The inverse of the analyzer's rule lifting: given an
+//! [`InductiveRule`] or [`DeductiveRule`] hydrated from its
+//! `dialog.rule/source` body, emit the notation block that
+//! re-compiles to the *same content-addressed rule*. The invariant
+//! callers should hold the output to is `encode()` byte equality
+//! (and therefore `this()` equality) between the stored rule and
+//! the re-analyzed render.
+//!
+//! What makes the inverse exact:
+//!
+//! - Variables are stored *by name* in the canonical body, so the
+//!   content address is name-sensitive. Every named variable —
+//!   including analyzer-minted `__N` names from omitted `this:`
+//!   slots — is emitted verbatim; `?__7` re-lifts to the identical
+//!   representation.
+//! - A blank (nameless) concept-field term re-lifts from an
+//!   *omitted* field, so blanks are rendered by omission. Blanks
+//!   in `this` or formula/constraint operands have no notation
+//!   spelling (`_` there mints a *named* unique variable) and fail
+//!   the render instead.
+//! - Concept references have no inline-descriptor notation form;
+//!   the head and every concept premise must resolve to a
+//!   published name whose descriptor matches the embedded one in
+//!   *serde form* (not content address — the address ignores
+//!   descriptions and field names, but the stored body embeds
+//!   them, so a drifted description would silently change the
+//!   re-compiled bytes).
+//!
+//! Rules that cannot be expressed in notation — deductive `reduce`
+//! folds, typed variables, byte/record/symbol constants, sparse
+//! term maps from foreign authoring — return a
+//! [`RenderRuleError`] so the caller can skip them loudly rather
+//! than emit a block that re-compiles to a different rule.
+
+use std::fmt::Write as _;
+
+use dialog_query::{ConceptDescriptor, ConceptQuery, Proposition};
+use serde_json::Value as Json;
+use thiserror::Error;
+
+use crate::rule::{DeductiveRule, InductiveRule, Rule};
+
+/// Why a stored rule could not be rendered as notation.
+#[derive(Debug, Error)]
+pub enum RenderRuleError {
+    /// Deductive `reduce` folds have no notation encoding yet.
+    #[error("deductive `reduce` folds have no notation form")]
+    ReduceNotSupported,
+    /// A variable carries a type stamp, which notation cannot spell.
+    #[error("variable {name:?} carries a type stamp notation cannot express")]
+    TypedVariable {
+        /// The stamped variable's name, when it has one.
+        name: String,
+    },
+    /// A constant value kind notation cannot spell.
+    #[error("{kind} constants have no notation form")]
+    InexpressibleConstant {
+        /// Human tag of the offending value kind.
+        kind: &'static str,
+    },
+    /// A concept premise's term map does not cover exactly
+    /// `this` + the predicate's fields — foreign authoring.
+    #[error("concept premise terms do not match the predicate's fields")]
+    SparseConceptTerms,
+    /// A blank term sits in a slot whose omission would re-mint a
+    /// *named* unique variable instead of a blank.
+    #[error("blank {slot} operand has no notation form")]
+    BlankOperand {
+        /// The slot the blank sits in (`this`, or an operand name).
+        slot: String,
+    },
+    /// No published name carries a descriptor equal (in serde
+    /// form) to the one embedded in the rule.
+    #[error("no published concept name matches the embedded descriptor ({concept})")]
+    UnresolvedConcept {
+        /// Compact summary of the unmatched descriptor —
+        /// description plus field names — for the skip comment.
+        concept: String,
+    },
+    /// The rule body failed to serialize — should not happen for a
+    /// rule that was hydrated from storage.
+    #[error("rule body failed to serialize: {0}")]
+    Serialize(String),
+}
+
+/// Resolve an embedded concept descriptor to the published name the
+/// notation should reference. Implementations must match by *serde
+/// form* equality (`serde_json::to_value` of both sides), not by
+/// content address — see the module docs for why.
+pub trait ConceptNames {
+    /// The name to write for `descriptor`, or
+    /// [`RenderRuleError::UnresolvedConcept`].
+    fn reference(&mut self, descriptor: &ConceptDescriptor) -> Result<String, RenderRuleError>;
+}
+
+/// Render either rule kind.
+pub fn render_rule(rule: &Rule, names: &mut dyn ConceptNames) -> Result<String, RenderRuleError> {
+    match rule {
+        Rule::Inductive(rule) => render_inductive(rule, names),
+        Rule::Deductive(rule) => render_deductive(rule, names),
+    }
+}
+
+/// Render an inductive rule as a `rule!:` block with an `assert!:`
+/// or `retract!:` head.
+pub fn render_inductive(
+    rule: &InductiveRule,
+    names: &mut dyn ConceptNames,
+) -> Result<String, RenderRuleError> {
+    let descriptor = rule.descriptor();
+    let (head_key, head) = match (&descriptor.assert, &descriptor.retract) {
+        (Some(head), None) => ("assert!", head),
+        (None, Some(head)) => ("retract!", head),
+        // `descriptor()` on a compiled rule always sets exactly one.
+        _ => {
+            return Err(RenderRuleError::Serialize(
+                "inductive descriptor without exactly one head".to_owned(),
+            ));
+        }
+    };
+    render_block(
+        descriptor.description.as_deref(),
+        head_key,
+        head,
+        &descriptor.when,
+        &descriptor.unless,
+        names,
+    )
+}
+
+/// Render a deductive rule as a `rule!:` block with the no-bang
+/// `assert:` head the analyzer compiles to a deduction.
+pub fn render_deductive(
+    rule: &DeductiveRule,
+    names: &mut dyn ConceptNames,
+) -> Result<String, RenderRuleError> {
+    let descriptor = rule.descriptor();
+    if !descriptor.reduce.is_empty() {
+        return Err(RenderRuleError::ReduceNotSupported);
+    }
+    render_block(
+        descriptor.description.as_deref(),
+        "assert",
+        &descriptor.deduce,
+        &descriptor.when,
+        &descriptor.unless,
+        names,
+    )
+}
+
+fn render_block(
+    description: Option<&str>,
+    head_key: &str,
+    head: &ConceptDescriptor,
+    when: &[Proposition],
+    unless: &[Proposition],
+    names: &mut dyn ConceptNames,
+) -> Result<String, RenderRuleError> {
+    let mut out = String::from("rule!:\n");
+    if let Some(description) = description {
+        let _ = writeln!(out, "  description: {}", quote(description));
+    }
+    let _ = writeln!(
+        out,
+        "  {head_key}: {}",
+        concept_reference(&names.reference(head)?)
+    );
+    for (key, premises) in [("when", when), ("unless", unless)] {
+        if premises.is_empty() {
+            continue;
+        }
+        let _ = writeln!(out, "  {key}:");
+        for premise in premises {
+            render_premise(&mut out, premise, names)?;
+        }
+    }
+    Ok(out)
+}
+
+fn render_premise(
+    out: &mut String,
+    premise: &Proposition,
+    names: &mut dyn ConceptNames,
+) -> Result<(), RenderRuleError> {
+    match premise {
+        Proposition::Concept(query) => render_concept_premise(out, query, names),
+        // Formula, constraint, and resolver premises share the
+        // `{assert: <name>, where: {operands}}` serde shape; the
+        // variant only decides how blanks are treated.
+        Proposition::Formula(_) | Proposition::Constraint(_) => {
+            render_operand_premise(out, premise, SlotPolicy::Operand)
+        }
+        // A resolver's unwritten operands default to blank on the
+        // deserialize path, so omission is their spelling.
+        Proposition::Resolver(_) => {
+            render_operand_premise(out, premise, SlotPolicy::ResolverOperand)
+        }
+        // Attribute-query premises have no formal-notation
+        // encoding, and dialog refuses to store rules containing
+        // them — reachable only through foreign bodies.
+        Proposition::Attribute(_) | Proposition::OptionalAttribute(_) => Err(
+            RenderRuleError::Serialize("attribute-query premises have no notation form".to_owned()),
+        ),
+    }
+}
+
+fn render_concept_premise(
+    out: &mut String,
+    query: &ConceptQuery,
+    names: &mut dyn ConceptNames,
+) -> Result<(), RenderRuleError> {
+    let name = names.reference(&query.predicate)?;
+    let terms = serde_json::to_value(&query.terms)
+        .map_err(|error| RenderRuleError::Serialize(error.to_string()))?;
+    let Json::Object(terms) = terms else {
+        return Err(RenderRuleError::Serialize(
+            "concept premise terms did not serialize as a map".to_owned(),
+        ));
+    };
+    // The analyzer's lifting fills a term for `this` plus *every*
+    // predicate field, so a stored map with any other key set is
+    // foreign authoring the re-lift would silently reshape.
+    let fields: Vec<&str> = query.predicate.with().keys().collect();
+    if terms.len() != fields.len() + 1 || !terms.contains_key("this") {
+        return Err(RenderRuleError::SparseConceptTerms);
+    }
+    for field in &fields {
+        if !terms.contains_key(*field) {
+            return Err(RenderRuleError::SparseConceptTerms);
+        }
+    }
+
+    let _ = writeln!(out, "    - assert: {}", concept_reference(&name));
+    let _ = writeln!(out, "      where:");
+    // `this` first, then the predicate's field order. Order is
+    // free — the analyzer rebuilds a map — but determinism keeps
+    // the output diffable.
+    render_operand(out, "this", &terms["this"], SlotPolicy::ConceptThis)?;
+    for field in fields {
+        render_operand(out, field, &terms[field], SlotPolicy::ConceptField)?;
+    }
+    Ok(())
+}
+
+fn render_operand_premise(
+    out: &mut String,
+    premise: &Proposition,
+    blanks: SlotPolicy,
+) -> Result<(), RenderRuleError> {
+    let json = serde_json::to_value(premise)
+        .map_err(|error| RenderRuleError::Serialize(error.to_string()))?;
+    let (Some(Json::String(name)), Some(Json::Object(operands))) =
+        (json.get("assert"), json.get("where"))
+    else {
+        return Err(RenderRuleError::Serialize(
+            "operand premise did not serialize as {assert, where}".to_owned(),
+        ));
+    };
+    let _ = writeln!(out, "    - assert: {}", concept_reference(name));
+    let _ = writeln!(out, "      where:");
+    // Operand maps serialize from a HashMap; sort for determinism.
+    let mut sorted: Vec<(&String, &Json)> = operands.iter().collect();
+    sorted.sort_by_key(|(key, _)| key.as_str());
+    for (operand, term) in sorted {
+        render_operand(out, operand, term, blanks)?;
+    }
+    Ok(())
+}
+
+/// How the slot at hand treats blanks and type stamps.
+#[derive(Clone, Copy, PartialEq)]
+enum SlotPolicy {
+    /// Concept field: blanks spell as omission (re-lifting an
+    /// omitted field mints a blank again); a type stamp cannot be
+    /// re-derived from notation and fails the render.
+    ConceptField,
+    /// Concept `this`: omission mints a *named* unique variable,
+    /// so a blank has no spelling; type stamps fail as above.
+    ConceptThis,
+    /// Formula / constraint operand: blanks have no spelling
+    /// (omission mints a named variable, `_` likewise), but type
+    /// stamps are structural — the operand cell re-derives the
+    /// same type when the notation is lifted — so `?name` alone
+    /// is the faithful spelling.
+    Operand,
+    /// Resolver operand: unwritten operands default to blank on
+    /// the deserialize path, so omission is their spelling; type
+    /// stamps are structural as above.
+    ResolverOperand,
+}
+
+impl SlotPolicy {
+    fn omits_blanks(self) -> bool {
+        matches!(self, Self::ConceptField | Self::ResolverOperand)
+    }
+
+    fn derives_types(self) -> bool {
+        matches!(self, Self::Operand | Self::ResolverOperand)
+    }
+}
+
+fn render_operand(
+    out: &mut String,
+    slot: &str,
+    term: &Json,
+    policy: SlotPolicy,
+) -> Result<(), RenderRuleError> {
+    // Serialized `Term`: `{"?": {"name"?, "type"?}}` for a
+    // variable, any other JSON value for a constant.
+    if let Some(var) = term.get("?") {
+        if var.get("type").is_some() && !policy.derives_types() {
+            return Err(RenderRuleError::TypedVariable {
+                name: var
+                    .get("name")
+                    .and_then(Json::as_str)
+                    .unwrap_or_default()
+                    .to_owned(),
+            });
+        }
+        return match var.get("name").and_then(Json::as_str) {
+            Some(name) => {
+                let _ = writeln!(out, "        {slot}: ?{name}");
+                Ok(())
+            }
+            None if policy.omits_blanks() => Ok(()),
+            None => Err(RenderRuleError::BlankOperand {
+                slot: slot.to_owned(),
+            }),
+        };
+    }
+    let rendered = render_constant(term)?;
+    let _ = writeln!(out, "        {slot}: {rendered}");
+    Ok(())
+}
+
+/// Spell a constant term so the analyzer lifts it back to the same
+/// [`dialog_artifacts::Value`]:
+///
+/// - strings always quoted (a bare `42`, `true`, or `id:x` would
+///   misclassify), except entity URIs which must stay *unquoted*
+///   (quoting one would demote it to a string and trip the
+///   `as: entity` type check);
+/// - floats through `{:?}` so `2.0` keeps its dot and re-parses as
+///   a float rather than an integer.
+///
+/// Bytes, records, and symbols have no notation spelling. Entity
+/// vs string is decided the way the term serializer decided it:
+/// dialog serializes `Value::Entity` as its URI string, and the
+/// deserialize path (like the analyzer's lifting) reclassifies by
+/// URI shape — so a `Value::String` that *looks* like an entity URI
+/// already round-trips as an entity in the canonical body, and
+/// spelling it unquoted is byte-faithful.
+fn render_constant(term: &Json) -> Result<String, RenderRuleError> {
+    match term {
+        Json::String(text) => {
+            if is_entity_uri(text) {
+                Ok(text.clone())
+            } else {
+                Ok(quote(text))
+            }
+        }
+        Json::Bool(flag) => Ok(flag.to_string()),
+        Json::Number(number) => {
+            if let Some(unsigned) = number.as_u64() {
+                Ok(unsigned.to_string())
+            } else if let Some(signed) = number.as_i64() {
+                Ok(signed.to_string())
+            } else if let Some(float) = number.as_f64() {
+                if !float.is_finite() {
+                    return Err(RenderRuleError::InexpressibleConstant {
+                        kind: "non-finite float",
+                    });
+                }
+                Ok(format!("{float:?}"))
+            } else {
+                Err(RenderRuleError::InexpressibleConstant {
+                    kind: "out-of-range number",
+                })
+            }
+        }
+        // Bytes serialize as arrays, records/symbols as objects —
+        // neither has a notation spelling.
+        Json::Array(_) => Err(RenderRuleError::InexpressibleConstant { kind: "bytes" }),
+        _ => Err(RenderRuleError::InexpressibleConstant {
+            kind: "structured value",
+        }),
+    }
+}
+
+/// `true` when `text` parses as an entity URI, which the analyzer
+/// (and dialog's own untagged deserialize) classifies ahead of
+/// plain strings.
+fn is_entity_uri(text: &str) -> bool {
+    text.parse::<dialog_artifacts::Entity>().is_ok()
+}
+
+/// Spell a concept / formula / constraint name. Bare only when it
+/// is shaped like the symbols the notation classifier accepts
+/// (lowercase kebab, optionally `/`-qualified); quoted otherwise —
+/// the premise `assert:` and rule heads both accept quoted strings.
+fn concept_reference(name: &str) -> String {
+    let symbol_shaped = !name.is_empty()
+        && name.split('/').all(|segment| {
+            !segment.is_empty()
+                && segment
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c.is_ascii_lowercase())
+                && segment
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        })
+        && name.matches('/').count() <= 1;
+    if symbol_shaped {
+        name.to_owned()
+    } else {
+        quote(name)
+    }
+}
+
+fn quote(text: &str) -> String {
+    let mut out = String::with_capacity(text.len() + 2);
+    out.push('"');
+    for character in text.chars() {
+        match character {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            character => out.push(character),
+        }
+    }
+    out.push('"');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use dialog_query::{DeductiveRuleDescriptor, InductiveRuleDescriptor};
+    use serde_json::json;
+
+    use super::*;
+
+    /// Name table keyed by descriptor serde form — the same
+    /// matching rule real callers must use.
+    struct Names(Vec<(Json, String)>);
+
+    impl Names {
+        fn new(entries: &[(&Json, &str)]) -> Self {
+            Self(
+                entries
+                    .iter()
+                    .map(|(descriptor, name)| ((*descriptor).clone(), (*name).to_string()))
+                    .collect(),
+            )
+        }
+    }
+
+    impl ConceptNames for Names {
+        fn reference(&mut self, descriptor: &ConceptDescriptor) -> Result<String, RenderRuleError> {
+            let form = serde_json::to_value(descriptor)
+                .map_err(|error| RenderRuleError::Serialize(error.to_string()))?;
+            self.0
+                .iter()
+                .find(|(candidate, _)| *candidate == form)
+                .map(|(_, name)| name.clone())
+                .ok_or_else(|| RenderRuleError::UnresolvedConcept {
+                    concept: form.to_string(),
+                })
+        }
+    }
+
+    fn counter_concept() -> Json {
+        json!({
+            "with": {
+                "count": {
+                    "the": "counter/count",
+                    "as": "UnsignedInteger",
+                    "cardinality": "one",
+                    "description": "the count"
+                }
+            }
+        })
+    }
+
+    /// Normalize a raw descriptor JSON through the typed
+    /// `ConceptDescriptor` so name-table entries compare in the
+    /// same serde form the renderer produces.
+    fn normalized(descriptor: &Json) -> Json {
+        let typed: ConceptDescriptor = serde_json::from_value(descriptor.clone()).unwrap();
+        serde_json::to_value(&typed).unwrap()
+    }
+
+    #[dialog_common::test]
+    fn it_renders_an_asserting_rule_with_concept_and_formula_premises() {
+        let counter = counter_concept();
+        let descriptor: InductiveRuleDescriptor = serde_json::from_value(json!({
+            "assert!": counter,
+            "when": [
+                {
+                    "assert": counter,
+                    "where": {
+                        "this": { "?": { "name": "this" } },
+                        "count": { "?": { "name": "prev" } }
+                    }
+                },
+                {
+                    "assert": "math/sum",
+                    "where": {
+                        "of": { "?": { "name": "prev" } },
+                        "with": 1,
+                        "is": { "?": { "name": "count" } }
+                    }
+                }
+            ]
+        }))
+        .unwrap();
+        let rule = descriptor.compile().unwrap();
+        let counter_form = normalized(&counter);
+        let mut names = Names::new(&[(&counter_form, "counter")]);
+
+        let rendered = render_inductive(&rule, &mut names).unwrap();
+
+        assert_eq!(
+            rendered,
+            r#"rule!:
+  assert!: counter
+  when:
+    - assert: counter
+      where:
+        this: ?this
+        count: ?prev
+    - assert: math/sum
+      where:
+        is: ?count
+        of: ?prev
+        with: 1
+"#
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_renders_retract_heads_unless_blocks_and_constants() {
+        let counter = counter_concept();
+        let descriptor: InductiveRuleDescriptor = serde_json::from_value(json!({
+            "retract!": counter,
+            "when": [{
+                "assert": counter,
+                "where": {
+                    "this": { "?": { "name": "this" } },
+                    "count": { "?": { "name": "count" } }
+                }
+            }],
+            "unless": [{
+                "assert": counter,
+                "where": {
+                    "this": { "?": { "name": "this" } },
+                    "count": 2.0
+                }
+            }]
+        }))
+        .unwrap();
+        let rule = descriptor.compile().unwrap();
+        let counter_form = normalized(&counter);
+        let mut names = Names::new(&[(&counter_form, "counter")]);
+
+        let rendered = render_inductive(&rule, &mut names).unwrap();
+
+        assert!(rendered.contains("  retract!: counter\n"));
+        assert!(rendered.contains("  unless:\n"), "{rendered}");
+        // `{:?}` keeps the dot so the value re-lifts as a float.
+        assert!(rendered.contains("count: 2.0\n"), "{rendered}");
+    }
+
+    #[dialog_common::test]
+    fn it_renders_a_deductive_rule_with_the_no_bang_head() {
+        let counter = counter_concept();
+        let descriptor: DeductiveRuleDescriptor = serde_json::from_value(json!({
+            "deduce": counter,
+            "when": [{
+                "assert": counter,
+                "where": {
+                    "this": { "?": { "name": "this" } },
+                    "count": { "?": { "name": "count" } }
+                }
+            }]
+        }))
+        .unwrap();
+        let rule = descriptor.compile().unwrap();
+        let counter_form = normalized(&counter);
+        let mut names = Names::new(&[(&counter_form, "counter")]);
+
+        let rendered = render_deductive(&rule, &mut names).unwrap();
+
+        assert!(
+            rendered.starts_with("rule!:\n  assert: counter\n"),
+            "{rendered}"
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_keeps_minted_variable_names_and_omits_blank_fields() {
+        let counter = counter_concept();
+        let descriptor: InductiveRuleDescriptor = serde_json::from_value(json!({
+            "assert!": counter,
+            "when": [
+                {
+                    "assert": counter,
+                    "where": {
+                        "this": { "?": { "name": "this" } },
+                        "count": { "?": { "name": "count" } }
+                    }
+                },
+                {
+                    "assert": counter,
+                    "where": {
+                        // An omitted `this:` at authoring time
+                        // minted this name; it must survive
+                        // verbatim.
+                        "this": { "?": { "name": "__7" } },
+                        // A blank field spells as omission.
+                        "count": { "?": {} }
+                    }
+                }
+            ]
+        }))
+        .unwrap();
+        let rule = descriptor.compile().unwrap();
+        let counter_form = normalized(&counter);
+        let mut names = Names::new(&[(&counter_form, "counter")]);
+
+        let rendered = render_inductive(&rule, &mut names).unwrap();
+
+        assert!(rendered.contains("this: ?__7\n"), "{rendered}");
+        // The blank-count premise renders its `where:` with only
+        // the `this` line; the named-count premise keeps its line.
+        assert!(
+            rendered.contains("      where:\n        this: ?__7\n"),
+            "{rendered}"
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_rejects_reduce_folds_and_unresolved_concepts() {
+        let counter = counter_concept();
+        let reduced: DeductiveRuleDescriptor = serde_json::from_value(json!({
+            "deduce": counter,
+            "when": [{
+                "assert": counter,
+                "where": {
+                    "this": { "?": { "name": "this" } },
+                    "count": { "?": { "name": "n" } }
+                }
+            }],
+            "reduce": { "count": { "apply": "sum", "of": { "?": { "name": "n" } } } }
+        }))
+        .unwrap();
+        let rule = reduced.compile().unwrap();
+        let counter_form = normalized(&counter);
+        let mut names = Names::new(&[(&counter_form, "counter")]);
+        assert!(matches!(
+            render_deductive(&rule, &mut names),
+            Err(RenderRuleError::ReduceNotSupported)
+        ));
+
+        let plain: InductiveRuleDescriptor = serde_json::from_value(json!({
+            "assert!": counter,
+            "when": [{
+                "assert": counter,
+                "where": {
+                    "this": { "?": { "name": "this" } },
+                    "count": { "?": { "name": "count" } }
+                }
+            }]
+        }))
+        .unwrap();
+        let rule = plain.compile().unwrap();
+        let mut empty = Names::new(&[]);
+        assert!(matches!(
+            render_inductive(&rule, &mut empty),
+            Err(RenderRuleError::UnresolvedConcept { .. })
+        ));
+    }
+
+    #[dialog_common::test]
+    fn it_spells_strings_quoted_and_entities_bare() {
+        assert_eq!(
+            render_constant(&json!("plain text")).unwrap(),
+            "\"plain text\""
+        );
+        assert_eq!(render_constant(&json!("id:vault")).unwrap(), "id:vault");
+        assert_eq!(render_constant(&json!(true)).unwrap(), "true");
+        assert_eq!(render_constant(&json!(3)).unwrap(), "3");
+    }
+}


### PR DESCRIPTION
## Why

#722 was the second time a format change forced hand-translating dialog's internal representation of commands and rules out of an old repository. The durable fix is an intermediary format we already have: asserted notation. This PR makes `tonk schema` able to emit a branch's complete behavior — attributes, concepts, commands, rules, views — as a document that re-evaluates cleanly on a fresh branch, so at the next format break the old CLI synthesizes YAML and the new CLI just evaluates it.

## How

`tonk schema` gains composable `--concepts` / `--rules` / `--views` selectors and `--all`, emitting sections in re-evaluation order. The bare command keeps its old scope with fidelity fixed: transient concepts re-emit as `command!:` (same derived entity as `concept!:` + `transient:`), concept descriptions and `maybe:` fields are recovered, pinned `this:` entities are preserved, and built-ins are recognized by registry entity rather than a name list (the `command` sentinel had started leaking through the name list).

Rules are read from their canonical `dialog.rule/source` bodies (both kinds, content-address verified, behind one seam function a future dialog-native enumeration API will replace) and rendered back to `rule!:` notation by a new `tonk-schema::rule_notation` module built as a provable inverse of the analyzer's lifting: variable names — including analyzer-minted `__N` ones — are part of the content address and re-emit verbatim; blanks spell as omission only where re-lifting mints a blank; anything notation cannot express (deductive `reduce` folds, typed concept variables, foreign term maps) becomes an explanatory comment instead of a silently different rule.

Concept references resolve to published names by structural subsumption (analysis narrows embedded descriptors to the fields a premise binds) with a tightest-fit tiebreak, ignoring description drift — an attribute's description is one global claim, so authoring-time prose can disagree with the branch; dropping a rule's behavior to preserve prose would be the wrong trade.

## Verification

- New round-trip test: author attribute/command/concept/rule/view → synthesize → evaluate onto a fresh branch → the authored rule arrives byte-identically (same content address) and concepts/views synthesize identically there.
- The long-ignored `it_emits_a_re_submittable_notation_document` is re-enabled and passes.
- Renderer unit tests cover each head/premise/constant shape and every refusal case.
- `cargo clippy --all --all-targets --all-features -- -D warnings`, `cargo fmt`, wasm no-run build of tonk-schema.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `tonk` CLI and schema handling by adding new functionalities for schema rendering, including rules and views. It introduces new command-line arguments for better selection of output sections and improves the handling of concepts and rules in the schema.

### Detailed summary
- Added `rule_notation` module for rendering rules in notation.
- Introduced new command-line arguments: `concepts`, `rules`, `views`, and `all` for `tonk schema`.
- Enhanced `print_schema` function to handle sections based on command-line arguments.
- Updated `render` functions to include rules and views.
- Improved concept handling by allowing optional names and transient markers.
- Added tests for round-tripping behavior through notation.
- Improved error handling for rendering rules that can't be expressed in notation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->