### PR TITLE
chore: move staging onto tonk.network

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -36,7 +36,7 @@ before a profile exists report as `tonk:anonymous`.
 
 Every web event additionally carries an `environment` super property
 derived from the hostname: `production` (tonk.network), `staging`
-(staging.tonk.xyz), or `dev` (anything else). The marketing site's
+(staging.tonk.network), or `dev` (anything else). The marketing site's
 own snippet registers `environment = "website"` in its repo, so all
 surfaces share one filterable dimension within the PostHog project.
 

--- a/rust/tonk-access-service/README.md
+++ b/rust/tonk-access-service/README.md
@@ -78,7 +78,7 @@ The S3 address uses region `auto`, as R2 requires.
 
 As a Cloudflare Worker, build and deploy with `worker-build` / `wrangler` like any `worker`-based crate (the `cdylib` target).
 
-`wrangler.toml` at the repo root carries three environments. The top level is production on `tonk.network`, `[env.staging]` is `staging.tonk.xyz`, and `[env.preview]` is on no route: the deploy workflow uploads one version of it per pull request under a `pr-<number>` preview alias, reached at a workers.dev URL. Each has its own R2 buckets, because this Worker presigns writes into whichever bucket it is bound to and a preview must not be able to write into a real one.
+`wrangler.toml` at the repo root carries three environments. The top level is production on `tonk.network`, `[env.staging]` is `staging.tonk.network`, and `[env.preview]` is on no route: the deploy workflow uploads one version of it per pull request under a `pr-<number>` preview alias, reached at a workers.dev URL. Each has its own R2 buckets, because this Worker presigns writes into whichever bucket it is bound to and a preview must not be able to write into a real one.
 
 `ACCOUNT_SERVICE_URL` and `REVOCATION_RELAY_URL` are checked in for production and staging but overridden per pull request for preview, since the account worker's own alias URL is not known until its upload returns. The checked-in preview values point at an unresolvable host on purpose: a preview that failed to wire itself has to break rather than serve a real registry through `/.well-known/tonk` to browsers that trust it. Bootstrapping the preview environment is described in `tonk-account-service`'s README.
 

--- a/rust/tonk-account-service/README.md
+++ b/rust/tonk-account-service/README.md
@@ -40,7 +40,7 @@ own disjoint credentials, so none of them can derive an apex root key.
 Two things follow. Production account ceremonies run only on `tonk.network`;
 `tonk-ui` refuses ceremonies on every other production-facing host rather than
 writing a second, disjoint identity for the same person into this registry.
-And staging runs off-apex on `staging.tonk.xyz` against its own registry,
+And staging runs off-apex on `staging.tonk.network` against its own registry,
 minting staging-only credentials.
 
 Widening the RP ID later is possible via Related Origin Requests. Narrowing it
@@ -179,7 +179,7 @@ First deploy, in order:
 
 ### Staging
 
-Staging is a wrangler environment in the same config, on `accounts-staging.tonk.xyz`
+Staging is a wrangler environment in the same config, on `accounts-staging.tonk.network`
 with its own database and bucket. Deploy it the same way, in order:
 
 1. `wrangler d1 create tonk-accounts-staging` and paste the returned id into
@@ -191,24 +191,26 @@ with its own database and bucket. Deploy it the same way, in order:
    Secrets are per-environment, so this has to be set explicitly — with the
    same value as production's key, since staging sends from the same verified
    domain.
-6. Add the WAF rate limiting rule for `accounts-staging.tonk.xyz`, matching
-   the production rule above. Staging shares the production Resend key, so it
-   shares the email fan-out vector.
+6. Add the WAF rate limiting rule for `accounts-staging.tonk.network`, matching
+   the production rule above. Note the zone differs: staging is on the
+   `tonk.network` zone, so the rule has to be created there rather than
+   alongside production's on `tonk.xyz`. Staging shares the production Resend
+   key, so it shares the email fan-out vector.
 7. `wrangler deploy -c wrangler.account.toml --env staging`.
 
 There is no DNS step: the route is a Custom Domain (`custom_domain = true`),
 so wrangler provisions the record and certificate itself on deploy. Creating
-`accounts-staging.tonk.xyz` by hand beforehand conflicts with that and blocks
+`accounts-staging.tonk.network` by hand beforehand conflicts with that and blocks
 the deploy.
 
 Exercise the flow against staging by creating an account on
