### PR TITLE
Join a spot from a pasted invite link

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,6 +2003,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5410,6 +5422,7 @@ version = "0.6.7"
 dependencies = [
  "custom-elements",
  "dialog-common",
+ "gloo-timers",
  "js-sys",
  "reqwest 0.12.28",
  "serde",

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -830,7 +830,9 @@ concept!: &join/failure
       cardinality: one
       as: text
     kind:
-      description: The failure class, one of malformed, audience-mismatch, or claim-failed.
+      description: >
+        The failure class: malformed, audience-mismatch, revoked,
+        unavailable, refused, or claim-failed.
       the: xyz.tonk.join/kind
       cardinality: one
       as: text
@@ -869,55 +871,27 @@ view/directory!:
   this: id:tonk:join/status/view
   model: tonk:join/status
   display: |
-    <main class="join-view">
+    <div class="join-card-wrap">
       <style>
-        /* The paste form is the route's EMPTY state: the directory chrome
-           renders with zero `tonk:join/status` instances, which is exactly
-           the case where no invite was in the URL (the command asserts no
-           status then). A join in flight or failed has an instance, so the
-           `:has()` rule hides the form and the card below carries the
-           spinner or the failure. */
-        .join-paste { display: flex; flex-direction: column; gap: 14px;
-          width: min(540px, 100%); margin: 0 auto; }
-        .join-paste wa-input { width: 100%; }
-        .join-paste wa-button { align-self: center; min-width: 220px; }
-        .join-paste-error { display: none; color: var(--wa-color-danger-on-quiet); }
-        tonk-invite-link[data-state="invalid"] ~ .join-paste-error { display: block; }
-        .join-view:has(.join-status) .join-paste { display: none; }
-        .join-view:not(:has(.join-status)) .join-card { display: none; }
+        .join-card { display: block; margin: 40px auto; width: min(540px, 100%); }
       </style>
-      <tonk-page onmount=tonk:join>
-      <!-- No invite in the URL: someone arrived holding a link. The same
-           element the Hub uses resolves it (expanding a shortened link on
-           its own origin) and navigates to this route with the invite in
-           place, where the ordinary claim path takes over. -->
-      <form class="join-paste">
-        <h1>Join a spot</h1>
-        <p>Paste the invite link someone shared with you.</p>
-        <wa-input name="url" placeholder="https://&hellip;" autocomplete="off" required></wa-input>
-        <tonk-invite-link field="url"></tonk-invite-link>
-        <p class="join-paste-error">That doesn't look like an invite link.</p>
-        <wa-button type="submit" variant="brand">Join spot</wa-button>
-      </form>
-      <wa-card class="join-card">
-        <div slot="header"><h1>Joining…</h1></div>
-        <wa-spinner></wa-spinner>
-        <!-- `data-id={this}` designates the repeat row without granting a
-             routing context (the status entity is not a repository). -->
-        <div class="join-status" data-id={this}>
+      <!-- Only the in-flight and failed states live here. The resting
+           (paste) state is the ROUTE view's, because this directory is
+           empty until a join starts and an empty nested directory renders
+           nothing. `data-id={this}` marks the repeat row; the card is
+           inside it, so the whole surface is per-status. -->
+      <div class="join-status" data-id={this}>
+        <wa-card class="join-card">
+          <div slot="header"><h1>Joining…</h1></div>
+          <wa-spinner></wa-spinner>
           <tonk-display entity={this} model=tonk:join/failure>
-            <!-- While the join is pending there is a `tonk:join/status` but
-                 no `tonk:join/failure` yet: stay quiet (empty slots) instead
-                 of the built-in "Not found" callout. The failure view only
-                 renders once a failure is actually recorded. -->
             <span slot="no-entity"></span>
             <span slot="no-model"></span>
             <span slot="loading"></span>
           </tonk-display>
-        </div>
-      </wa-card>
-      </tonk-page>
-    </main>
+        </wa-card>
+      </div>
+    </div>
 
 # The failure view — the default view for `tonk:join/failure`, so the join
 # directory's per-instance `<tonk-display model=tonk:join/failure>` renders
@@ -1070,7 +1044,57 @@ view!: &join/route-view
   display: |
     <div class="display-view-slot">
       <tonk-title text="Tonk"></tonk-title>
-      <tonk-display model="tonk:join/status"></tonk-display>
+      <main class="join-view">
+        <style>
+          /* The paste form is this route's RESTING state and renders from
+             the route view itself — an entity view on the site, the same
+             shape the Hub uses. It deliberately does NOT live behind the
+             nested `tonk:join/status` directory: that directory is empty
+             until a join is actually in flight, and an empty nested
+             directory renders nothing at all, which left `/join` on a
+             spinner forever. The status directory below now carries ONLY
+             the in-flight and failed states, and hides the form once it
+             has a row to show. */
+          .join-paste { display: flex; flex-direction: column; gap: 14px;
+            width: min(540px, 100%); margin: 40px auto; }
+          .join-paste wa-input { width: 100%; }
+          .join-paste wa-button { align-self: center; min-width: 220px; }
+          .join-paste-error { display: none; color: var(--wa-color-danger-on-quiet); }
+          tonk-invite-link[data-state="invalid"] ~ .join-paste-error { display: block; }
+          /* A join in flight or failed gives the status display a row;
+             `data-state=ready` is `<tonk-display>`'s own signal for that,
+             so the form steps aside without depending on the row's markup. */
+          .join-view:has(.join-status-slot[data-state="ready"]) .join-paste { display: none; }
+        </style>
+        <tonk-page onmount=tonk:join></tonk-page>
+        <!-- `onmount`, not `onsubmit`: `<tonk-invite-link>` cancels the
+             submit, resolves the pasted text (expanding a short link on
+             its minting origin), and re-fires it as a bubbling `mount`
+             carrying `detail.href` — the one read path `tonk:join`
+             declares. Same command, same handler, whether the invite
+             arrived in the address bar or in this box. -->
+        <form class="join-paste" onmount=tonk:join>
+          <h1>Join a spot</h1>
+          <p>Paste the invite link someone shared with you.</p>
+          <wa-input name="url" placeholder="https://&hellip;" autocomplete="off" required></wa-input>
+          <tonk-invite-link field="url"></tonk-invite-link>
+          <p class="join-paste-error">That doesn't look like an invite link.</p>
+          <wa-button type="submit" variant="brand">Join spot</wa-button>
+        </form>
+        <!-- The `tonk:join` trigger lives INSIDE the status display, not
+             beside the form. `<tonk-page>` waits for its enclosing
+             `<tonk-display>` to mark `data-bound` before firing, and a
+             trigger placed in the route view waits on the ROUTE's display —
+             which does not finish binding until its children render, so the
+             page never painted. Nested here it waits on the status display
+             instead, which binds independently, and the form above it is
+             plain markup that renders regardless of any command. -->
+        <tonk-display class="join-status-slot" model="tonk:join/status">
+          <span slot="empty"></span>
+          <span slot="loading"></span>
+          <span slot="no-entity"></span>
+        </tonk-display>
+      </main>
     </div>
 
 # The /inspector and /diagnose routes: the same query-inspector and

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -349,13 +349,15 @@ view/directory!:
           background: var(--wa-color-surface-default); color: var(--wa-color-text-normal); }
         #wiz-start:checked ~ .spot-overlay,
         #wiz-tmpl:checked ~ .spot-overlay,
-        #wiz-agent:checked ~ .spot-overlay { display: block; }
+        #wiz-agent:checked ~ .spot-overlay,
+        #wiz-invite:checked ~ .spot-overlay { display: block; }
         /* chooser paging: the wiz radios (siblings of .spot-overlay) switch screens */
         .onb-screen { display: none; position: absolute; inset: 0; flex-direction: column;
           align-items: center; justify-content: center; gap: 34px; padding: 60px 40px; }
         #wiz-start:checked ~ .spot-overlay .onb-screen--start { display: flex; }
         #wiz-tmpl:checked ~ .spot-overlay .onb-screen--details,
         #wiz-agent:checked ~ .spot-overlay .onb-screen--details { display: flex; }
+        #wiz-invite:checked ~ .spot-overlay .onb-screen--invite { display: flex; }
         .onb-tpl { display: none; }
         .onb-nav { position: absolute; top: 16px; }
         .onb-nav--close { right: 20px; }
@@ -369,7 +371,18 @@ view/directory!:
         /* Start-screen choices + template grid are Web Awesome cards wrapped
            in a <label> so a click toggles the driving radio. The card carries
            the surface/border/hover; the label only forwards the click. */
