### PR TITLE
feat: deny service until the account confirms its email

### DIFF
--- a/plan/account-activation-gate.md
+++ b/plan/account-activation-gate.md
@@ -1,0 +1,130 @@
+# Account activation gate
+
+Status: draft for implementation
+Scope: `tonk-access-service` presign path, the browser custody ceremony, and the worker's pending-publish outbox
+Builds on: #726 (`feat/account-envelope`), implements the enforcement half of `plan/Access metering.md` §3.1–3.2
+
+## 1. What is missing
+
+`plan/Access metering.md` already specifies the registration lifecycle, and #726 implements all of it: `/customer/enroll` writes a `Registered` customer, the service emails a self-signed `/customer/activate` invocation, and executing it flips the customer to `Active`. The status is recorded, surfaced on the dashboard, and polled.
+
+Nothing reads it on the hot path. `provisioning::screen` exists in `rust/tonk-access-service/src/provisioning.rs` and is never called: the presign path runs `screen_credentials` and `screen_consumer_state` and stops there. Every space, and every account, is served identically whether or not its customer ever confirmed an email address. Any self-minted keypair stores bytes under its own namespace, unbilled and unattributable.
+
+This plan wires the gate in and enforces it unconditionally.
+
+## 2. The rule
+
+A subject is servable only when an `Active` customer pays for it:
+
+- the subject is itself a customer with `status = Active`, or
+- the subject is a consumer whose `provider` names a customer with `status = Active`.
+
+`Registered` (enrolled, email not yet confirmed) and `Suspended` both deny. An unknown subject, and a consumer with no provider, deny. A store failure is the service's own unavailability — 503, not a denial billed to the customer.
+
+That is exactly what `screen` already implements. This plan does not change the predicate; it calls it.
+
+### Adding also requires activation
+
+Registration commands are intercepted in `serve` before `presign` runs (`handlers/ucan.rs`), so `/customer/enroll`, `/customer/activate`, `/provider/add`, and the deletion family never reach the presign gate. For enroll and activate that is load-bearing: activation itself must work while the customer is `Registered`, or nothing could ever activate.
+
+`/provider/add` is different, and this plan **reverses `plan/Access metering.md` §3.3**. That section allowed adding under a `Registered` customer on the grounds that servability is derived state and such a consumer derives to denied anyway. The reversal makes the rule uniform instead: an unactivated customer gets nothing, neither service nor provisioning. `add` checks the status itself and refuses anything but `Active`.
+
+The cost §3.3 predicted is real — a client that creates spaces before the email is confirmed now holds deferred provisioning work — and section 5 is where that queue is specified. What it buys is one rule with one enforcement point per act, rather than an accepted write whose effect is silently withheld.
+
+## 3. Enforcement
+
+`provisioning::screen` is called from both presign paths, after cryptographic authorization succeeds and alongside the existing screens:
+
+- the worker: `presign` in `rust/tonk-access-service/src/handlers/ucan.rs`
+- the native twin: `handle_request` in `rust/tonk-access-service/src/helpers/server.rs`
+
+Always enforced. No configuration var, no ramp: a flag defaulted off is a gate that is not there, and one defaulted on is a switch for turning billing enforcement off in production. The refusal is an `AuthorizeError::PolicyViolation` carrying the cause, which answers 403 and meters as an attributable denial through the path that already exists.
+
+Both paths must gate. The native server backs the integration tests and `tonk dev`, so a gate wired only into the worker would be untested and would behave differently in development than in production.
+
+## 4. The ceremony ordering problem
+
+With the gate on, browser account creation breaks. Today (`rust/tonk-identity/src/ceremony.rs`, `create_custody_account`):
+
+```
+1. generate the account secret, create the custody passkey, seal the envelope
+2. publish the custody cell        <- /memory/publish on the CUSTODY DID, via /ucan/
+3. sign the account-creation request
+4. /customer/enroll                <- the account DID becomes a Registered customer
+5. /provider/add kind=custody      <- the custody DID becomes a consumer
+```
+
+Step 2 is a data-plane write screened by the gate, and at that moment its subject is neither a customer nor a consumer: both rows are created in steps 4–5. So it is denied, and `create_custody_account` treats a refused publish as fatal — deliberately, because an account whose sealed secret was never published can only be unlocked by the page that is still holding it.
+
+Regular spaces do not have this problem. `create_repository` invokes `/provider/add` before any remote is attached, and the first block write happens later, only once sync is enabled. Provisioning already precedes the data plane there.
+
+## 5. The pending-work queue
+
+Nothing an unactivated customer asks for can succeed: not `/provider/add`, not the custody publish, not provisioning a space created in the meantime. Rather than fail each of those at its call site, the client records them as pending work and replays them when activation lands.
+
+The queue is a list of entries at a credential site in the profile repository, the way the account provider record and the customer record already live (`state.profile.credential().site(...)`). It survives reload and browser restart, which page memory does not — the activation click routinely lands in a different tab, and may land days later.
+
+Two entry kinds:
+
+- **provision** — a consumer DID, its consent chain, and its kind (`space` or `custody`); replayed as `/provider/add`
+- **publish** — the custody DID and the sealed envelope bytes; replayed as the `/memory/publish` that fills the custody cell
+
+Ordering matters within the queue: a publish for a custody DID must not be replayed before that DID's provision entry, or the presign gate denies it for having no provider. Entries replay in the order they were recorded, which gives that for free.
+
+Account creation becomes:
+
+```
+1. generate the account secret, create the custody passkey, seal the envelope
+2. sign the account-creation request
+3. /customer/enroll                     -> Registered
+4. queue provision(custody, kind=custody)
+5. queue publish(custody cell, sealed)
+6. drain                                -> both refused while Registered; entries stand
+   ...
+7. user clicks the activation link      -> Active
+8. drain                                -> provision, then publish; entries cleared
+```
+
+A space created before activation appends a `provision` entry the same way and is simply not hosted until the drain succeeds; it works locally throughout.
+
+The envelope is sealed under the passkey's PRF-derived KEK before it is ever handed out, so what waits at rest is ciphertext, not key material. That is the same envelope that would otherwise sit in the custody cell, which is itself remote storage the service can read; parking it locally is strictly less exposure, not more.
+
+### Drain points
+
+The queue is drained whenever the customer's status is read or changes:
+
+- immediately after an entry is appended, so an already-active customer never waits
+- on the customer status probe the dashboard polls, which is what notices activation
+- after `/customer/activate` completes in the same browser
+
+No timer and no background loop: the status probe already runs on the account panel, and it is the only thing that learns about activation. A drain stops at the first entry that fails and leaves it, and everything after it, queued — this is what keeps provision-before-publish honest without the drain having to know why an entry failed.
+
+An entry whose failure means the work is already done is cleared rather than retried: `ConsumerProvided` for a provision (some other device got there first), and a custody cell that already holds an envelope for this credential, which is how `enroll_custody` already reconciles a re-enrolled credential.
+
+### Failure surface
+
+Until the publish lands, the account cannot be unlocked from a *different* browser — `assert_unlock` resolves the cell, and there is nothing there. The creating browser is unaffected: it holds the queue. This is a real narrowing of the window in which an account is portable, and it is why the drain is driven from the status probe rather than left for the next ceremony.
+
+## 6. Saying why
+
+A refusal that only says "forbidden" is unactionable: the user's account is fine, they simply have an unopened email. Both refusal paths name that cause.
+
+The presign gate answers `AuthorizeError::PolicyViolation` whose predicate distinguishes the reason — `"awaits email activation"` for a `Registered` provider, as against `"is suspended"` or `"is not provisioned"`. That string is already what `provisioning::denial` builds; it reaches the client because the refusal body is the serde-tagged error itself, on both the worker and the native server.
+
+`/provider/add` gets a first-class `RegistrationError::CustomerInactive`, alongside the existing `CustomerActive` and `CustomerSuspended`, carrying the same meaning in the registration vocabulary: enrolled, awaiting email confirmation. The worker maps it to a queued entry rather than a surfaced failure, and the dashboard's activation notice — which already reads "Sync activation pending: open the link we emailed to …" — is what the user sees.
+
+### Getting another email
+
+The way out of a stuck `Registered` is always available: `/customer/enroll` is idempotent while `Registered` — the rows stand and the activation email is resent (§3.1 names this the recovery for an expired link, and the link carries its own `exp`, so an expired one fails without any stored state). Enroll is a registration command, so it never touches the presign gate and cannot be locked out by it. The dashboard's activation notice gets a resend control wired to the `enroll_customer` call it already makes, so a user whose link expired or never arrived is one click from another. Nothing else in this plan may refuse while a customer is `Registered` without leaving that path open.
+
+## 7. Tests
+
+- `provisioning.rs` unit tests already cover the predicate. They stay.
+- Service: a presign against an unprovisioned subject, against a consumer of a `Registered` customer, and against a consumer of an `Active` customer — the first two 403, the third serves. Driven through the native server so the HTTP path is covered, not just `screen`.
+- Service: activation flips a previously denied consumer to servable without any further provisioning call, which is the §3.2 rewrite guarantee.
+- Worker: a recorded pending publish is retried and cleared once the customer activates.
+- Browser: `it_signs_up_through_the_account_panels` already creates an account and follows the activation link. It gains an assertion that the custody cell is absent while `Registered` and present after activation.
+
+## 7. Consequences for existing deployments
+
+Every space already served by a deployment that has no `consumer` row, or whose provider never activated, stops being served on deploy. That is the intended effect and the reason the metering plan calls provisioning "state, not a credential" — but it is not a silent change, and staging should be watched through a full sign-up before production follows.

--- a/plan/account-activation-gate.md
+++ b/plan/account-activation-gate.md
@@ -81,6 +81,12 @@ A **publish** is signed by the custody key, which is PRF-derived inside a passke
 
 Because each publish costs a passkey prompt, the panel reads the queue first and raises an assertion only when something is actually waiting.
 
+### Drain before unlocking
+
+A queued publish is not only the dashboard's business. Every root-signed ceremony — CLI approval, link completion, revocation, unlocking on this browser — resolves the custody cell to recover the account secret, so any of them run against a still-queued cell fails with "no account custody is published for this passkey".
+
+That is not hypothetical: it broke three CLI-handoff browser tests as soon as the publish was deferred, for a browser that activated without returning to the dashboard. Each of those call sites drains the queue immediately before unlocking. Anything added later that unlocks the root must do the same.
+
 Account creation becomes:
 
 ```
@@ -141,12 +147,13 @@ The way out of a stuck `Registered` is always available: `/customer/enroll` is i
 - Service: the custody protocol test now activates before provisioning, so it exercises the gate end to end rather than around it.
 - Queue: `tonk_account::pending` unit tests cover recorded order, duplicate suppression, partial clearing after a drain that stopped early, and round-tripping.
 - Fixtures: `AccessServiceAddress::activate_customer` for suites holding a root signer, `provision_subject` for subjects that are repository DIDs no test holds a signer for.
-- Browser: `sign_up` follows the emailed activation link, so every caller gets an account that can host a space; `it_signs_up_through_the_account_panels` asserts the registration row reads `Active` and the pending banner is gone.
+- Browser: `sign_up` follows the emailed activation link, so every caller gets an account that can host a space; `enroll_only` stops at `Registered` for tests that want the waiting window. `it_signs_up_through_the_account_panels` asserts the registration row reads `Active` and the pending banner is gone.
+- Browser: `it_hosts_a_space_created_before_activation_once_the_email_is_confirmed` is the queue end to end — space creation succeeds locally while `Registered`, its push is refused, and after the email is confirmed the same push succeeds with nothing further asked of the user.
 
 ## 9. Still to do
 
-- A browser test that pushes a space *before* clicking the link, then activates and asserts the space becomes hosted — end-to-end proof of the queue, which today is covered only at the unit and service layers.
-- The resend control on the activation notice (§6): `enroll_customer` already resends, and the notice already names the address, but there is no button wired to it yet.
+- Nothing blocking. The queue is proven end to end by `it_hosts_a_space_created_before_activation_once_the_email_is_confirmed`, and the resend control is wired.
+- Worth revisiting: the custody publish drains only where a page can raise an assertion. If a headless client ever needs to publish one, that constraint has to be solved rather than worked around — the key is PRF-derived and a signed invocation lives five minutes.
 
 ## 7. Consequences for existing deployments
 

--- a/plan/account-activation-gate.md
+++ b/plan/account-activation-gate.md
@@ -71,19 +71,32 @@ Two entry kinds:
 
 Ordering matters within the queue: a publish for a custody DID must not be replayed before that DID's provision entry, or the presign gate denies it for having no provider. Entries replay in the order they were recorded, which gives that for free.
 
+### Who replays what
+
+The two kinds drain in different places, because only one of them can be signed without a user present.
+
+A **provision** is signed by the device key, which the worker holds, so the worker replays it directly — from the customer status probe that notices activation, and immediately after any entry is appended so an already-active customer never waits.
+
+A **publish** is signed by the custody key, which is PRF-derived inside a passkey assertion and never stored. The worker cannot sign one, and a pre-signed invocation is not an option either: `/memory/publish` carries `Timestamp::five_minutes_from_now()`, which cannot outlive a wait for an email click. So only the sealed bytes are queued, and the account panel replays them behind a fresh assertion once it observes `Active`. The worker's own drain reports a publish entry as still waiting, which stops the drain there rather than letting later entries overtake it.
+
+Because each publish costs a passkey prompt, the panel reads the queue first and raises an assertion only when something is actually waiting.
+
 Account creation becomes:
 
 ```
 1. generate the account secret, create the custody passkey, seal the envelope
+   (the ceremony no longer publishes; it returns the sealed bytes)
 2. sign the account-creation request
 3. /customer/enroll                     -> Registered
-4. queue provision(custody, kind=custody)
+4. provision(custody, kind=custody)     -> refused, queued
 5. queue publish(custody cell, sealed)
-6. drain                                -> both refused while Registered; entries stand
    ...