-`https://staging.tonk.xyz/account`—the page reads the staging provider from
+`https://staging.tonk.network/account`—the page reads the staging provider from
 `GET /.well-known/tonk`—then linking the CLI:
 
 ```
 tonk account link \
-  --service-url https://accounts-staging.tonk.xyz \
-  --account-url https://staging.tonk.xyz/account/link
+  --service-url https://accounts-staging.tonk.network \
+  --account-url https://staging.tonk.network/account/link
 ```
 
 ### Preview

--- a/rust/tonk-analytics/src/web.rs
+++ b/rust/tonk-analytics/src/web.rs
@@ -65,11 +65,11 @@ export function ph_init(key, host) {
         // environment = "website" in its own repo) apart within the
         // shared PostHog project.
         // tonk.network is the production origin the CLI builds invite links
-        // against. Staging has only its staging.tonk.xyz origin.
+        // against. Staging has only its staging.tonk.network origin.
         var host = location.hostname;
         var environment =
             host === "tonk.network" ? "production"
-            : host === "staging.tonk.xyz" ? "staging"
+            : host === "staging.tonk.network" ? "staging"
             : "dev";
         window.posthog.register({ environment: environment });
         return true;

--- a/rust/tonk-cli/src/invite.rs
+++ b/rust/tonk-cli/src/invite.rs
@@ -654,14 +654,14 @@ mod tests {
 
         #[dialog_common::test]
         fn it_replaces_the_access_service_path_with_join() {
-            let base = base_url_for_remote("https://staging.tonk.xyz/ucan/").unwrap();
-            assert_eq!(base, "https://staging.tonk.xyz/join");
+            let base = base_url_for_remote("https://staging.tonk.network/ucan/").unwrap();
+            assert_eq!(base, "https://staging.tonk.network/join");
         }
 
         #[dialog_common::test]
         fn it_handles_an_endpoint_with_no_path() {
-            let base = base_url_for_remote("https://staging.tonk.xyz").unwrap();
-            assert_eq!(base, "https://staging.tonk.xyz/join");
+            let base = base_url_for_remote("https://staging.tonk.network").unwrap();
+            assert_eq!(base, "https://staging.tonk.network/join");
         }
 
         /// `/ucan` and `/ucan/` behave identically: joining an
@@ -672,8 +672,8 @@ mod tests {
         #[dialog_common::test]
         fn it_treats_a_trailing_slash_as_irrelevant() {
             assert_eq!(
-                base_url_for_remote("https://staging.tonk.xyz/ucan").unwrap(),
-                base_url_for_remote("https://staging.tonk.xyz/ucan/").unwrap(),
+                base_url_for_remote("https://staging.tonk.network/ucan").unwrap(),
+                base_url_for_remote("https://staging.tonk.network/ucan/").unwrap(),
             );
         }
 

--- a/rust/tonk-host/src/space_origin.rs
+++ b/rust/tonk-host/src/space_origin.rs
@@ -9,7 +9,7 @@
 //! resolution; classification then reduces to an origin comparison.
 //!
 //! It is an ILLUSION. The document is really served from the host origin
-//! (`staging.tonk.xyz`) at `/space/{did}/...`; the host translates a
+//! (`staging.tonk.network`) at `/space/{did}/...`; the host translates a
 //! guest-world path back to the real route at the bridge. Only the guest's
 //! internal coordinate system is the per-space origin.
 //!

--- a/rust/tonk-identity/src/passkey.rs
+++ b/rust/tonk-identity/src/passkey.rs
@@ -324,7 +324,7 @@ mod tests {
         assert_eq!(apex_rp_id("www.tonk.network"), None);
         assert_eq!(apex_rp_id("hub.tonk.network"), None);
         assert_eq!(apex_rp_id("a.b.tonk.network"), None);
-        assert_eq!(apex_rp_id("staging.tonk.xyz"), None);
+        assert_eq!(apex_rp_id("staging.tonk.network"), None);
         assert_eq!(apex_rp_id("localhost"), None);
         // A suffix match must not treat a sibling registrable domain as ours.
         assert_eq!(apex_rp_id("evil-tonk.network"), None);

--- a/wrangler.account.toml
+++ b/wrangler.account.toml
@@ -30,7 +30,7 @@ EMAIL_FROM = "tonk <accounts@tonk.xyz>"
 # tonk.network apex so staging mints its own passkey credentials rather than
 # production ones (see the RP ID invariants in the crate README).
 [env.staging]
-routes = [{ pattern = "accounts-staging.tonk.xyz", custom_domain = true }]
+routes = [{ pattern = "accounts-staging.tonk.network", custom_domain = true }]
 
 # Ships empty on purpose, as production's did: wrangler refuses to deploy
 # without it, so there is no way to silently deploy staging against the

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -66,7 +66,7 @@ REVOCATION_RELAY_URL = "https://accounts.tonk.xyz/revocations"
 EMAIL_FROM = "tonk <accounts@tonk.xyz>"
 
 [env.staging]
-routes = [{ pattern = "staging.tonk.xyz", custom_domain = true }]
+routes = [{ pattern = "staging.tonk.network", custom_domain = true }]
 
 [[env.staging.r2_buckets]]
 binding = "BUCKET"
@@ -93,8 +93,8 @@ migrations_dir = "rust/tonk-access-service/migrations-ingest"
 [env.staging.vars]
 R2_ACCOUNT_ID = "5f20ca8a0de0a5ac52a14fa8bf9c90db"
 R2_BUCKET_NAME = "tonk-spaces-staging"
-ACCOUNT_SERVICE_URL = "https://accounts-staging.tonk.xyz"
-REVOCATION_RELAY_URL = "https://accounts-staging.tonk.xyz/revocations"
+ACCOUNT_SERVICE_URL = "https://accounts-staging.tonk.network"
+REVOCATION_RELAY_URL = "https://accounts-staging.tonk.network/revocations"
 EMAIL_FROM = "tonk <accounts@tonk.xyz>"
 
 # Preview. Every pull request uploads a version of this environment under a


### PR DESCRIPTION
#730 moved production to the `tonk.network` apex but left staging on `staging.tonk.xyz`, so the two deployments now straddle different registrable domains. That split is the kind of thing that quietly rots: anything reasoning about "our origin" has to know about two of them, and the analytics environment tag had already drifted as a result. This moves staging onto the same domain as production.

Routes become `staging.tonk.network` and `accounts-staging.tonk.network`. The access service's staging vars follow, since they name the account service directly. Custom Domains provision their own DNS record and certificate on deploy, so there is no DNS step to do by hand.

The passkey RP ID is the reason to be careful here, and it survives the move intact. `apex_rp_id` matches the apex exactly (`host == RP_APEX`), so `staging.tonk.network` is off-apex and mints its own credentials rather than production's — the same property `staging.tonk.xyz` had, now holding for a subdomain of the apex rather than a separate domain. The test that pinned this was asserting it about the retired hostname, so it now asserts it about the one that actually ships.

One change is not cosmetic: `tonk-analytics` decides the PostHog `environment` super-property by comparing `location.hostname` literally. Left alone, every staging event would have been tagged `dev` and mixed into the dev bucket in the shared project.

## Deployment note

The WAF rate limiting rule for the account service does not carry over. It is scoped to zone `tonk.xyz` and matches on `http.host`, so moving staging to `tonk.network` puts it in a different zone and the rule stops applying. It is the only per-IP limit on unauthenticated `POST /codes`, `/accounts/preflight`, and `/links` — the service enforces a per-email cooldown but nothing per-IP, and staging shares production's Resend key. It needs recreating on the `tonk.network` zone at deploy time; the account service README now says so.

## Verification

- `cargo fmt --all` clean
- `cargo clippy --all --all-targets --all-features -- -D warnings` clean
- `cargo test -p tonk-identity -p tonk-analytics` passing
- `cargo test --no-run --target wasm32-unknown-unknown -p tonk-identity -p tonk-analytics` compiles, so the wasm-gated RP-ID test is not stale
- Both wrangler configs parse and resolve to the intended routes
- Two `tonk-cli` `when_migrating_from_carry` failures are pre-existing on `staging` (malformed stored account-session state, `missing field pending_detaches`) and unrelated; confirmed by running them against an unmodified tree
- No CI changes needed: `publish.yml` deploys via `--env staging -c wrangler.toml` and reads the route from config, and `.github/` contains no hostname literals

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating references from `staging.tonk.xyz` to `staging.tonk.network` across various files to ensure consistency in the staging environment URLs.

### Detailed summary
- Updated documentation comments in `rust/tonk-host/src/space_origin.rs`.
- Changed assertions in `rust/tonk-identity/src/passkey.rs`.
- Modified route patterns in `wrangler.account.toml` and `wrangler.toml`.
- Updated environment descriptions in `docs/telemetry.md`.
- Adjusted comments in `rust/tonk-analytics/src/web.rs`.
- Changed URLs in `rust/tonk-cli/src/invite.rs`.
- Updated service URLs in `rust/tonk-access-service/README.md` and `rust/tonk-account-service/README.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->