-        .onb-choices { display: grid; grid-template-columns: repeat(2, minmax(0,300px)); gap: 18px; }
+        .onb-choices { display: grid; grid-template-columns: repeat(3, minmax(0,280px)); gap: 18px; }
+        /* Paste-an-invite screen: one input, one button. The error line is
+           hidden until `<tonk-invite-link>` stamps `data-state=invalid` on
+           itself — pure sibling CSS, no script in the template. */
+        .onb-join { display: flex; flex-direction: column; gap: 14px;
+          width: min(540px, 100%); }
+        .onb-join wa-input { width: 100%; }
+        .onb-join wa-button { align-self: center; min-width: 220px; }
+        .onb-join-error { display: none; color: var(--wa-color-danger-on-quiet); }
+        tonk-invite-link[data-state="invalid"] ~ .onb-join-error { display: block; }
+        .onb-art--invite { background: var(--wa-color-surface-lowered);
+          font-size: 30px; color: var(--wa-color-text-quiet); }
         /* The template picker: a grid of card <label>s (2x2 at four
            templates), shown once the template path is chosen. */
         .onb-grid { display: none; grid-template-columns: repeat(2, minmax(0,280px));
@@ -493,6 +506,7 @@ view/directory!:
       <input class="spot-wiz" type="radio" name="__wiz" id="wiz-start">
       <input class="spot-wiz" type="radio" name="__wiz" id="wiz-tmpl">
       <input class="spot-wiz" type="radio" name="__wiz" id="wiz-agent">
+      <input class="spot-wiz" type="radio" name="__wiz" id="wiz-invite">
 
       <header class="spot-top">
         <div class="spot-brand">
@@ -603,6 +617,16 @@ view/directory!:
                   <div class="onb-card__cta">start blank &rsaquo;</div>
                 </wa-card>
               </label>
+              <label class="onb-card" for="wiz-invite">
+                <wa-card appearance="outlined">
+                  <div class="onb-art onb-art--invite">
+                    <wa-icon name="link"></wa-icon>
+                  </div>
+                  <div class="onb-card__name">From an invite link</div>
+                  <div class="onb-card__desc">Join a spot shared with you, wherever it is hosted.</div>
+                  <div class="onb-card__cta">paste a link &rsaquo;</div>
+                </wa-card>
+              </label>
             </div>
           </div>
 
@@ -666,6 +690,38 @@ view/directory!:
             </div>
           </div>
         </form>
+
+        <!-- Paste-an-invite screen. Its OWN form, as a SIBLING of the
+             create form (forms cannot nest): `.onb-screen` is absolutely
+             positioned against `.spot-overlay`, so it pages exactly like
+             the create screens via the `wiz-invite` radio. The invite URL
+             carries the space's sync remote in its query/fragment, so a
+             link minted on another deployment joins here while syncing
+             from wherever the invite says the space lives —
+             `<tonk-invite-link>` rewrites the pasted link onto this
+             deployment's /join route and the ordinary claim pipeline does
+             the rest. -->
+        <div class="onb-screen onb-screen--invite">
+          <label class="onb-nav onb-nav--back" for="wiz-start">
+            <wa-button variant="neutral" appearance="plain" size="small">
+              <wa-icon slot="start" name="angle-left"></wa-icon>back
+            </wa-button>
+          </label>
+          <label class="onb-nav onb-nav--close" for="wiz-closed">
+            <wa-button variant="neutral" appearance="plain" size="small">close</wa-button>
+          </label>
+          <div class="onb-head">
+            <h3>Join with an invite link</h3>
+            <p class="onb-lede">Paste a link someone shared with you. The spot syncs from
+              wherever the invite says it lives, so links from other deployments work too.</p>
+          </div>
+          <form class="onb-join">
+            <wa-input name="url" placeholder="https://&hellip;/join?&hellip;" autocomplete="off" required></wa-input>
+            <tonk-invite-link field="url"></tonk-invite-link>
+            <p class="onb-join-error onb-lede">That doesn't look like an invite link.</p>
+            <wa-button type="submit" variant="brand">Join spot</wa-button>
+          </form>
+        </div>
       </div>
     </div>
 

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -369,9 +369,7 @@ view/directory!:
         /* Start-screen choices + template grid are Web Awesome cards wrapped
            in a <label> so a click toggles the driving radio. The card carries
            the surface/border/hover; the label only forwards the click. */
-        .onb-choices { display: grid; grid-template-columns: repeat(3, minmax(0,280px)); gap: 18px; }
-        .onb-art--invite { background: var(--wa-color-surface-lowered);
-          font-size: 30px; color: var(--wa-color-text-quiet); }
+        .onb-choices { display: grid; grid-template-columns: repeat(2, minmax(0,280px)); gap: 18px; }
         /* The template picker: a grid of card <label>s (2x2 at four
            templates), shown once the template path is chosen. */
         .onb-grid { display: none; grid-template-columns: repeat(2, minmax(0,280px));
@@ -605,16 +603,6 @@ view/directory!:
                   <div class="onb-card__cta">start blank &rsaquo;</div>
                 </wa-card>
               </label>
-              <a class="onb-card" href="/join">
-                <wa-card appearance="outlined">
-                  <div class="onb-art onb-art--invite">
-                    <wa-icon name="link"></wa-icon>
-                  </div>
-                  <div class="onb-card__name">From an invite link</div>
-                  <div class="onb-card__desc">Join a spot shared with you, wherever it is hosted.</div>
-                  <div class="onb-card__cta">paste a link &rsaquo;</div>
-                </wa-card>
-              </a>
             </div>
           </div>
 

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -349,15 +349,13 @@ view/directory!:
           background: var(--wa-color-surface-default); color: var(--wa-color-text-normal); }
         #wiz-start:checked ~ .spot-overlay,
         #wiz-tmpl:checked ~ .spot-overlay,
-        #wiz-agent:checked ~ .spot-overlay,
-        #wiz-invite:checked ~ .spot-overlay { display: block; }
+        #wiz-agent:checked ~ .spot-overlay { display: block; }
         /* chooser paging: the wiz radios (siblings of .spot-overlay) switch screens */
         .onb-screen { display: none; position: absolute; inset: 0; flex-direction: column;
           align-items: center; justify-content: center; gap: 34px; padding: 60px 40px; }
         #wiz-start:checked ~ .spot-overlay .onb-screen--start { display: flex; }
         #wiz-tmpl:checked ~ .spot-overlay .onb-screen--details,
         #wiz-agent:checked ~ .spot-overlay .onb-screen--details { display: flex; }
-        #wiz-invite:checked ~ .spot-overlay .onb-screen--invite { display: flex; }
         .onb-tpl { display: none; }
         .onb-nav { position: absolute; top: 16px; }
         .onb-nav--close { right: 20px; }
@@ -372,15 +370,6 @@ view/directory!:
            in a <label> so a click toggles the driving radio. The card carries
            the surface/border/hover; the label only forwards the click. */
         .onb-choices { display: grid; grid-template-columns: repeat(3, minmax(0,280px)); gap: 18px; }
-        /* Paste-an-invite screen: one input, one button. The error line is
-           hidden until `<tonk-invite-link>` stamps `data-state=invalid` on
-           itself — pure sibling CSS, no script in the template. */
-        .onb-join { display: flex; flex-direction: column; gap: 14px;
-          width: min(540px, 100%); }
-        .onb-join wa-input { width: 100%; }
-        .onb-join wa-button { align-self: center; min-width: 220px; }
-        .onb-join-error { display: none; color: var(--wa-color-danger-on-quiet); }
-        tonk-invite-link[data-state="invalid"] ~ .onb-join-error { display: block; }
         .onb-art--invite { background: var(--wa-color-surface-lowered);
           font-size: 30px; color: var(--wa-color-text-quiet); }
         /* The template picker: a grid of card <label>s (2x2 at four
@@ -506,7 +495,6 @@ view/directory!:
       <input class="spot-wiz" type="radio" name="__wiz" id="wiz-start">
       <input class="spot-wiz" type="radio" name="__wiz" id="wiz-tmpl">
       <input class="spot-wiz" type="radio" name="__wiz" id="wiz-agent">
-      <input class="spot-wiz" type="radio" name="__wiz" id="wiz-invite">
 
       <header class="spot-top">
         <div class="spot-brand">
@@ -617,7 +605,7 @@ view/directory!:
                   <div class="onb-card__cta">start blank &rsaquo;</div>
                 </wa-card>
               </label>
-              <label class="onb-card" for="wiz-invite">
+              <a class="onb-card" href="/join">
                 <wa-card appearance="outlined">
                   <div class="onb-art onb-art--invite">
                     <wa-icon name="link"></wa-icon>
@@ -626,7 +614,7 @@ view/directory!:
                   <div class="onb-card__desc">Join a spot shared with you, wherever it is hosted.</div>
                   <div class="onb-card__cta">paste a link &rsaquo;</div>
                 </wa-card>
-              </label>
+              </a>
             </div>
           </div>
 
@@ -691,37 +679,6 @@ view/directory!:
           </div>
         </form>
 
-        <!-- Paste-an-invite screen. Its OWN form, as a SIBLING of the
-             create form (forms cannot nest): `.onb-screen` is absolutely
-             positioned against `.spot-overlay`, so it pages exactly like
-             the create screens via the `wiz-invite` radio. The invite URL
-             carries the space's sync remote in its query/fragment, so a
-             link minted on another deployment joins here while syncing
-             from wherever the invite says the space lives —
-             `<tonk-invite-link>` rewrites the pasted link onto this
-             deployment's /join route and the ordinary claim pipeline does
-             the rest. -->
-        <div class="onb-screen onb-screen--invite">
-          <label class="onb-nav onb-nav--back" for="wiz-start">
-            <wa-button variant="neutral" appearance="plain" size="small">
-              <wa-icon slot="start" name="angle-left"></wa-icon>back
-            </wa-button>
-          </label>
-          <label class="onb-nav onb-nav--close" for="wiz-closed">
-            <wa-button variant="neutral" appearance="plain" size="small">close</wa-button>
-          </label>
-          <div class="onb-head">
-            <h3>Join with an invite link</h3>
-            <p class="onb-lede">Paste a link someone shared with you. The spot syncs from
-              wherever the invite says it lives, so links from other deployments work too.</p>
-          </div>
-          <form class="onb-join">
-            <wa-input name="url" placeholder="https://&hellip;/join?&hellip;" autocomplete="off" required></wa-input>
-            <tonk-invite-link field="url"></tonk-invite-link>
-            <p class="onb-join-error onb-lede">That doesn't look like an invite link.</p>
-            <wa-button type="submit" variant="brand">Join spot</wa-button>
-          </form>
-        </div>
       </div>
     </div>
 
@@ -913,7 +870,35 @@ view/directory!:
   model: tonk:join/status
   display: |
     <main class="join-view">
+      <style>
+        /* The paste form is the route's EMPTY state: the directory chrome
+           renders with zero `tonk:join/status` instances, which is exactly
+           the case where no invite was in the URL (the command asserts no
+           status then). A join in flight or failed has an instance, so the
+           `:has()` rule hides the form and the card below carries the
+           spinner or the failure. */
+        .join-paste { display: flex; flex-direction: column; gap: 14px;
+          width: min(540px, 100%); margin: 0 auto; }
+        .join-paste wa-input { width: 100%; }
+        .join-paste wa-button { align-self: center; min-width: 220px; }
+        .join-paste-error { display: none; color: var(--wa-color-danger-on-quiet); }
+        tonk-invite-link[data-state="invalid"] ~ .join-paste-error { display: block; }
+        .join-view:has(.join-status) .join-paste { display: none; }
+        .join-view:not(:has(.join-status)) .join-card { display: none; }
+      </style>
       <tonk-page onmount=tonk:join>
+      <!-- No invite in the URL: someone arrived holding a link. The same
+           element the Hub uses resolves it (expanding a shortened link on
+           its own origin) and navigates to this route with the invite in
+           place, where the ordinary claim path takes over. -->
+      <form class="join-paste">
+        <h1>Join a spot</h1>
+        <p>Paste the invite link someone shared with you.</p>
+        <wa-input name="url" placeholder="https://&hellip;" autocomplete="off" required></wa-input>
+        <tonk-invite-link field="url"></tonk-invite-link>
+        <p class="join-paste-error">That doesn't look like an invite link.</p>
+        <wa-button type="submit" variant="brand">Join spot</wa-button>
+      </form>
       <wa-card class="join-card">
         <div slot="header"><h1>Joining…</h1></div>
         <wa-spinner></wa-spinner>

--- a/rust/tonk-worker-api/src/join.rs
+++ b/rust/tonk-worker-api/src/join.rs
@@ -16,6 +16,13 @@ pub enum JoinFailureKind {
     Revoked,
     /// The remote could not be reached, or could not serve the space.
     Unavailable,
+    /// The remote evaluated the invite's authority and declined it on
+    /// policy grounds — the delegation is well-formed and unexpired, but
+    /// its conditions do not hold for this space (an unprovisioned
+    /// subject, a lapsed plan). Distinct from [`Self::ClaimFailed`],
+    /// which means something on THIS device went wrong: retrying or
+    /// re-inviting changes nothing here, the space's owner has to act.
+    Refused,
     /// A local failure stopped the join.
     ClaimFailed,
 }
@@ -28,6 +35,7 @@ impl JoinFailureKind {
             Self::AudienceMismatch => "audience-mismatch",
             Self::Revoked => "revoked",
             Self::Unavailable => "unavailable",
+            Self::Refused => "refused",
             Self::ClaimFailed => "claim-failed",
         }
     }