-7. user clicks the activation link      -> Active
-8. drain                                -> provision, then publish; entries cleared
+6. user clicks the activation link      -> Active
+7. status probe drains the provision
+8. account panel drains the publish behind a fresh assertion
 ```
+
+Step 1 is the load-bearing change to `create_custody_account`: it used to treat a refused publish as fatal, on the grounds that an account whose sealed secret was never published can only be unlocked by the page still holding it. That reasoning stands — which is why the sealed bytes must reach the queue before the ceremony reports success, and why failing to record them is the one error creation surfaces rather than warns about.
 
 A space created before activation appends a `provision` entry the same way and is simply not hosted until the drain succeeds; it works locally throughout.
 
@@ -95,11 +108,13 @@ The queue is drained whenever the customer's status is read or changes:
 
 - immediately after an entry is appended, so an already-active customer never waits
 - on the customer status probe the dashboard polls, which is what notices activation
-- after `/customer/activate` completes in the same browser
+- on the account panel, for the publish entries only the page can sign
 
 No timer and no background loop: the status probe already runs on the account panel, and it is the only thing that learns about activation. A drain stops at the first entry that fails and leaves it, and everything after it, queued — this is what keeps provision-before-publish honest without the drain having to know why an entry failed.
 
-An entry whose failure means the work is already done is cleared rather than retried: `ConsumerProvided` for a provision (some other device got there first), and a custody cell that already holds an envelope for this credential, which is how `enroll_custody` already reconciles a re-enrolled credential.
+An entry whose failure means the work is already done is treated as success and cleared: `ConsumerProvided` for a provision (some other device got there first), and a custody cell that already holds this account's envelope, which is how `enroll_custody` already reconciles a re-enrolled credential.
+
+A queued publish is opened against the asserting passkey's KEK before it is written. A cell that the credential owning it cannot unseal is worse than no cell, so a mismatch fails rather than publishing.
 
 ### Failure surface
 

--- a/plan/account-activation-gate.md
+++ b/plan/account-activation-gate.md
@@ -132,13 +132,21 @@ The presign gate answers `AuthorizeError::PolicyViolation` whose predicate disti
 
 The way out of a stuck `Registered` is always available: `/customer/enroll` is idempotent while `Registered` — the rows stand and the activation email is resent (§3.1 names this the recovery for an expired link, and the link carries its own `exp`, so an expired one fails without any stored state). Enroll is a registration command, so it never touches the presign gate and cannot be locked out by it. The dashboard's activation notice gets a resend control wired to the `enroll_customer` call it already makes, so a user whose link expired or never arrived is one click from another. Nothing else in this plan may refuse while a customer is `Registered` without leaving that path open.
 
-## 7. Tests
+## 8. Tests
 
 - `provisioning.rs` unit tests already cover the predicate. They stay.
-- Service: a presign against an unprovisioned subject, against a consumer of a `Registered` customer, and against a consumer of an `Active` customer — the first two 403, the third serves. Driven through the native server so the HTTP path is covered, not just `screen`.
-- Service: activation flips a previously denied consumer to servable without any further provisioning call, which is the §3.2 rewrite guarantee.
-- Worker: a recorded pending publish is retried and cleared once the customer activates.
-- Browser: `it_signs_up_through_the_account_panels` already creates an account and follows the activation link. It gains an assertion that the custody cell is absent while `Registered` and present after activation.
+- Service: `it_denies_presign_until_the_customer_confirms_their_email` drives the real HTTP endpoints — an unprovisioned subject 403s naming "not provisioned", an enrolled-but-unactivated customer's own account subject 403s naming "awaits email activation", and following the emailed link lifts it with no further provisioning call. That last step is also the §3.2 rewrite guarantee, and the proof that enrollment's atomic self-consumer row is what makes the account space servable.
+- Service: `it_refuses_provisioning_until_the_customer_confirms_their_email` asserts `CustomerInactive`, that no consumer row is written, and that the same add replays successfully after activation — the contract the client queue depends on.
+- Service: provisioning idempotence, both directions. Re-adding under the same customer succeeds and leaves the row untouched (clients retry freely); a different customer holding the space's consent is refused and the original provider keeps paying.
+- Service: the custody protocol test now activates before provisioning, so it exercises the gate end to end rather than around it.
+- Queue: `tonk_account::pending` unit tests cover recorded order, duplicate suppression, partial clearing after a drain that stopped early, and round-tripping.
+- Fixtures: `AccessServiceAddress::activate_customer` for suites holding a root signer, `provision_subject` for subjects that are repository DIDs no test holds a signer for.
+- Browser: `sign_up` follows the emailed activation link, so every caller gets an account that can host a space; `it_signs_up_through_the_account_panels` asserts the registration row reads `Active` and the pending banner is gone.
+
+## 9. Still to do
+
+- A browser test that pushes a space *before* clicking the link, then activates and asserts the space becomes hosted — end-to-end proof of the queue, which today is covered only at the unit and service layers.
+- The resend control on the activation notice (§6): `enroll_customer` already resends, and the notice already names the address, but there is no button wired to it yet.
 
 ## 7. Consequences for existing deployments
 

--- a/plan/account-model.md
+++ b/plan/account-model.md
@@ -1,0 +1,132 @@
+# Account and profile model
+
+Status: draft. Captures the identity model for onboarding, account linking, and service registration. Companion to the access service metering spec, which depends on registration but not on how linking works.
+
+## 1 Credentials
+
+Three kinds of keypair participate, at descending durability.
+
+### Account
+
+An account serves same purpose as the **role** does in traditional access control list (ACL) - It is assigned set of permissions that members with those roles can excercise.
+
+Our system uses an object capability model and we do not have central list. That means accounts are represented via [DID](https://www.w3.org/TR/did-core/) identifier and they are assigned permissions through [UCAN delegation](https://ucan.xyz/delegation/).
+
+A deterministic Ed25519 keypair derived from a passkey. WebAuthn PRF extension is used to obtain a stable secret, signing a known phrase derives the keypair from the result.
+
+> [!note]
+>
+> PRF is currently the only route to deterministic signatures from a passkey, so it is a hard dependency until we teach UCANs how to sign and verify with passkey directly [#450](https://github.com/ucan-wg/ucan/issues/450).
+
+Passkeys are origin scoped by the browser, so the derivation phrase does not need to carry service-specific entropy to keep account DIDs distinct across origins. The phrase does admit multiple accounts per passkey if that is ever wanted, which is not planned.
+
+The account is recoverable on any device that can present the passkey. It is the durable root of user identity.
+
+**Profile.** A non-extractable keypair generated at onboarding and stored locally. It represents an authorization session on one device. It is not recoverable elsewhere, by construction, since the private key never leaves the device.
+
+**Operator.** An ephemeral keypair created per application session. Operators represent a profile inside a specific application. They have no network access, so a compromised operator cannot exfiltrate the delegations it holds except by persisting them locally.
+
+Accounts and profiles are also referred to as account credentials and profile credentials. This document uses the short forms.
+
+## 2 Before linking
+
+Onboarding creates a profile immediately. It is not linked to any account, and the user may not have one.
+
+A space created in this state delegates to the profile, because the profile is the only durable key the client knows. The chain is space to profile to operator, and the operator drives the space.
+
+The consequence is that these spaces are device local. There is no key outside the device that holds authority over them, so access cannot be recovered elsewhere. This is a known limitation of the pre-linking state, not a design goal.
+
+Sync is unavailable in this state, since sync requires a registered account.
+
+## 3 Linking
+
+Linking establishes an account and connects it to the current profile. It runs three operations.
+
+**Mutual powerline delegation.** The account delegates to the profile and the profile delegates to the account. Both directions assert that the profile is the same entity as the account on this device. The account to profile direction is what gives a device its authority. The profile to account direction carries forward everything the profile already holds.
+
+**Direct space delegation.** Every space that currently delegates to the profile issues a fresh delegation directly to the account. The powerline delegation already makes those spaces transitively reachable from the account, so this step is redundant on the happy path. It exists for the compromise path: if the profile is later revoked, the transitive route dies at the profile, and only the direct route survives.
+
+This enumeration is only possible at link time, while the client still holds the full local set. That is why both paths are established rather than relying on the transitive one.
+
+**Cleanup.** Once the direct delegations exist, the space to profile delegations are redundant and are deleted locally. Deleting at link time closes the window in which a profile compromise would still confer space authority.
+
+Deletion rather than revocation is acceptable under current assumptions. Delegation chains travel with invocations, so the service does see them, but the service verifies and discards rather than storing. Operators are local and networkless. So the only durable copies are on the device, and removing them removes them. See open question 4.
+
+## 4 After linking
+
+New spaces delegate to the account only. The profile receives authority by delegation from the account, the same as any other holder.
+
+This completes the transition. Profile as a space anchor is a pre-linking workaround, not a permanent structural role. After linking the account is the sole anchor and authority flows downward from it.
+
+The compromise response follows from this. Revoke the account to profile delegation, issue a replacement to a new profile, and nothing about the spaces changes.
+
+Additional devices repeat the linking step. Each generates its own profile and exchanges mutual powerline delegations with the account. An account may have many profiles.
+
+```mermaid
+flowchart TD
+  subgraph before["Before linking"]
+    S1[Space] --> P1[Profile]
+    P1 --> O1[Operator]
+  end
+
+  subgraph after["After linking"]
+    A[Account]
+    S2[Space] --> A
+    A <--> P2[Profile]
+    P2 --> O2[Operator]
+    A <--> P3[Profile on second device]
+  end
+```
+
+## 5 Linked state signal
+
+Whether a profile has a linked account is read from the remote on the main
+branch. If a remote exists whose subject is an account DID, the profile is
+linked. If not, it is not.
+
+No separate flag is stored. The remote is the state, and it is the same value
+sync needs anyway.
+
+## 6 Registration
+
+Linking is local. Registration is the service side and is a distinct step: an
+account may exist and be linked without being registered.
+
+To register, the account delegates to the service the capability to write into a
+branch of the account. The service verifies the delegation and marks the account
+registered. From that point an upstream replica exists and push and pull are
+available.
+
+The metering spec treats the resulting record as the service-rooted grant. A
+delegation chain rooted at a space DID proves present authority over the data
+but says nothing about whether the service agreed to serve it. Registration
+state is that agreement, held as a looked-up row rather than a credential, so it
+can be revoked.
+
+## 7 Open questions
+
+1. **Which branch does the service write to.** The registration delegation grants
+   write access to a branch of the account. Whether that is the main branch or a
+   dedicated one for billing and metering state is unresolved. A dedicated
+   branch narrows the grant, which argues for it.
+
+2. **Delegation lifetime.** Whether the registration delegation is open ended or
+   carries a TTL requiring renewal. A TTL gives the service a natural expiry to
+   act on when a subscription ends, at the cost of a refresh path. This
+   interacts with the metering spec's decision to hold provisioning as state
+   rather than a credential.
+
+3. **Recovery of pre-link spaces on a second device.** Spaces created before
+   linking are reachable from the account after linking, so a second device
+   linked to the same account reaches them. Worth confirming this holds for a
+   device linked after the first device is lost, where no profile to profile
+   path exists.
+
+4. **Revocation.** Deletion is currently sufficient because the service does not
+   store delegations. Making revocation meaningful would require the service to
+   maintain and check a revocation list, which is a larger protocol change than
+   issuing revocation records. Deferred deliberately.
+
+5. **PRF availability.** Deterministic derivation depends on the WebAuthn PRF
+   extension. Behaviour when a platform authenticator does not support it is
+   unspecified, and there is no fallback path to a deterministic account key.

--- a/rust/tonk-access-service/src/handlers/ucan.rs
+++ b/rust/tonk-access-service/src/handlers/ucan.rs
@@ -144,6 +144,8 @@ async fn presign(body_bytes: &[u8], env: &Env) -> std::result::Result<(Response,
     screen_credentials(body_bytes, env).await?;
     #[cfg(target_arch = "wasm32")]
     screen_consumer_state(body_bytes, env).await?;
+    #[cfg(target_arch = "wasm32")]
+    screen_provisioning(body_bytes, env).await?;
 
     // Write permits carry the declared size as a signed Content-Length,
     // which is the exact byte figure metering records.
@@ -183,6 +185,51 @@ async fn screen_consumer_state(body_bytes: &[u8], env: &Env) -> std::result::Res
         }
         _ => Ok(()),
     }
+}
+
+/// Screen the subject against the provisioning gate: a space is served
+/// only while an active customer pays for it. Registration commands
+/// never reach here — `serve` answers them before the presign path —
+/// so enrolling and activating stay possible while the gate denies the
+/// data plane.
+#[cfg(target_arch = "wasm32")]
+async fn screen_provisioning(body_bytes: &[u8], env: &Env) -> std::result::Result<(), Refusal> {
+    use crate::provisioning::{container_subject, screen};
+    use crate::store::d1::D1Store;
+
+    let Some(subject) = container_subject(body_bytes) else {
+        // The authorizer accepted these bytes, so a subject we cannot
+        // read is shape drift between two parsers rather than a caller
+        // error. There is nothing to screen against, so it cannot clear.
+        console_error!("provisioning screen unavailable, container has no readable subject");
+        return Err(provisioning_unavailable());
+    };
+    let store = D1Store::new(env.d1("CONTROL").map_err(|err| {
+        console_error!("provisioning screen unavailable, no CONTROL binding: {err}");
+        provisioning_unavailable()
+    })?);
+    match screen(&store, &subject).await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(reason)) => {
+            worker::console_log!("presign rejected: {subject} is not servable ({reason})");
+            Err(reason.into())
+        }
+        Err(err) => {
+            // The gate fails closed, but a store failure is the
+            // service's own unavailability, not a denial to bill.
+            console_error!("presign refused, control store unreachable: {err}");
+            Err(provisioning_unavailable())
+        }
+    }
+}
+
+/// The 503 for a gate that could not reach a verdict.
+#[cfg(target_arch = "wasm32")]
+fn provisioning_unavailable() -> Refusal {
+    AuthorizeError::Unavailable {
+        detail: "provisioning registry unavailable, retry shortly".to_string(),
+    }
+    .into()
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/rust/tonk-access-service/src/helpers.rs
+++ b/rust/tonk-access-service/src/helpers.rs
@@ -29,6 +29,132 @@ pub struct AccessServiceAddress {
     pub service_did: String,
 }
 
+/// Enrolling and activating a customer against a test service.
+///
+/// The provisioning gate serves a subject only while an active customer
+/// pays for it, so a test that presigns anything needs its subject's
+/// customer past email confirmation first. Doing that by hand is three
+/// round trips of ceremony that has nothing to do with what most tests
+/// are checking.
+#[cfg(all(feature = "helpers", not(target_arch = "wasm32")))]
+impl AccessServiceAddress {
+    /// The `/ucan/` endpoint of this service.
+    pub fn ucan_endpoint(&self) -> String {
+        format!("{}/ucan/", self.access_service_url.trim_end_matches('/'))
+    }
+
+    /// Make `subject` servable without running the registration
+    /// ceremony: enroll a customer, activate it, and provision `subject`
+    /// under it, all straight against the control store.
+    ///
+    /// For tests whose subject is a repository or space DID they hold no
+    /// signer for, and whose point is not registration. A test that is
+    /// about the ceremony itself should drive the real endpoints
+    /// instead — see [`Self::activate_customer`].
+    pub async fn provision_subject(&self, subject: &str) -> anyhow::Result<()> {
+        let response = reqwest::Client::new()
+            .post(format!(
+                "{}/_test/provision",
+                self.access_service_url.trim_end_matches('/')
+            ))
+            .json(&serde_json::json!({ "subject": subject }))
+            .send()
+            .await?;
+        anyhow::ensure!(
+            response.status().is_success(),
+            "provisioning {subject} failed ({}): {}",
+            response.status(),
+            response.text().await.unwrap_or_default()
+        );
+        Ok(())
+    }
+
+    /// Enroll `customer` and confirm its email, leaving it `Active` and
+    /// providing its own account space. Returns once the service has
+    /// recorded the activation, so a presign on `customer`'s subject
+    /// immediately afterwards is served.
+    pub async fn activate_customer(
+        &self,
+        customer: &dialog_credentials::Ed25519Signer,
+        email: &str,
+    ) -> anyhow::Result<()> {
+        use dialog_varsig::Principal as _;
+
+        let service = self
+            .service_did
+            .parse()
+            .map_err(|error| anyhow::anyhow!("the test service DID does not parse: {error:?}"))?;
+        let device = dialog_credentials::Ed25519Signer::generate()
+            .await
+            .map_err(|error| anyhow::anyhow!("device signer: {error:?}"))?;
+        let link =
+            tonk_identity::delegation::mint_device_delegation(customer.clone(), &device.did())
+                .await?;
+        // The ceremony hands these back hex-encoded, for the JS bridge;
+        // the invocation builder takes the bytes themselves.
+        let deposits = tonk_identity::ceremony::mint_service_deposits(customer, &service)
+            .await?
+            .iter()
+            .map(hex::decode)
+            .collect::<Result<Vec<_>, _>>()?;
+        let container = tonk_identity::request::build_enroll_invocation_with_deposits(
+            device, &link, email, &deposits,
+        )
+        .await?;
+
+        let client = reqwest::Client::new();
+        let endpoint = self.ucan_endpoint();
+        let response = client
+            .post(&endpoint)
+            .header("Content-Type", "application/cbor")
+            .body(container)
+            .send()
+            .await?;
+        anyhow::ensure!(
+            response.status().is_success(),
+            "enrollment refused ({}): {}",
+            response.status(),
+            response.text().await.unwrap_or_default()
+        );
+
+        // The emailed link carries a complete service-signed invocation;
+        // presenting it is activating.
+        let inbox: Vec<(String, String)> = client
+            .get(format!(
+                "{}/_test/emails",
+                self.access_service_url.trim_end_matches('/')
+            ))
+            .send()
+            .await?
+            .json()
+            .await?;
+        let (_, link) = inbox
+            .into_iter()
+            .rev()
+            .find(|(to, _)| to == email)
+            .ok_or_else(|| anyhow::anyhow!("no activation email was captured for {email}"))?;
+        let encoded = link
+            .split_once("ucan=")
+            .map(|(_, value)| value)
+            .ok_or_else(|| anyhow::anyhow!("the activation link carries no invocation"))?;
+        let bytes =
+            base64::Engine::decode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, encoded)?;
+        let response = client
+            .post(&endpoint)
+            .header("Content-Type", "application/cbor")
+            .body(bytes)
+            .send()
+            .await?;
+        anyhow::ensure!(
+            response.status().is_success(),
+            "activation refused ({}): {}",
+            response.status(),
+            response.text().await.unwrap_or_default()
+        );
+        Ok(())
+    }
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 pub mod server;
 

--- a/rust/tonk-access-service/src/helpers/server.rs
+++ b/rust/tonk-access-service/src/helpers/server.rs
@@ -286,6 +286,40 @@ async fn handle_request(
                 .unwrap(),
         ));
     }
+    // Test-only shortcut past the registration ceremony: make a subject
+    // servable by provisioning it under a synthetic active customer.
+    // For tests whose subject is a repository DID they hold no signer
+    // for; anything testing registration itself drives the real
+    // endpoints.
+    if req.method() == Method::POST && req.uri().path() == "/_test/provision" {
+        use http_body_util::BodyExt;
+
+        let body = req.into_body().collect().await.map(|c| c.to_bytes());
+        let subject = body
+            .ok()
+            .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
+            .and_then(|value| value["subject"].as_str().map(str::to_owned));
+        let Some(subject) = subject else {
+            return Ok(cors_response(
+                Response::builder()
+                    .status(StatusCode::BAD_REQUEST)
+                    .body(Full::new(Bytes::from("a subject is required")))
+                    .unwrap(),
+            ));
+        };
+        return Ok(cors_response(
+            match provision_for_tests(&registration.store, &subject).await {
+                Ok(()) => Response::builder()
+                    .status(StatusCode::OK)
+                    .body(Full::new(Bytes::new()))
+                    .unwrap(),
+                Err(error) => Response::builder()
+                    .status(StatusCode::INTERNAL_SERVER_ERROR)
+                    .body(Full::new(Bytes::from(error.to_string())))
+                    .unwrap(),
+            },
+        ));
+    }
     if req.method() == Method::GET && req.uri().path() == "/_test/ingest" {
         let count = registration.ingest.invocations().unwrap_or_default();
         return Ok(cors_response(
@@ -520,6 +554,39 @@ async fn handle_request(
             _ => {}
         }
     }
+    // The provisioning gate, mirroring the worker: a subject is served
+    // only while an active customer pays for it. Registration commands
+    // returned above, so enrolling and activating stay possible while
+    // this denies the data plane.
+    if outcome.is_ok() {
+        match crate::provisioning::container_subject(&body_bytes) {
+            Some(subject) => match crate::provisioning::screen(&registration.store, &subject).await
+            {
+                Ok(Ok(())) => {}
+                Ok(Err(reason)) => {
+                    return Ok(cors_response(authorize_error_response(
+                        StatusCode::FORBIDDEN,
+                        &reason,
+                    )));
+                }
+                Err(error) => {
+                    // Fails closed, but as our own unavailability rather
+                    // than a denial billed to the customer.
+                    eprintln!("presign refused, control store unreachable: {error}");
+                    return Ok(cors_response(authorize_error_response(
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        &unavailable_provisioning(),
+                    )));
+                }
+            },
+            None => {
+                return Ok(cors_response(authorize_error_response(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    &unavailable_provisioning(),
+                )));
+            }
+        }
+    }
     // Metering mirrors the worker: permits and attributable denials are
     // recorded, infra failures and unparseable containers are not.
     let metered = match &outcome {
@@ -584,6 +651,58 @@ fn unix_now() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .expect("system clock is past the epoch")
         .as_secs()
+}
+
+/// Provision `subject` under a synthetic active customer, so the
+/// provisioning gate serves it. Idempotent, and derived from the
+/// subject so two subjects never collide on one provider row.
+async fn provision_for_tests(store: &SqliteStore, subject: &str) -> anyhow::Result<()> {
+    use crate::store::{ConsumerKind, SIGNUP_PLAN, Store};
+
+    let provider = format!("did:test:provider-for-{subject}");
+    if store
+        .customer(&provider)
+        .await
+        .map_err(|error| anyhow::anyhow!("{error}"))?
+        .is_none()
+    {
+        store
+            .enroll_customer(&provider, "tests@example.com", b"", SIGNUP_PLAN, 0)
+            .await
+            .map_err(|error| anyhow::anyhow!("{error}"))?;
+        store
+            .activate_customer(&provider, "test", 1)
+            .await
+            .map_err(|error| anyhow::anyhow!("{error}"))?;
+    }
+    store
+        .add_consumer(subject, &provider, 0, ConsumerKind::Space)
+        .await
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+    Ok(())
+}
+
+/// The refusal a gate that could not reach a verdict answers with.
+fn unavailable_provisioning() -> dialog_capability::access::AuthorizeError {
+    dialog_capability::access::AuthorizeError::Unavailable {
+        detail: "provisioning registry unavailable, retry shortly".to_string(),
+    }
+}
+
+/// Answer a refusal as the worker does: the serde-tagged
+/// [`AuthorizeError`] itself, which is what the client parses back out.
+/// A plain-text body would classify as unclassified on the other side.
+fn authorize_error_response(
+    status: StatusCode,
+    reason: &dialog_capability::access::AuthorizeError,
+) -> Response<http_body_util::Full<bytes::Bytes>> {
+    Response::builder()
+        .status(status)
+        .header(CONTENT_TYPE, "application/json")
+        .body(http_body_util::Full::new(bytes::Bytes::from(
+            serde_json::to_vec(reason).expect("authorize refusal serializes"),
+        )))
+        .unwrap()
 }
 
 fn deletion_error_response(

--- a/rust/tonk-access-service/src/provisioning.rs
+++ b/rust/tonk-access-service/src/provisioning.rs
@@ -8,11 +8,11 @@
 //! rule the `Consumer` row has always documented. Without it, any
 //! self-minted keypair stores bytes under its own namespace unbilled.
 //!
-//! Behind a flag (`REQUIRE_PROVISIONING`), default off: existing
-//! deployments ramp it only once their spaces are provisioned, and the
-//! browser's creation ceremony still publishes the custody cell before
-//! the account registers — that ordering must move before a deployment
-//! that serves browsers can enforce.
+//! Always enforced, on both the worker and the native server: a flag
+//! defaulted off is a gate that is not there, and one defaulted on is a
+//! switch for turning billing enforcement off in production. Clients
+//! hold work that lands before activation as a pending queue and replay
+//! it once the email is confirmed, rather than relying on a ramp.
 
 use dialog_capability::access::AuthorizeError;
 use dialog_ucan_core::{Container, Invocation};

--- a/rust/tonk-access-service/src/registration.rs
+++ b/rust/tonk-access-service/src/registration.rs
@@ -304,9 +304,9 @@ impl<S: Store, E: EmailSender> Registration<'_, S, E> {
     /// Execute a verified `/provider/add`: validate the deposited consent
     /// and provision the consumer under the invoking customer.
     /// Re-provisioning under the same customer is a no-op success; a
-    /// consumer another customer provides is refused. Activation is not
-    /// required to add, only to serve: consumers added while the provider
-    /// is `Registered` go live with its activation.
+    /// consumer another customer provides is refused. The customer must
+    /// be `Active`: an unactivated customer provisions nothing, so the
+    /// same email confirmation gates adding and serving alike.
     pub async fn add(
         &self,
         capability: Capability<Add>,
@@ -320,10 +320,15 @@ impl<S: Store, E: EmailSender> Registration<'_, S, E> {
             .map_err(internal)?
         {
             None => return Err(RegistrationError::UnknownCustomer),
-            Some(customer) if customer.status == CustomerStatus::Suspended => {
-                return Err(RegistrationError::CustomerSuspended);
-            }
-            Some(_) => {}
+            Some(customer) => match customer.status {
+                CustomerStatus::Active => {}
+                // An unactivated customer gets nothing: not service, and
+                // not provisioning either. The client holds the add as
+                // pending work and replays it once the email is
+                // confirmed; re-enrolling resends that email.
+                CustomerStatus::Registered => return Err(RegistrationError::CustomerInactive),
+                CustomerStatus::Suspended => return Err(RegistrationError::CustomerSuspended),
+            },
         }
         let consent = self.deposited_delegation(&effect.consent.to_string())?;
         self.verify_consent(&consent.delegation, &effect.consumer, &provider)

--- a/rust/tonk-access-service/tests/account_remote.rs
+++ b/rust/tonk-access-service/tests/account_remote.rs
@@ -127,6 +127,9 @@ async fn it_reports_a_never_published_authorized_branch_as_absent() -> anyhow::R
         .perform(&operator)
         .await?;
     profile.access().save(ownership).perform(&operator).await?;
+    // The gate serves a subject only while an active customer pays for
+    // it; this test is about absence probing, not registration.
+    env.provision_subject(repository.did().as_str()).await?;
 
     let origin = repository
         .remote("origin")
@@ -160,6 +163,7 @@ async fn it_never_classifies_remote_failures_as_absence() -> anyhow::Result<()> 
         .perform(&operator)
         .await?;
     profile.access().save(ownership).perform(&operator).await?;
+    env.provision_subject(repository.did().as_str()).await?;
 
     let forbidden = static_access_endpoint(StatusCode::FORBIDDEN, b"forbidden").await;
     let unauthorized = static_access_endpoint(StatusCode::UNAUTHORIZED, b"unauthorized").await;
@@ -207,6 +211,12 @@ async fn it_atomically_publishes_one_account_genesis_and_keeps_syncing() -> anyh
     let endpoint = service.address.access_service_url.clone();
     let root = Ed25519Signer::generate().await?;
     let root_did = root.did();
+    // The account space is servable only once its customer confirms the
+    // emailed activation link.
+    service
+        .address
+        .activate_customer(&root, "genesis@example.com")
+        .await?;
 
     let device_a = account_device(&root, &endpoint).await?;
     let device_b = account_device(&root, &endpoint).await?;
@@ -333,6 +343,10 @@ async fn it_adopts_a_losing_candidate_onto_the_winners_content() -> anyhow::Resu
     let service = AccessServiceAddress::start(Default::default()).await?;
     let endpoint = service.address.access_service_url.clone();
     let root = Ed25519Signer::generate().await?;
+    service
+        .address
+        .activate_customer(&root, "adopt@example.com")
+        .await?;
 
     let winner = account_device(&root, &endpoint).await?;
     let loser = account_device(&root, &endpoint).await?;

--- a/rust/tonk-access-service/tests/registration.rs
+++ b/rust/tonk-access-service/tests/registration.rs
@@ -77,6 +77,23 @@ impl Fixture {
         }
     }
 
+    /// Enroll `customer` and finalize it by presenting the emailed
+    /// activation invocation, leaving it `Active`. Provisioning requires
+    /// activation, so most consumer tests need a customer past this
+    /// point rather than a freshly enrolled one.
+    async fn enroll_and_activate(&self, customer: &Ed25519Signer, email: &str) {
+        let container = enroll_container(customer, &self.service.did(), email).await;
+        self.registration(&container)
+            .handle()
+            .await
+            .expect("enrollment succeeds");
+        let container = link_container(&self.last_email().1);
+        self.registration(&container)
+            .handle()
+            .await
+            .expect("activation succeeds");
+    }
+
     fn last_email(&self) -> (String, String) {
         self.emails
             .0
@@ -497,11 +514,10 @@ async fn it_provisions_a_consumer_with_the_spaces_consent() -> anyhow::Result<()
     let fixture = Fixture::new().await;
     let customer = Ed25519Signer::generate().await?;
     let space = Ed25519Signer::generate().await?;
-    let container = enroll_container(&customer, &fixture.service.did(), "alice@example.com").await;
-    fixture.registration(&container).handle().await.unwrap();
+    fixture
+        .enroll_and_activate(&customer, "alice@example.com")
+        .await;
 
-    // Activation is not required to add, only to serve: the customer is
-    // still Registered here.
     let container = add_container(&customer, &space, &customer.did()).await;
     let Answer::Consumer(receipt) = fixture.registration(&container).handle().await.unwrap() else {
         panic!("expected a consumer receipt");
@@ -524,18 +540,48 @@ async fn it_provisions_a_consumer_with_the_spaces_consent() -> anyhow::Result<()
 }
 
 #[dialog_common::test]
+async fn it_refuses_provisioning_until_the_customer_confirms_their_email() -> anyhow::Result<()> {
+    let fixture = Fixture::new().await;
+    let customer = Ed25519Signer::generate().await?;
+    let space = Ed25519Signer::generate().await?;
+    let container = enroll_container(&customer, &fixture.service.did(), "alice@example.com").await;
+    fixture.registration(&container).handle().await.unwrap();
+
+    // Enrolled but not activated: nothing may be provisioned yet, and
+    // the refusal names the cause so the client can say so.
+    let container = add_container(&customer, &space, &customer.did()).await;
+    let refusal = fixture.registration(&container).handle().await.unwrap_err();
+    assert!(matches!(refusal, RegistrationError::CustomerInactive));
+    assert!(
+        fixture
+            .store
+            .consumer(space.did().as_str())
+            .await
+            .unwrap()
+            .is_none(),
+        "a refused add writes no consumer row"
+    );
+
+    // The same add replays successfully once the email is confirmed,
+    // which is what the client's pending-work queue relies on.
+    let container = link_container(&fixture.last_email().1);
+    fixture.registration(&container).handle().await.unwrap();
+    let container = add_container(&customer, &space, &customer.did()).await;
+    assert!(fixture.registration(&container).handle().await.is_ok());
+    Ok(())
+}
+
+#[dialog_common::test]
 async fn it_refuses_provisioning_someone_elses_consumer() -> anyhow::Result<()> {
     let fixture = Fixture::new().await;
     let alice = Ed25519Signer::generate().await?;
     let mallory = Ed25519Signer::generate().await?;
     let space = Ed25519Signer::generate().await?;
-    let service = fixture.service.did();
     for (customer, email) in [
         (&alice, "alice@example.com"),
         (&mallory, "mallory@example.com"),
     ] {
-        let container = enroll_container(customer, &service, email).await;
-        fixture.registration(&container).handle().await.unwrap();
+        fixture.enroll_and_activate(customer, email).await;
     }
 
     let container = add_container(&alice, &space, &alice.did()).await;
@@ -553,9 +599,9 @@ async fn it_refuses_a_consent_issued_to_another_customer() -> anyhow::Result<()>
     let alice = Ed25519Signer::generate().await?;
     let mallory = Ed25519Signer::generate().await?;
     let space = Ed25519Signer::generate().await?;
-    let service = fixture.service.did();
-    let container = enroll_container(&mallory, &service, "mallory@example.com").await;
-    fixture.registration(&container).handle().await.unwrap();
+    fixture
+        .enroll_and_activate(&mallory, "mallory@example.com")
+        .await;
 
     // The space consented to Alice; Mallory presenting that consent must
     // not become its provider.
@@ -668,8 +714,118 @@ async fn it_drives_registration_over_http(env: AccessServiceAddress) -> anyhow::
     Ok(())
 }
 
-/// The custody protocol end to end (`plan/Account custody.md`): a
-/// registered account provisions the custody DID as a consumer, the
+/// The presign gate: a subject is served only while an active customer
+/// pays for it, and confirming the email is what lifts the denial for
+/// every consumer that customer funds at once.
+#[dialog_common::test]
+async fn it_denies_presign_until_the_customer_confirms_their_email(
+    env: AccessServiceAddress,
+) -> anyhow::Result<()> {
+    use tonk_identity::custody;
+
+    let client = reqwest::Client::new();
+    let base = env.access_service_url.trim_end_matches('/').to_string();
+    let ucan = format!("{base}/ucan/");
+    let service_did: Did = env.service_did.parse()?;
+    let custody_key = custody_signer_for(&[31u8; 32]).await?;
+
+    // A subject nobody pays for is never served.
+    let resolve = custody::build_resolve_invocation(custody_key.clone()).await?;
+    let response = client
+        .post(&ucan)
+        .header("Content-Type", "application/cbor")
+        .body(resolve.clone())
+        .send()
+        .await?;
+    assert_eq!(response.status(), 403, "an unprovisioned subject is served");
+    let reason: serde_json::Value = response.json().await?;
+    assert_eq!(reason["kind"], "PolicyViolation");
+    assert!(
+        reason["predicate"]
+            .as_str()
+            .expect("the refusal names its predicate")
+            .contains("not provisioned"),
+        "the refusal must say why: {reason}"
+    );
+
+    // Enrolled but unactivated: the customer's own account subject is
+    // refused, and the refusal points at the unopened email.
+    let account = Ed25519Signer::generate().await?;
+    let container = enroll_container(&account, &service_did, "gate@example.com").await;
+    let response = client
+        .post(&ucan)
+        .header("Content-Type", "application/cbor")
+        .body(container)
+        .send()
+        .await?;
+    assert_eq!(response.status(), 200, "enrollment refused");
+
+    let account_resolve = custody::build_resolve_invocation(account.clone()).await?;
+    let response = client
+        .post(&ucan)
+        .header("Content-Type", "application/cbor")
+        .body(account_resolve.clone())
+        .send()
+        .await?;
+    assert_eq!(response.status(), 403, "a Registered customer is served");
+    let reason: serde_json::Value = response.json().await?;
+    assert!(
+        reason["predicate"]
+            .as_str()
+            .expect("the refusal names its predicate")
+            .contains("awaits email activation"),
+        "the refusal must name the unopened email: {reason}"
+    );
+
+    // Confirming the email lifts it, without any further provisioning
+    // call: enrollment already wrote the account's own consumer row
+    // self-provided, so activation alone makes the account space
+    // servable — along with everything else this customer funds.
+    activate_over_http(&client, &base).await?;
+    let response = client
+        .post(&ucan)
+        .header("Content-Type", "application/cbor")
+        .body(account_resolve)
+        .send()
+        .await?;
+    assert_ne!(
+        response.status(),
+        403,
+        "activation did not lift the provisioning denial"
+    );
+    Ok(())
+}
+
+/// A custody signer at a fixed entry-function output, standing in for
+/// what a PRF assertion would produce.
+async fn custody_signer_for(key: &[u8; 32]) -> anyhow::Result<Ed25519Signer> {
+    tonk_identity::envelope::custody_signer(key).await
+}
+
+/// Activate the customer the last captured email was sent to, over
+/// HTTP. Provisioning and presign both require an `Active` customer, so
+/// a test driving the real endpoints enrolls and then comes through
+/// here before it can do anything else.
+async fn activate_over_http(client: &reqwest::Client, base: &str) -> anyhow::Result<()> {
+    let emails: Vec<(String, String)> = client
+        .get(format!("{base}/_test/emails"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    let (_, link) = emails.last().cloned().expect("an activation email");
+    let response = client
+        .post(format!("{base}/ucan/"))
+        .header("Content-Type", "application/cbor")
+        .body(link_container(&link))
+        .send()
+        .await?;
+    assert_eq!(response.status(), 200, "activation refused");
+    Ok(())
+}
+
+/// The custody protocol end to end (`plan/Account custody.md`): an
+/// activated account provisions the custody DID as a consumer, the
 /// custody key publishes the wrapped account secret as a raw memory
 /// cell, and a fresh resolve reads the same bytes back holding nothing
 /// but the custody key. No repository exists anywhere in this flow.
@@ -698,6 +854,10 @@ async fn it_publishes_and_resolves_the_custody_cell(
         .send()
         .await?;
     assert_eq!(response.status(), 200, "enrollment refused");
+
+    // Confirming the email is what unlocks everything below: an
+    // unactivated customer provisions nothing and is served nothing.
+    activate_over_http(&client, &base).await?;
 
     // The entry function's two outputs; a PRF would produce these
     // inside one assertion, at the two custody salts.

--- a/rust/tonk-access-service/tests/registration.rs
+++ b/rust/tonk-access-service/tests/registration.rs
@@ -533,9 +533,27 @@ async fn it_provisions_a_consumer_with_the_spaces_consent() -> anyhow::Result<()
         .expect("the consumer row exists");
     assert_eq!(consumer.provider.as_deref(), Some(customer.did().as_str()));
 
-    // Re-provisioning under the same customer is a no-op success.
+    // Re-provisioning under the same customer succeeds and changes
+    // nothing: clients retry provisioning freely (a queued entry
+    // replayed twice, two devices racing), so it must be idempotent
+    // rather than a conflict.
+    let registered_at = consumer.registered;
     let container = add_container(&customer, &space, &customer.did()).await;
-    assert!(fixture.registration(&container).handle().await.is_ok());
+    let Answer::Consumer(receipt) = fixture.registration(&container).handle().await.unwrap() else {
+        panic!("expected a consumer receipt");
+    };
+    assert_eq!(receipt.provider, customer.did());
+    let again = fixture
+        .store
+        .consumer(space.did().as_str())
+        .await
+        .unwrap()
+        .expect("the consumer row still exists");
+    assert_eq!(again.provider.as_deref(), Some(customer.did().as_str()));
+    assert_eq!(
+        again.registered, registered_at,
+        "re-provisioning must not re-register the consumer"
+    );
     Ok(())
 }
 
@@ -587,9 +605,23 @@ async fn it_refuses_provisioning_someone_elses_consumer() -> anyhow::Result<()> 
     let container = add_container(&alice, &space, &alice.did()).await;
     fixture.registration(&container).handle().await.unwrap();
 
+    // Mallory holds the space's consent to herself, and is active in her
+    // own right; what stops her is that the space already has a
+    // provider. A consumer has exactly one.
     let container = add_container(&mallory, &space, &mallory.did()).await;
     let refusal = fixture.registration(&container).handle().await.unwrap_err();
     assert!(matches!(refusal, RegistrationError::ConsumerProvided));
+    let consumer = fixture
+        .store
+        .consumer(space.did().as_str())
+        .await
+        .unwrap()
+        .expect("the consumer row exists");
+    assert_eq!(
+        consumer.provider.as_deref(),
+        Some(alice.did().as_str()),
+        "a refused takeover must leave the original provider paying"
+    );
     Ok(())
 }
 

--- a/rust/tonk-access-service/tests/ucan_integration.rs
+++ b/rust/tonk-access-service/tests/ucan_integration.rs
@@ -45,6 +45,9 @@ async fn it_pushes_and_pulls_via_ucan(env: AccessServiceAddress) -> anyhow::Resu
         .perform(&operator)
         .await?;
     profile.access().save(ownership).perform(&operator).await?;
+    // The gate serves a subject only while an active customer pays
+    // for it; these tests are about sync, not registration.
+    env.provision_subject(repo.did().as_str()).await?;
 
     // Set up UCAN remote pointing at our access service
     let address = UcanAddress::new(&env.access_service_url);
@@ -129,6 +132,9 @@ async fn it_collaborates_via_ucan_delegation(env: AccessServiceAddress) -> anyho
         .save(ownership)
         .perform(&alice_op)
         .await?;
+    // Bob syncs Alice's repository, so it is Alice's subject that must
+    // be paid for; Bob's own repo is never pushed.
+    env.provision_subject(alice_repo.did().as_str()).await?;
 
     // Alice sets up UCAN remote
     let address = UcanAddress::new(&env.access_service_url);
@@ -254,6 +260,9 @@ async fn it_syncs_blobs_via_ucan(env: AccessServiceAddress) -> anyhow::Result<()
         .perform(&operator)
         .await?;
     profile.access().save(ownership).perform(&operator).await?;
+    // The gate serves a subject only while an active customer pays
+    // for it; these tests are about sync, not registration.
+    env.provision_subject(repo.did().as_str()).await?;
 
     let address = UcanAddress::new(&env.access_service_url);
     let origin = repo

--- a/rust/tonk-account/src/customer.rs
+++ b/rust/tonk-account/src/customer.rs
@@ -247,6 +247,11 @@ pub enum RegistrationError {
     /// The customer is already active, so enrollment is refused.
     #[error("this customer is already active")]
     CustomerActive,
+    /// The customer enrolled but has not confirmed their email address,
+    /// so nothing may be provisioned under them yet. Recoverable by the
+    /// customer alone: re-enrolling resends the activation email.
+    #[error("this customer is awaiting email activation")]
+    CustomerInactive,
     /// The customer is suspended, so nothing self-serve applies.
     #[error("this customer is suspended")]
     CustomerSuspended,
@@ -267,6 +272,7 @@ impl RegistrationError {
             RegistrationError::Forbidden { .. } => 403,
             RegistrationError::UnknownCustomer => 404,
             RegistrationError::CustomerActive
+            | RegistrationError::CustomerInactive
             | RegistrationError::CustomerSuspended
             | RegistrationError::ConsumerProvided => 409,
             RegistrationError::Internal { .. } => 500,

--- a/rust/tonk-account/src/lib.rs
+++ b/rust/tonk-account/src/lib.rs
@@ -13,6 +13,8 @@ mod descriptor;
 pub mod detach;
 /// Shared wire and browser-ceremony contracts for native account handoffs.
 pub mod handoff;
+/// Work deferred until the account confirms its email.
+pub mod pending;
 /// Provider-neutral account spot backup artifacts.
 pub mod prefix;
 mod provider;
@@ -45,6 +47,10 @@ pub const ACCOUNT_PROVIDER_CREDENTIAL_SITE: &str = "tonk-account-provider-v1";
 pub const CUSTOMER_CREDENTIAL_SITE: &str = "tonk-customer-v1";
 /// Credential site holding the trusted descriptor hash.
 pub const TRUSTED_BASE_CREDENTIAL_SITE: &str = "tonk-account-trusted-base-v1";
+/// Credential site holding work that cannot run until the account
+/// confirms its email: provisioning calls and the custody-cell publish.
+/// See [`pending`] and `plan/account-activation-gate.md` §5.
+pub const PENDING_WORK_CREDENTIAL_SITE: &str = "tonk-pending-work-v1";
 
 /// What the account service says when an account predates the repository
 /// descriptor and has not established one yet.

--- a/rust/tonk-account/src/pending.rs
+++ b/rust/tonk-account/src/pending.rs
@@ -1,0 +1,168 @@
+//! Work deferred until the account confirms its email.
+//!
+//! The access service serves nothing, and provisions nothing, for a
+//! customer that has enrolled but not yet clicked the emailed
+//! activation link (`plan/account-activation-gate.md`). Everything a
+//! client would otherwise do in that window — provisioning the custody
+//! space, publishing the sealed account secret, provisioning a space
+//! created before the email arrived — is recorded here instead and
+//! replayed once the customer goes `Active`.
+//!
+//! Order is the queue's only invariant: a custody cell may only be
+//! published after that custody DID has been provisioned, and replaying
+//! entries in the order they were recorded gives that for free. A drain
+//! therefore stops at the first entry it cannot complete and leaves the
+//! rest queued, rather than skipping ahead.
+
+use serde::{Deserialize, Serialize};
+
+/// One deferred act.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum PendingWork {
+    /// Provision a consumer under this account: a `/provider/add`
+    /// carrying the consumer's own consent.
+    #[serde(rename_all = "camelCase")]
+    Provision {
+        /// The consumer being provisioned.
+        consumer: String,
+        /// Hex-encoded consent delegation chain the consumer minted.
+        consent_hex: String,
+        /// `space` or `custody`; absent means `space`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        consumer_kind: Option<String>,
+    },
+    /// Publish a sealed account secret into a custody space's cell.
+    ///
+    /// Only the sealed bytes are queued, never a signed invocation: the
+    /// custody key is PRF-derived inside a passkey assertion and never
+    /// stored, and an invocation signed during the ceremony carries a
+    /// five-minute expiration that cannot outlive a wait for an email
+    /// click. Replaying therefore needs a fresh assertion, which only a
+    /// page can raise — so this entry drains from the account panel
+    /// rather than from the worker's own status probe.
+    ///
+    /// The envelope is already sealed under the passkey's KEK when it
+    /// arrives here, so what waits is ciphertext rather than key
+    /// material — the same bytes that would otherwise sit in the custody
+    /// cell, which is itself storage the service can read.
+    #[serde(rename_all = "camelCase")]
+    PublishCustody {
+        /// The custody space's DID: the invocation's subject, and what
+        /// must be provisioned before this can be served.
+        custody: String,
+        /// Hex-encoded sealed envelope, the content to publish.
+        sealed_hex: String,
+    },
+}
+
+impl PendingWork {
+    /// The subject this entry acts on, for logging and de-duplication.
+    pub fn subject(&self) -> &str {
+        match self {
+            Self::Provision { consumer, .. } => consumer,
+            Self::PublishCustody { custody, .. } => custody,
+        }
+    }
+}
+
+/// The recorded queue, oldest first.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct PendingQueue(pub Vec<PendingWork>);
+
+impl PendingQueue {
+    /// Whether anything is waiting.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// How many entries are waiting.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Append `work`, unless an identical entry is already queued.
+    ///
+    /// Re-running a ceremony that was interrupted must not grow the
+    /// queue without bound, and replaying the same act twice is at best
+    /// wasted round trips.
+    pub fn push(&mut self, work: PendingWork) {
+        if !self.0.contains(&work) {
+            self.0.push(work);
+        }
+    }
+
+    /// The entries in replay order.
+    pub fn entries(&self) -> &[PendingWork] {
+        &self.0
+    }
+
+    /// Drop the first `count` entries, the ones a drain completed.
+    pub fn retain_after(&mut self, count: usize) {
+        self.0.drain(..count.min(self.0.len()));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provision(consumer: &str) -> PendingWork {
+        PendingWork::Provision {
+            consumer: consumer.to_string(),
+            consent_hex: "aa".to_string(),
+            consumer_kind: Some("custody".to_string()),
+        }
+    }
+
+    #[test]
+    fn it_keeps_recorded_order_and_ignores_duplicates() {
+        let mut queue = PendingQueue::default();
+        queue.push(provision("did:key:zCustody"));
+        queue.push(PendingWork::PublishCustody {
+            custody: "did:key:zCustody".to_string(),
+            sealed_hex: "bb".to_string(),
+        });
+        queue.push(provision("did:key:zCustody"));
+
+        assert_eq!(queue.len(), 2, "an identical entry is not queued twice");
+        assert_eq!(queue.entries()[0].subject(), "did:key:zCustody");
+        assert!(
+            matches!(queue.entries()[1], PendingWork::PublishCustody { .. }),
+            "the publish must stay behind the provision that makes it servable"
+        );
+    }
+
+    #[test]
+    fn it_clears_only_the_entries_a_drain_completed() {
+        let mut queue = PendingQueue::default();
+        queue.push(provision("did:key:zOne"));
+        queue.push(provision("did:key:zTwo"));
+        queue.push(provision("did:key:zThree"));
+
+        // A drain that completed one entry and stopped at the second
+        // leaves the rest queued, in order.
+        queue.retain_after(1);
+        assert_eq!(queue.len(), 2);
+        assert_eq!(queue.entries()[0].subject(), "did:key:zTwo");
+        assert_eq!(queue.entries()[1].subject(), "did:key:zThree");
+
+        queue.retain_after(99);
+        assert!(queue.is_empty(), "clearing past the end empties the queue");
+    }
+
+    #[test]
+    fn it_round_trips_through_the_recorded_form() {
+        let mut queue = PendingQueue::default();
+        queue.push(provision("did:key:zCustody"));
+        queue.push(PendingWork::PublishCustody {
+            custody: "did:key:zCustody".to_string(),
+            sealed_hex: "bb".to_string(),
+        });
+
+        let bytes = serde_json::to_vec(&queue).expect("queue serializes");
+        let restored: PendingQueue = serde_json::from_slice(&bytes).expect("queue deserializes");
+        assert_eq!(restored, queue);
+    }
+}

--- a/rust/tonk-cli/src/account_state.rs
+++ b/rust/tonk-cli/src/account_state.rs
@@ -831,6 +831,13 @@ mod tests {
             .await
             .unwrap();
         let root = Ed25519Signer::generate().await.unwrap();
+        // The account space is servable only once its customer has
+        // confirmed the emailed activation link.
+        service
+            .address
+            .activate_customer(&root, "account-state@example.com")
+            .await
+            .unwrap();
         let live_remote = format!(
             "{}/",
             service.address.access_service_url.trim_end_matches('/')
@@ -998,6 +1005,13 @@ mod tests {
             .await
             .unwrap();
         let root = Ed25519Signer::generate().await.unwrap();
+        // The account space is servable only once its customer has
+        // confirmed the emailed activation link.
+        service
+            .address
+            .activate_customer(&root, "account-state@example.com")
+            .await
+            .unwrap();
         let remote = format!(
             "{}/",
             service.address.access_service_url.trim_end_matches('/')

--- a/rust/tonk-cli/tests/account_authority.rs
+++ b/rust/tonk-cli/tests/account_authority.rs
@@ -32,6 +32,9 @@ async fn it_pushes_a_spot_whose_account_prefix_was_never_stored(
     env: AccessServiceAddress,
 ) -> Result<()> {
     let fixture = common::AccountFixture::new().await?;
+    // The access service serves nothing for an account that has not
+    // confirmed its email.
+    fixture.activate_with(&env).await?;
     let site = TonkSite::init_at_with(
         &fixture.tmp.path().join("upgraded"),
         account_config(&fixture),
@@ -46,6 +49,10 @@ async fn it_pushes_a_spot_whose_account_prefix_was_never_stored(
         .perform(&site.operator)
         .await?;
     configure_upstream(&site, &env.access_service_url).await?;
+    // What is under test is push authority, not provisioning; the space
+    // still has to be someone's to serve.
+    env.provision_subject(site.repository.did().as_str())
+        .await?;
 
     tonk_cli::sync::push(&site).await?;
 
@@ -127,6 +134,9 @@ async fn it_installs_authority_from_a_callback_authorization(
 
     let remote = format!("{}/", env.access_service_url.trim_end_matches('/'));
     let fixture = common::AccountFixture::with_account_remote(&remote).await?;
+    // The access service serves nothing for an account that has not
+    // confirmed its email.
+    fixture.activate_with(&env).await?;
     let operator = fixture.pre_account_site.operator.inner();
 
     // Exactly what the page mints: the account's powerline to this profile,
@@ -235,6 +245,8 @@ async fn it_installs_authority_from_a_callback_authorization(
     )
     .await?;
     configure_upstream(&site, &env.access_service_url).await?;
+    env.provision_subject(site.repository.did().as_str())
+        .await?;
     tonk_cli::sync::push(&site)
         .await
         .context("a spot must push under authority that reaches the account root")?;
@@ -257,6 +269,9 @@ async fn it_discovers_a_space_through_the_account(env: AccessServiceAddress) -> 
 
     let remote = format!("{}/", env.access_service_url.trim_end_matches('/'));
     let owner = common::AccountFixture::with_account_remote(&remote).await?;
+    // The access service serves nothing for an account that has not
+    // confirmed its email.
+    owner.activate_with(&env).await?;
     let owner_operator = owner.pre_account_site.operator.inner();
     let account_root = owner.link.issuer().clone();
 
@@ -454,6 +469,9 @@ async fn it_recovers_space_access_on_a_second_device(env: AccessServiceAddress) 
     // Device one: an account, and a spot whose authority it retains there.
     let remote = format!("{}/", env.access_service_url.trim_end_matches('/'));
     let first = common::AccountFixture::with_account_remote(&remote).await?;
+    // The access service serves nothing for an account that has not
+    // confirmed its email.
+    first.activate_with(&env).await?;
     let site = TonkSite::init_at_with(&first.tmp.path().join("device-one"), account_config(&first))
         .await?;
     configure_upstream(&site, &env.access_service_url).await?;
@@ -600,9 +618,14 @@ async fn it_pushes_a_spot_created_before_the_account_existed(
     env: AccessServiceAddress,
 ) -> Result<()> {
     let fixture = common::AccountFixture::new().await?;
+    // The access service serves nothing for an account that has not
+    // confirmed its email.
+    fixture.activate_with(&env).await?;
     let path = fixture.pre_account_site.root.clone();
     let site = TonkSite::open_with(&path, account_config(&fixture)).await?;
     configure_upstream(&site, &env.access_service_url).await?;
+    env.provision_subject(site.repository.did().as_str())
+        .await?;
 
     tonk_cli::sync::push(&site).await?;
 

--- a/rust/tonk-cli/tests/account_spots.rs
+++ b/rust/tonk-cli/tests/account_spots.rs
@@ -250,9 +250,12 @@ async fn pull_from_a_live_access_service_syncs_the_canonical_unbound_site(
     env: AccessServiceAddress,
 ) -> Result<()> {
     let fixture = common::AccountFixture::new().await?;
+    fixture.activate_with(&env).await?;
     let source_root = fixture.tmp.path().join("published-source");
     let source = TonkSite::init_at_with(&source_root, fixture.config.clone()).await?;
     let subject = source.repository.did();
+    // The published space has to be someone's to serve before it syncs.
+    env.provision_subject(subject.as_str()).await?;
     let source_branch = source.branch().await?;
     source_branch
         .handle()
@@ -497,6 +500,9 @@ async fn list_hydrates_a_linked_but_unhydrated_profile(env: AccessServiceAddress
     // Descriptor remotes are canonical with a trailing slash.
     let remote = format!("{}/", env.access_service_url.trim_end_matches('/'));
     let fixture = common::AccountFixture::unhydrated_with_account_remote(&remote).await?;
+    // Hydration syncs the account space, which is servable only once
+    // its customer has confirmed the emailed activation link.
+    fixture.activate_with(&env).await?;
     let operator = fixture.operator().await?;
     assert!(
         tonk_cli::account_state::open_account_branch_in(

--- a/rust/tonk-cli/tests/cli_spot.rs
+++ b/rust/tonk-cli/tests/cli_spot.rs
@@ -86,23 +86,28 @@ const DEAD_RELAY: &str = "http://127.0.0.1:9/revocations";
 /// in order. `tonk remote add` wires the *first* remote as `main`'s
 /// upstream and leaves it alone after that, so `remotes[0]` is the one
 /// the repo pushes to.
-fn spot_with_remotes(state_dir: &Path, remotes: &[(&str, &str)]) {
+fn spot_with_remotes(state_dir: &Path, remotes: &[(&str, &str)]) -> String {
     let relayed: Vec<(&str, &str, Option<&str>)> = remotes
         .iter()
         .map(|(name, endpoint)| (*name, *endpoint, None))
         .collect();
-    spot_with_relayed_remotes(state_dir, &relayed);
+    spot_with_relayed_remotes(state_dir, &relayed)
 }
 
 /// The same, with a revocation relay per remote. An invite that embeds a
 /// remote must name a relay for its revocations to reach, so a mint against
 /// a relay-less remote is refused — see
 /// `when_a_remote_carries_no_revocation_relay`.
-fn spot_with_relayed_remotes(state_dir: &Path, remotes: &[(&str, &str, Option<&str>)]) {
+fn spot_with_relayed_remotes(state_dir: &Path, remotes: &[(&str, &str, Option<&str>)]) -> String {
     let site = state_dir.join("site");
     let site = site.to_str().expect("utf-8 site path");
     let output = run(state_dir, &["spot", "new", "demo", "--site", site], &[]);
     assert!(output.status.success(), "{}", stderr_of(&output));
+    let did = stdout_of(&output)
+        .lines()
+        .find_map(|line| line.strip_prefix("DID: "))
+        .expect("spot new reports the new spot's DID")
+        .to_owned();
 
     for (name, endpoint, relay) in remotes {
         let mut args = vec!["remote", "add", name, endpoint];
@@ -112,6 +117,7 @@ fn spot_with_relayed_remotes(state_dir: &Path, remotes: &[(&str, &str, Option<&s
         let output = run(state_dir, &args, &[]);
         assert!(output.status.success(), "{}", stderr_of(&output));
     }
+    did
 }
 
 /// Write a `spots.json` registry directly (bypassing the CLI) so
@@ -583,12 +589,29 @@ mod when_minting_against_a_live_remote {
     /// `#[tokio::test]`, whose current-thread runtime is also hosting
     /// the access service — block that thread on a subprocess and the
     /// service the CLI is talking to can never answer.
