### PR TITLE
fix(cli): make the list verbs and the assert/invite errors tell the truth

### DIFF
--- a/.claude/commands/tonk.md
+++ b/.claude/commands/tonk.md
@@ -18,8 +18,8 @@ attach it once instead.
 tonk guide            # one-screen index of the agent reference
 tonk schema           # every concept + attribute on the branch, as notation
 tonk schema <concept> # one concept's subset, same format
-tonk concept ls       # name<TAB>description, one row per user concept
-tonk view ls          # renderable entities (text/html claim carriers)
+tonk concept ls       # name<TAB>description, one row per concept this space defines
+tonk view ls          # name<TAB>entity<TAB>model<TAB>bytes, one row per renderable claim carrier
 tonk status           # synced | ahead | behind | diverged | no-upstream
 ```
 

--- a/guide/src/reference.md
+++ b/guide/src/reference.md
@@ -81,7 +81,7 @@ the associative memory, referenced from it by a content-addressed
 |--------------------------|---------------------------------------------------------|
 | `tonk blob add <file>`   | Ingest a file, print its `blob:<hash>` reference.        |
 | `tonk blob cat <blob:hash>` | Write a blob's bytes to stdout.                       |
-| `tonk blob ls`           | List blobs in the branch's index with size and content type. |
+| `tonk blob ls`           | List the branch's blobs from their metadata facts: reference, content type, name. |
 
 The reference is just another URI value, so assert it onto any
 concept like `id:` or `did:key:…`:

--- a/rust/tonk-cli/README.md
+++ b/rust/tonk-cli/README.md
@@ -44,7 +44,7 @@ tonk eval -c 'person:' --format json --quiet
 
 # Inspect the branch.
 tonk schema       # every named attribute + concept as re-submittable notation
-tonk concept ls   # user-defined concepts: name<TAB>description
+tonk concept ls   # concepts this space defines: name<TAB>description
 tonk view ls      # entities with a template claim: name<TAB>entity<TAB>model<TAB>bytes
 tonk blob ls      # ingested blobs: entity<TAB>content-type<TAB>name
 tonk guide        # baked-in asserted-notation reference (also: guide notation|views|all)

--- a/rust/tonk-cli/README.md
+++ b/rust/tonk-cli/README.md
@@ -45,7 +45,7 @@ tonk eval -c 'person:' --format json --quiet
 # Inspect the branch.
 tonk schema       # every named attribute + concept as re-submittable notation
 tonk concept ls   # user-defined concepts: name<TAB>description
-tonk view ls      # entities with a text/html claim: name<TAB>entity<TAB>bytes
+tonk view ls      # entities with a template claim: name<TAB>entity<TAB>model<TAB>bytes
 tonk blob ls      # ingested blobs: entity<TAB>content-type<TAB>name
 tonk guide        # baked-in asserted-notation reference (also: guide notation|views|all)
 

--- a/rust/tonk-cli/README.md
+++ b/rust/tonk-cli/README.md
@@ -46,6 +46,7 @@ tonk eval -c 'person:' --format json --quiet
 tonk schema       # every named attribute + concept as re-submittable notation
 tonk concept ls   # user-defined concepts: name<TAB>description
 tonk view ls      # entities with a text/html claim: name<TAB>entity<TAB>bytes
+tonk blob ls      # ingested blobs: entity<TAB>content-type<TAB>name
 tonk guide        # baked-in asserted-notation reference (also: guide notation|views|all)
 
 # Argument-based data verbs — a constrained front-end over `eval`.

--- a/rust/tonk-cli/src/agents.rs
+++ b/rust/tonk-cli/src/agents.rs
@@ -56,14 +56,19 @@ pub struct SpotAgents {
     pub markdown: String,
 }
 
+/// Whether the `tonk/agents` concept is declared on this branch.
+///
+/// Asked by name rather than by scanning `list_concepts`: the claim
+/// rides a standard-library concept, which that listing deliberately
+/// omits.
+pub async fn is_declared(site: &TonkSite) -> Result<bool> {
+    Ok(schema::find_concept(site, CONCEPT_NAME).await?.is_some())
+}
+
 /// Read the current claim, returning `None` for spots that have never defined
 /// or asserted it.
 pub async fn get(site: &TonkSite) -> Result<Option<SpotAgents>> {
-    let declared = schema::list_concepts(site)
-        .await?
-        .iter()
-        .any(|concept| concept.name == CONCEPT_NAME);
-    if !declared {
+    if !is_declared(site).await? {
         return Ok(None);
     }
     get_declared(site).await
@@ -126,11 +131,11 @@ pub async fn set(site: &TonkSite, markdown: &str, sync: bool) -> Result<SpotAgen
         );
     }
 
-    let declared = schema::list_concepts(site)
-        .await?
-        .iter()
-        .any(|concept| concept.name == CONCEPT_NAME);
-    let schema_document = if declared { "" } else { SCHEMA_DOCUMENT };
+    let schema_document = if is_declared(site).await? {
+        ""
+    } else {
+        SCHEMA_DOCUMENT
+    };
     let entity = site.repository.did();
     let encoded = serde_json::to_string(markdown).context("encode AGENTS.md Markdown")?;
     let doc = format!(

--- a/rust/tonk-cli/src/authoring.rs
+++ b/rust/tonk-cli/src/authoring.rs
@@ -17,6 +17,8 @@
 
 use std::fmt::Write as _;
 
+use crate::schema::SPACE_HOME_CONCEPT;
+
 /// One parsed `--attr field:type:cardinality` flag, ready to render
 /// into an `attribute!:` block and a `with:` entry.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -295,7 +297,11 @@ pub fn build_view_decl(anchor: &str, model: &str, template: &str) -> String {
 pub fn build_home_recipe(models: &[String]) -> String {
     let mut out = String::new();
 
-    out.push_str("concept!: &space-home\n");
+    // The anchor doubles as the concept's published name, and
+    // agent-facing listings filter on that name — so it comes from
+    // the same const the filter reads, not a second copy of the
+    // literal.
+    let _ = writeln!(out, "concept!: &{SPACE_HOME_CONCEPT}");
     out.push_str("  this: space:home\n");
     let _ = writeln!(
         out,
@@ -313,7 +319,7 @@ pub fn build_home_recipe(models: &[String]) -> String {
     out.push_str("      as: entity\n");
     out.push('\n');
 
-    out.push_str("view!: &space-home-view\n");
+    let _ = writeln!(out, "view!: &{SPACE_HOME_CONCEPT}-view");
     out.push_str("  this: id:space:home/view\n");
     out.push_str("  model: space:home\n");
     out.push_str("  display: |\n");

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -858,11 +858,13 @@ enum ConceptCommand {
         description: Option<String>,
     },
 
-    /// List user-defined concepts on the branch
+    /// List the concepts this space defines
     ///
     /// One row per concept, tab-separated `name<TAB>description`.
-    /// Built-in concepts (`attribute`, `concept`, …) are omitted —
-    /// they're resolvable everywhere and would just be noise.
+    /// The runtime vocabulary — analyzer built-ins, the standard
+    /// library, the space-home recipe — is omitted; it resolves
+    /// everywhere and would bury what you defined. `tonk schema`
+    /// still shows the whole branch.
     #[command(after_help = "Examples:\n  tonk concept ls")]
     Ls,
 }

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -896,11 +896,13 @@ enum ViewCommand {
         name: Option<String>,
     },
 
-    /// List renderable entities (those carrying a text/html claim)
+    /// List renderable entities (those carrying a template claim)
     ///
-    /// One row per entity, tab-separated `name<TAB>entity<TAB>bytes`.
-    /// Claim-driven: surfaces anything the host route would serve,
-    /// regardless of how the claim was asserted.
+    /// One row per entity, tab-separated
+    /// `name<TAB>entity<TAB>model<TAB>bytes`. Claim-driven: surfaces
+    /// anything the display stack or the host route would render,
+    /// regardless of how the claim was asserted. Standard-library
+    /// views are omitted.
     #[command(after_help = "Examples:\n  tonk view ls")]
     Ls,
 }
@@ -3292,7 +3294,8 @@ async fn home_op(models: Vec<String>, spot: Option<&str>) -> ExitCode {
 }
 
 /// List renderable entities (`tonk view ls`), one tab-separated
-/// `name<TAB>entity<TAB>bytes` row per `text/html` claim carrier.
+/// `name<TAB>entity<TAB>model<TAB>bytes` row per template-claim
+/// carrier.
 async fn list_views_op(site: &site::TonkSite) -> ExitCode {
     let listed = match views::list(site).await {
         Ok(v) => v,
@@ -3310,7 +3313,12 @@ async fn list_views_op(site: &site::TonkSite) -> ExitCode {
 
 fn print_view_row(out: &mut impl std::io::Write, row: &ViewSummary) -> std::io::Result<()> {
     let name = row.name.as_deref().unwrap_or("-");
-    writeln!(out, "{}\t{}\t{}", name, row.entity, row.body_bytes)
+    let model = row.model.as_deref().unwrap_or("-");
+    writeln!(
+        out,
+        "{}\t{}\t{}\t{}",
+        name, row.entity, model, row.body_bytes
+    )
 }
 
 async fn print_schema(concept: Option<String>, spot: Option<&str>) -> ExitCode {

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -824,7 +824,13 @@ enum BlobCommand {
         #[arg(value_name = "BLOB_URI")]
         reference: String,
     },
-    /// List blobs in the index with size and content type
+    /// List ingested blobs with their content type and file name
+    ///
+    /// One row per blob, tab-separated
+    /// `entity<TAB>content-type<TAB>name`. Read from the metadata
+    /// facts `tonk blob add` asserts, so bytes attached without
+    /// metadata don't appear, and a row means the facts are here, not
+    /// necessarily the bytes.
     #[command(after_help = "Examples:\n  tonk blob ls")]
     Ls,
 }
@@ -2684,10 +2690,10 @@ async fn blob_op(command: BlobCommand, spot: Option<&str>) -> ExitCode {
 fn print_blob_ls(rows: &[blob::LsRow]) {
     for row in rows {
         println!(
-            "{uri}  {size}  {content_type}",
+            "{uri}\t{content_type}\t{name}",
             uri = row.entity.as_str(),
-            size = row.size,
             content_type = row.content_type.as_deref().unwrap_or("-"),
+            name = row.name.as_deref().unwrap_or("-"),
         );
     }
 }

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -2717,7 +2717,7 @@ async fn mint_invite(
     no_shorten: bool,
     spot: Option<&str>,
 ) -> ExitCode {
-    let (_, site) = match open_selected(spot).await {
+    let (selected, site) = match open_selected(spot).await {
         Ok(opened) => opened,
         Err(code) => return code,
     };
@@ -2732,6 +2732,11 @@ async fn mint_invite(
     // `--no-remote` suppresses only the embedded endpoint. The link
     // still belongs on the remote's origin: moving it to the canonical
     // base is the same split this resolution exists to prevent.
+    // Whether `None` below means "the user waved off a choice between
+    // several remotes" rather than "this space has none". The first
+    // still wants the canonical base; the second has no honest origin
+    // to offer.
+    let mut declined_an_origin = false;
     let resolved = match remote::resolve(&site, remote_name.as_deref()).await {
         Ok(record) => record,
         // `--no-remote` is the documented way out of the ambiguity
@@ -2744,6 +2749,7 @@ async fn mint_invite(
                  {base}\n         name an origin with `--base-url <URL>` if that is wrong",
                 base = invite::DEFAULT_BASE_URL,
             );
+            declined_an_origin = true;
             None
         }
         Err(err) => {
@@ -2785,7 +2791,27 @@ async fn mint_invite(
             Ok(derived) => derived,
             Err(err) => return print_failure(err),
         },
-        (None, None) => invite::DEFAULT_BASE_URL.to_owned(),
+        (None, None) if declined_an_origin => invite::DEFAULT_BASE_URL.to_owned(),
+        // A space with no remote has no deployment serving it, so
+        // there is no origin a recipient could join it from. Minting
+        // against the canonical base would hand them a link to
+        // production, which holds none of this data — a share that
+        // reads as successful and works for nobody. Refuse instead,
+        // and name each way to give the space an origin.
+        (None, None) => {
+            let name = &selected.name;
+            let base = invite::DEFAULT_BASE_URL;
+            return print_error(format!(
+                "'{name}' has no remote, so there is nowhere to invite anyone to\n\
+                 \x20      its data lives only on this device, and a link would point at \
+                 {base}, which serves none of it\n\
+                 \x20      give it a home first: `tonk account link` then \
+                 `tonk space link {name}`, or `tonk remote add <name> <URL> \
+                 --revocation-url <URL>` then `tonk remote set-upstream <name>`\n\
+                 \x20      to mint against a deployment tonk doesn't know about, pass \
+                 `--base-url <URL>`"
+            ));
+        }
     };
 
     // Carried when the remote names one, absent when it does not. A relay is

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -2817,7 +2817,7 @@ async fn mint_invite(
                  {base}, which serves none of it\n\
                  \x20      give it a home first: `tonk account link` then \
                  `tonk space link {name}`, or `tonk remote add <name> <URL> \