@@ -39,6 +47,9 @@ impl JoinFailureKind {
             Self::AudienceMismatch => "This invite was issued to a different identity.",
             Self::Revoked => "This invite has been revoked.",
             Self::Unavailable => "Tonk could not reach this spot. Try again.",
+            Self::Refused => {
+                "This spot's host declined the invite. Its owner needs to check the spot's plan."
+            }
             Self::ClaimFailed => "Tonk could not join this spot.",
         }
     }

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -275,10 +275,14 @@ impl std::fmt::Debug for JoinFailure {
 
 impl JoinFailure {
     fn new(kind: JoinFailureKind, detail: impl Into<String>) -> Self {
-        Self {
-            kind,
-            detail: detail.into(),
-        }
+        let detail = detail.into();
+        // The only place the detail is ever emitted. Every recipient-facing
+        // surface shows the kind's fixed copy so an upstream body cannot
+        // leak, which leaves a failed join otherwise undiagnosable: one
+        // sentence on screen standing for any of a dozen causes. Logged at
+        // construction so every constructor is covered by one line.
+        log!("join failed ({}): {detail}", kind.as_str());
+        Self { kind, detail }
     }
 
     /// The classification, for the caller that renders a terminal state.
@@ -300,6 +304,10 @@ impl JoinFailure {
 
     fn unavailable(detail: impl Into<String>) -> Self {
         Self::new(JoinFailureKind::Unavailable, detail)
+    }
+
+    fn refused(detail: impl Into<String>) -> Self {
+        Self::new(JoinFailureKind::Refused, detail)
     }
 
     pub(crate) fn claim_failed(detail: impl Into<String>) -> Self {
@@ -324,6 +332,11 @@ impl From<JoinFailure> for TonkWorkerError {
                 code: Some("JOIN_UNAVAILABLE".to_string()),
                 message,
             },
+            JoinFailureKind::Refused => TonkWorkerError::Upstream {
+                status: 403,
+                code: Some("JOIN_REFUSED".to_string()),
+                message,
+            },
             JoinFailureKind::ClaimFailed => TonkWorkerError::Internal(message),
         }
     }
@@ -338,14 +351,15 @@ mod failure_vocabulary {
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     wasm_bindgen_test_configure!(run_in_service_worker);
 
-    use super::{JoinFailure, JoinFailureKind, JoinRejection};
+    use super::{AuthorizeError, JoinFailure, JoinFailureKind, JoinRejection};
     use crate::TonkWorkerError;
 
-    const KINDS: [JoinFailureKind; 5] = [
+    const KINDS: [JoinFailureKind; 6] = [
         JoinFailureKind::Malformed,
         JoinFailureKind::AudienceMismatch,
         JoinFailureKind::Revoked,
         JoinFailureKind::Unavailable,
+        JoinFailureKind::Refused,
         JoinFailureKind::ClaimFailed,
     ];
 
@@ -359,6 +373,7 @@ mod failure_vocabulary {
                 "This invite was issued to a different identity.",
                 "This invite has been revoked.",
                 "Tonk could not reach this spot. Try again.",
+                "This spot's host declined the invite. Its owner needs to check the spot's plan.",
                 "Tonk could not join this spot.",
             ],
         );
@@ -374,6 +389,7 @@ mod failure_vocabulary {
                 "audience-mismatch",
                 "revoked",
                 "unavailable",
+                "refused",
                 "claim-failed",
             ],
         );
@@ -419,6 +435,31 @@ mod failure_vocabulary {
         };
         assert_eq!(status, 503);
         assert_eq!(code.as_deref(), Some("JOIN_UNAVAILABLE"));
+    }
+
+    /// A policy refusal is the REMOTE's verdict on a chain that proved
+    /// out, not a local breakage. It landed in the `_` catch-all and was
+    /// reported as `claim-failed` ("Tonk could not join this spot"),
+    /// which blames this device for a decision taken on the server —
+    /// the real one being an unprovisioned subject, which no amount of
+    /// retrying or re-inviting fixes.
+    #[dialog_common::test]
+    fn it_reports_a_policy_refusal_as_the_remotes_verdict() {
+        let failure = super::classify_authorization(&AuthorizeError::PolicyViolation {
+            predicate: "subject is provisioned by an active customer".to_string(),
+        });
+
+        assert_eq!(failure.kind(), JoinFailureKind::Refused);
+        assert!(
+            !failure.kind().retryable(),
+            "the same request will be refused again until the owner acts"
+        );
+
+        let TonkWorkerError::Upstream { status, code, .. } = TonkWorkerError::from(failure) else {
+            panic!("a refusal is the upstream's answer, not an internal fault");
+        };
+        assert_eq!(status, 403);
+        assert_eq!(code.as_deref(), Some("JOIN_REFUSED"));
     }
 
     #[dialog_common::test]
@@ -1937,23 +1978,40 @@ fn classify_pull(error: &PullError) -> JoinFailure {
     // `AuthorizeError` / `Rejection` intact from the service boundary),
     // so classification is a match, not a code-table lookup.
     if let Some(authorization) = crate::router::sync::authorization_reason(error) {
-        return match authorization {
-            AuthorizeError::Revoked { .. } => {
-                JoinFailure::revoked("remote access has been revoked")
-            }
-            AuthorizeError::InvalidAudience { .. } | AuthorizeError::UnprovenSubject { .. } => {
-                JoinFailure::audience_mismatch(format!("remote refused: {authorization}"))
-            }
-            AuthorizeError::Unavailable { .. } | AuthorizeError::UnavailableProof { .. } => {
-                JoinFailure::unavailable(format!("remote answered: {authorization}"))
-            }
-            _ => JoinFailure::claim_failed(format!("remote refused: {authorization}")),
-        };
+        return classify_authorization(authorization);
     }
     if let Some(rejection) = crate::router::sync::rejection_reason(error) {
         return JoinFailure::unavailable(format!("remote answered: {rejection}"));
     }
     JoinFailure::unavailable("the remote could not be reached")
+}
+
+/// Map one authorization verdict to the failure the user is shown.
+///
+/// Split from [`classify_pull`] so it can be tested without building a
+/// `PullError`: the mapping is the part that decides what the page says,
+/// and one arm landing in the wrong bucket is invisible until someone
+/// reads a log.
+fn classify_authorization(authorization: &AuthorizeError) -> JoinFailure {
+    match authorization {
+        AuthorizeError::Revoked { .. } => JoinFailure::revoked("remote access has been revoked"),
+        AuthorizeError::InvalidAudience { .. } | AuthorizeError::UnprovenSubject { .. } => {
+            JoinFailure::audience_mismatch(format!("remote refused: {authorization}"))
+        }
+        AuthorizeError::Unavailable { .. } | AuthorizeError::UnavailableProof { .. } => {
+            JoinFailure::unavailable(format!("remote answered: {authorization}"))
+        }
+        // The chain proved out and the remote evaluated it; a policy
+        // predicate on the delegation said no (an unprovisioned subject
+        // is the common one). Nothing on this device is wrong, so
+        // `claim-failed` — which says the local claim broke, and reads
+        // as "Tonk could not join this spot" — pointed the user at the
+        // wrong thing entirely.
+        AuthorizeError::PolicyViolation { .. } => {
+            JoinFailure::refused(format!("remote refused: {authorization}"))
+        }
+        _ => JoinFailure::claim_failed(format!("remote refused: {authorization}")),
+    }
 }
 
 /// Check that a branch carries what navigating into the space needs: the
@@ -2356,7 +2414,7 @@ pub(crate) async fn find_replica_for_subject(
 /// The fixed entity the in-flight join status lives at. Both the handler
 /// (writes overlay status) and the `/join` view (`entity=tonk:join/status`)
 /// agree on this URI, so there's no per-attempt id to thread.
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
 const JOIN_STATUS_URI: &str = "tonk:join/status";
 
 /// Post-commit handler for the [`Join`] command.
@@ -2439,6 +2497,37 @@ fn carries_invite(url: &str) -> bool {
     })
 }
 
