### PR TITLE
test(cli): avoid revision-hash collision in live migration assertion

### DIFF
--- a/rust/tonk-cli/tests/live_migration.rs
+++ b/rust/tonk-cli/tests/live_migration.rs
@@ -74,21 +74,29 @@ concept!: &pong
     // The derived fact is durable...
     let pong = test
         .eval_inline("pong:\n  this: ?this\n  tag: ?tag\n")
-        .await?
-        .stdout;
-    assert!(
-        pong.contains("hi"),
-        "the rule must derive a durable pong from the ping command; saw:\n{pong}"
+        .await?;
+    let pong_results = &pong.response.matches_after[0].results;
+    assert_eq!(
+        pong_results.len(),
+        1,
+        "the rule must derive exactly one durable pong from the ping command; saw:\n{}",
+        pong.stdout
+    );
+    assert_eq!(
+        pong_results[0].fields.get("tag"),
+        Some(&serde_json::json!("hi")),
+        "the derived pong must retain the command's tag; saw:\n{}",
+        pong.stdout
     );
 
     // ...and the command itself was swept, never committed.
     let ping = test
         .eval_inline("ping:\n  this: ?this\n  tag: ?tag\n")
-        .await?
-        .stdout;
+        .await?;
     assert!(
-        !ping.contains("hi"),
-        "a command must not persist past the commit that dispatched it; saw:\n{ping}"
+        ping.response.matches_after[0].results.is_empty(),
+        "a command must not persist past the commit that dispatched it; saw:\n{}",
+        ping.stdout
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

- assert live-migration query results through structured matches instead of rendered stdout
- verify the derived pong row and its tag directly
- verify the transient ping query returns zero rows

## Root cause

The staging failure was a false positive. The test searched the entire rendered response for `hi`; the failing response had zero claims, but its revision hash contained `hi` (`#5aivuLX7hi7FF...`).

## Verification

- `cargo fmt --all -- --check`
- `nix develop path:. -c cargo test -p tonk-cli --test live_migration -- --nocapture` (3 passed)
- `nix develop path:. -c test:native:debug` (1,497 passed, 4 skipped)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the assertions in the test for live migration in the `tonk-cli` by ensuring that the derived `pong` retains the correct tag and that the `ping` command does not persist after execution.

### Detailed summary
- Changed the assertion for `pong` to check the length of results and ensure exactly one result is derived.
- Updated the assertion for `pong` to confirm the derived tag matches the expected value.
- Modified the assertion for `ping` to check that no results persist after execution.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->