-                 --revocation-url <URL>` then `tonk remote set-upstream <name>`\n\
+                 --revocation-url <URL>`\n\
                  \x20      to mint against a deployment tonk doesn't know about, pass \
                  `--base-url <URL>`"
             ));

--- a/rust/tonk-cli/src/blob.rs
+++ b/rust/tonk-cli/src/blob.rs
@@ -7,12 +7,11 @@
 //! that entity using the `tonk:blob` concept's attributes
 //! (`xyz.tonk.blob/content-type`, `xyz.tonk.blob/name`) from the
 //! standard library. `cat` reads a blob's bytes back out by
-//! reference. `ls` is deferred: the current dialog-db pin exposes no
-//! blob-enumeration API (see [`ls`]).
+//! reference. `ls` enumerates those same metadata facts (see [`ls`]).
 
 use std::path::Path;
 
-use dialog_artifacts::{ArtifactSelector, Entity};
+use dialog_artifacts::Entity;
 use dialog_effects::blob::BlobError as UpstreamBlobError;
 use dialog_query::Attribute;
 use dialog_reactor::BranchSession;
@@ -21,7 +20,7 @@ use thiserror::Error;
 
 use crate::site::TonkSite;
 
-/// Failure modes for [`add`] (and, later, `cat`/`ls`).
+/// Failure modes shared by [`add`], [`attach`], [`cat`], and [`ls`].
 #[derive(Debug, Error)]
 pub enum BlobError {
     /// Reading the source file failed.
@@ -35,9 +34,6 @@ pub enum BlobError {
     /// remote.
     #[error("blob not available locally or from the remote: {0}")]
     NotFound(String),
-    /// The subcommand isn't available on the current dialog-db pin.
-    #[error("{0}")]
-    Unsupported(String),
 }
 
 impl BlobError {
@@ -47,7 +43,6 @@ impl BlobError {
             BlobError::Io(_) => crate::ExitCode::IoError,
             BlobError::Site(_) => crate::ExitCode::CommitError,
             BlobError::NotFound(_) => crate::ExitCode::IoError,
-            BlobError::Unsupported(_) => crate::ExitCode::CommitError,
         }
     }
 }
@@ -250,86 +245,103 @@ pub async fn cat(
     Ok(written)
 }
 
-/// One row of [`ls`]: a blob's entity, size, and content type (if
-/// the `xyz.tonk.blob/content-type` fact was ever asserted on it).
+/// One row of [`ls`]: a blob's entity, plus the metadata facts
+/// [`add`] asserted alongside it.
 pub struct LsRow {
     /// The blob's `blob:<hash>` entity.
     pub entity: Entity,
-    /// Size in bytes, from the branch's blob index.
-    pub size: u64,
     /// Asserted MIME type, if any.
     pub content_type: Option<String>,
+    /// Asserted file name, if any.
+    pub name: Option<String>,
 }
 
-/// Enumerate every blob referenced by the branch's current tree,
-/// paired with its size and (best-effort) content type.
+/// Enumerate the branch's blobs from their metadata facts, sorted by
+/// entity.
 ///