+/// Drop this join's own overlay facts, and only those (scoped clear).
+///
+/// The branch overlay is SHARED: the tab's `tonk:site` facts (path,
+/// route, concept) live there too, and they are what every view on the
+/// page resolves through. A blanket `clear_overlay()` therefore wiped
+/// the site out from under the page on every `/join` mount — the site
+/// display lost its entity, fell back to its pending spinner, and
+/// nothing downstream ever rendered. Scope the clear to the join's own
+/// entities, exactly as the site re-stamp does with its own.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+fn clear_join_overlay(session: &dialog_reactor::BranchSession, status: &dialog_artifacts::Entity) {
+    let status = status.clone();
+    session
+        .state
+        .retain_overlay_entities(move |overlaid| retains_overlay_entity(overlaid, &status));
+}
+
+/// Whether an overlaid entity SURVIVES a join's scoped clear.
+///
+/// Everything but the join's own status entity does. Split out from
+/// [`clear_join_overlay`] so the rule can be tested off-wasm: it is the
+/// whole contract, and getting it backwards is invisible until a page
+/// silently stops rendering.
+#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
+fn retains_overlay_entity(
+    overlaid: &dialog_artifacts::Entity,
+    status: &dialog_artifacts::Entity,
+) -> bool {
+    overlaid != status
+}
+
 /// Run the join operation from the command's full URL and drive the
 /// overlay-only join status. Always leaves the overlay in a terminal state
 /// (status retracted on success, `failed` on error).
@@ -2474,15 +2563,16 @@ async fn run_join(env: &crate::router::CommandEnv, command: tonk_schema::command
         }
     };
 
-    // A `/join` opened with no invite in its URL is not a failed
-    // attempt — it is someone who arrived holding a link they have not
-    // pasted yet. Claiming nothing and asserting no status leaves the
-    // view in its own inviteless state (the paste form) rather than
+    // A `/join` opened with no invite in its URL is not a failed attempt
+    // — it is someone who arrived holding a link they have not pasted
+    // yet. Asserting `pending` here is what made the paste form flash
+    // and vanish behind a spinner that waited on nothing. Claiming
+    // nothing leaves the view in its own inviteless state rather than
     // flashing a spinner for an invite that will never arrive. A URL
     // that carries an invite is untouched by this and proceeds exactly
     // as before.
     if !carries_invite(&command.url.0) {
-        session.state.clear_overlay();
+        clear_join_overlay(&session, &status_entity);
         tonk.reactor.schedule_poll(Arc::clone(&session.state));
         tonk.reactor.run_scheduled_polls(&tonk.operator).await;
         return;
@@ -2490,7 +2580,7 @@ async fn run_join(env: &crate::router::CommandEnv, command: tonk_schema::command
 
     // Pending: a fresh attempt clears any prior status, then marks
     // pending. Schedule a poll so the view shows "Joining…".
-    session.state.clear_overlay();
+    clear_join_overlay(&session, &status_entity);
     session.state.assert_overlay(JoinStatus {
         this: status_entity.clone(),
         status: Status(
@@ -2533,7 +2623,7 @@ async fn run_join(env: &crate::router::CommandEnv, command: tonk_schema::command
             // the page that asked is a `postMessage` to its client. We post
             // `{ type: "navigate", href }`; the page's `<tonk-host>` performs
             // the navigation.
-            session.state.clear_overlay();
+            clear_join_overlay(&session, &status_entity);
             tonk.reactor.schedule_poll(Arc::clone(&session.state));
             tonk.reactor.run_scheduled_polls(&tonk.operator).await;
             let href = format!("/space/{key}", key = outcome.key);
@@ -2659,6 +2749,36 @@ mod invite_presence_tests {
             "https://tonk.spot/join?remote=https%3A%2F%2Fs"
         ));
         assert!(!carries_invite("not a url"));
+    }
+}
+
+/// The join's overlay clear must be SCOPED. The branch overlay is
+/// shared: the tab's `tonk:site` facts (path, route, concept) live
+/// there too, and every view on the page resolves through them. A
+/// blanket clear wiped the site out from under the page on each
+/// `/join` mount, so the site display lost its entity and fell back to
+/// its spinner forever. Pinned here because the failure is silent —
+/// nothing errors, the page just stops rendering.
+#[cfg(test)]
+mod overlay_scope_tests {
+    use super::{JOIN_STATUS_URI, retains_overlay_entity};
+    use dialog_artifacts::Entity;
+
+    #[test]
+    fn it_clears_only_the_joins_own_overlay_entity() {
+        let status: Entity = JOIN_STATUS_URI.parse().expect("status URI parses");
+
+        assert!(
+            !retains_overlay_entity(&status, &status),
+            "the join's own status is what the clear is for"
+        );
+
+        for foreign in ["tonk:site", "tonk:join/route", "tonk:replica"] {
+            assert!(
+                retains_overlay_entity(&foreign.parse::<Entity>().expect("URI parses"), &status),
+                "{foreign} belongs to the page, not to this join"
+            );
+        }
     }
 }
 

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -2423,6 +2423,22 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for JoinHandler {
     }
 }
 
+/// Whether a `/join` URL carries an invite at all.
+///
+/// The delegation chain rides in `access`, so its presence is what
+/// separates "redeem this" from "someone opened /join to paste a link".
+/// Deliberately a query test and not a parse: a malformed or truncated
+/// invite IS an attempt and must still fail loudly with its reason,
+/// rather than being silently treated as an empty visit.
+#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
+fn carries_invite(url: &str) -> bool {
+    url::Url::parse(url).is_ok_and(|parsed| {
+        parsed
+            .query_pairs()
+            .any(|(key, value)| key == "access" && !value.is_empty())
+    })
+}
+
 /// Run the join operation from the command's full URL and drive the
 /// overlay-only join status. Always leaves the overlay in a terminal state
 /// (status retracted on success, `failed` on error).
@@ -2457,6 +2473,20 @@ async fn run_join(env: &crate::router::CommandEnv, command: tonk_schema::command
             return;
         }
     };
+
+    // A `/join` opened with no invite in its URL is not a failed
+    // attempt — it is someone who arrived holding a link they have not
+    // pasted yet. Claiming nothing and asserting no status leaves the
+    // view in its own inviteless state (the paste form) rather than
+    // flashing a spinner for an invite that will never arrive. A URL
+    // that carries an invite is untouched by this and proceeds exactly
+    // as before.
+    if !carries_invite(&command.url.0) {
+        session.state.clear_overlay();
+        tonk.reactor.schedule_poll(Arc::clone(&session.state));
+        tonk.reactor.run_scheduled_polls(&tonk.operator).await;
+        return;
+    }
 
     // Pending: a fresh attempt clears any prior status, then marks
     // pending. Schedule a poll so the view shows "Joining…".
@@ -2600,6 +2630,36 @@ pub(crate) fn notify_sync(client: Option<&crate::router::ClientId>) {
             log!("notify_sync: post_message(sync) failed: {e:?}");
         }
     });
