### PR TITLE
test(worker): cover torn-down IndexedDB shims

### DIFF
--- a/rust/tonk-worker/src/lib.rs
+++ b/rust/tonk-worker/src/lib.rs
@@ -109,6 +109,47 @@ extern "C" {
     pub fn patch_idb_dead_shims();
 }
 
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod idb_lifecycle_tests {
+    use wasm_bindgen::prelude::wasm_bindgen;
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+
+    wasm_bindgen_test_configure!(run_in_service_worker);
+
+    #[wasm_bindgen(inline_js = r#"
+export function dropped_idb_request_handler() {
+    const request = indexedDB.deleteDatabase(
+        `tonk-dropped-idb-handler-${Date.now()}-${Math.random()}`
+    );
+    request.onsuccess = () => {
+        throw new Error('closure invoked recursively or after being dropped');
+    };
+    const handler = request.onsuccess;
+    try {
+        handler.call(request, new Event('success'));
+        return 'ignored';
+    } catch (error) {
+        return String(error && error.message || error);
+    } finally {
+        request.onsuccess = null;
+    }
+}
+"#)]
+    extern "C" {
+        fn dropped_idb_request_handler() -> String;
+    }
+
+    /// A browser may still deliver an event after its originating wasm
+    /// instance has been torn down. That one known stale-shim exception is a
+    /// no-op addressed to dead code, while every other handler error remains
+    /// visible.
+    #[dialog_common::test]
+    fn it_ignores_an_idb_event_for_a_dropped_wasm_closure() {
+        crate::patch_idb_dead_shims();
+        assert_eq!(dropped_idb_request_handler(), "ignored");
+    }
+}
+
 mod broadcast;
 pub use broadcast::*;
 


### PR DESCRIPTION
## Summary

- cover the service-worker guard for IndexedDB events delivered to a torn-down wasm instance
- reproduce the browser exception reported during invite mounting and reload
- assert that the known dead-shim callback becomes a no-op

The current staging base already contains the runtime fixes: Dialog arms and watchdogs IndexedDB transaction settlement, and Tonk wraps stale IndexedDB event handlers. This PR adds Tonk-side regression coverage without duplicating that runtime logic.

## Verification

- focused headless Chrome regression: 1 passed, 0 failed
- cargo check -p tonk-worker --target wasm32-unknown-unknown
- cargo fmt --all -- --check
- git diff --check
- full test:web:debug reached 934 passes before the runner exhausted disk space; the failure was No space left on device while generating a separate tonk-ui wasm test

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new module for testing the behavior of IndexedDB requests in a WebAssembly context, specifically handling scenarios where a request's success handler is invoked after the associated closure has been dropped.

### Detailed summary
- Added a new module `idb_lifecycle_tests` for testing.
- Configured tests to run in a service worker environment.
- Implemented `dropped_idb_request_handler` function in JavaScript to simulate dropped handlers.
- Created a test function `it_ignores_an_idb_event_for_a_dropped_wasm_closure` to validate that dropped handlers do not trigger errors.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->