-/// Deferred: the current dialog-db pin's blob API is entity-keyed
-/// (read/write/size by `blob:<hash>`) and exposes no way to
-/// enumerate the blobs a branch holds. `ls` returns an
-/// [`BlobError::Unsupported`] until the pin advances to a dialog-db
-/// that offers a blob-enumeration API (at which point the
-/// [`query_content_type`] helper below wires the per-blob content
-/// type back in).
-pub async fn ls(_site: &TonkSite) -> Result<Vec<LsRow>, BlobError> {
-    Err(BlobError::Unsupported(
-        "tonk blob ls is not supported on the current dialog-db pin \
-         (no blob-enumeration API)"
-            .to_string(),
-    ))
-}
-
-/// Look up the `xyz.tonk.blob/content-type` fact for `entity`,
-/// returning `None` if it was never asserted.
+/// Fact-driven, not index-driven. The dialog-db pin's blob API is
+/// entity-keyed (read and write by `blob:<hash>`) and exposes no way
+/// to walk the blobs a branch holds, so this reads the other half of
+/// what [`add`] wrote: the `xyz.tonk.blob/content-type` and
+/// `xyz.tonk.blob/name` claims on the blob entity. Every ingest path
+/// that means a blob to be found again asserts them — [`add`] here,
+/// and the worker's upload route in the browser.
 ///
-/// Goes straight at the branch's raw claims index
-/// (`Branch::claims().select(ArtifactSelector)`) rather than the
-/// `Query::<Concept>`-and-`try_vec` surface `remote.rs` uses for
-/// `RemoteConcept`: that surface exists to bind several attributes
-/// of a whole concept at once via a `#[derive(Concept)]` struct,
-/// which would mean inventing a one-field concept type just to ask
-/// "what's the value of this single attribute on this single
-/// entity". `ArtifactSelector::new().the(..).of(..)` expresses
-/// exactly that constraint directly, with no extra type needed.
+/// Two consequences worth knowing. Bytes attached without metadata
+/// (see [`attach`], which deployment uses) are invisible to this
+/// listing; and a row proves a fact was asserted, not that the bytes
+/// are on this device — a blob whose claims synced ahead of its
+/// content still lists, and [`cat`] is what reports it missing.
 ///