+}
+
+/// The inviteless-`/join` guard, pinned on every target: it decides
+/// whether the route claims or offers its paste form, and getting it
+/// wrong flashes the form before a spinner for an invite that will
+/// never arrive.
+#[cfg(test)]
+mod invite_presence_tests {
+    use super::carries_invite;
+
+    #[test]
+    fn it_separates_a_redeemable_invite_from_an_empty_visit() {
+        assert!(carries_invite(
+            "https://tonk.spot/join?access=chain&remote=https%3A%2F%2Fs#seed"
+        ));
+        // A malformed chain is still an ATTEMPT: it must reach the claim
+        // path and fail with its reason, not be mistaken for an empty visit.
+        assert!(carries_invite("https://tonk.spot/join?access=not-a-chain"));
+
+        assert!(!carries_invite("https://tonk.spot/join"));
+        assert!(!carries_invite("https://tonk.spot/join#seed"));
+        assert!(
+            !carries_invite("https://tonk.spot/join?access="),
+            "an empty access parameter carries no chain"
+        );
+        assert!(!carries_invite(
+            "https://tonk.spot/join?remote=https%3A%2F%2Fs"
+        ));
+        assert!(!carries_invite("not a url"));
+    }
 }
 
 #[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]

--- a/rust/tonk-workspace/Cargo.toml
+++ b/rust/tonk-workspace/Cargo.toml
@@ -26,6 +26,7 @@ tonk-common = { workspace = true }
 tonk-host = { workspace = true }
 tonk-worker-api = { workspace = true }
 reqwest = { workspace = true }
+gloo-timers = { version = "0.3", features = ["futures"] }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 web-sys = { workspace = true, features = [

--- a/rust/tonk-workspace/src/invite_link.rs
+++ b/rust/tonk-workspace/src/invite_link.rs
@@ -1,6 +1,6 @@
 //! `<tonk-invite-link>` — turn a pasted invite URL into a local `/join`.
 //!
-//! An invite link carries everything a join needs in its query and
+//! A long invite link carries everything a join needs in its query and
 //! fragment — the delegation chain, the space's sync remote, the
 //! revocation relay — so the origin it was minted on is only a doorway.
 //! Pasting a link minted elsewhere (say, production) into this deployment
@@ -8,13 +8,20 @@
 //! invite names — which is exactly what local debugging against real
 //! data wants.
 //!
-//! Static notation can't read an input, rewrite a URL, or navigate, so
-//! this dumb element bridges the gap the same way [`super::default_remote`]
-//! does for the origin: it sits inside the paste `<form>`, intercepts its
-//! `submit`, swaps the pasted link's origin for this page's own `/join`
-//! route (keeping query + fragment verbatim), and hands the result to the
-//! ordinary navigation path. All join policy stays in the worker's claim
-//! pipeline.
+//! Minted links are usually SHORT, though: `{origin}/@/{hash}#{seed}`,
+//! where the chain and remote live behind that origin's shortcut service
+//! and only the seed rides the fragment. Those must be expanded on the
+//! origin that minted them — a local shortcut service has never seen the
+//! hash. So this element resolves a short link first (`GET /@/{hash}`
+//! answers a relative `Location` and the route is permissionless and
+//! `Access-Control-Allow-Origin: *`), then rewrites the expanded query
+//! onto this deployment's `/join`. The seed never leaves the browser: it
+//! is a fragment, so it is never sent with the request, and this code
+//! carries it across from the pasted link itself.
+//!
+//! Static notation can't read an input, fetch, or navigate, so this dumb
+//! element bridges the gap the same way [`super::default_remote`] does
+//! for the origin. All join policy stays in the worker's claim pipeline.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -63,7 +70,8 @@ impl CustomElement for TonkInviteLink {
             // navigation, so the default is cancelled unconditionally
             // and validity only decides whether we navigate.
             event.prevent_default();
-            submit(&host);
+            let host = host.clone();
+            wasm_bindgen_futures::spawn_local(async move { submit(&host).await });
         }) as Box<dyn FnMut(Event)>);
         let _ = form.add_event_listener_with_callback("submit", listener.as_ref().unchecked_ref());
         *self.submit.borrow_mut() = Some(listener);
@@ -74,12 +82,13 @@ impl CustomElement for TonkInviteLink {
     }
 }
 