-    async fn mint_against(state_dir: PathBuf, endpoint: String, args: &[&str]) -> Output {
+    async fn mint_against(
+        env: &AccessServiceAddress,
+        state_dir: PathBuf,
+        endpoint: String,
+        args: &[&str],
+    ) -> Output {
         let args: Vec<String> = args.iter().map(|arg| (*arg).to_owned()).collect();
-        tokio::task::spawn_blocking(move || {
+        let setup_dir = state_dir.clone();
+        let setup_endpoint = endpoint.clone();
+        // Create the spot first so its DID can be provisioned: minting
+        // pushes, and the access service serves no unprovisioned space.
+        let did = tokio::task::spawn_blocking(move || {
             // With a relay, because these mints embed the remote: an invite
             // that carries an endpoint has to say where its revocations go.
-            spot_with_relayed_remotes(&state_dir, &[("origin", &endpoint, Some(DEAD_RELAY))]);
+            spot_with_relayed_remotes(&setup_dir, &[("origin", &setup_endpoint, Some(DEAD_RELAY))])
+        })
+        .await
+        .expect("blocking spot setup joins");
+        env.provision_subject(&did)
+            .await
+            .expect("the spot provisions");
+
+        tokio::task::spawn_blocking(move || {
             let args: Vec<&str> = args.iter().map(String::as_str).collect();
             run(&state_dir, &args, &[])
         })
@@ -606,7 +629,13 @@ mod when_minting_against_a_live_remote {
         let state = tempfile::tempdir()?;
         let origin = env.access_service_url.trim_end_matches('/').to_owned();
 
-        let output = mint_against(state.path().to_path_buf(), origin.clone(), &["invite"]).await;
+        let output = mint_against(
+            &env,
+            state.path().to_path_buf(),
+            origin.clone(),
+            &["invite"],
+        )
+        .await;
         assert!(output.status.success(), "{}", stderr_of(&output));
 
         let stdout = stdout_of(&output);
@@ -652,6 +681,7 @@ mod when_minting_against_a_live_remote {
         let origin = env.access_service_url.trim_end_matches('/').to_owned();
 
         let output = mint_against(
+            &env,
             state.path().to_path_buf(),
             origin.clone(),
             &["invite", "--no-remote"],
@@ -682,6 +712,7 @@ mod when_minting_against_a_live_remote {
         let origin = env.access_service_url.trim_end_matches('/').to_owned();
 
         let output = mint_against(
+            &env,
             state.path().to_path_buf(),
             origin,
             &["invite", "--base-url", "http://127.0.0.1:9/join"],
@@ -718,9 +749,18 @@ mod when_status_is_synced {
         let state_dir = state.path().to_path_buf();
         let endpoint = env.access_service_url.trim_end_matches('/').to_owned();
 
-        let (expected_hash, status) = tokio::task::spawn_blocking(move || {
-            spot_with_remotes(&state_dir, &[("origin", &endpoint)]);
+        let setup_dir = state_dir.clone();
+        let setup_endpoint = endpoint.clone();
+        let did = tokio::task::spawn_blocking(move || {
+            spot_with_remotes(&setup_dir, &[("origin", &setup_endpoint)])
+        })
+        .await
+        .expect("blocking spot setup joins");
+        env.provision_subject(&did)
+            .await
+            .expect("the spot provisions");
 
+        let (expected_hash, status) = tokio::task::spawn_blocking(move || {
             let pushed = run(&state_dir, &["push"], &[]);
             assert!(pushed.status.success(), "{}", stderr_of(&pushed));
             let pushed = stdout_of(&pushed);

--- a/rust/tonk-cli/tests/common.rs
+++ b/rust/tonk-cli/tests/common.rs
@@ -203,6 +203,25 @@ impl AccountFixture {
         })
     }
 
+    /// Enroll this fixture's account root with `access` and confirm its
+    /// email, so the access service will serve and provision for it.
+    ///
+    /// The gate serves nothing for a customer that has not confirmed an
+    /// email address, so any fixture that pushes, pulls, or provisions
+    /// against a live access service comes through here first.
+    pub async fn activate_with(
+        &self,
+        access: &tonk_access_service::helpers::AccessServiceAddress,
+    ) -> Result<()> {
+        let root = dialog_credentials::Ed25519Signer::import(&self.root_prf).await?;
+        access.activate_customer(&root, "person@example.com").await
+    }
+
+    /// This fixture's account root signer.
+    pub async fn root_signer(&self) -> Result<dialog_credentials::Ed25519Signer> {
+        Ok(dialog_credentials::Ed25519Signer::import(&self.root_prf).await?)
+    }
+
     /// Mint a `space → account-root` chain for a synthetic space.
     pub async fn space_chain(
         &self,

--- a/rust/tonk-identity/src/ceremony.rs
+++ b/rust/tonk-identity/src/ceremony.rs
@@ -65,6 +65,11 @@ pub struct CustodyAccountCeremony {
     pub custody_did: String,
     /// Hex-encoded consent chain for `/provider/add`.
     pub consent_hex: String,
+    /// Hex-encoded sealed account secret, when the custody cell could
+    /// not be published during the ceremony because the account has not
+    /// confirmed its email yet. The caller queues it and publishes once
+    /// activation lands; `None` means the cell is already published.
+    pub sealed_hex: Option<String>,
 }
 
 /// Informational metadata captured by the browser that created a passkey.
@@ -223,11 +228,14 @@ pub async fn create_account(
 /// stored anywhere; every later custody operation derives its keys
 /// inside a fresh assertion.
 ///
-/// The cell publishes before anything registers: creation without it
-/// would mint an account only this page's memory can unlock, so a
-/// refused publish fails the whole ceremony instead.
+/// The cell cannot publish here: the account has not enrolled yet, let
+/// alone confirmed its email, and the access service serves nothing for
+/// an unactivated customer. The sealed envelope comes back instead, for
+/// the caller to queue and publish once activation lands
+/// (`plan/account-activation-gate.md` §5). It is ciphertext under the
+/// passkey's KEK, so holding it is not holding key material — but until
+/// it is published the account can only be unlocked on this browser.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-#[allow(clippy::too_many_arguments)]
 pub async fn create_custody_account(
     email: String,
     device_did: dialog_varsig::Did,
@@ -235,7 +243,6 @@ pub async fn create_custody_account(
     remote: String,
     created_on: Option<&str>,
     service: Option<&dialog_varsig::Did>,
-    endpoint: &str,
 ) -> Result<CustodyAccountCeremony> {
     use crate::envelope::{AccountSecret, KekMethod, custody_kek, custody_signer};
 
@@ -259,9 +266,6 @@ pub async fn create_custody_account(
     let custody = custody_signer(&evaluation.key).await?;
     let kek = custody_kek(&evaluation.kek);
     let sealed = kek.seal(&secret, KekMethod::Passkey)?.encode();
-    crate::custody::publish_secret(custody.clone(), &sealed, endpoint, None)
-        .await
-        .context("failed to publish the custody cell; the account was not created")?;
     let consent = crate::custody::mint_custody_consent(custody.clone(), &root.did()).await?;
     let consent_hex = hex::encode(
         consent
@@ -297,6 +301,7 @@ pub async fn create_custody_account(
         deposits_hex,
         custody_did: custody.did().to_string(),
         consent_hex,
+        sealed_hex: Some(hex::encode(&sealed)),
     })
 }
 
@@ -347,6 +352,10 @@ pub struct CustodyEnrollment {
     /// Hex-encoded consent chain for `/provider/add`: the custody
     /// key's agreement to being provided by the account.
     pub consent_hex: String,
+    /// Hex-encoded sealed account secret, when the cell could not be
+    /// published yet — the new custody DID is not provisioned until the
+    /// caller deposits the consent above. `None` once it is published.
+    pub sealed_hex: Option<String>,
 }
 
 /// Enroll an additional custody passkey: unlock the account through an
@@ -384,24 +393,40 @@ pub async fn enroll_custody(
     let kek = custody_kek(&evaluation.kek);
     let sealed = kek.seal(&secret, KekMethod::Passkey)?.encode();
 
+    // A brand new custody DID is nobody's consumer until the caller
+    // deposits the consent below, and the access service serves no
+    // unprovisioned subject — so a refusal here is the expected first
+    // outcome, not a failure. Hand the sealed bytes back to be queued
+    // and published once provisioning lands.
+    let mut sealed_hex = Some(hex::encode(&sealed));
     if let Err(publish_error) =
         crate::custody::publish_secret(custody.clone(), &sealed, endpoint, None).await
     {
         // The cell may already exist: the same credential re-enrolled
         // names the same space. Anything that opens to this account is
-        // that case; anything else is a real refusal.
+        // that case, and needs no republish; anything else waits.
         match crate::custody::resolve_secret(custody.clone(), endpoint).await {
             Ok(Some(existing)) => {
                 let published = Envelope::decode(&existing)
                     .ok()
                     .and_then(|envelope| kek.open(&envelope).ok());
                 match published {
-                    Some(open) if open.signing_seed() == secret.signing_seed() => {}
+                    Some(open) if open.signing_seed() == secret.signing_seed() => {
+                        sealed_hex = None;
+                    }
                     _ => anyhow::bail!("the custody space already holds a different account"),
                 }
             }
-            _ => return Err(publish_error),
+            // Not published, and not already ours: leave `sealed_hex`
+            // set so the caller queues it. The error itself is the
+            // caller's to report, once it knows whether provisioning is
+            // still pending.
+            _ => {
+                let _ = publish_error;
+            }
         }
+    } else {
+        sealed_hex = None;
     }
 
     let consent = crate::custody::mint_custody_consent(custody.clone(), &root.did()).await?;
@@ -414,7 +439,49 @@ pub async fn enroll_custody(
         custody_did: custody.did().to_string(),
         credential_id,
         consent_hex,
+        sealed_hex,
     })
+}
+
+/// Publish a queued custody cell, with a fresh assertion.
+///
+/// The queued bytes were sealed under this passkey's KEK during the
+/// ceremony that created it; the assertion here re-derives the custody
+/// key that signs the publish, and proves the same credential is
+/// present. A cell that already holds this account's envelope is
+/// success — another device got there first.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub async fn publish_queued_custody(
+    custody_did: &str,
+    sealed: &[u8],
+    endpoint: &str,
+) -> Result<()> {
+    use crate::envelope::{custody_kek, custody_signer};
+
+    let evaluated = crate::passkey::evaluate_custody_passkey().await?;
+    let evaluation = evaluated
+        .evaluation
+        .context("the authenticator returned no PRF outputs")?;
+    let custody = custody_signer(&evaluation.key).await?;
+    if custody.did().to_string() != custody_did {
+        anyhow::bail!("the asserted passkey derives a different custody space");
+    }
+    // Prove the queued bytes open under this passkey before publishing:
+    // a cell that cannot be unsealed by the credential that owns it is
+    // worse than no cell at all.
+    let kek = custody_kek(&evaluation.kek);
+    let envelope = crate::envelope::Envelope::decode(sealed)
+        .map_err(|error| anyhow::anyhow!("the queued envelope is unreadable: {error}"))?;
+    kek.open(&envelope)
+        .map_err(|error| anyhow::anyhow!("the queued envelope did not open: {error}"))?;
+
+    match crate::custody::publish_secret(custody.clone(), sealed, endpoint, None).await {
+        Ok(()) => Ok(()),
+        Err(publish_error) => match crate::custody::resolve_secret(custody, endpoint).await {
+            Ok(Some(_)) => Ok(()),
+            _ => Err(publish_error),
+        },
+    }
 }
 
 /// A passkey unlock's outcome: the device-link ceremony minted from

--- a/rust/tonk-identity/src/install.rs
+++ b/rust/tonk-identity/src/install.rs
@@ -191,7 +191,6 @@ async fn create_account(input: JsValue) -> Result<JsValue, JsValue> {
         .map_err(|error| JsValue::from_str(&format!("invalid deviceDid: {error}")))?;
     let device_name = string_property(&input, "deviceName")?;
     let remote = string_property(&input, "remote")?;
-    let endpoint = string_property(&input, "endpoint")?;
     let created_on = optional_string_property(&input, "createdOn");
     let service = service_did_property(&input)?;
     let ceremony = crate::ceremony::create_custody_account(
@@ -201,7 +200,6 @@ async fn create_account(input: JsValue) -> Result<JsValue, JsValue> {
         remote,
         created_on.as_deref(),
         service.as_ref(),
-        &endpoint,
     )
     .await
     .map_err(js_error)?;
@@ -217,13 +215,19 @@ async fn create_account(input: JsValue) -> Result<JsValue, JsValue> {
     set_deposits(&result, &ceremony.deposits_hex)?;
     Reflect::set(&result, &"custodyDid".into(), &ceremony.custody_did.into())?;
     Reflect::set(&result, &"consentHex".into(), &ceremony.consent_hex.into())?;
+    if let Some(sealed_hex) = ceremony.sealed_hex {
+        Reflect::set(&result, &"sealedHex".into(), &sealed_hex.into())?;
+    }
     Ok(result)
 }
 
 /// `enrollCustodyPasskey({ accountDid, label?, endpoint })` →
-/// `{ custodyDid, credentialId, consentHex }`. Creates the custody
-/// passkey, seals the secret under its KEK, and publishes the cell;
-/// the caller provisions the custody DID with the consent afterwards.
+/// `{ custodyDid, credentialId, consentHex, sealedHex? }`. Creates the
+/// custody passkey and seals the secret under its KEK. The caller
+/// provisions the custody DID with the consent; `sealedHex` is present
+/// when the cell could not be published yet — the new custody DID is
+/// nobody's consumer until that provisioning lands — and the caller
+/// queues those bytes to publish afterwards.
 async fn enroll_custody_passkey(input: JsValue) -> Result<JsValue, JsValue> {
     let account_did = string_property(&input, "accountDid")?;
     let label = optional_string_property(&input, "label");
@@ -247,7 +251,25 @@ async fn enroll_custody_passkey(input: JsValue) -> Result<JsValue, JsValue> {
         &"consentHex".into(),
         &enrollment.consent_hex.into(),
     )?;
+    if let Some(sealed_hex) = enrollment.sealed_hex {
+        Reflect::set(&result, &"sealedHex".into(), &sealed_hex.into())?;
+    }
     Ok(result.into())
+}
+
+/// `publishQueuedCustody({ custodyDid, sealedHex, endpoint })` → `{}`.
+/// Publishes a custody cell that could not be written when its
+/// ceremony ran, using a fresh assertion of the same passkey.
+async fn publish_queued_custody(input: JsValue) -> Result<JsValue, JsValue> {
+    let custody_did = string_property(&input, "custodyDid")?;
+    let sealed_hex = string_property(&input, "sealedHex")?;
+    let endpoint = string_property(&input, "endpoint")?;
+    let sealed = hex::decode(&sealed_hex)
+        .map_err(|error| JsValue::from_str(&format!("sealedHex is not hex: {error}")))?;
+    crate::ceremony::publish_queued_custody(&custody_did, &sealed, &endpoint)
+        .await
+        .map_err(js_error)?;
+    Ok(Object::new().into())
 }
 
 /// `unlockWithPasskey({ deviceDid, deviceName, endpoint, serviceDid? })`
@@ -374,6 +396,16 @@ pub fn install() {
         enroll_custody_passkey.as_ref().unchecked_ref(),
     );
     enroll_custody_passkey.forget();
+
+    let publish_queued = Closure::<dyn FnMut(JsValue) -> Promise>::new(|input: JsValue| {
+        future_to_promise(publish_queued_custody(input))
+    });
+    let _ = Reflect::set(
+        &identity,
+        &"publishQueuedCustody".into(),
+        publish_queued.as_ref().unchecked_ref(),
+    );
+    publish_queued.forget();
 
     let unlock_with_passkey = Closure::<dyn FnMut(JsValue) -> Promise>::new(|input: JsValue| {
         future_to_promise(unlock_with_passkey(input))

--- a/rust/tonk-ui/src/account.html
+++ b/rust/tonk-ui/src/account.html
@@ -64,6 +64,7 @@
   <div id="account-success" class="account__panel account__dashboard" hidden>
     <p id="account-success-message" class="account__status">Signed in on this device.</p>
     <p id="account-activation-notice" class="account__hint" role="status" hidden></p>
+    <button id="account-resend-activation" class="account__button account__button--quiet" type="button" hidden>Resend activation email</button>
 
     <section class="account__section account__passkey" aria-labelledby="account-passkey-title">
       <div class="account__section-heading">

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -1676,6 +1676,9 @@ fn bind(host: &HtmlElement) {
                 // One assertion derives the custody keypair, one
                 // presigned GET fetches the sealed envelope, and the
                 // unwrapped secret self-issues this device's delegation.
+                // Unlocking reads the custody cell, which stays queued
+                // while the customer is unactivated.
+                publish_queued_custody().await;
                 let ceremony = unlock_with_passkey(UnlockWithPasskeyInput {
                     device_did,
                     device_name,
@@ -1730,6 +1733,12 @@ fn bind(host: &HtmlElement) {
                                 })?;
                         }
                     }
+                    // Unlocking the account reads the custody cell, which
+                    // stays queued while the customer is unactivated. A
+                    // browser that activated without returning to the
+                    // dashboard still has it waiting, so drain before
+                    // asking the ceremony to resolve it.
+                    publish_queued_custody().await;
                     set_busy(&host, true, "Waiting for your passkey…");
                     // The descriptor must name the same sync remote signup
                     // established — the page's own `/ucan/` endpoint — or the
@@ -1801,6 +1810,9 @@ fn bind(host: &HtmlElement) {
         set_busy(&host, true, "Waiting for your passkey…");
         spawn_local(async move {
             let result = async {
+                // Unlocking reads the custody cell, which stays queued
+                // while the customer is unactivated.
+                publish_queued_custody().await;
                 let ceremony = complete_link(CompleteLinkInput {
                     token_hash: handoff.token_hash,
                     device_did: handoff.device_did,
@@ -2204,6 +2216,9 @@ fn begin_revoke(
                     return;
                 }
             };
+            // Signing a revocation unlocks the root, which reads the
+            // custody cell.
+            publish_queued_custody().await;
             let signed: Result<RevocationOutput, String> = sign_revocation(SignRevocationInput {
                 delegation_cid,
                 path_hex: delegation_hex,

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -312,6 +312,9 @@ fn load_activation_notice(host: HtmlElement) {
             publish_queued_custody().await;
         }
         if state["status"].as_str() != Some("Registered") {
+            if let Ok(Some(resend)) = host.query_selector("#account-resend-activation") {
+                let _ = resend.set_attribute("hidden", "");
+            }
             return;
         }
         let Ok(Some(notice)) = host.query_selector("#account-activation-notice") else {
@@ -325,6 +328,12 @@ fn load_activation_notice(host: HtmlElement) {
         };
         notice.set_text_content(Some(&message));
         let _ = notice.remove_attribute("hidden");
+        // The way out of a stuck Registered: enrollment is idempotent
+        // while Registered and resends the link, which is also the
+        // recovery for one that expired.
+        if let Ok(Some(resend)) = host.query_selector("#account-resend-activation") {
+            let _ = resend.remove_attribute("hidden");
+        }
     });
 }
 
@@ -1553,6 +1562,26 @@ fn bind(host: &HtmlElement) {
             if let Err(error) = result {
                 set_busy(&host, false, "");
                 show_error(&host, error);
+            }
+        });
+    });
+
+    on_click(host, "#account-resend-activation", |host| {
+        clear_error(&host);
+        set_busy(&host, true, "Sending another activation email…");
+        spawn_local(async move {
+            // Enrollment is idempotent while Registered: the rows stand
+            // and the link is sent again. No ceremony is at hand here,
+            // so the deposits are the device-chained fallback.
+            let result = crate::api::enroll_customer(None, &[]).await;
+            set_busy(&host, false, "");
+            match result {
+                Ok(_) => set_text(
+                    &host,
+                    "#account-activation-notice",
+                    "Sent. Open the link in your activation email.",
+                ),
+                Err(error) => show_error(&host, format!("could not resend: {error}")),
             }
         });
     });

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -199,6 +199,59 @@ fn show_success(host: &HtmlElement) {
 /// every other answer: an active customer needs no notice, and a
 /// deployment without registration should not decorate the panel with
 /// its absence.
+/// Publish every custody cell queued while the account was waiting on
+/// email confirmation.
+///
+/// Each publish needs a fresh passkey assertion, which is a user
+/// prompt, so this runs only when there is something queued — an
+/// activated account with nothing waiting must never see a passkey
+/// dialog it did not ask for. Failures stay queued for the next load.
+async fn publish_queued_custody() {
+    let queue = match crate::api::pending_work().await {
+        Ok(queue) => queue,
+        Err(error) => {
+            web_sys::console::warn_1(&format!("pending work unreadable: {error}").into());
+            return;
+        }
+    };
+    let endpoint = match proposed_remote() {
+        Ok(endpoint) => endpoint,
+        Err(error) => return web_sys::console::warn_1(&format!("no remote: {error}").into()),
+    };
+    for work in queue.entries() {
+        let tonk_account::pending::PendingWork::PublishCustody {
+            custody,
+            sealed_hex,
+        } = work
+        else {
+            continue;
+        };
+        match crate::identity_bridge::publish_queued_custody(
+            crate::identity_bridge::PublishQueuedCustodyInput {
+                custody_did: custody.clone(),
+                sealed_hex: sealed_hex.clone(),
+                endpoint: endpoint.clone(),
+            },
+        )
+        .await
+        {
+            Ok(()) => {
+                if let Err(error) = crate::api::complete_custody_publish(custody).await {
+                    web_sys::console::warn_1(
+                        &format!("custody published but still queued: {error}").into(),
+                    );
+                }
+            }
+            Err(error) => {
+                web_sys::console::warn_1(&format!("custody publish still pending: {error}").into());
+                // Stop at the first failure: a later entry must not
+                // overtake one that is still waiting on provisioning.
+                break;
+            }
+        }
+    }
+}
+
 fn load_activation_notice(host: HtmlElement) {
     spawn_local(async move {
         if !wants_enrollment().await {
@@ -251,6 +304,13 @@ fn load_activation_notice(host: HtmlElement) {
             _ => "Not registered",
         };
         set_text(&host, "#account-registration-value", label);
+        // Activation is what unblocks the queued custody publish, and
+        // only a page can sign it — the custody key lives inside a
+        // passkey assertion. This notice is the one place that both
+        // learns about activation and can raise one.
+        if state["status"].as_str() == Some("Active") {
+            publish_queued_custody().await;
+        }
         if state["status"].as_str() != Some("Registered") {
             return;
         }
@@ -1446,7 +1506,6 @@ fn bind(host: &HtmlElement) {
                     device_did,
                     device_name,
                     remote: proposed_remote()?,
-                    endpoint: proposed_remote()?,
                     created_on: Some(crate::device_name::current()),
                     service_did: deployment_service_did().await,
                 })
@@ -1468,14 +1527,25 @@ fn bind(host: &HtmlElement) {
                 };
                 set_busy(&host, true, "Creating your account…");
                 complete_remote(&host, "/accounts", ceremony, true, Some(&email)).await?;
-                // Provisioning the custody space is retryable; the
-                // published cell is the account's durability.
+                // Neither of these can land before the emailed link is
+                // clicked: the service provisions nothing, and serves
+                // nothing, for a customer that has not confirmed its
+                // email. Both queue instead, and replay on activation.
                 if let Err(error) =
                     crate::api::provision_custody(&created.custody_did, &created.consent_hex).await
                 {
                     web_sys::console::warn_1(
                         &format!("custody provisioning deferred: {error}").into(),
                     );
+                }
+                if let Some(sealed_hex) = &created.sealed_hex
+                    && let Err(error) =
+                        crate::api::queue_custody_publish(&created.custody_did, sealed_hex).await
+                {
+                    // The sealed secret is only in this page's memory
+                    // until it is recorded, so failing to queue it is
+                    // the one loss worth surfacing.
+                    return Err(format!("could not record the account secret: {error}"));
                 }
                 Ok::<(), String>(())
             }
@@ -1516,8 +1586,9 @@ fn bind(host: &HtmlElement) {
                 })
                 .await
                 .map_err(|error| error.to_string())?;
-                // Provisioning is retryable; the published cell is the
-                // account's durability, so a refusal here only warns.
+                // Provision before publishing: the new custody DID is
+                // nobody's consumer until this deposit lands, and the
+                // service serves no unprovisioned subject.
                 if let Err(error) =
                     crate::api::provision_custody(&enrolled.custody_did, &enrolled.consent_hex)
                         .await
@@ -1525,6 +1596,17 @@ fn bind(host: &HtmlElement) {
                     web_sys::console::warn_1(
                         &format!("custody provisioning deferred: {error}").into(),
                     );
+                }
+                // The ceremony hands back sealed bytes when its publish
+                // was refused. Retry now that provisioning has run, and
+                // queue what still will not land.
+                if let Some(sealed_hex) = &enrolled.sealed_hex
+                    && let Err(error) =
+                        crate::api::queue_custody_publish(&enrolled.custody_did, sealed_hex).await
+                {
+                    return Err(format!(
+                        "could not record the sealed account secret: {error}"
+                    ));
                 }
                 crate::api::save_root(
                     enrolled.credential_id,

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -361,6 +361,17 @@ mod tests {
         path
     }
 
+    fn tonk_command_in(env: &TestEnvironment, profile: &TempDir) -> Command {
+        let mut command = tonk_command(profile);
+        // Trust this harness's Caddy root specifically. A process-wide
+        // SSL_CERT_FILE would be whichever concurrent harness wrote it
+        // last, leaving this child unable to reach its own origin.
+        if let Some(ca) = &env.ca_certificate {
+            command.env("SSL_CERT_FILE", ca);
+        }
+        command
+    }
+
     fn tonk_command(profile: &TempDir) -> Command {
         let mut command = Command::new(tonk_bin());
         command
@@ -385,8 +396,12 @@ mod tests {
         stderr: String,
     }
 
-    async fn run_cli(profile: &TempDir, args: &[String]) -> Result<CliOutput> {
-        let output = tonk_command(profile).args(args).output().await?;
+    async fn run_cli(
+        env: &TestEnvironment,
+        profile: &TempDir,
+        args: &[String],
+    ) -> Result<CliOutput> {
+        let output = tonk_command_in(env, profile).args(args).output().await?;
         Ok(CliOutput {
             status: output.status,
             stdout: String::from_utf8(output.stdout)?,
@@ -441,7 +456,7 @@ mod tests {
         register_first: bool,
     ) -> Result<LinkedCli> {
         let profile = tempfile::tempdir()?;
-        let mut command = tonk_command(&profile);
+        let mut command = tonk_command_in(env, &profile);
         command
             .args([
                 "account",
@@ -564,6 +579,7 @@ mod tests {
 
     async fn devices(profile: &TempDir, env: &TestEnvironment) -> Result<CliOutput> {
         run_cli(
+            env,
             profile,
             &[
                 "account".to_string(),
@@ -802,6 +818,7 @@ mod tests {
         let mut last_seen = String::from("<spots never completed a run>");
         let recorded = loop {
             let run = run_cli(
+                &env,
                 &second_device.profile,
                 &["account".to_string(), "spots".to_string()],
             )
@@ -812,8 +829,19 @@ mod tests {
                 }
                 last_seen = run.stdout;
             } else if run.stderr.contains("first sync has not succeeded yet") {
-                // Not a failure: hydration is retried on the next
-                // invocation, and this device linked moments ago.
+                // Hydration maps every underlying error to Unhydrated,
+                // so this one message covers both a first sync that has
+                // genuinely not landed yet and one that cannot land at
+                // all. Only the former is worth waiting on: a transport
+                // failure means the harness origin is unreachable from
+                // this CLI child, which no amount of retrying fixes.
+                if run.stderr.contains("Transport error") {
+                    return Err(anyhow!(
+                        "the linked CLI cannot reach the harness origin, so the account \
+                         can never sync: {}",
+                        run.stderr.trim()
+                    ));
+                }
                 last_seen = format!("not hydrated yet: {}", run.stderr.trim());
             } else {
                 // Any other non-zero exit is a real error; failing here
@@ -1082,6 +1110,7 @@ mod tests {
         let linked = link_cli(&driver, &env).await?;
 
         let status = run_cli(
+            &env,
             &linked.profile,
             &["account".to_string(), "status".to_string()],
         )
@@ -1126,6 +1155,7 @@ mod tests {
         let linked = link_cli_with(&driver, &env, true).await?;
 
         let status = run_cli(
+            &env,
             &linked.profile,
             &["account".to_string(), "status".to_string()],
         )

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -139,7 +139,25 @@ mod tests {
             .ok_or_else(|| anyhow!("Chrome omitted the virtual authenticator credentials"))
     }
 
+    /// Create an account and confirm its email, leaving it able to host
+    /// spaces. Most callers want this.
     pub(crate) async fn sign_up(
+        driver: &WebDriver,
+        env: &TestEnvironment,
+        email: &str,
+    ) -> Result<()> {
+        enroll_only(driver, env, email).await?;
+        // The access service provisions nothing and serves nothing for a
+        // customer that has not confirmed its email, so a signed-up
+        // account cannot host a space until this happens.
+        activate(driver, env, email).await?;
+        Ok(())
+    }
+
+    /// Create an account and stop, leaving the customer `Registered`
+    /// with its activation email unopened — the window in which the
+    /// service refuses everything and the client queues it.
+    pub(crate) async fn enroll_only(
         driver: &WebDriver,
         env: &TestEnvironment,
         email: &str,
@@ -186,13 +204,6 @@ mod tests {
                 "account creation stopped in mode {mode:?}; error={error:?}; status={working:?}"
             ));
         }
-
-        // Confirm the email: the access service provisions nothing and
-        // serves nothing for a customer that has not, so a signed-up
-        // account cannot host a space until this happens. Callers that
-        // push data need the account past this point, and callers that
-        // do not are unaffected by it.
-        activate(driver, env, email).await?;
         Ok(())
     }
 
@@ -495,6 +506,12 @@ mod tests {
                 .await?
                 .click()
                 .await?;
+            // Approving unlocks the account, which reads the custody
+            // cell — and that cell cannot be published until the
+            // customer confirms its email. Do it here, then return to
+            // the approval the signup interrupted.
+            activate(driver, env, EMAIL).await?;
+            driver.goto(approval_url.as_str()).await?;
         }
         element(driver, "tonk-account[data-mode=\"handoff\"]").await?;
         wait_for_text(driver, "#account-handoff-name", "e2e terminal").await?;
@@ -621,6 +638,94 @@ mod tests {
             (fields.len() == 3 && fields[1] == name)
                 .then(|| fields[2].trim_end_matches(" (this device)"))
         })
+    }
+
+    /// The pending-work queue, end to end: a space created before the
+    /// activation email is opened cannot be hosted, and becomes hosted
+    /// once it is — with no second attempt from the user.
+    ///
+    /// This is the whole point of the queue. The service refuses both
+    /// provisioning and presign for a `Registered` customer, so a space
+    /// created in that window works locally and syncs nothing; the
+    /// client records the provisioning and replays it when the customer
+    /// activates.
+    #[dialog_common::test]
+    async fn it_hosts_a_space_created_before_activation_once_the_email_is_confirmed(
+        env: TestEnvironment,
+    ) -> Result<()> {
+        let driver = driver_with_prf(&env).await?;
+        let email = "queued@example.com";
+        // Stop at Registered: the activation email is sent but unopened.
+        enroll_only(&driver, &env, email).await?;
+        wait_for_text_containing(&driver, "#account-activation-notice", "activation pending")
+            .await?;
+
+        // The space is created locally and works; only its hosting is
+        // withheld. Creation must not fail on the refused provisioning.
+        let created = post_json(
+            &driver,
+            "/api/spaces",
+            serde_json::json!({
+                "name": "Made While Waiting",
+                "remote": env.tonk_web.join("ucan/")?,
+                "revocation_url": env.account_service.join("revocations")?,
+                "template": "blank",
+            }),
+        )
+        .await?;
+        let key = successful_body("create space before activation", &created)["key"]
+            .as_str()
+            .context("create response omitted the spot key")?
+            .to_string();
+
+        // Pushing it now must fail: nobody is paying for this subject.
+        let refused = post_json(
+            &driver,
+            &format!("/api/repository/{key}/branch/main/sync/push"),
+            serde_json::json!({}),
+        )
+        .await?;
+        assert!(
+            refused.get("error").is_none(),
+            "the push request itself must reach the worker: {refused}"
+        );
+        assert!(
+            !refused["status"]
+                .as_u64()
+                .is_some_and(|status| (200..300).contains(&status)),
+            "an unactivated account must not be able to host a space: {refused}"
+        );
+
+        // Confirm the email. Nothing else is asked of the user: the
+        // queued provisioning replays off the status probe.
+        activate(&driver, &env, email).await?;
+        wait_for_text(&driver, "#account-registration-value", "Active").await?;
+
+        // The same push now succeeds, with no further provisioning call
+        // from the test — the queue did it.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        loop {
+            let pushed = post_json(
+                &driver,
+                &format!("/api/repository/{key}/branch/main/sync/push"),
+                serde_json::json!({}),
+            )
+            .await?;
+            let ok = pushed["status"]
+                .as_u64()
+                .is_some_and(|status| (200..300).contains(&status));
+            if ok {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "the queued provisioning never replayed after activation: {pushed}"
+            );
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+
+        driver.quit().await?;
+        Ok(())
     }
 
     #[dialog_common::test]

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -791,33 +791,44 @@ mod tests {
         // spot back out of the synced account DB — the real
         // cross-device path, not a service-side artifact store.
         let second_device = link_cli_with(&claimer, &env, false).await?;
-        // The browser pushes the directory facts on its next sync
-        // drain, so a freshly linked device may pull before they land.
-        // `spots` pulls best-effort on every run; poll until the
-        // recording arrives — the assertion is that promotion recorded
-        // the spot, not that it won a push race.
-        let mut spots = run_cli(
-            &second_device.profile,
-            &["account".to_string(), "spots".to_string()],
-        )
-        .await?;
-        assert!(spots.status.success(), "spots failed: {}", spots.stderr);
-        for _ in 0..30 {
-            if spots.stdout.contains(&key) {
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-            spots = run_cli(
+        // Two things have to land before this reads: the freshly linked
+        // device's first account sync (until then `spots` exits non-zero
+        // with "not yet hydrated"), and the browser's push of the
+        // directory facts, which happens on its next sync drain. Both
+        // are timing, not behaviour, so poll on the outcome under test —
+        // that promotion recorded the spot — rather than asserting on
+        // whichever intermediate state the first run happened to catch.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+        let mut last_seen = String::from("<spots never completed a run>");
+        let recorded = loop {
+            let run = run_cli(
                 &second_device.profile,
                 &["account".to_string(), "spots".to_string()],
             )
             .await?;
-            assert!(spots.status.success(), "spots failed: {}", spots.stderr);
-        }
+            if run.status.success() {
+                if run.stdout.contains(&key) {
+                    break true;
+                }
+                last_seen = run.stdout;
+            } else if run.stderr.contains("first sync has not succeeded yet") {
+                // Not a failure: hydration is retried on the next
+                // invocation, and this device linked moments ago.
+                last_seen = format!("not hydrated yet: {}", run.stderr.trim());
+            } else {
+                // Any other non-zero exit is a real error; failing here
+                // beats burning the deadline on it.
+                return Err(anyhow!("spots failed: {}", run.stderr));
+            }
+            if tokio::time::Instant::now() >= deadline {
+                break false;
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        };
         assert!(
-            spots.stdout.contains(&key),
-            "promotion completed without recording the claimed spot in the account directory: {}",
-            spots.stdout
+            recorded,
+            "promotion completed without recording the claimed spot in the account \
+             directory; last `spots` output was: {last_seen}"
         );
 
         let devtools = ChromeDevTools::new(claimer.handle.clone());

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -817,6 +817,12 @@ mod tests {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
         let mut last_seen = String::from("<spots never completed a run>");
         let recorded = loop {
+            // Drive the browser's sync drain rather than waiting for
+            // incidental traffic to trigger one. Promotion writes the
+            // directory facts locally; publishing them to the account
+            // remote happens on a drain, and once the test stops
+            // touching the page nothing else schedules one.
+            let _ = post_json(&claimer, "/api/sync", serde_json::json!({})).await;
             let run = run_cli(
                 &env,
                 &second_device.profile,

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -186,6 +186,31 @@ mod tests {
                 "account creation stopped in mode {mode:?}; error={error:?}; status={working:?}"
             ));
         }
+
+        // Confirm the email: the access service provisions nothing and
+        // serves nothing for a customer that has not, so a signed-up
+        // account cannot host a space until this happens. Callers that
+        // push data need the account past this point, and callers that
+        // do not are unaffected by it.
+        activate(driver, env, email).await?;
+        Ok(())
+    }
+
+    /// Follow the emailed activation link and accept, leaving the
+    /// customer `Active` and its queued work drained.
+    pub(crate) async fn activate(
+        driver: &WebDriver,
+        env: &TestEnvironment,
+        email: &str,
+    ) -> Result<()> {
+        let link = activation_link(env, email).await?;
+        let account = driver.current_url().await?;
+        driver.goto(&link).await?;
+        element(driver, "#activate-accept").await?.click().await?;
+        element(driver, "#activate-done").await?;
+        // Back to where the caller was: activation is a detour, not a
+        // navigation the caller asked for.
+        driver.goto(account.as_str()).await?;
         Ok(())
     }
 
@@ -216,12 +241,17 @@ mod tests {
         // Signup enrolled the account as a customer: the dashboard names
         // the pending activation, and the emailed link completes it from
         // this (or any) device without a key.
-        wait_for_text_containing(&driver, "#account-activation-notice", "activation pending")
-            .await?;
-        let link = activation_link(&env, EMAIL).await?;
-        driver.goto(&link).await?;
-        element(&driver, "#activate-accept").await?.click().await?;
-        element(&driver, "#activate-done").await?;
+        // sign_up already followed the emailed link, so the account is
+        // past activation: the registration row says so, and the
+        // pending-activation banner is gone.
+        wait_for_text(&driver, "#account-registration-value", "Active").await?;
+        if let Ok(notice) = driver.find(By::Css("#account-activation-notice")).await {
+            let text = notice.text().await.unwrap_or_default();
+            assert!(
+                !text.contains("activation pending"),
+                "an activated account must not still nag about activation, got {text:?}"
+            );
+        }
 
         driver.quit().await?;
         Ok(())

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -521,10 +521,15 @@ mod tests {
                 .await?
                 .click()
                 .await?;
+            // Let the creation ceremony finish before navigating
+            // anywhere: it lands back on the approval it interrupted,
+            // and leaving mid-flight loses whatever it had not yet
+            // persisted.
+            element(driver, "tonk-account[data-mode=\"handoff\"]").await?;
             // Approving unlocks the account, which reads the custody
             // cell — and that cell cannot be published until the
-            // customer confirms its email. Do it here, then return to
-            // the approval the signup interrupted.
+            // customer confirms its email. Do it now, then come back to
+            // the approval.
             activate(driver, env, EMAIL).await?;
             driver.goto(approval_url.as_str()).await?;
         }

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -669,6 +669,71 @@ pub async fn provision_custody(custody: &str, consent_hex: &str) -> Result<(), T
     }
 }
 
+/// The work queued until the account confirms its email, so the page
+/// can run the parts only it can sign.
+pub async fn pending_work() -> Result<tonk_account::pending::PendingQueue, TonkUiError> {
+    tonk_host::ready::wait().await;
+    let response = reqwest::Client::new()
+        .get(format!("{}/api/customer/pending", origin()))
+        .send()
+        .await
+        .map_err(into_api_error)?;
+    if response.status().is_success() {
+        response.json().await.map_err(into_api_error)
+    } else {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        Err(TonkUiError::ApiError(format!(
+            "GET /api/customer/pending returned {status}: {text}"
+        )))
+    }
+}
+
+/// Queue a custody cell that could not be published yet, so it is
+/// republished once provisioning and email activation let it through.
+pub async fn queue_custody_publish(custody: &str, sealed_hex: &str) -> Result<(), TonkUiError> {
+    tonk_host::ready::wait().await;
+    let response = reqwest::Client::new()
+        .post(format!("{}/api/custody/queue", origin()))
+        .json(&serde_json::json!({
+            "custody": custody,
+            "sealedHex": sealed_hex,
+        }))
+        .send()
+        .await
+        .map_err(into_api_error)?;
+    if response.status().is_success() {
+        Ok(())
+    } else {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        Err(TonkUiError::ApiError(format!(
+            "POST /api/custody/queue returned {status}: {text}"
+        )))
+    }
+}
+
+/// Tell the worker a queued custody publish is done, so it drops the
+/// entry and drains whatever it was holding back.
+pub async fn complete_custody_publish(custody: &str) -> Result<(), TonkUiError> {
+    tonk_host::ready::wait().await;
+    let response = reqwest::Client::new()
+        .post(format!("{}/api/customer/pending/custody", origin()))
+        .json(&serde_json::json!({ "custody": custody }))
+        .send()
+        .await
+        .map_err(into_api_error)?;
+    if response.status().is_success() {
+        Ok(())
+    } else {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        Err(TonkUiError::ApiError(format!(
+            "POST /api/customer/pending/custody returned {status}: {text}"
+        )))
+    }
+}
+
 /// Register a device with the account service through the worker, so a
 /// grant recipient is already listed before its delegation is delivered.
 pub async fn register_account_device(

--- a/rust/tonk-ui/src/helpers.rs
+++ b/rust/tonk-ui/src/helpers.rs
@@ -14,6 +14,11 @@ pub struct TestEnvironment {
     /// Base URL of the live native access service, reached directly
     /// (unproxied) for test inspection such as captured activation emails.
     pub access_service: Url,
+    /// This harness's Caddy root certificate, for CLI children that must
+    /// trust its origin. Per-harness rather than process-wide: each run
+    /// mints its own CA, so a single `SSL_CERT_FILE` would leave
+    /// concurrent runs trusting whichever one started last.
+    pub ca_certificate: Option<std::path::PathBuf>,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -204,10 +209,11 @@ mod native {
                         &format!("{access_service_port}"),
                     ])
                     // Pin Caddy's data dir so its per-run internal CA
-                    // root lands at a knowable path: native CLI
-                    // processes the tests spawn are pointed at it via
-                    // SSL_CERT_FILE, so they can speak TLS to the
-                    // harness origin the descriptors name.
+                    // root lands at a knowable path: it rides on
+                    // `TestEnvironment::ca_certificate`, and each native
+                    // CLI child is given it as its own SSL_CERT_FILE so
+                    // it can speak TLS to the harness origin the
+                    // descriptors name.
                     .env("XDG_DATA_HOME", &caddy_data)
                     .stdout(Stdio::piped())
                     // Nix writes build progress to stderr. Inheriting it prevents a
@@ -267,12 +273,11 @@ mod native {
                 }
                 tokio::time::sleep(std::time::Duration::from_millis(50)).await;
             }
-            if caddy_root.exists() {
-                // Safe under parallel tests: every TestServers run in
-                // this process serves the same purpose, and children
-                // only ever need whichever harness spawned them last.
-                unsafe { std::env::set_var("SSL_CERT_FILE", &caddy_root) };
-            }
+            // Handed to CLI children individually rather than exported:
+            // each harness mints its own CA under its own port, so a
+            // process-wide `SSL_CERT_FILE` makes concurrent runs trust
+            // the wrong root and fail to connect.
+            let ca_certificate = caddy_root.exists().then_some(caddy_root);
 
             // Start ChromeDriver
             let chromedriver_port =
@@ -313,6 +318,7 @@ mod native {
                     chromedriver: Url::parse(&format!("http://127.0.0.1:{chromedriver_port}"))?,
                     account_service: account_service_url,
                     access_service: Url::parse(&access_service_address.access_service_url)?,
+                    ca_certificate,
                 },
             ))
         }

--- a/rust/tonk-ui/src/helpers.rs
+++ b/rust/tonk-ui/src/helpers.rs
@@ -267,17 +267,25 @@ mod native {
                 .join("authorities")
                 .join("local")
                 .join("root.crt");
-            for _ in 0..100 {
+            // Caddy mints the CA lazily, on its first TLS handshake, so
+            // this can take a moment on a cold machine.
+            for _ in 0..200 {
                 if caddy_root.exists() {
                     break;
                 }
                 tokio::time::sleep(std::time::Duration::from_millis(50)).await;
             }
+            if !caddy_root.exists() {
+                return Err(anyhow!(
+                    "Caddy never minted its root certificate at {}; CLI children could not                      trust the harness origin",
+                    caddy_root.display()
+                ));
+            }
             // Handed to CLI children individually rather than exported:
             // each harness mints its own CA under its own port, so a
             // process-wide `SSL_CERT_FILE` makes concurrent runs trust
             // the wrong root and fail to connect.
-            let ca_certificate = caddy_root.exists().then_some(caddy_root);
+            let ca_certificate = Some(caddy_root);
 
             // Start ChromeDriver
             let chromedriver_port =

--- a/rust/tonk-ui/src/identity_bridge.rs
+++ b/rust/tonk-ui/src/identity_bridge.rs
@@ -9,8 +9,10 @@ use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 
 /// Input for creating an account and its first custody passkey in one
-/// ceremony: the secret is generated, sealed under the passkey's KEK,
-/// and published as the custody cell before the creation request signs.
+/// ceremony: the secret is generated and sealed under the passkey's
+/// KEK. The custody cell cannot publish here — the account has not
+/// confirmed its email, and the service serves no unactivated customer
+/// — so the sealed bytes come back to be queued.
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct CreateAccountInput {
@@ -18,9 +20,6 @@ pub(crate) struct CreateAccountInput {
     pub device_did: String,
     pub device_name: String,
     pub remote: String,
-    /// The access service's `/ucan/` endpoint the custody cell
-    /// publishes through.
-    pub endpoint: String,
     /// Browser/OS label recorded with the created passkey.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub created_on: Option<String>,
@@ -45,6 +44,10 @@ pub(crate) struct CreateAccountOutput {
     pub deposits_hex: Vec<String>,
     pub custody_did: String,
     pub consent_hex: String,
+    /// The sealed account secret, queued until provisioning and
+    /// activation let it publish.
+    #[serde(default)]
+    pub sealed_hex: Option<String>,
 }
 
 /// Input for enrolling a custody passkey for a locally held account.
@@ -67,6 +70,10 @@ pub(crate) struct EnrollCustodyOutput {
     pub custody_did: String,
     pub credential_id: String,
     pub consent_hex: String,
+    /// Present when the cell could not publish yet, because the new
+    /// custody DID is not provisioned until the consent is deposited.
+    #[serde(default)]
+    pub sealed_hex: Option<String>,
 }
 
 /// Input for unlocking an account with a custody passkey on this browser.
@@ -214,6 +221,25 @@ pub(crate) async fn enroll_custody_passkey(
     input: EnrollCustodyInput,
 ) -> Result<EnrollCustodyOutput, IdentityBridgeError> {
     call("enrollCustodyPasskey", input).await
+}
+
+/// Input for publishing a custody cell that was queued when its
+/// ceremony could not write it.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PublishQueuedCustodyInput {
+    pub custody_did: String,
+    pub sealed_hex: String,
+    /// The access service's `/ucan/` endpoint.
+    pub endpoint: String,
+}
+
+pub(crate) async fn publish_queued_custody(
+    input: PublishQueuedCustodyInput,
+) -> Result<(), IdentityBridgeError> {
+    call::<_, serde::de::IgnoredAny>("publishQueuedCustody", input)
+        .await
+        .map(|_| ())
 }
 
 pub(crate) async fn unlock_with_passkey(

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -170,7 +170,13 @@ pub fn api_router_from_state(state: AppState) -> (Router, Arc<LspHub>) {
         // Customer registration with the same-origin access service.
         .route("/api/customer", get(customer::get_state))
         .route("/api/customer/enroll", post(customer::enroll))
+        .route("/api/customer/pending", get(customer::get_pending))
+        .route(
+            "/api/customer/pending/custody",
+            post(customer::complete_pending_custody),
+        )
         .route("/api/custody/provision", post(customer::provision_custody))
+        .route("/api/custody/queue", post(customer::queue_custody))
         .route("/api/account/devices", get(account_devices::list))
         .route("/api/account/summary", get(account_devices::summary))
         .route(

--- a/rust/tonk-worker/src/router/account_state.rs
+++ b/rust/tonk-worker/src/router/account_state.rs
@@ -1454,6 +1454,14 @@ mod tests {
 
         let root = Ed25519Signer::generate().await.unwrap();
         let root_signer = root.clone();
+        // Hydration syncs the account space, which the access service
+        // serves only once its customer has confirmed the emailed
+        // activation link.
+        service
+            .address
+            .activate_customer(&root, "worker-account-state@example.com")
+            .await
+            .unwrap();
         let remote = format!(
             "{}/",
             service.address.access_service_url.trim_end_matches('/')

--- a/rust/tonk-worker/src/router/account_state.rs
+++ b/rust/tonk-worker/src/router/account_state.rs
@@ -484,6 +484,30 @@ async fn hydrate_untrusted(tonk: &TonkState) -> Result<(), TonkWorkerError> {
 /// `Err` names the step that did not land, so the caller can report a sweep
 /// worth retrying. Convergence failing is not one of those: it is per-space and
 /// keeps its own retry list, so it is logged and the sweep still counts.
+/// Push profile main to the account remote.
+///
+/// Split out because both sweep arms need it: the ready arm as the tail
+/// of `sync_ready`, and the hydrate arm as the step that publishes what
+/// hydration just established. Only these two paths push profile main —
+/// the generic per-branch sync returns before it reaches the account
+/// key — so a sweep that skips this leaves local facts unpublished.
+async fn push_account_main(tonk: &TonkState) -> Result<(), String> {
+    let session = tonk
+        .reactor
+        .profile_repository()
+        .branch(tonk_account::MAIN_BRANCH)
+        .acquire(&tonk.operator)
+        .await
+        .map_err(|error| format!("account branch unavailable: {error}"))?;
+    session
+        .handle()
+        .push()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|error| format!("account push failed: {error}"))?;
+    Ok(())
+}
+
 async fn sync_ready(tonk: &TonkState, _key: &str) -> Result<(), String> {
     let session = tonk
         .reactor
@@ -517,6 +541,9 @@ async fn sync_ready(tonk: &TonkState, _key: &str) -> Result<(), String> {
     if let Err(error) = converge_account_state(tonk).await {
         log!("account-state convergence after sync failed: {error}");
     }
+    // Pushed through the session this function already holds, rather
+    // than `push_account_main`, which acquires one of its own for the
+    // hydrate arm.
     session
         .handle()
         .push()
@@ -602,7 +629,17 @@ pub(crate) async fn ensure_account_state_swept(
                     if let Err(error) = converge_account_state(tonk).await {
                         log!("account-state convergence after hydration failed: {error}");
                     }
-                    (AccountStateStatus::Ready, Ok(()))
+                    // Push what this sweep just made durable. Without
+                    // it, hydrating leaves the account Ready but never
+                    // uploaded, so nothing local reaches the account
+                    // remote until some *later* sweep happens to take
+                    // the `marker_matches` arm above — which is the only
+                    // other place profile main is pushed. A device that
+                    // is not poked again simply never publishes: its
+                    // spaces stay invisible to the account's other
+                    // devices.
+                    let pushed = push_account_main(tonk).await;
+                    (AccountStateStatus::Ready, pushed)
                 }
                 Err(error) => {
                     log!("account repository hydrated but marker save failed: {error}");

--- a/rust/tonk-worker/src/router/customer.rs
+++ b/rust/tonk-worker/src/router/customer.rs
@@ -17,8 +17,9 @@ use dialog_ucan_core::time::timestamp::Timestamp;
 use serde::{Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tokio::sync::oneshot;
-use tonk_account::CUSTOMER_CREDENTIAL_SITE;
 use tonk_account::customer::{CustomerStatus, Receipt};
+use tonk_account::pending::{PendingQueue, PendingWork};
+use tonk_account::{CUSTOMER_CREDENTIAL_SITE, PENDING_WORK_CREDENTIAL_SITE};
 use tonk_common::log;
 use tonk_identity::request::{build_enroll_invocation, build_enroll_invocation_with_deposits};
 use url::Url;
@@ -181,6 +182,11 @@ pub async fn get_state(
                 };
                 save_customer(&state, &refreshed).await?;
             }
+            // This probe is what notices activation, so it is where
+            // work deferred during the wait gets replayed.
+            if receipt.status == CustomerStatus::Active {
+                drain_pending(&state).await;
+            }
             Some(receipt.status)
         }
         Err(HttpError::Upstream(failure)) if failure.status == 404 => None,
@@ -223,8 +229,75 @@ pub async fn provision_custody(
         .map_err(|error| TonkWorkerError::Router(format!("consent is not hex: {error}")))?;
     let consent = dialog_ucan_core::DelegationChain::try_from(bytes.as_slice())
         .map_err(|error| TonkWorkerError::Router(format!("consent does not decode: {error}")))?;
-    provision_consumer(&state, &custody, &consent, Some("custody")).await?;
+    provision_or_defer(&state, &custody, &consent, Some("custody")).await?;
     Ok(Json(()))
+}
+
+/// `POST /api/custody/queue` request body: a custody cell that could
+/// not be published yet.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueueCustodyRequest {
+    /// The custody space whose cell is waiting.
+    pub custody: String,
+    /// Hex-encoded sealed envelope to publish.
+    pub sealed_hex: String,
+}
+
+/// POST `/api/custody/queue` → record a custody cell for publication
+/// once its space is provisioned and the account confirms its email.
+/// The page publishes it — only a fresh passkey assertion can sign for
+/// the custody key — so this records rather than performs.
+#[wasm_compat]
+pub async fn queue_custody(
+    State(state): State<AppState>,
+    Json(request): Json<QueueCustodyRequest>,
+) -> Result<Json<()>, TonkWorkerError> {
+    let state = state.read().await;
+    defer(
+        &state,
+        PendingWork::PublishCustody {
+            custody: request.custody,
+            sealed_hex: request.sealed_hex,
+        },
+    )
+    .await?;
+    Ok(Json(()))
+}
+
+/// Provision `consumer`, or queue it when the account has not yet
+/// confirmed its email.
+///
+/// The access service provisions nothing for a customer that is only
+/// `Registered`, so that refusal is not a failure here — it is the
+/// expected answer during the window between enrolling and clicking the
+/// emailed link. The entry replays from the status probe that notices
+/// activation. Every other refusal propagates.
+pub(crate) async fn provision_or_defer(
+    state: &crate::worker::TonkState,
+    consumer: &dialog_varsig::Did,
+    consent: &dialog_ucan_core::DelegationChain,
+    kind: Option<&str>,
+) -> Result<(), TonkWorkerError> {
+    match provision_consumer(state, consumer, consent, kind).await {
+        Err(TonkWorkerError::Upstream { ref code, .. })
+            if code.as_deref() == Some("CustomerInactive") =>
+        {
+            log!("{consumer} queued until the account confirms its email");
+            defer(
+                state,
+                PendingWork::Provision {
+                    consumer: consumer.to_string(),
+                    consent_hex: hex::encode(consent.to_bytes().map_err(|error| {
+                        TonkWorkerError::Internal(format!("consent does not encode: {error}"))
+                    })?),
+                    consumer_kind: kind.map(str::to_owned),
+                },
+            )
+            .await
+        }
+        other => other,
+    }
 }
 
 /// Provision `consumer` with the same-origin access service under this
@@ -379,6 +452,183 @@ async fn save_customer(
         .map_err(|error| {
             TonkWorkerError::Internal(format!("failed to save the customer record: {error}"))
         })
+}
+
+async fn load_pending(state: &crate::worker::TonkState) -> Result<PendingQueue, TonkWorkerError> {
+    let bytes = match state
+        .profile
+        .credential()
+        .site(PENDING_WORK_CREDENTIAL_SITE)
+        .load::<Vec<u8>>()
+        .perform(&state.operator)
+        .await
+    {
+        Ok(bytes) => bytes,
+        Err(error) if crate::credential::is_missing(&error) => return Ok(PendingQueue::default()),
+        Err(error) => {
+            return Err(TonkWorkerError::Internal(format!(
+                "failed to load pending work: {error}"
+            )));
+        }
+    };
+    if bytes.is_empty() {
+        return Ok(PendingQueue::default());
+    }
+    match serde_json::from_slice(&bytes) {
+        Ok(queue) => Ok(queue),
+        Err(error) => {
+            // An unreadable queue would otherwise wedge every later
+            // append. The work it held is recoverable — re-running the
+            // ceremony re-queues it — where a permanently poisoned site
+            // is not.
+            log!("stored pending work is unreadable, starting a fresh queue: {error}");
+            Ok(PendingQueue::default())
+        }
+    }
+}
+
+async fn save_pending(
+    state: &crate::worker::TonkState,
+    queue: &PendingQueue,
+) -> Result<(), TonkWorkerError> {
+    let bytes = serde_json::to_vec(queue).map_err(|error| {
+        TonkWorkerError::Internal(format!("failed to serialize pending work: {error}"))
+    })?;
+    state
+        .profile
+        .credential()
+        .site(PENDING_WORK_CREDENTIAL_SITE)
+        .save(bytes)
+        .perform(&state.operator)
+        .await
+        .map_err(|error| TonkWorkerError::Internal(format!("failed to save pending work: {error}")))
+}
+
+/// Record `work` for replay once the account confirms its email, then
+/// try to drain immediately — an already-active customer must not wait
+/// for the next status probe.
+pub(crate) async fn defer(
+    state: &crate::worker::TonkState,
+    work: PendingWork,
+) -> Result<(), TonkWorkerError> {
+    let mut queue = load_pending(state).await?;
+    queue.push(work);
+    save_pending(state, &queue).await?;
+    drain_pending(state).await;
+    Ok(())
+}
+
+/// Replay queued work in the order it was recorded, stopping at the
+/// first entry that does not complete.
+///
+/// Stopping rather than skipping is the ordering invariant: a custody
+/// cell may only be published once its DID is provisioned, so an entry
+/// that fails must hold back everything behind it. Best effort by
+/// design — a drain that cannot run leaves the queue exactly as it was,
+/// and the next probe tries again.
+pub(crate) async fn drain_pending(state: &crate::worker::TonkState) {
+    let mut queue = match load_pending(state).await {
+        Ok(queue) => queue,
+        Err(error) => return log!("pending work unreadable: {error}"),
+    };
+    if queue.is_empty() {
+        return;
+    }
+
+    let mut completed = 0;
+    for work in queue.entries() {
+        match run_pending(state, work).await {
+            Ok(()) => completed += 1,
+            Err(error) => {
+                log!("pending work for {} still waiting: {error}", work.subject());
+                break;
+            }
+        }
+    }
+    if completed == 0 {
+        return;
+    }
+    queue.retain_after(completed);
+    if let Err(error) = save_pending(state, &queue).await {
+        // The work itself succeeded; failing to shorten the queue only
+        // costs a repeat, and every entry is idempotent.
+        log!("pending work ran but the queue could not be shortened: {error}");
+    }
+}
+
+/// Perform one queued entry.
+///
+/// A custody publish needs the PRF-derived custody key, which only a
+/// page holding a fresh passkey assertion has, so the worker cannot run
+/// one and reports it as still waiting. That halts the drain by design:
+/// the publish must not be overtaken by entries recorded after it.
+async fn run_pending(
+    state: &crate::worker::TonkState,
+    work: &PendingWork,
+) -> Result<(), TonkWorkerError> {
+    match work {
+        PendingWork::Provision {
+            consumer,
+            consent_hex,
+            consumer_kind,
+        } => {
+            let consumer: dialog_varsig::Did = consumer.parse().map_err(|error| {
+                TonkWorkerError::Router(format!("queued consumer DID is invalid: {error:?}"))
+            })?;
+            let bytes = hex::decode(consent_hex).map_err(|error| {
+                TonkWorkerError::Router(format!("queued consent is not hex: {error}"))
+            })?;
+            let consent =
+                dialog_ucan_core::DelegationChain::try_from(bytes.as_slice()).map_err(|error| {
+                    TonkWorkerError::Router(format!("queued consent does not decode: {error}"))
+                })?;
+            provision_consumer(state, &consumer, &consent, consumer_kind.as_deref()).await
+        }
+        PendingWork::PublishCustody { custody, .. } => Err(TonkWorkerError::Router(format!(
+            "custody publish for {custody} needs a passkey assertion, so a page must run it"
+        ))),
+    }
+}
+
+/// `GET /api/customer/pending` → the queued work a page may have to
+/// run: the account panel reads this to learn whether it must raise a
+/// passkey assertion and publish a custody cell.
+#[wasm_compat]
+pub async fn get_pending(
+    State(state): State<AppState>,
+) -> Result<Json<PendingQueue>, TonkWorkerError> {
+    let state = state.read().await;
+    Ok(Json(load_pending(&state).await?))
+}
+
+/// `POST /api/customer/pending/custody` request body: the custody DID
+/// whose queued publish a page just completed.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CompletedCustodyRequest {
+    /// The custody space whose cell is now published.
+    pub custody: String,
+}
+
+/// `POST /api/customer/pending/custody` → drop the queued publish for
+/// `custody`, which a page completed with its own assertion, then drain
+/// whatever it was holding back.
+#[wasm_compat]
+pub async fn complete_pending_custody(
+    State(state): State<AppState>,
+    Json(request): Json<CompletedCustodyRequest>,
+) -> Result<Json<()>, TonkWorkerError> {
+    let state = state.read().await;
+    let mut queue = load_pending(&state).await?;
+    let before = queue.len();
+    queue.0.retain(|work| {
+        !matches!(work, PendingWork::PublishCustody { custody, .. } if custody == &request.custody)
+    });
+    if queue.len() != before {
+        save_pending(&state, &queue).await?;
+    }
+    drain_pending(&state).await;
+    Ok(Json(()))
 }
 
 pub(crate) async fn clear_customer(

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -2793,7 +2793,7 @@ pub async fn create_repository(
     // consent. Best effort for the same reason retain is — a space is
     // usable the moment its delegations exist locally.
     if let Err(error) =
-        super::customer::provision_consumer(tonk, &repository.did(), &prefix, None).await
+        super::customer::provision_or_defer(tonk, &repository.did(), &prefix, None).await
     {
         log!("consumer provisioning skipped: {error}");
     }
@@ -2948,7 +2948,7 @@ pub(crate) async fn adopt_profile_spaces(tonk: &TonkState) {
             continue;
         };
         super::account_state::retain_space_delegation(tonk, &chain).await;
-        if let Err(error) = super::customer::provision_consumer(tonk, &subject, &chain, None).await
+        if let Err(error) = super::customer::provision_or_defer(tonk, &subject, &chain, None).await
         {
             log!("adopted space '{subject}' provisioning skipped: {error}");
         }


### PR DESCRIPTION
Implements the enforcement half of `plan/Access metering.md` §3.1–3.2: an account that never confirmed its email now gets nothing.

**The gap.** #726 records activation, surfaces it, and polls it, but nothing reads it on the hot path. `provisioning::screen` had been written and never called, so every space was served identically whether or not anyone confirmed an email address. Any self-minted keypair stored bytes under its own namespace, unbilled and unattributable.

**One rule, both acts.** The gate is wired into both presign paths, and `/provider/add` checks the same status itself. This **reverses `Access metering.md` §3.3**, which allowed adding under a `Registered` customer on the grounds that such a consumer derives to denied anyway. Making it uniform is worth the queue it costs: an accepted write whose effect is silently withheld is a worse contract than a refusal that says why. Enroll and activate stay ungated, or nothing could ever activate.

**Enforced unconditionally.** A flag defaulted off is a gate that is not there, and one defaulted on is a switch for turning billing enforcement off in production. Deployments ramp through the client queue instead.

**Refusals name the cause.** The presign gate answers `PolicyViolation` whose predicate distinguishes "awaits email activation" from "is suspended" and "is not provisioned"; `/provider/add` gets `CustomerInactive`. The dashboard's pending banner gains a resend button, wired to the enrollment call that already resends idempotently — the link expires, so the recovery cannot be undiscoverable.

**The client had to reorder.** Account creation published the custody cell *before* enrolling, and treated a refusal as fatal — correctly, since an account whose sealed secret was never published can only be unlocked by the page still holding it. That publish is now denied, so the ceremony returns the sealed envelope instead and creation records it as pending work in the profile. Spaces created before activation queue their provisioning the same way and keep working locally.

The two entry kinds drain in different places. A provision is device-signed, so the worker replays it from the status probe that notices activation. A publish is signed by the custody key, which is PRF-derived inside a passkey assertion and never stored — and a pre-signed invocation carries a five-minute expiration that cannot outlive a wait for an email click, so only a page can sign one. Entries replay in recorded order and a drain stops at the first failure, so a publish never overtakes the provisioning it needs.

**Deferring the publish broke every root-signed ceremony,** which the browser tests caught: CLI approval, link completion, and revocation all unlock the account by resolving the custody cell, and a browser that activated without returning to the dashboard still had that cell queued. Each of those paths now drains before unlocking; `plan/account-activation-gate.md` §5 records the rule.

## Bugs this surfaced

Enforcing the gate exposed three defects that were already latent. Each is fixed here, and each stands on its own.

**The account never published after hydrating.** Only the `marker_matches` arm of the account sweep pushed profile main; the hydrate arm marked trusted, seeded, converged, and returned `Ready` having published nothing. A freshly hydrated account therefore needed a *second* sweep before anything reached the account remote, and sweeps only happen on browser traffic. The gate made this reachable — signup hydrates before it enrolls, and the account subject *is* the customer DID, so it is screened before its customer row exists — but the missing push was always there: a device nobody pokes again simply never publishes, and its spaces stay invisible to the account's other devices.

**Concurrent test harnesses clobbered each other's TLS trust.** `SSL_CERT_FILE` was exported process-wide while each harness mints its own Caddy CA under a port-keyed directory, so with two alive the second overwrote the first and its CLI children could not reach their own origin. The comment on that `unsafe` set_var claimed it was safe under parallel tests; it was the cause. The root now rides on `TestEnvironment` and is handed to each child directly.

**Two harness waits fell through silently.** The chromedriver readiness loop and the Caddy CA wait both proceeded as if they had succeeded on timeout, so the real cause surfaced later as an unrelated-looking failure against a dead port or an untrusted origin. Both now error with what went wrong.

## Tests

The queue is proven end to end in a real browser: `it_hosts_a_space_created_before_activation_once_the_email_is_confirmed` signs up and stops at `Registered`, creates a space (which must still succeed locally), watches its push get refused, confirms the email, then watches the same push succeed with nothing further asked of the user.

On the service side the gate is driven through the real HTTP endpoints, and provisioning idempotence is asserted both ways — re-adding under the same customer leaves the row untouched, while a different customer holding the space's consent is refused and the original provider keeps paying.

Most fixtures minted an ad-hoc root and synced without ever enrolling. `AccessServiceAddress::activate_customer` runs the real ceremony for fixtures holding a root signer; `provision_subject` shortcuts past registration for subjects that are repository DIDs no test holds a signer for.

**Verification.** Workspace suite green (115 test binaries). Browser suite run against a live Chrome in CI's serialized configuration: 14/14, three consecutive runs, 45-53s each. The spot-backup test that caught the publish bug was measured at 3/5 failures before the fix and 5/5 passes after.

**Deploy note.** Every space with no consumer row, or whose provider never activated, stops being served on deploy. That is the intended effect, but it is not silent — staging should be watched through a full sign-up before production follows.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the user account management system by implementing email activation processes, managing pending work related to custody cells, and refining the customer provisioning workflow.

### Detailed summary
- Added a `Resend activation email` button in `account.html`.
- Introduced new API routes for pending customer actions in `router.rs`.
- Updated error handling for customer activation status in `customer.rs`.
- Implemented a pending work queue for unactivated customers in `pending.rs`.
- Enhanced account activation logic to handle queued custody cells in `account.rs`.
- Added methods to publish queued custody cells and manage deferred actions in `identity.rs`.
- Updated client-side logic to handle email activation and pending work in `account.rs`.

> The following files were skipped due to too many changes: `rust/tonk-ui/src/account.rs`, `plan/account-model.md`, `rust/tonk-worker/src/router/customer.rs`, `rust/tonk-access-service/tests/registration.rs`, `rust/tonk-ui/src/account_flow.rs`, `plan/account-activation-gate.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->