-/// Retained for the deferred [`ls`]: it's the per-blob content-type
-/// lookup that a future blob-enumeration API will pair with each
-/// listed entity.
-#[allow(dead_code)]
-async fn query_content_type(
-    session: &BranchSession,
-    operator: &dialog_operator::Operator<dialog_storage::provider::storage::NativeSpace>,
-    entity: &Entity,
-) -> Result<Option<String>, BlobError> {
-    use futures_util::StreamExt as _;
-
-    let selector = ArtifactSelector::new()
-        .the(ContentType::the().into())
-        .of(entity.clone());
-
-    let artifacts = session
-        .handle()
-        .claims()
-        .select(selector)
-        .perform(operator)
+/// Size is absent for the same reason the index is: the pin offers no
+/// size effect, and reading each blob through to its end to count
+/// bytes would make listing cost as much as downloading.
+pub async fn ls(site: &TonkSite) -> Result<Vec<LsRow>, BlobError> {
+    let session = site
+        .branch()
         .await
-        .map_err(|e| BlobError::Site(format!("content-type query: {e}")))?;
-    let mut artifacts = Box::pin(artifacts);
+        .map_err(|e| BlobError::Site(format!("acquire branch: {e}")))?;
+    let content_types = claims_by_entity(site, &session, ContentType::the())
+        .await
+        .map_err(|e| BlobError::Site(format!("content-type enumeration: {e}")))?;
+    let names = claims_by_entity(site, &session, Name::the())
+        .await
+        .map_err(|e| BlobError::Site(format!("name enumeration: {e}")))?;
 
-    match artifacts.next().await {
-        Some(Ok(artifact)) => {
-            let value = artifact
-                .value()
-                .map_err(|e| BlobError::Site(format!("content-type decode: {e}")))
-                .and_then(|value| {
-                    String::try_from(value)
-                        .map_err(|e| BlobError::Site(format!("content-type decode: {e}")))
-                })?;
-            Ok(Some(value))
-        }
-        Some(Err(e)) => Err(BlobError::Site(format!("content-type query: {e}"))),
-        None => Ok(None),
-    }
+    // A blob is listed if it carries either fact: `add` writes both,
+    // but a hand-authored claim need not, and a half-described blob is
+    // still one the author can `cat`.
+    let mut entities: Vec<Entity> = content_types
+        .keys()
+        .chain(names.keys())
+        .filter(|entity| entity.blob_hash().is_some())
+        .cloned()
+        .collect();
+    entities.sort_by_key(|entity| entity.to_string());
+    entities.dedup();
+
+    Ok(entities
+        .into_iter()
+        .map(|entity| LsRow {
+            content_type: content_types.get(&entity).cloned(),
+            name: names.get(&entity).cloned(),
+            entity,
+        })
+        .collect())
+}
+
+/// Select every current claim under `the` and index it by subject.
+/// Both blob metadata attributes are cardinality-one, so the last
+/// value for an entity is its only value.
+async fn claims_by_entity(
+    site: &TonkSite,
+    session: &BranchSession,
+    the: dialog_query::attribute::The,
+) -> Result<std::collections::HashMap<Entity, String>, String> {
+    use dialog_query::{AttributeQuery, Output as _, Term, attribute};
+
+    let claims: Vec<dialog_query::Claim> = session
+        .handle()
+        .query()
+        .select(AttributeQuery::new(
+            Term::from(the),
+            Term::<Entity>::var("of"),
+            Term::<dialog_query::Any>::var("is"),
+            Term::<attribute::Cause>::blank(),
+            None,
+        ))
+        .perform(&site.operator)
+        .try_vec()
+        .await
+        .map_err(|e| format!("{e:?}"))?;
+
+    Ok(claims
+        .into_iter()
+        .filter_map(|claim| match claim.is {
+            dialog_artifacts::Value::String(value) => Some((claim.of, value)),
+            _ => None,
+        })
+        .collect())
 }
 
 /// MIME type of a blob's content. Matches the standard library's

--- a/rust/tonk-cli/src/context.rs
+++ b/rust/tonk-cli/src/context.rs
@@ -109,7 +109,11 @@ impl From<FieldSummary> for FieldContext {
 
 /// Read the selected spot and derive direct workflows from its live schema.
 pub async fn inspect(resolved: &Resolved, site: &TonkSite) -> Result<ContextReport> {
-    let live_concepts = schema::list_concepts(site).await?;
+    // One enumeration answers both questions: whether the branch
+    // declares the standard library's `tonk/agents` concept, and which
+    // concepts this space's author defined. `is_system_concept` is the
+    // same filter `tonk concept ls` applies.
+    let live_concepts = schema::list_all_concepts(site).await?;
     let agents_declared = live_concepts
         .iter()
         .any(|concept| concept.name == agents::CONCEPT_NAME);
@@ -120,11 +124,7 @@ pub async fn inspect(resolved: &Resolved, site: &TonkSite) -> Result<ContextRepo
     };
     let concepts = live_concepts
         .into_iter()
-        .filter(|concept| {
-            concept.name != "command"
-                && concept.name != "space-home"
-                && !crate::site::standard_library_has_name(&concept.name)
-        })
+        .filter(|concept| !schema::is_system_concept(&concept.name))
         .map(|concept| {
             let name = concept.name;
             let update_field = concept

--- a/rust/tonk-cli/src/data_ops.rs
+++ b/rust/tonk-cli/src/data_ops.rs
@@ -21,12 +21,16 @@ pub mod flags;
 /// [`crate::invite::InviteError`].
 #[derive(Debug, thiserror::Error)]
 pub enum DataOpError {
-    /// No user concept with this name; lists the known concept names.
-    #[error("no concept named '{name}'; known concepts: {}", known.join(", "))]
+    /// No concept with this name; lists the ones this space defines.
+    ///
+    /// The list is the author's vocabulary, not the branch's — the
+    /// runtime's forty-odd concepts are still addressable, but naming
+    /// them here would bury the handful an agent might have meant.
+    #[error("no concept named '{name}'; {}", describe_known(known))]
     NoConcept {
         /// The concept name that was looked up.
         name: String,
-        /// Names of every concept actually defined on the branch.
+        /// Names of the concepts this space's author defined.
         known: Vec<String>,
     },
     /// The supersede form of `assert` named an entity that doesn't
@@ -83,6 +87,20 @@ pub enum DataOpError {
     /// I/O, schema read, or repo-not-found failure.
     #[error("{0}")]
     Io(String),
+}
+
+/// Render the tail of [`DataOpError::NoConcept`]: the concepts this
+/// space defines, or — on a space that defines none yet — the command
+/// that defines the first one. "known concepts: " followed by nothing
+/// reads as a listing failure rather than as an empty space.
+fn describe_known(known: &[String]) -> String {
+    if known.is_empty() {
+        "this space defines no concepts yet; add one with \
+         `tonk concept add <name> --attr <field>:<type>:<cardinality>`"
+            .to_string()
+    } else {
+        format!("concepts in this space: {}", known.join(", "))
+    }
 }
 
 /// Strip clap's own `"error: "` header off a rendered

--- a/rust/tonk-cli/src/data_ops.rs
+++ b/rust/tonk-cli/src/data_ops.rs
@@ -579,3 +579,26 @@ pub async fn view_add(
     }
     Ok(out)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[dialog_common::test]
+    fn it_names_the_concepts_a_space_defines() {
+        assert_eq!(
+            describe_known(&["page".to_string(), "note".to_string()]),
+            "concepts in this space: page, note"
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_points_at_concept_add_when_a_space_defines_none() {
+        let described = describe_known(&[]);
+        assert!(
+            described.starts_with("this space defines no concepts yet"),
+            "{described}"
+        );
+        assert!(described.contains("tonk concept add"), "{described}");
+    }
+}

--- a/rust/tonk-cli/src/data_ops/flags.rs
+++ b/rust/tonk-cli/src/data_ops/flags.rs
@@ -25,7 +25,18 @@ pub fn parse_field_flags(
     argv: &[String],
     all_required: bool,
 ) -> Result<Vec<(String, String)>, clap::Error> {
-    let mut cmd = clap::Command::new(format!("tonk … {concept}")).no_binary_name(true);
+    // The usage line clap renders is the one an agent reads on every
+    // mis-shaped write, so it has to be a command that can be copied.
+    // `all_required` is the mint form (no entity); the supersede form
+    // takes the entity between the concept and the flags.
+    let invocation = if all_required {
+        format!("tonk assert {concept}")
+    } else {
+        format!("tonk assert {concept} <ENTITY>")
+    };
+    let mut cmd = clap::Command::new(invocation.clone())
+        .bin_name(invocation)
+        .no_binary_name(true);
     if let Some(about) = descriptor.description() {
         cmd = cmd.about(about.to_string());
     }

--- a/rust/tonk-cli/src/guide-index.md
+++ b/rust/tonk-cli/src/guide-index.md
@@ -44,7 +44,7 @@ active for this invocation.
 1. Discover what's already on the branch — don't guess or memorize:
    - `tonk schema [<concept>]` — attributes and concepts, as re-submittable notation
    - `tonk concept ls` — user-defined concepts (name + description)
-   - `tonk view ls`    — entities carrying a renderable claim
+   - `tonk view ls`    — entities carrying a renderable claim, and the model each renders
 2. Define schema: `tonk concept add <name> --attr <field>:<type>:<card> …`
    (types enumerate on a miss; `one`/`many` cardinality). The concept is
    immediately usable: `tonk assert <name> --help` shows its typed flags.

--- a/rust/tonk-cli/src/guide-index.md
+++ b/rust/tonk-cli/src/guide-index.md
@@ -43,7 +43,7 @@ active for this invocation.
 
 1. Discover what's already on the branch — don't guess or memorize:
    - `tonk schema [<concept>]` — attributes and concepts, as re-submittable notation
-   - `tonk concept ls` — user-defined concepts (name + description)
+   - `tonk concept ls` — the concepts this space defines (name + description)
    - `tonk view ls`    — entities carrying a renderable claim, and the model each renders
 2. Define schema: `tonk concept add <name> --attr <field>:<type>:<card> …`
    (types enumerate on a miss; `one`/`many` cardinality). The concept is

--- a/rust/tonk-cli/src/guide-views.md
+++ b/rust/tonk-cli/src/guide-views.md
@@ -234,12 +234,12 @@ page!: &about
 `tonk view ls` lists every entity carrying a renderable claim: the
 four view-template attributes the display stack resolves, plus
 `text/html`. It is claim-driven, so a plain concept like this `page`
-shows up next to real views — but no route serves a bare claim. The page reaches a
-browser through `<tonk-portal>`, the sandboxed iframe the display
-stack mounts for a view whose projected `type` is `text/html`; the
-worker serves the body behind it. So you reach it the way you reach
-any view: `/space/<space>/<entity>@<model>!<view>`, or
-`tonk render <entity>@<model>!<view>` headlessly.
+shows up next to real views — but no route serves a bare claim. The
+page reaches a browser through `<tonk-portal>`, the sandboxed iframe
+the display stack mounts for a view whose projected `type` is
+`text/html`; the worker serves the body behind it. So you reach it
+the way you reach any view: `/space/<space>/<entity>@<model>!<view>`
+in a browser, or `tonk render <entity>@<model>!<view>` headlessly.
 
 ---
 

--- a/rust/tonk-cli/src/guide-views.md
+++ b/rust/tonk-cli/src/guide-views.md
@@ -231,9 +231,10 @@ page!: &about
     <h1>About</h1>
 ```
 
-`tonk view ls` lists every entity carrying a `text/html` claim. It is
-claim-driven, so a plain concept like this `page` shows up next to
-real views — but no route serves a bare claim. The page reaches a
+`tonk view ls` lists every entity carrying a renderable claim: the
+four view-template attributes the display stack resolves, plus
+`text/html`. It is claim-driven, so a plain concept like this `page`
+shows up next to real views — but no route serves a bare claim. The page reaches a
 browser through `<tonk-portal>`, the sandboxed iframe the display
 stack mounts for a view whose projected `type` is `text/html`; the
 worker serves the body behind it. So you reach it the way you reach

--- a/rust/tonk-cli/src/schema.rs
+++ b/rust/tonk-cli/src/schema.rs
@@ -83,11 +83,28 @@ pub struct FieldSummary {
     pub description: String,
 }
 
-/// Enumerate every user-defined concept on the meta branch,
-/// returning a slim per-concept summary. Built-in concepts
-/// (`attribute`, `concept`, etc.) are filtered out — see
-/// [`is_builtin_concept`].
+/// Enumerate the concepts this space's author defined, returning a
+/// slim per-concept summary. Runtime concepts — analyzer built-ins,
+/// the seeded standard library, the CLI's own space-home recipe — are
+/// filtered out; see [`is_system_concept`].
+///
+/// The filter is presentational, not a scoping rule: a system concept
+/// is still addressable by name through [`find_concept`], so
+/// `tonk query member` keeps working while `tonk concept ls` stays
+/// about the space's own vocabulary.
 pub async fn list_concepts(site: &TonkSite) -> Result<Vec<ConceptSummary>> {
+    let mut concepts = list_all_concepts(site).await?;
+    concepts.retain(|concept| !is_system_concept(&concept.name));
+    Ok(concepts)
+}
+
+/// Every concept on the branch, runtime vocabulary included.
+///
+/// For callers that need to answer a question about a system concept
+/// and list the author's in the same pass — `tonk context` reads the
+/// `tonk/agents` claim and prints the author's concepts, and would
+/// otherwise enumerate the branch twice.
+pub async fn list_all_concepts(site: &TonkSite) -> Result<Vec<ConceptSummary>> {
     let infos = enumerate_concepts(site).await?;
     Ok(infos
         .into_iter()
@@ -373,6 +390,12 @@ async fn enumerate_concepts(site: &TonkSite) -> Result<Vec<ConceptInfo>> {
 /// rejected — built-ins carry attributes without descriptions, and
 /// the analyzer's `attribute!` validator requires non-empty
 /// descriptions.
+///
+/// Deliberately not the whole registry: `command` is a queryable view
+/// over the branch's transient concepts, and dropping it here would
+/// also drop it from [`find_concept`], breaking `tonk query command`.
+/// [`is_system_concept`] reads the registry instead, because hiding a
+/// name from a listing costs nothing.
 fn is_builtin_concept(name: &str) -> bool {
     matches!(
         name,
@@ -385,6 +408,28 @@ fn is_builtin_concept(name: &str) -> bool {
             | "remote"
             | "tracking-branch"
     )
+}
+
+/// Name of the concept `tonk home` authors to key the space home.
+/// Machinery for the home recipe, not vocabulary the author asserts
+/// against, so it is filtered out of agent-facing listings alongside
+/// the standard library.
+pub const SPACE_HOME_CONCEPT: &str = "space-home";
+
+/// Whether `name` belongs to the runtime rather than to this space's
+/// author: an analyzer built-in, a standard-library concept or
+/// command, or the CLI's own space-home recipe.
+///
+/// A fresh space carries forty-one of these. Listing them alongside
+/// the one concept an agent just defined — and pasting the same list
+/// into every "no concept named X" error — buries the answer, so
+/// every agent-facing surface filters on this.
+pub fn is_system_concept(name: &str) -> bool {
+    tonk_schema::builtin::concept_registry()
+        .iter()
+        .any(|(builtin, _)| *builtin == name)
+        || name == SPACE_HOME_CONCEPT
+        || crate::site::standard_library_declares_concept(name)
 }
 
 // ---------------------------------------------------------------- //

--- a/rust/tonk-cli/src/schema.rs
+++ b/rust/tonk-cli/src/schema.rs
@@ -98,7 +98,10 @@ pub async fn list_concepts(site: &TonkSite) -> Result<Vec<ConceptSummary>> {
     Ok(concepts)
 }
 
-/// Every concept on the branch, runtime vocabulary included.
+/// Every concept on the branch bar the analyzer's built-ins: the
+/// author's own, plus the runtime vocabulary the standard library
+/// seeds. `command` is the one built-in kept — see
+/// [`is_builtin_concept`] for why the rest are dropped here.
 ///
 /// For callers that need to answer a question about a system concept
 /// and list the author's in the same pass — `tonk context` reads the

--- a/rust/tonk-cli/src/site.rs
+++ b/rust/tonk-cli/src/site.rs
@@ -57,6 +57,32 @@ pub(crate) fn standard_library_has_name(name: &str) -> bool {
     })
 }
 
+/// Whether the seeded standard library pins `uri` as the `this:` of
+/// one of its own declarations.
+///
+/// Every library declaration that matters here — its views above all —
+/// carries an explicit `this:`, so the set of pinned URIs is exactly
+/// the set of entities the library seeded. Listings of branch data
+/// (`tonk view ls`) use it to tell the library's twenty-five views
+/// from the author's own.
+///
+/// Query variables (`this: ?this`, inside the library's rules) are not
+/// entities and never match a claim's subject, so they are skipped.
+pub(crate) fn standard_library_pins_entity(uri: &str) -> bool {
+    STANDARD_LIBRARY
+        .lines()
+        .filter_map(pinned_entity)
+        .any(|pinned| pinned == uri)
+}
+
+/// The `this:` value declared on one standard-library line, at any
+/// indentation. `None` for every other line, and for the query
+/// variables the library's rule bodies bind.
+fn pinned_entity(line: &str) -> Option<&str> {
+    let value = line.trim_start().strip_prefix("this:")?.trim();
+    (!value.is_empty() && !value.starts_with('?')).then_some(value)
+}
+
 /// Name of the dialog repository tonk uses inside `.tonk/`.
 pub const REPO_NAME: &str = "main";
 

--- a/rust/tonk-cli/src/site.rs
+++ b/rust/tonk-cli/src/site.rs
@@ -12,7 +12,9 @@
 //! against: profile, operator (rooted at the site directory), the
 //! repository, and the opened `main` branch.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 
 use anyhow::{Context, Result, bail};
 use dialog_capability::Subject;
@@ -53,19 +55,29 @@ const STANDARD_LIBRARY: &str = include_str!("../../tonk-core/assets/library/core
 /// different namespace: a concept named after one of them is the
 /// author's, not the library's.
 pub(crate) fn standard_library_declares_concept(name: &str) -> bool {
-    STANDARD_LIBRARY.lines().any(|line| {
-        let Some(anchor) = line
-            .strip_prefix("concept!: &")
-            .or_else(|| line.strip_prefix("command!: &"))
-        else {
-            return false;
-        };
-        anchor
-            .split_ascii_whitespace()
-            .next()
-            .map(|anchor| anchor.trim_end_matches(':'))
-            == Some(name)
-    })
+    STANDARD_LIBRARY_CONCEPTS.contains(name)
+}
+
+/// Every concept and command anchor the library declares, scanned
+/// once. See [`STANDARD_LIBRARY_PINS`] for why these are sets and not
+/// a scan per lookup.
+static STANDARD_LIBRARY_CONCEPTS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+    STANDARD_LIBRARY
+        .lines()
+        .filter_map(declared_concept)
+        .collect()
+});
+
+/// The concept (or command) anchor declared on one standard-library
+/// line. `None` for every other line.
+fn declared_concept(line: &str) -> Option<&str> {
+    let anchor = line
+        .strip_prefix("concept!: &")
+        .or_else(|| line.strip_prefix("command!: &"))?;
+    anchor
+        .split_ascii_whitespace()
+        .next()
+        .map(|anchor| anchor.trim_end_matches(':'))
 }
 
 /// Whether the seeded standard library pins `uri` as the `this:` of
@@ -80,11 +92,16 @@ pub(crate) fn standard_library_declares_concept(name: &str) -> bool {
 /// Query variables (`this: ?this`, inside the library's rules) are not
 /// entities and never match a claim's subject, so they are skipped.
 pub(crate) fn standard_library_pins_entity(uri: &str) -> bool {
-    STANDARD_LIBRARY
-        .lines()
-        .filter_map(pinned_entity)
-        .any(|pinned| pinned == uri)
+    STANDARD_LIBRARY_PINS.contains(uri)
 }
+
+/// Every entity the library pins, scanned once.
+///
+/// The listing that calls this asks per claim row and per renderable
+/// attribute, so a scan per lookup would walk the whole embedded
+/// document a few thousand times to list a handful of views.
+static STANDARD_LIBRARY_PINS: LazyLock<HashSet<&'static str>> =
+    LazyLock::new(|| STANDARD_LIBRARY.lines().filter_map(pinned_entity).collect());
 
 /// The `this:` value declared on one standard-library line, at any
 /// indentation. `None` for every other line, and for the query

--- a/rust/tonk-cli/src/site.rs
+++ b/rust/tonk-cli/src/site.rs
@@ -40,13 +40,24 @@ use tonk_account::prefix::{
 /// repository creation.
 const STANDARD_LIBRARY: &str = include_str!("../../tonk-core/assets/library/core.yaml");
 
-/// Whether the seeded standard library publishes `name`.
+/// Whether the seeded standard library declares a concept (or a
+/// command, its transient sibling) called `name`.
 ///
-/// Live schema enumeration also sees runtime/system concepts. Agent-facing
-/// workflow surfaces use this to keep the application vocabulary short.
-pub(crate) fn standard_library_has_name(name: &str) -> bool {
+/// Live schema enumeration also sees these runtime concepts, and on a
+/// fresh space they outnumber the author's own by forty to one.
+/// Agent-facing listings use this to keep the application vocabulary
+/// short — see [`crate::schema::is_system_concept`].
+///
+/// Only `concept!:` and `command!:` anchors count. The library also
+/// anchors attributes, views, and routes, but those live in a
+/// different namespace: a concept named after one of them is the
+/// author's, not the library's.
+pub(crate) fn standard_library_declares_concept(name: &str) -> bool {
     STANDARD_LIBRARY.lines().any(|line| {
-        let Some((_, anchor)) = line.split_once("!: &") else {
+        let Some(anchor) = line
+            .strip_prefix("concept!: &")
+            .or_else(|| line.strip_prefix("command!: &"))
+        else {
             return false;
         };
         anchor

--- a/rust/tonk-cli/src/views.rs
+++ b/rust/tonk-cli/src/views.rs
@@ -1,17 +1,31 @@
-//! `tonk view ls` — enumerate every entity holding a `text/html`
-//! claim on the local branch.
+//! `tonk view ls` — enumerate every entity on the local branch that
+//! carries a renderable claim.
 //!
-//! Claim-driven, not concept-driven: we don't care whether an
-//! entity is a member of the `view` concept or got its
-//! `text/html` claim some other way. The host route at
-//! `/api/repository/{repo}/branch/{branch}/host/{host}/{entity}`
-//! ultimately selects on `(the=text/html, of=<entity>)`, so
-//! anything that satisfies that selector is a candidate view
-//! and should surface here.
+//! Claim-driven, not concept-driven: we don't care whether an entity
+//! is a member of the `view` concept or picked its claim up some
+//! other way. What counts is the attribute the renderer selects on,
+//! and there are five of them:
+//!
+//! - the four template attributes the display stack resolves —
+//!   `xyz.tonk.view/display` (what `tonk view add` writes), plus the
+//!   `/directory`, `/label`, and `/title` view kinds;
+//! - `text/html`, which the host route at
+//!   `/api/repository/{repo}/branch/{branch}/host/{host}/{entity}`
+//!   selects on for a one-off page.
+//!
+//! Listing only `text/html` — as this module once did — meant
+//! `tonk view ls` came back empty right after `tonk view add`
+//! succeeded, because the two were looking at different claims.
+//!
+//! The standard library seeds twenty-five views of its own. Those are
+//! filtered out for the same reason `tonk concept ls` drops the
+//! runtime vocabulary: they resolve everywhere, and listing them
+//! buries the view the author just wrote.
 //!
 //! Used by `tonk view ls`, the only caller.
 
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 
 use anyhow::{Context, Result, anyhow};
 use dialog_artifacts::{Attribute, Entity, Value};
@@ -26,36 +40,65 @@ pub struct ViewSummary {
     /// asserted. The same name might be reused across the
     /// branch's history; we surface the current binding only.
     pub name: Option<String>,
-    /// Entity URI carrying the `text/html` claim — what the
-    /// host route's trailing `{entity}` segment takes.
+    /// Entity URI carrying the renderable claim — what a route's
+    /// trailing `{entity}` segment takes.
     pub entity: Entity,
+    /// What the view renders: the published name of the concept its
+    /// `xyz.tonk.view/model` points at, or that entity's URI when the
+    /// model publishes no name. `None` for a bare `text/html` page,
+    /// which binds no model.
+    pub model: Option<String>,
     /// Byte length of the body claim. Lets the listing show a
     /// rough "is this empty / huge?" without dumping the HTML.
-    /// When an entity holds more than one `text/html` claim
-    /// (which the seed schema's cardinality-many allows in
-    /// theory but git-tag semantics make uncommon), this is the
-    /// longest one — the most likely candidate for "the current
+    /// When an entity holds more than one renderable claim, this is
+    /// the longest one — the most likely candidate for "the current
     /// view body."
     pub body_bytes: usize,
 }
 
-/// Enumerate every distinct entity on the branch holding a
-/// `text/html` claim.
+/// The attributes a renderable claim can land under. The four view
+/// kinds the display stack resolves, then the host route's raw page
+/// body. Kept in one place so the listing and its documentation
+/// cannot drift apart.
+const RENDERABLE_ATTRIBUTES: &[&str] = &[
+    "xyz.tonk.view/display",
+    "xyz.tonk.view/directory",
+    "xyz.tonk.view/label",
+    "xyz.tonk.view/title",
+    "text/html",
+];
+
+/// The attribute binding a view to the concept it renders.
+const MODEL_ATTRIBUTE: &str = "xyz.tonk.view/model";
+
+/// Enumerate every distinct entity on the branch holding a renderable
+/// claim, minus the ones the standard library seeded.
 ///
-/// One row per entity. When an entity carries multiple
-/// `text/html` claims, the [`ViewSummary::body_bytes`] field
-/// records the longest; the name lookup is unaffected (each
-/// entity has at most one `db.meta/name` claim).
+/// One row per entity. When an entity carries several renderable
+/// claims — a model with both a detail and a directory template, say —
+/// the [`ViewSummary::body_bytes`] field records the longest; the name
+/// and model lookups are unaffected (each entity has at most one of
+/// each).
 pub async fn list(site: &TonkSite) -> Result<Vec<ViewSummary>> {
     let entities_with_lengths = enumerate_view_claims(site).await?;
     if entities_with_lengths.is_empty() {
         return Ok(Vec::new());
     }
     let names = name_claims_by_entity(site).await?;
+    let models = model_claims_by_entity(site).await?;
     let mut out: Vec<ViewSummary> = entities_with_lengths
         .into_iter()
         .map(|(entity, body_bytes)| ViewSummary {
             name: names.get(&entity).cloned(),
+            // A model is an entity reference; show the concept name it
+            // publishes, since that is the name `tonk view add` took
+            // and `tonk query` will take back.
+            model: models.get(&entity).map(|model| {
+                names
+                    .get(model)
+                    .cloned()
+                    .unwrap_or_else(|| model.to_string())
+            }),
             entity,
             body_bytes,
         })
@@ -92,17 +135,56 @@ pub async fn entity_has_text_html(site: &TonkSite, entity: &Entity) -> Result<bo
     Ok(!rows.is_empty())
 }
 
-/// Run the `(text/html, ?of, ?is)` query and reduce each entity
-/// to (entity, max body length). String, symbol, and bytes
-/// payloads are all counted by their on-disk byte length; other
-/// value flavours surface as zero — they shouldn't appear under
-/// `text/html` in practice, but ignoring them keeps the listing
-/// from panicking if something weird sneaks in.
+/// Run one `(<attribute>, ?of, ?is)` query per entry of
+/// [`RENDERABLE_ATTRIBUTES`] and reduce each entity to (entity, max
+/// body length), dropping the entities the standard library pinned.
+/// String, symbol, and bytes payloads are all counted by their
+/// on-disk byte length; other value flavours surface as zero — they
+/// shouldn't appear under a template attribute in practice, but
+/// ignoring them keeps the listing from panicking if something weird
+/// sneaks in.
 async fn enumerate_view_claims(site: &TonkSite) -> Result<Vec<(Entity, usize)>> {
-    let the = text_html_attribute()?;
+    let mut by_entity: HashMap<Entity, usize> = HashMap::new();
+    for uri in RENDERABLE_ATTRIBUTES {
+        for row in claims_for_attribute(site, uri).await? {
+            if crate::site::standard_library_pins_entity(&row.of.to_string()) {
+                continue;
+            }
+            let len = body_byte_len(&row.is);
+            by_entity
+                .entry(row.of)
+                .and_modify(|current| {
+                    if len > *current {
+                        *current = len;
+                    }
+                })
+                .or_insert(len);
+        }
+    }
+    Ok(by_entity.into_iter().collect())
+}
+
+/// Pull every `xyz.tonk.view/model` claim and return a
+/// `view entity → model entity` map. One branch query, for the same
+/// reason [`name_claims_by_entity`] is one.
+async fn model_claims_by_entity(site: &TonkSite) -> Result<HashMap<Entity, Entity>> {
+    let mut out = HashMap::new();
+    for claim in claims_for_attribute(site, MODEL_ATTRIBUTE).await? {
+        if let Value::Entity(model) = claim.is {
+            out.insert(claim.of, model);
+        }
+    }
+    Ok(out)
+}
+
+/// Select every current claim under one attribute URI.
+async fn claims_for_attribute(site: &TonkSite, uri: &str) -> Result<Vec<dialog_query::Claim>> {
+    let the: Attribute = uri
+        .parse()
+        .map_err(|e| anyhow!("{uri} should be a valid attribute URI: {e:?}"))?;
     let the_term: attribute::The = the.into();
     let session = site.branch().await?;
-    let rows: Vec<dialog_query::Claim> = session
+    session
         .handle()
         .query()
         .select(AttributeQuery::new(
@@ -115,21 +197,7 @@ async fn enumerate_view_claims(site: &TonkSite) -> Result<Vec<(Entity, usize)>> 
         .perform(&site.operator)
         .try_vec()
         .await
-        .map_err(|e| anyhow!("text/html enumeration failed: {e:?}"))?;
-
-    let mut by_entity: HashMap<Entity, usize> = HashMap::new();
-    for row in rows {
-        let len = body_byte_len(&row.is);
-        by_entity
-            .entry(row.of)
-            .and_modify(|current| {
-                if len > *current {
-                    *current = len;
-                }
-            })
-            .or_insert(len);
-    }
-    Ok(by_entity.into_iter().collect())
+        .map_err(|e| anyhow!("{uri} enumeration failed: {e:?}"))
 }
 
 fn body_byte_len(value: &Value) -> usize {
@@ -179,7 +247,20 @@ async fn name_claims_by_entity(site: &TonkSite) -> Result<HashMap<Entity, String
             continue;
         };
         if let Value::Entity(target) = claim.is {
-            out.insert(target, name);
+            // The relation is many-to-one — `space:home`, for one,
+            // answers to both `space-home` and the `tonk/space` alias —
+            // so inverting it has to pick. Take the lexicographically
+            // first, which at least makes the listing reproducible
+            // instead of leaving it to claim order.
+            match out.entry(target) {
+                Entry::Occupied(mut held) if name < *held.get() => {
+                    held.insert(name);
+                }
+                Entry::Occupied(_) => {}
+                Entry::Vacant(slot) => {
+                    slot.insert(name);
+                }
+            }
         }
     }
     Ok(out)

--- a/rust/tonk-cli/tests/blob.rs
+++ b/rust/tonk-cli/tests/blob.rs
@@ -159,22 +159,49 @@ async fn it_cats_a_blob_back() -> Result<()> {
     Ok(())
 }
 
-/// `ls` is deferred: the current dialog-db pin's entity-keyed blob
-/// API offers no way to enumerate a branch's blobs, so `tonk blob ls`
-/// reports `Unsupported` rather than listing. When the pin advances to
-/// a dialog-db with a blob-enumeration API, restore the listing test:
-/// add a blob, then assert `ls` returns one row matching the added
-/// entity, its size, and its `image/png` content type.
+/// `ls` reads the metadata `add` asserted, so a freshly added blob is
+/// listed with the content type and file name it was ingested under.
 #[tokio::test]
-async fn it_reports_ls_unsupported_on_the_current_pin() -> Result<()> {
+async fn it_lists_an_added_blob_with_its_metadata() -> Result<()> {
     let test = TestSite::new().await?;
     let file = test.parent.join("pic.png");
     tokio::fs::write(&file, b"\x89PNG bytes").await?;
-    blob::add(&test.site, &file, None).await?;
+    let added = blob::add(&test.site, &file, None).await?;
 
-    assert!(matches!(
-        blob::ls(&test.site).await,
-        Err(blob::BlobError::Unsupported(_))
-    ));
+    let rows = blob::ls(&test.site).await?;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].entity, added.entity);
+    assert_eq!(rows[0].content_type.as_deref(), Some("image/png"));
+    assert_eq!(rows[0].name.as_deref(), Some("pic.png"));
+    Ok(())
+}
+
+/// Re-adding the same bytes is idempotent all the way through the
+/// listing: one entity, one row.
+#[tokio::test]
+async fn it_lists_one_row_per_distinct_blob() -> Result<()> {
+    let test = TestSite::new().await?;
+    let first = test.parent.join("a.png");
+    let second = test.parent.join("b.txt");
+    tokio::fs::write(&first, b"\x89PNG bytes").await?;
+    tokio::fs::write(&second, b"plain").await?;
+    blob::add(&test.site, &first, None).await?;
+    blob::add(&test.site, &first, None).await?;
+    blob::add(&test.site, &second, None).await?;
+
+    let rows = blob::ls(&test.site).await?;
+    assert_eq!(rows.len(), 2);
+    let mut types: Vec<_> = rows.iter().filter_map(|r| r.content_type.clone()).collect();
+    types.sort();
+    assert_eq!(types, vec!["image/png", "text/plain"]);
+    Ok(())
+}
+
+/// A branch that has ingested nothing lists nothing — an empty
+/// listing, not an error.
+#[tokio::test]
+async fn it_lists_nothing_on_a_branch_with_no_blobs() -> Result<()> {
+    let test = TestSite::new().await?;
+    assert!(blob::ls(&test.site).await?.is_empty());
     Ok(())
 }

--- a/rust/tonk-cli/tests/cli_spot.rs
+++ b/rust/tonk-cli/tests/cli_spot.rs
@@ -620,48 +620,95 @@ mod when_the_invite_remote_is_the_upstream {
     }
 }
 
-/// The base-selection arm nothing could reach before: no remotes at
-/// all, so no origin resolves and the canonical base is the answer.
+/// A space with no remote is served by no deployment, so an invite to
+/// it has no origin. The canonical base is not a fallback here — it is
+/// production, which holds none of this space's data — so the mint is
+/// refused rather than handed over as a link that reads fine and works
+/// for nobody.
 ///
-/// `--no-shorten` is what makes this testable. Shortening PUTs to the
-/// link's own origin, which here is production — so without it this
-/// test would write to the real shortcut store on every run.
+/// `--base-url` is the way through for a deployment tonk doesn't know
+/// about. `--no-shorten` is what makes *that* testable: shortening
+/// PUTs to the link's own origin, so without it these would reach the
+/// wire on every run.
 mod when_no_remote_is_registered_at_all {
     use super::*;
 
+    const UNREGISTERED_BASE: &str = "http://127.0.0.1:9/join";
+
     #[dialog_common::test]
-    fn it_mints_on_the_canonical_base() {
+    fn it_refuses_rather_than_minting_a_link_to_production() {
         let state = tempfile::tempdir().expect("tempdir");
         spot_with_remotes(state.path(), &[]);
 
         let output = run(state.path(), &["invite", "--no-shorten"], &[]);
+
+        assert!(!output.status.success(), "{}", stdout_of(&output));
+        assert!(
+            stdout_of(&output).trim().is_empty(),
+            "no link should reach stdout: {}",
+            stdout_of(&output)
+        );
+        let stderr = stderr_of(&output);
+        assert!(stderr.contains("'demo' has no remote"), "{stderr}");
+        assert!(
+            stderr.contains(tonk_cli::invite::DEFAULT_BASE_URL),
+            "the refusal names the origin it would otherwise have used: {stderr}"
+        );
+    }
+
+    /// The refusal is only useful if it names every way out: hand the
+    /// space to an account, register a remote, or override the origin.
+    #[dialog_common::test]
+    fn it_names_each_way_to_give_the_space_an_origin() {
+        let state = tempfile::tempdir().expect("tempdir");
+        spot_with_remotes(state.path(), &[]);
+
+        let output = run(state.path(), &["invite", "--no-shorten"], &[]);
+        let stderr = stderr_of(&output);
+
+        assert!(stderr.contains("tonk account link"), "{stderr}");
+        assert!(stderr.contains("tonk space link demo"), "{stderr}");
+        assert!(stderr.contains("tonk remote add"), "{stderr}");
+        assert!(stderr.contains("--base-url"), "{stderr}");
+    }
+
+    /// An explicit `--base-url` is the caller saying which deployment
+    /// serves this space, so the mint proceeds on that origin.
+    #[dialog_common::test]
+    fn it_mints_on_an_explicitly_named_base() {
+        let state = tempfile::tempdir().expect("tempdir");
+        spot_with_remotes(state.path(), &[]);
+
+        let output = run(
+            state.path(),
+            &["invite", "--no-shorten", "--base-url", UNREGISTERED_BASE],
+            &[],
+        );
         assert!(output.status.success(), "{}", stderr_of(&output));
 
         let url = stdout_of(&output);
         let url = url.trim();
-        assert!(
-            url.starts_with(tonk_cli::invite::DEFAULT_BASE_URL),
-            "canonical base: {url}"
-        );
+        assert!(url.starts_with(UNREGISTERED_BASE), "named base: {url}");
         assert!(url.contains("access="), "a real invite: {url}");
     }
 
-    /// The environment form of the same switch, so automation can opt
+    /// The environment form of `--no-shorten`, so automation can opt
     /// out without threading a flag through every call site.
     #[dialog_common::test]
     fn it_honours_the_environment_switch() {
         let state = tempfile::tempdir().expect("tempdir");
         spot_with_remotes(state.path(), &[]);
 
-        let output = run(state.path(), &["invite"], &[("TONK_NO_SHORTEN", "1")]);
+        let output = run(
+            state.path(),
+            &["invite", "--base-url", UNREGISTERED_BASE],
+            &[("TONK_NO_SHORTEN", "1")],
+        );
         assert!(output.status.success(), "{}", stderr_of(&output));
 
         let url = stdout_of(&output);
         let url = url.trim();
-        assert!(
-            url.starts_with(tonk_cli::invite::DEFAULT_BASE_URL),
-            "canonical base: {url}"
-        );
+        assert!(url.starts_with(UNREGISTERED_BASE), "named base: {url}");
         assert!(!url.contains("/@/"), "not shortened: {url}");
     }
 }

--- a/rust/tonk-cli/tests/data_verbs.rs
+++ b/rust/tonk-cli/tests/data_verbs.rs
@@ -217,6 +217,50 @@ mod when_asserting_a_new_instance {
         );
         Ok(())
     }
+
+    /// The usage line is what an agent reads on every mis-shaped
+    /// write, so it has to be a command that runs, not a sketch of
+    /// one. It used to render `tonk … task`, with a literal ellipsis
+    /// where the verb belongs.
+    #[dialog_common::test]
+    async fn it_renders_a_runnable_usage_line() -> Result<()> {
+        let test = TestSite::new().await?;
+        test.eval_inline(ATTRIBUTE_DECL).await?;
+        test.eval_inline(CONCEPT_DECL).await?;
+        let argv = vec!["--nope".to_string(), "x".to_string()];
+
+        let mint = tonk_cli::data_ops::assert_op(&test.site, "task", None, &argv)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            mint.contains("Usage: tonk assert task --"),
+            "mint form should name the verb and the concept:\n{mint}"
+        );
+        assert!(
+            mint.contains("--title <TEXT>"),
+            "mint form should name the required flags:\n{mint}"
+        );
+        assert!(!mint.contains('…'), "no placeholder ellipsis:\n{mint}");
+
+        // The supersede form takes the entity between the concept and
+        // the flags, so its usage line has to show that too.
+        test.eval_inline("task!: &chore\n  title: \"Chore\"\n  done: false\n")
+            .await?;
+        let supersede = tonk_cli::data_ops::assert_op(&test.site, "task", Some("chore"), &argv)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            supersede.contains("Usage: tonk assert task <ENTITY>"),
+            "supersede form should show where the entity goes:\n{supersede}"
+        );
+        assert!(
+            !supersede.contains('…'),
+            "no placeholder ellipsis:\n{supersede}"
+        );
+        Ok(())
+    }
 }
 
 // `task` has two required fields (`title`, `done`; see the note

--- a/rust/tonk-cli/tests/render.rs
+++ b/rust/tonk-cli/tests/render.rs
@@ -45,14 +45,16 @@ async fn seeded() -> Result<TestSite> {
 
 #[dialog_common::test]
 async fn it_seeds_the_standard_library_on_init() -> Result<()> {
-    // A fresh site has the built-in `view` concept without any manual
-    // seeding — proof that site init lowered core.yaml.
+    // A fresh site resolves the standard library's `view` concept
+    // without any manual seeding — proof that site init lowered
+    // core.yaml. Asked by name: `list_concepts` is the author-facing
+    // listing and deliberately omits everything init seeded.
     let test = TestSite::new().await?;
-    let concepts = tonk_cli::schema::list_concepts(&test.site).await?;
     assert!(
-        concepts.iter().any(|c| c.name == "view"),
-        "the built-in `view` concept should be seeded at init: {:?}",
-        concepts.iter().map(|c| &c.name).collect::<Vec<_>>()
+        tonk_cli::schema::find_concept(&test.site, "view")
+            .await?
+            .is_some(),
+        "the standard library's `view` concept should be seeded at init"
     );
     Ok(())
 }

--- a/rust/tonk-cli/tests/site.rs
+++ b/rust/tonk-cli/tests/site.rs
@@ -987,6 +987,45 @@ mod when_listing_concepts {
     }
 
     #[dialog_common::test]
+    async fn it_omits_the_runtime_vocabulary_a_fresh_site_seeds() -> Result<()> {
+        // Site init lowers core.yaml and the analyzer registers its
+        // built-ins, so a fresh branch carries forty-odd concepts the
+        // author never wrote. None of them belongs in the listing.
+        let test = common::TestSite::new().await?;
+        let concepts = schema::list_concepts(&test.site).await?;
+        assert!(
+            concepts.is_empty(),
+            "a fresh site defines no concepts of its own; saw {:?}",
+            concepts.iter().map(|c| &c.name).collect::<Vec<_>>()
+        );
+
+        // Each of these is a different source of noise: an analyzer
+        // built-in, a standard-library concept, and a standard-library
+        // command. Naming them pins the filter to all three.
+        test.eval_inline(ATTRIBUTE_DECL).await?;
+        test.eval_inline(CONCEPT_DECL).await?;
+        let listed: Vec<_> = schema::list_concepts(&test.site)
+            .await?
+            .into_iter()
+            .map(|c| c.name)
+            .collect();
+        assert_eq!(listed, vec!["task".to_string()]);
+        for omitted in ["command", "view", "tonk/agents", "tonk/invite"] {
+            assert!(
+                !listed.contains(&omitted.to_string()),
+                "{omitted} is runtime vocabulary and should not be listed"
+            );
+            // Omitted from the listing, but still addressable by name:
+            // the filter is presentational, not a scoping rule.
+            assert!(
+                schema::find_concept(&test.site, omitted).await?.is_some(),
+                "{omitted} should still resolve by name"
+            );
+        }
+        Ok(())
+    }
+
+    #[dialog_common::test]
     async fn it_excludes_user_defined_concepts_absent_on_a_fresh_site() -> Result<()> {
         // A fresh site has no user-defined `task` concept — only
         // built-ins are seeded. This pins that the user-defined

--- a/rust/tonk-cli/tests/site.rs
+++ b/rust/tonk-cli/tests/site.rs
@@ -1017,6 +1017,52 @@ mod when_listing_views {
         Ok(())
     }
 
+    /// `view add` writes `xyz.tonk.view/display`; the listing used to
+    /// select on `text/html` alone and so came back empty right after
+    /// a successful add.
+    #[dialog_common::test]
+    async fn it_lists_a_view_authored_through_view_add() -> Result<()> {
+        let test = common::TestSite::new().await?;
+        test.eval_inline(common::ATTRIBUTE_DECL).await?;
+        test.eval_inline(common::CONCEPT_DECL).await?;
+        tonk_cli::data_ops::view_add(&test.site, "task", None, "<b>{title}</b>").await?;
+
+        let listed = views::list(&test.site).await?;
+        let row = listed
+            .iter()
+            .find(|row| row.name.as_deref() == Some("task-view"))
+            .expect("the authored view should be listed");
+        assert_eq!(row.model.as_deref(), Some("task"));
+        // The `display: |` block scalar keeps its trailing newline.
+        assert_eq!(row.body_bytes, "<b>{title}</b>\n".len());
+        Ok(())
+    }
+
+    /// The standard library seeds twenty-five views. They are branch
+    /// data like any other, so only the pin filter keeps them out.
+    #[dialog_common::test]
+    async fn it_omits_the_views_the_standard_library_seeds() -> Result<()> {
+        let test = common::TestSite::new().await?;
+        assert!(views::list(&test.site).await?.is_empty());
+
+        test.eval_inline(common::ATTRIBUTE_DECL).await?;
+        test.eval_inline(common::CONCEPT_DECL).await?;
+        tonk_cli::data_ops::view_add(&test.site, "task", None, "<b>{title}</b>").await?;
+
+        let listed = views::list(&test.site).await?;
+        assert!(
+            listed
+                .iter()
+                .all(|row| row.entity.to_string() != "tonk:blob/media-view"),
+            "seeded views should stay out of the listing: {:?}",
+            listed
+                .iter()
+                .map(|row| row.entity.to_string())
+                .collect::<Vec<_>>()
+        );
+        Ok(())
+    }
+
     #[dialog_common::test]
     async fn it_surfaces_every_bookmarked_view() -> Result<()> {
         let test = common::TestSite::new().await?;


### PR DESCRIPTION
Stacked on #738 — review that one first; this PR's diff is only the five commits below.

## Summary

Five independent CLI fixes, each one a command that was reporting something other than what it does:

- **`tonk assert <concept> --help`** names the verb it is actually documenting in its usage line.
- **`tonk invite`** refuses to mint a link for a space that has no origin, instead of handing out one nobody can claim.
- **`tonk blob ls`** lists blobs from their metadata facts. It was a stub that reported the subcommand as unsupported on the current dialog-db pin.
- **`tonk view ls`** lists the views `tonk view add` writes, rather than every entity carrying a `text/html` claim.
- **`tonk concept ls`** lists only the concepts a space defines, without the built-ins that are resolvable everywhere.

## Testing

- `cargo test -p tonk-cli --features integration-tests`
- `cargo clippy -p tonk-cli --all-targets --all-features`
- `cargo fmt --all -- --check`

## Note

These were committed onto #738's branch by a parallel session and have been split back out here so the account-model change can be reviewed on its own. The two branches together are byte-identical to what #738 carried before the split.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the documentation and functionality of the `tonk` CLI commands, particularly around blob handling, concept listing, and view rendering. It improves clarity in command outputs and refines the underlying logic for better user experience.

### Detailed summary
- Updated `tonk blob ls` to list blobs with metadata: reference, content type, name.
- Refined `tonk concept ls` to list concepts defined in the space, excluding built-in concepts.
- Enhanced `tonk view ls` to show entities with template claims, including model references.
- Improved error handling for missing concepts in user-defined contexts.
- Adjusted tests to reflect changes in blob listing and concept visibility.
- Clarified comments and documentation throughout the codebase for better understanding.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->