-fn submit(this: &HtmlElement) {
+async fn submit(this: &HtmlElement) {
     let field = this
         .get_attribute("field")
         .unwrap_or_else(|| DEFAULT_FIELD.to_string());
     let pasted = read_field(this, &field).unwrap_or_default();
-    match local_join_href(pasted.trim()) {
+    let _ = this.set_attribute(STATE_ATTR, "resolving");
+    match local_join_href(pasted.trim()).await {
         Some(href) => {
             let _ = this.remove_attribute(STATE_ATTR);
             navigate(&href);
@@ -102,23 +111,56 @@ fn read_field(this: &HtmlElement, field: &str) -> Option<String> {
 }
 
 /// Rewrite a pasted invite URL into this deployment's `/join` route,
-/// keeping the query and fragment — where the invite's chain, remote,
-/// and seed actually live — byte for byte. The pasted origin and path
-/// are deliberately discarded: they only say where the link was minted.
-fn local_join_href(pasted: &str) -> Option<String> {
+/// expanding a short link on its own origin first.
+///
+/// The invite's substance is its query (`access`, `remote`, `revocation`)
+/// and its fragment (an open invite's seed). The pasted origin and path
+/// are deliberately discarded — they only say where the link was minted —
+/// EXCEPT for the one thing only that origin can do: expand `/@/{hash}`
+/// into the query it stands for.
+async fn local_join_href(pasted: &str) -> Option<String> {
     if pasted.is_empty() {
         return None;
     }
     let url = web_sys::Url::new(pasted).ok()?;
-    let search = url.search();
-    let hash = url.hash();
-    // A bare origin (or any URL with neither query nor fragment) carries
-    // no invite; refusing here keeps the error visible at the form
-    // instead of bouncing through /join to its failure screen.
-    if search.is_empty() && hash.is_empty() {
+    // The seed rides the fragment and is never sent to any server; carry
+    // it across from the pasted link whichever form the link took.
+    let fragment = url.hash();
+    let query = match shortcut_hash(&url) {
+        Some(_) => expand_shortcut(&url).await?,
+        None => url.search(),
+    };
+    // No query means no delegation chain, so there is no invite to
+    // redeem; refusing here keeps the error at the form instead of
+    // bouncing through /join to its failure screen.
+    if query.is_empty() {
         return None;
     }
-    Some(format!("/join{search}{hash}"))
+    Some(format!("/join{query}{fragment}"))
+}
+
+/// The hash of a `{origin}/@/{hash}` shortcut link, if the path is one.
+fn shortcut_hash(url: &web_sys::Url) -> Option<String> {
+    let hash = url.pathname().strip_prefix("/@/")?.to_string();
+    (!hash.is_empty() && !hash.contains('/')).then_some(hash)
+}
+
+/// Expand a short invite on the origin that minted it: `GET /@/{hash}`
+/// answers a permanent redirect whose `Location` is the stored path +
+/// query, relative and verbatim.
+///
+/// `redirect: "manual"` would give an opaque response no script can read,
+/// so the redirect is followed normally and the landing URL's query is
+/// what the shortcut stored. The join route answers the app shell for any
+/// path, so following costs one document fetch and reveals the query.
+async fn expand_shortcut(url: &web_sys::Url) -> Option<String> {
+    let response = reqwest::Client::new().get(url.href()).send().await.ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    let landed = web_sys::Url::new(response.url().as_str()).ok()?;
+    let query = landed.search();
+    (!query.is_empty()).then_some(query)
 }
 
 /// Navigate through the guest's bridge when sealed (`window.tonk.navigate`),
@@ -156,25 +198,44 @@ mod tests {
 
     wasm_bindgen_test_configure!(run_in_browser);
 
-    /// The rewrite keeps query + fragment verbatim and discards the
-    /// minting origin; inputs carrying no invite material are refused.
+    /// A long link rewrites straight onto the local join route, keeping
+    /// query and fragment verbatim; anything carrying no delegation
+    /// chain is refused rather than bounced through /join.
     #[dialog_common::test]
     async fn it_rewrites_a_foreign_invite_onto_the_local_join_route() {
         assert_eq!(
-            local_join_href("https://staging.tonk.xyz/join?ucan=abc#seed"),
-            Some("/join?ucan=abc#seed".to_string()),
+            local_join_href("https://staging.tonk.xyz/join?access=abc&remote=https%3A%2F%2Fs#seed")
+                .await,
+            Some("/join?access=abc&remote=https%3A%2F%2Fs#seed".to_string()),
         );
+        assert_eq!(local_join_href("").await, None, "empty paste is refused");
         assert_eq!(
-            local_join_href("https://tonk.network/join#onlyfragment"),
-            Some("/join#onlyfragment".to_string()),
-        );
-        assert_eq!(local_join_href(""), None, "empty paste is refused");
-        assert_eq!(
-            local_join_href("https://staging.tonk.xyz/"),
+            local_join_href("https://staging.tonk.xyz/").await,
             None,
             "a bare origin carries no invite"
         );
-        assert_eq!(local_join_href("not a url"), None);
+        assert_eq!(
+            local_join_href("https://staging.tonk.xyz/join#onlyfragment").await,
+            None,
+            "a fragment alone carries no delegation chain"
+        );
+        assert_eq!(local_join_href("not a url").await, None);
+    }
+
+    /// A short link is recognized by its `/@/{hash}` path — the form that
+    /// must be expanded on the minting origin, because the chain and the
+    /// remote live behind that origin's shortcut service and a local one
+    /// has never seen the hash.
+    #[dialog_common::test]
+    async fn it_recognizes_short_links_by_their_shortcut_path() {
+        let short = web_sys::Url::new("https://staging.tonk.xyz/@/abc123#seed").unwrap();
+        assert_eq!(shortcut_hash(&short).as_deref(), Some("abc123"));
+
+        let long = web_sys::Url::new("https://staging.tonk.xyz/join?access=abc#seed").unwrap();
+        assert_eq!(shortcut_hash(&long), None);
+
+        let nested = web_sys::Url::new("https://staging.tonk.xyz/@/a/b").unwrap();
+        assert_eq!(shortcut_hash(&nested), None, "a hash carries no slash");
     }
 
     /// Submitting the form navigates nowhere on an invalid paste and
@@ -207,6 +268,13 @@ mod tests {
             event.default_prevented(),
             "the sealed guest must never run a native form submit"
         );
+        // The submit resolves on a task; yield until it settles.
+        for _ in 0..20 {
+            if element.get_attribute(STATE_ATTR).as_deref() == Some("invalid") {
+                break;
+            }
+            gloo_timers::future::TimeoutFuture::new(10).await;
+        }
         assert_eq!(
             element.get_attribute(STATE_ATTR).as_deref(),
             Some("invalid"),

--- a/rust/tonk-workspace/src/invite_link.rs
+++ b/rust/tonk-workspace/src/invite_link.rs
@@ -70,9 +70,17 @@ impl CustomElement for TonkInviteLink {
         };
         let host = this.clone();
         let listener = Closure::wrap(Box::new(move |event: Event| {
-            // The sealed guest must never fall back to a native form
-            // navigation, so the default is cancelled unconditionally
-            // and validity only decides whether we navigate.
+            // The submit never reaches the network: this element resolves
+            // the pasted text into a redeemable `/join` URL and hands it
+            // to the bound `tonk:join` command as a `mount` event, the
+            // same shape `<tonk-page>` fires on a real page load. That is
+            // why the form binds `onmount` and not `onsubmit`: `Join`
+            // reads `dom.event.detail/href`, an event-read path a submit
+            // event has no way to satisfy.
+            //
+            // Always cancelled: even an already-complete link has to be
+            // re-delivered as `detail.href`, and resolving a short one is
+            // async besides.
             event.prevent_default();
             let host = host.clone();
             wasm_bindgen_futures::spawn_local(async move { submit(&host).await });
@@ -86,6 +94,16 @@ impl CustomElement for TonkInviteLink {
     }
 }
 
+/// Resolve the pasted text and hand the redeemable URL to the bound
+/// command as a `mount` event.
+///
+/// The invite has to arrive as `detail.href` because that is the single
+/// read path `Join` declares (`dom.event.detail/href`), and a concept's
+/// `the:` is one slot serving as both the event read path and the stored
+/// attribute — there is no second place to say "read it from here, file
+/// it under there". So rather than a second command shaped around the
+/// form, the form speaks the shape the existing command already reads,
+/// and one handler serves both the pasted link and the visited one.
 async fn submit(this: &HtmlElement) {
     let field = this
         .get_attribute("field")
@@ -95,12 +113,60 @@ async fn submit(this: &HtmlElement) {
     match local_join_href(pasted.trim()).await {
         Some(href) => {
             let _ = this.remove_attribute(STATE_ATTR);
-            navigate(&href);
+            dispatch_mount(this, &href);
         }
         None => {
             let _ = this.set_attribute(STATE_ATTR, "invalid");
         }
     }
+}
+
+/// Fire a bubbling `mount` carrying the resolved invite, mirroring the
+/// flat URL-shaped detail `<tonk-page>` builds from a real location so
+/// both paths present the bound command with the same event.
+///
+/// Dispatched from the element itself so it bubbles to the `onmount`
+/// binding on the enclosing form, and on to the display's delegate.
+fn dispatch_mount(this: &HtmlElement, href: &str) {
+    let Ok(url) = web_sys::Url::new_with_base(href, &page_origin()) else {
+        return;
+    };
+    let detail = js_sys::Object::new();
+    let set = |key: &str, value: &str| {
+        let _ = js_sys::Reflect::set(&detail, &JsValue::from_str(key), &JsValue::from_str(value));
+    };
+    set("href", &url.href());
+    set("origin", &url.origin());
+    set("pathname", &url.pathname());
+    set("search", &url.search());
+    set("hash", &url.hash());
+
+    let init = web_sys::CustomEventInit::new();
+    init.set_bubbles(true);
+    init.set_detail(&detail);
+    if let Ok(event) = web_sys::CustomEvent::new_with_event_init_dict("mount", &init) {
+        let _ = this.dispatch_event(&event);
+    }
+}
+
+/// The origin a relative `/join` URL resolves against. Inside the sealed
+/// guest `window.location` is the guest's own `about:srcdoc`, so prefer
+/// the host-forwarded origin the bridge publishes; the fallback covers
+/// the top-page and test cases.
+fn page_origin() -> String {
+    window()
+        .and_then(|win| {
+            js_sys::Reflect::get(&win, &JsValue::from_str("tonk"))
+                .ok()
+                .and_then(|tonk| js_sys::Reflect::get(&tonk, &JsValue::from_str("context")).ok())
+                .and_then(|context| {
+                    js_sys::Reflect::get(&context, &JsValue::from_str("origin")).ok()
+                })
+                .and_then(|origin| origin.as_string())
+                .filter(|origin| !origin.is_empty())
+                .or_else(|| win.location().origin().ok())
+        })
+        .unwrap_or_default()
 }
 
 /// Read the `value` property of the form control named `field` within the
@@ -163,24 +229,6 @@ async fn resolve_invite(url: &web_sys::Url) -> Option<String> {
     // deployment that served its app shell for an unknown link lands
     // here with nothing, and that is a refusal, not an invite.
     carries_access(&landed).then(|| landed.search())
-}
-
-/// Navigate through the guest's bridge when sealed (`window.tonk.navigate`),
-/// falling back to a plain location assignment at the top-level shell.
-fn navigate(href: &str) {
-    let Some(win) = window() else { return };
-    let bridged = js_sys::Reflect::get(&win, &JsValue::from_str("tonk"))
-        .ok()
-        .and_then(|tonk| js_sys::Reflect::get(&tonk, &JsValue::from_str("navigate")).ok())
-        .and_then(|function| function.dyn_into::<js_sys::Function>().ok())
-        .and_then(|function| {
-            function
-                .call1(&JsValue::NULL, &JsValue::from_str(href))
-                .ok()
-        });
-    if bridged.is_none() {
-        let _ = win.location().assign(href);
-    }
 }
 
 /// Register `<tonk-invite-link>`. Idempotent.
@@ -261,11 +309,9 @@ mod tests {
         form.append_child(&element).unwrap();
         body.append_child(&form).unwrap();
 
-        let event = web_sys::Event::new_with_event_init_dict(
-            "submit",
-            web_sys::EventInit::new().cancelable(true),
-        )
-        .unwrap();
+        let init = web_sys::EventInit::new();
+        init.set_cancelable(true);
+        let event = web_sys::Event::new_with_event_init_dict("submit", &init).unwrap();
         let _ = form.dispatch_event(&event);
 
         assert!(
@@ -283,6 +329,80 @@ mod tests {
             element.get_attribute(STATE_ATTR).as_deref(),
             Some("invalid"),
         );
+
+        form.remove();
+    }
+
+    /// A complete pasted invite reaches the bound command as a `mount`
+    /// event carrying `detail.href` — the one read path `tonk:join`
+    /// declares. This is the whole reason the form binds `onmount`: a
+    /// submit event has no `detail`, so a paste bound to `onsubmit`
+    /// wrote a fact under an attribute no handler triggers on and the
+    /// button did nothing at all.
+    #[dialog_common::test]
+    async fn it_hands_a_pasted_invite_to_the_command_as_a_mount_event() {
+        register();
+        let document = window().unwrap().document().unwrap();
+        let body = document.body().unwrap();
+
+        let form = document.create_element("form").unwrap();
+        let input = document.create_element("input").unwrap();
+        input.set_attribute("name", "url").unwrap();
+        input
+            .set_attribute(
+                "value",
+                "https://staging.tonk.xyz/join?access=abc&remote=x#seed",
+            )
+            .unwrap();
+        let element = document.create_element("tonk-invite-link").unwrap();
+        form.append_child(&input).unwrap();
+        form.append_child(&element).unwrap();
+        body.append_child(&form).unwrap();
+
+        // Listen where the binding sits: `mount` must BUBBLE to the form
+        // for the display's delegate to see it.
+        let seen: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
+        let captured = Rc::clone(&seen);
+        let listener = Closure::wrap(Box::new(move |event: Event| {
+            let detail = event
+                .dyn_ref::<web_sys::CustomEvent>()
+                .map(|event| event.detail());
+            if let Some(detail) = detail {
+                let href = js_sys::Reflect::get(&detail, &JsValue::from_str("href"))
+                    .ok()
+                    .and_then(|href| href.as_string());
+                *captured.borrow_mut() = href;
+            }
+        }) as Box<dyn FnMut(Event)>);
+        form.add_event_listener_with_callback("mount", listener.as_ref().unchecked_ref())
+            .unwrap();
+
+        let init = web_sys::EventInit::new();
+        init.set_cancelable(true);
+        let event = web_sys::Event::new_with_event_init_dict("submit", &init).unwrap();
+        let _ = form.dispatch_event(&event);
+
+        assert!(
+            event.default_prevented(),
+            "the paste is delivered as `mount`, never as a native submit"
+        );
+
+        for _ in 0..20 {
+            if seen.borrow().is_some() {
+                break;
+            }
+            gloo_timers::future::TimeoutFuture::new(10).await;
+        }
+
+        let href = seen.borrow().clone().expect("mount carried no detail.href");
+        let url = web_sys::Url::new(&href).unwrap();
+        assert_eq!(url.pathname(), "/join", "redeemed on THIS deployment");
+        assert_eq!(
+            url.search_params().get("access").as_deref(),
+            Some("abc"),
+            "the delegation chain rides across verbatim"
+        );
+        assert_eq!(url.hash(), "#seed", "the seed never leaves the browser");
 
         form.remove();
     }

--- a/rust/tonk-workspace/src/invite_link.rs
+++ b/rust/tonk-workspace/src/invite_link.rs
@@ -1,0 +1,217 @@
+//! `<tonk-invite-link>` — turn a pasted invite URL into a local `/join`.
+//!
+//! An invite link carries everything a join needs in its query and
+//! fragment — the delegation chain, the space's sync remote, the
+//! revocation relay — so the origin it was minted on is only a doorway.
+//! Pasting a link minted elsewhere (say, production) into this deployment
+//! joins the space here while its blocks keep coming from the remote the
+//! invite names — which is exactly what local debugging against real
+//! data wants.
+//!
+//! Static notation can't read an input, rewrite a URL, or navigate, so
+//! this dumb element bridges the gap the same way [`super::default_remote`]
+//! does for the origin: it sits inside the paste `<form>`, intercepts its
+//! `submit`, swaps the pasted link's origin for this page's own `/join`
+//! route (keeping query + fragment verbatim), and hands the result to the
+//! ordinary navigation path. All join policy stays in the worker's claim
+//! pipeline.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use custom_elements::CustomElement;
+use wasm_bindgen::JsCast;
+use wasm_bindgen::prelude::*;
+use web_sys::{Event, HtmlElement, window};
+
+/// A retained submit-listener closure, kept alive for the element's
+/// lifetime so the listener stays valid.
+type SubmitClosure = Rc<RefCell<Option<Closure<dyn FnMut(Event)>>>>;
+
+/// The form-control `name` read when the element sets no `field`.
+const DEFAULT_FIELD: &str = "url";
+
+/// Attribute the element stamps with the outcome of the last submit —
+/// `invalid` when the pasted text isn't an invite URL — so the template
+/// can style an error state without any script of its own.
+const STATE_ATTR: &str = "data-state";
+
+#[derive(Default)]
+pub(crate) struct TonkInviteLink {
+    submit: SubmitClosure,
+}
+
+impl CustomElement for TonkInviteLink {
+    fn shadow() -> bool {
+        // Light DOM: the element must see its `<form>` ancestor.
+        false
+    }
+
+    fn observed_attributes() -> &'static [&'static str] {
+        &[]
+    }
+
+    fn inject_children(&mut self, _this: &HtmlElement) {}
+
+    fn connected_callback(&mut self, this: &HtmlElement) {
+        let Ok(Some(form)) = this.closest("form") else {
+            return;
+        };
+        let host = this.clone();
+        let listener = Closure::wrap(Box::new(move |event: Event| {
+            // The sealed guest must never fall back to a native form
+            // navigation, so the default is cancelled unconditionally
+            // and validity only decides whether we navigate.
+            event.prevent_default();
+            submit(&host);
+        }) as Box<dyn FnMut(Event)>);
+        let _ = form.add_event_listener_with_callback("submit", listener.as_ref().unchecked_ref());
+        *self.submit.borrow_mut() = Some(listener);
+    }
+
+    fn disconnected_callback(&mut self, _this: &HtmlElement) {
+        self.submit.borrow_mut().take();
+    }
+}
+
+fn submit(this: &HtmlElement) {
+    let field = this
+        .get_attribute("field")
+        .unwrap_or_else(|| DEFAULT_FIELD.to_string());
+    let pasted = read_field(this, &field).unwrap_or_default();
+    match local_join_href(pasted.trim()) {
+        Some(href) => {
+            let _ = this.remove_attribute(STATE_ATTR);
+            navigate(&href);
+        }
+        None => {
+            let _ = this.set_attribute(STATE_ATTR, "invalid");
+        }
+    }
+}
+
+/// Read the `value` property of the form control named `field` within the
+/// closest `<form>`. Property, not attribute: `<wa-input>` is a
+/// form-associated custom element and carries its live value there.
+fn read_field(this: &HtmlElement, field: &str) -> Option<String> {
+    let form = this.closest("form").ok()??;
+    let input = form.query_selector(&format!("[name=\"{field}\"]")).ok()??;
+    js_sys::Reflect::get(input.as_ref(), &JsValue::from_str("value"))
+        .ok()?
+        .as_string()
+}
+
+/// Rewrite a pasted invite URL into this deployment's `/join` route,
+/// keeping the query and fragment — where the invite's chain, remote,
+/// and seed actually live — byte for byte. The pasted origin and path
+/// are deliberately discarded: they only say where the link was minted.
+fn local_join_href(pasted: &str) -> Option<String> {
+    if pasted.is_empty() {
+        return None;
+    }
+    let url = web_sys::Url::new(pasted).ok()?;
+    let search = url.search();
+    let hash = url.hash();
+    // A bare origin (or any URL with neither query nor fragment) carries
+    // no invite; refusing here keeps the error visible at the form
+    // instead of bouncing through /join to its failure screen.
+    if search.is_empty() && hash.is_empty() {
+        return None;
+    }
+    Some(format!("/join{search}{hash}"))
+}
+
+/// Navigate through the guest's bridge when sealed (`window.tonk.navigate`),
+/// falling back to a plain location assignment at the top-level shell.
+fn navigate(href: &str) {
+    let Some(win) = window() else { return };
+    let bridged = js_sys::Reflect::get(&win, &JsValue::from_str("tonk"))
+        .ok()
+        .and_then(|tonk| js_sys::Reflect::get(&tonk, &JsValue::from_str("navigate")).ok())
+        .and_then(|function| function.dyn_into::<js_sys::Function>().ok())
+        .and_then(|function| {
+            function
+                .call1(&JsValue::NULL, &JsValue::from_str(href))
+                .ok()
+        });
+    if bridged.is_none() {
+        let _ = win.location().assign(href);
+    }
+}
+
+/// Register `<tonk-invite-link>`. Idempotent.
+pub(crate) fn register() {
+    let Some(elements) = window().map(|w| w.custom_elements()) else {
+        return;
+    };
+    if elements.get("tonk-invite-link").is_undefined() {
+        TonkInviteLink::define("tonk-invite-link");
+    }
+}
+
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    /// The rewrite keeps query + fragment verbatim and discards the
+    /// minting origin; inputs carrying no invite material are refused.
+    #[dialog_common::test]
+    async fn it_rewrites_a_foreign_invite_onto_the_local_join_route() {
+        assert_eq!(
+            local_join_href("https://staging.tonk.xyz/join?ucan=abc#seed"),
+            Some("/join?ucan=abc#seed".to_string()),
+        );
+        assert_eq!(
+            local_join_href("https://tonk.network/join#onlyfragment"),
+            Some("/join#onlyfragment".to_string()),
+        );
+        assert_eq!(local_join_href(""), None, "empty paste is refused");
+        assert_eq!(
+            local_join_href("https://staging.tonk.xyz/"),
+            None,
+            "a bare origin carries no invite"
+        );
+        assert_eq!(local_join_href("not a url"), None);
+    }
+
+    /// Submitting the form navigates nowhere on an invalid paste and
+    /// stamps the error state the template styles.
+    #[dialog_common::test]
+    async fn it_marks_an_invalid_paste_instead_of_navigating() {
+        register();
+        let document = window().unwrap().document().unwrap();
+        let body = document.body().unwrap();
+
+        let form = document.create_element("form").unwrap();
+        let input = document.create_element("input").unwrap();
+        input.set_attribute("name", "url").unwrap();
+        input
+            .set_attribute("value", "definitely not an invite")
+            .unwrap();
+        let element = document.create_element("tonk-invite-link").unwrap();
+        form.append_child(&input).unwrap();
+        form.append_child(&element).unwrap();
+        body.append_child(&form).unwrap();
+
+        let event = web_sys::Event::new_with_event_init_dict(
+            "submit",
+            web_sys::EventInit::new().cancelable(true),
+        )
+        .unwrap();
+        let _ = form.dispatch_event(&event);
+
+        assert!(
+            event.default_prevented(),
+            "the sealed guest must never run a native form submit"
+        );
+        assert_eq!(
+            element.get_attribute(STATE_ATTR).as_deref(),
+            Some("invalid"),
+        );
+
+        form.remove();
+    }
+}

--- a/rust/tonk-workspace/src/invite_link.rs
+++ b/rust/tonk-workspace/src/invite_link.rs
@@ -38,6 +38,10 @@ type SubmitClosure = Rc<RefCell<Option<Closure<dyn FnMut(Event)>>>>;
 /// The form-control `name` read when the element sets no `field`.
 const DEFAULT_FIELD: &str = "url";
 
+/// The query parameter naming an invite's delegation chain. Its presence
+/// is what makes a pasted link self-contained.
+const ACCESS_PARAM: &str = "access";
+
 /// Attribute the element stamps with the outcome of the last submit —
 /// `invalid` when the pasted text isn't an invite URL — so the template
 /// can style an error state without any script of its own.
@@ -126,41 +130,39 @@ async fn local_join_href(pasted: &str) -> Option<String> {
     // The seed rides the fragment and is never sent to any server; carry
     // it across from the pasted link whichever form the link took.
     let fragment = url.hash();
-    let query = match shortcut_hash(&url) {
-        Some(_) => expand_shortcut(&url).await?,
-        None => url.search(),
+    let query = if carries_access(&url) {
+        url.search()
+    } else {
+        resolve_invite(&url).await?
     };
-    // No query means no delegation chain, so there is no invite to
-    // redeem; refusing here keeps the error at the form instead of
-    // bouncing through /join to its failure screen.
-    if query.is_empty() {
-        return None;
-    }
     Some(format!("/join{query}{fragment}"))
 }
 
-/// The hash of a `{origin}/@/{hash}` shortcut link, if the path is one.
-fn shortcut_hash(url: &web_sys::Url) -> Option<String> {
-    let hash = url.pathname().strip_prefix("/@/")?.to_string();
-    (!hash.is_empty() && !hash.contains('/')).then_some(hash)
+/// Whether the link already carries its delegation chain, and so needs
+/// no round-trip to the origin that minted it.
+fn carries_access(url: &web_sys::Url) -> bool {
+    url.search_params().has(ACCESS_PARAM)
 }
 
-/// Expand a short invite on the origin that minted it: `GET /@/{hash}`
-/// answers a permanent redirect whose `Location` is the stored path +
-/// query, relative and verbatim.
+/// Resolve a link that carries no chain by following it on the origin
+/// that minted it. The shortcut service answers a permanent redirect
+/// whose `Location` is the stored path + query, relative and verbatim,
+/// so the URL the fetch lands on carries the invite.
 ///
 /// `redirect: "manual"` would give an opaque response no script can read,
 /// so the redirect is followed normally and the landing URL's query is
 /// what the shortcut stored. The join route answers the app shell for any
 /// path, so following costs one document fetch and reveals the query.
-async fn expand_shortcut(url: &web_sys::Url) -> Option<String> {
+async fn resolve_invite(url: &web_sys::Url) -> Option<String> {
     let response = reqwest::Client::new().get(url.href()).send().await.ok()?;
     if !response.status().is_success() {
         return None;
     }
     let landed = web_sys::Url::new(response.url().as_str()).ok()?;
-    let query = landed.search();
-    (!query.is_empty()).then_some(query)
+    // Only an answer that actually carries a chain is an invite: a
+    // deployment that served its app shell for an unknown link lands
+    // here with nothing, and that is a refusal, not an invite.
+    carries_access(&landed).then(|| landed.search())
 }
 
 /// Navigate through the guest's bridge when sealed (`window.tonk.navigate`),
@@ -214,28 +216,30 @@ mod tests {
             None,
             "a bare origin carries no invite"
         );
-        assert_eq!(
-            local_join_href("https://staging.tonk.xyz/join#onlyfragment").await,
-            None,
-            "a fragment alone carries no delegation chain"
-        );
         assert_eq!(local_join_href("not a url").await, None);
     }
 
-    /// A short link is recognized by its `/@/{hash}` path — the form that
-    /// must be expanded on the minting origin, because the chain and the
-    /// remote live behind that origin's shortcut service and a local one
-    /// has never seen the hash.
+    /// What decides whether a link needs resolving is the chain it
+    /// carries, never the shape of its path: the shortener's URL form is
+    /// the minting deployment's business, and a link that already holds
+    /// `access` is complete no matter what path it sits on.
     #[dialog_common::test]
-    async fn it_recognizes_short_links_by_their_shortcut_path() {
-        let short = web_sys::Url::new("https://staging.tonk.xyz/@/abc123#seed").unwrap();
-        assert_eq!(shortcut_hash(&short).as_deref(), Some("abc123"));
+    async fn it_resolves_links_that_carry_no_delegation_chain() {
+        let complete =
+            web_sys::Url::new("https://staging.tonk.xyz/join?access=abc&remote=x#seed").unwrap();
+        assert!(carries_access(&complete));
 
-        let long = web_sys::Url::new("https://staging.tonk.xyz/join?access=abc#seed").unwrap();
-        assert_eq!(shortcut_hash(&long), None);
+        let shortened = web_sys::Url::new("https://staging.tonk.xyz/@/abc123#seed").unwrap();
+        assert!(!carries_access(&shortened), "a short link must be resolved");
 
-        let nested = web_sys::Url::new("https://staging.tonk.xyz/@/a/b").unwrap();
-        assert_eq!(shortcut_hash(&nested), None, "a hash carries no slash");
+        // Any other link shape a deployment might mint resolves the same
+        // way — nothing here knows what its paths look like.
+        let other = web_sys::Url::new("https://tonk.network/i/xyz?utm=mail#seed").unwrap();
+        assert!(!carries_access(&other));
+
+        // An invite on an unexpected path is still complete.
+        let odd = web_sys::Url::new("https://tonk.network/anything?access=abc").unwrap();
+        assert!(carries_access(&odd));
     }
 
     /// Submitting the form navigates nowhere on an invalid paste and

--- a/rust/tonk-workspace/src/lib.rs
+++ b/rust/tonk-workspace/src/lib.rs
@@ -21,6 +21,7 @@ mod default_remote;
 mod editable;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 mod invite_link;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 mod join_retry;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 mod origin;

--- a/rust/tonk-workspace/src/lib.rs
+++ b/rust/tonk-workspace/src/lib.rs
@@ -20,6 +20,7 @@ mod default_remote;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 mod editable;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+mod invite_link;
 mod join_retry;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 mod origin;
@@ -51,4 +52,5 @@ pub fn register() {
     default_remote::register();
     editable::register();
     join_retry::register();
+    invite_link::register();
 }


### PR DESCRIPTION
Invites are minted against the deployment that issued them, so a link from staging could only be redeemed on staging. That makes debugging awkward: you want the UI on localhost while the blocks still come from the real remote. A long invite already carries everything a join needs (the delegation chain, the sync remote, the revocation relay), so the origin it was minted on is only a doorway.

`/join` now offers a paste form when it carries no invite, and redeems whatever you paste against this deployment. Short links (`{origin}/@/{hash}#{seed}`) still have to be expanded on the origin that minted them, since a local shortcut service has never seen the hash, so `<tonk-invite-link>` resolves those first and rewrites the expanded query onto the local `/join`. The seed rides the fragment and never leaves the browser.

The form binds `onmount`, not `onsubmit`. A concept's `the:` is a single slot serving as both the DOM read path and the stored attribute, and `Join` declares `dom.event.detail/href` — which a submit event has no way to satisfy. Rather than add a second command shaped around the form, the element cancels the submit, resolves the text, and re-fires it as a bubbling `mount` carrying `detail.href`, the same shape `<tonk-page>` produces on a real page load. One command and one handler serve both the pasted invite and the visited one.

Two bugs surfaced on the way:

**The join wiped the page's own routing state.** `run_join` called a blanket `clear_overlay()`, but that overlay is shared: the tab's `tonk:site` facts (path, route, concept) live there too and every view resolves through them. Every `/join` mount destroyed them, so the site display lost its entity and fell back to its spinner. Now scoped to the join's own entity, the way the site re-stamp already scopes to its own.

**A remote refusal was reported as our fault.** `AuthorizeError::PolicyViolation` fell into the catch-all and surfaced as `claim-failed` / "Tonk could not join this spot" — blaming the device for a decision taken on the server. It gets its own `refused` kind now, mapped to `403 JOIN_REFUSED`, telling the user the host declined and its owner has to act. The failure detail is also logged at construction, since every user-facing surface deliberately shows fixed copy and a failed join was otherwise undiagnosable.

The new-spot wizard's "From an invite link" card is gone. The wizard offers ways to create a spot; joining someone else's arrives by link and doesn't belong beside the template and agent choices.

## Verification

Manually exercised from cleared storage: inviteless `/join` shows the form; an invalid paste shows the inline error without navigating; `?access=notarealchain` still reports the link as invalid; a real staging invite reaches the claim and reports the refusal; returning to `/join` after a failure shows the form again rather than a stuck card.

Tests cover the mount-dispatch contract, the overlay-scope rule, and the policy-refusal classification.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `invite_link` module in the `tonk-worker-api`, enhancing the invite link handling for joining spots. It adds a new failure kind for declined invites, updates the frontend to manage invite links, and modifies styles and descriptions in the UI.

### Detailed summary
- Added `gloo-timers` dependency in `Cargo.toml`.
- Introduced `invite_link` module in `src/lib.rs`.
- Added `Refused` failure kind to `JoinFailureKind`.
- Updated descriptions and error messages for invite failures.
- Enhanced the form handling for invites in the frontend.
- Updated styles for the join view and invite link handling.
- Added tests for invite link processing and validation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->