### PR TITLE
fix(portal): render nested portals on Safari

### DIFF
--- a/rust/tonk-portal/Cargo.toml
+++ b/rust/tonk-portal/Cargo.toml
@@ -24,6 +24,8 @@ wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 web-sys = { workspace = true, features = [
     "console",
+    "Blob",
+    "BlobPropertyBag",
     "CssStyleDeclaration",
     "CustomElementRegistry",
     "Document",
@@ -46,6 +48,7 @@ web-sys = { workspace = true, features = [
     "RequestCache",
     "Response",
     "ResponseInit",
+    "Url",
     "Window",
 ] }
 

--- a/rust/tonk-portal/Cargo.toml
+++ b/rust/tonk-portal/Cargo.toml
@@ -30,6 +30,7 @@ web-sys = { workspace = true, features = [
     "Element",
     "HtmlElement",
     "HtmlIFrameElement",
+    "Location",
     "MessageChannel",
     "MessageEvent",
     "MessagePort",

--- a/rust/tonk-portal/src/bridge.rs
+++ b/rust/tonk-portal/src/bridge.rs
@@ -742,8 +742,10 @@ fn base_tag(base: &str) -> String {
     if base.is_empty() {
         String::new()
     } else {
-        // `base` is a same-origin literal we built (`https://{label}.tonk.network/`),
-        // so there is nothing to escape, but keep it minimal and attribute-safe.
+        // `base` is a URL we built (`https://{label}.tonk.network/`) or the
+        // creator's serialized `document.baseURI`. A serialized URL never
+        // holds a raw `"` or `>`, so there is nothing to escape. Keep it
+        // minimal and attribute-safe.
         format!("<base href=\"{base}\">")
     }
 }
@@ -2387,26 +2389,39 @@ fn build_context(host: &Element, state: &Rc<RefCell<PortalState>>) -> Object {
     // nesting level; it falls back to `location.origin` at the top document
     // (no parent portal, so `window.tonk` is absent).
     let origin = tonk_host::bridge::context_origin().unwrap_or_default();
-    // The guest's own `window.location` is `about:srcdoc`; its REAL location is
-    // the parent's. Pass the parent's path + search + hash so the guest stamps
-    // them on its requests (the SW reads them to route/contain) and so a
-    // location-reading guest control (e.g. `<tonk-page>`, which couriers an
-    // invite's `?access` + `#seed` into the join command) sees the real URL.
-    // `search`/`hash` especially: browsers strip the query only from the
-    // fragment, but the guest can't read EITHER off `about:srcdoc`, and the SW
-    // never sees the fragment on a network request.
-    let path = location
-        .as_ref()
-        .and_then(|l| l.pathname().ok())
-        .unwrap_or_default();
-    let search = location
-        .as_ref()
-        .and_then(|l| l.search().ok())
-        .unwrap_or_default();
-    let hash = location
-        .as_ref()
-        .and_then(|l| l.hash().ok())
-        .unwrap_or_default();
+    // The guest's own `window.location` is `about:srcdoc`. Its real location
+    // is the top page's. Pass the real path, search, and hash. The guest
+    // stamps them on its requests, and the SW reads them to route and
+    // contain. A guest control that reads the location also sees the real
+    // URL. For example, `<tonk-page>` couriers an invite's `?access` and
+    // `#seed` into the join command. The guest cannot read the query or the
+    // fragment off `about:srcdoc`. The SW never sees the fragment on a
+    // network request.
+    //
+    // Read them the same way as `origin`. A nested host forwards the values
+    // that its own parent gave it in `window.tonk.context`. Only the top
+    // document reads `window.location`. A nested host must not read its own
+    // location. That location is `about:srcdoc` (pathname `srcdoc`) or, for a
+    // host two or more frames deep, a `blob:` URL (see `shared::GuestSource`).
+    // Neither is the page the user is on.
+    let path = tonk_host::bridge::context_field("path").unwrap_or_else(|| {
+        location
+            .as_ref()
+            .and_then(|l| l.pathname().ok())
+            .unwrap_or_default()
+    });
+    let search = tonk_host::bridge::context_field("search").unwrap_or_else(|| {
+        location
+            .as_ref()
+            .and_then(|l| l.search().ok())
+            .unwrap_or_default()
+    });
+    let hash = tonk_host::bridge::context_field("hash").unwrap_or_else(|| {
+        location
+            .as_ref()
+            .and_then(|l| l.hash().ok())
+            .unwrap_or_default()
+    });
     let (repo, branch, with) = state
         .borrow()
         .with
@@ -3075,6 +3090,52 @@ mod tests {
             get_str(&context, "origin").as_deref(),
             Some("https://forwarded.test"),
             "a nested portal forwards the parent context origin, not `about:srcdoc`'s null",
+        );
+    }
+
+    /// The same rule for `path`, `search`, and `hash`. A nested host's own
+    /// location is `about:srcdoc` or a `blob:` URL. Neither is the page the
+    /// user is on. The host must forward what its parent gave it. The real
+    /// location then reaches every nesting level. The SW routes by
+    /// `x-tonk-path`, and `<tonk-page>` couriers `?access` and `#seed`.
+    #[dialog_common::test]
+    async fn it_forwards_the_parent_context_path_search_and_hash() {
+        let win = window().expect("window");
+        let tonk = Object::new();
+        let ctx = Object::new();
+        let _ = Reflect::set(&ctx, &"origin".into(), &"https://forwarded.test".into());
+        let _ = Reflect::set(&ctx, &"path".into(), &"/forwarded/path".into());
+        let _ = Reflect::set(&ctx, &"search".into(), &"?access=abc".into());
+        let _ = Reflect::set(&ctx, &"hash".into(), &"#seed".into());
+        let _ = Reflect::set(&tonk, &"context".into(), &ctx);
+        let _ = Reflect::set(&win, &"tonk".into(), &tonk);
+
+        let host = FakeHost::install();
+        let consumer = relay_consumer(&host, Some("id:demo-counter"), Some("counter"), None);
+        let state = Rc::new(RefCell::new(PortalState::new()));
+        let (listener, _port) = bind(&consumer, &state);
+
+        let ready = listener.wait_for("ready").await;
+        let context = Reflect::get(&ready, &"context".into()).expect("context");
+
+        // Restore before asserting so a failure doesn't leak `window.tonk`
+        // into a later test running in the same page.
+        let _ = Reflect::set(&win, &"tonk".into(), &JsValue::UNDEFINED);
+
+        assert_eq!(
+            get_str(&context, "path").as_deref(),
+            Some("/forwarded/path"),
+            "a nested portal forwards the parent context path, not its own pathname",
+        );
+        assert_eq!(
+            get_str(&context, "search").as_deref(),
+            Some("?access=abc"),
+            "a nested portal forwards the parent context search",
+        );
+        assert_eq!(
+            get_str(&context, "hash").as_deref(),
+            Some("#seed"),
+            "a nested portal forwards the parent context hash",
         );
     }
 

--- a/rust/tonk-portal/src/shared.rs
+++ b/rust/tonk-portal/src/shared.rs
@@ -4,6 +4,30 @@
 //! and wire it to the bridge; the only difference is how they style that
 //! iframe. This module provides the common setup path, parameterised by a
 //! caller-supplied style function.
+//!
+//! # How the guest document reaches its iframe
+//!
+//! A guest is normally loaded through `srcdoc`, so its document URL is
+//! `about:srcdoc`. WebKit refuses to load a frame when TWO of its ancestors
+//! already carry the requested URL (`HTMLFrameOwnerElement::
+//! isProhibitedSelfReference` — "we allow one level of self-reference"), and
+//! every sealed guest is `about:srcdoc`, so the THIRD nested guest never
+//! loads on Safari: the frame silently stays at its blank initial document.
+//! The chain is exactly that deep in practice — the shell's `<tonk-site>`
+//! guest, the space chrome's nested `<tonk-site>`, then a text/html view's
+//! `<tonk-portal>` — which is why portal views render empty on Safari and
+//! iOS while `<tonk-view>` content renders fine. WebKit fixed this upstream
+//! (bugs.webkit.org/305276, 2026-01), but shipping Safari still refuses it.
+//!
+//! So a guest created by a document that is itself nested below the top
+//! document ([`GuestSource::DataUrl`]) is loaded from a unique
+//! `data:text/html` URL instead. Same sandbox, same opaque origin, same
+//! bridge; only the document URL differs, and no two frames in one chain can
+//! share it. The top document and its direct guests keep `srcdoc`
+//! ([`GuestSource::Srcdoc`]), which is the path every other browser has
+//! always run. The one thing `srcdoc` gives a guest that a `data:` document
+//! lacks is the creator's base URL, so [`guest_document`] writes that out as
+//! an explicit `<base>` when the portal has no space base of its own.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -16,6 +40,21 @@ use wasm_bindgen::closure::Closure;
 use web_sys::{Element, HtmlElement, HtmlIFrameElement, window};
 
 use crate::bridge::{self, PortalState};
+
+/// How a guest document is handed to its iframe. See the module docs for
+/// why two sources exist.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum GuestSource {
+    /// The `srcdoc` attribute: the guest's document URL is `about:srcdoc`
+    /// and it inherits the creator's base URL. Used by the top document and
+    /// by guests that are its direct children.
+    Srcdoc,
+    /// A unique `data:text/html;charset=utf-8,…` URL in `src`: sidesteps
+    /// WebKit's self-reference refusal for the third (and any deeper) nested
+    /// `about:srcdoc` frame. Used by any creator that is itself nested below
+    /// the top document.
+    DataUrl,
+}
 
 /// Create and wire up the portal iframe, then store the resulting state.
 ///
@@ -81,22 +120,13 @@ pub(crate) fn connect_portal(
     bridge::register_portal(&iframe, &host, &state);
     install_method_delegates(&host, &state);
 
-    // Append before assigning `srcdoc` so `contentWindow` exists;
+    // Append before loading the document so `contentWindow` exists;
     // the `hello` listener matches the live `contentWindow`, so the
     // bootstrap script resolves this portal when it posts `hello`.
-    let content = host.get_attribute("content").unwrap_or_default();
-    // In `runtime` mode the guest renders OUR elements (a real
-    // `<tonk-display>`): the bootstrap additionally pulls in the
-    // injected element runtime + CSS before `content` upgrades.
-    let runtime = host.has_attribute("runtime");
     let _ = host.append_child(&iframe);
-    let base = space_base(&state.borrow());
-    let srcdoc = if runtime {
-        bridge::bootstrap_srcdoc_with_runtime(&content, &base)
-    } else {
-        bridge::bootstrap_srcdoc(&content, &base)
-    };
-    let _ = iframe.set_attribute("srcdoc", &srcdoc);
+    let source = guest_source(&host);
+    let html = guest_document(&host, &state.borrow(), source);
+    mount_guest(&iframe, &html, source);
 
     state.borrow_mut().iframe = Some(iframe);
     *inner.borrow_mut() = Some(state);
@@ -111,15 +141,152 @@ pub(crate) fn reload_portal(host: &Element, state: &Rc<RefCell<PortalState>>) {
     let mut s = state.borrow_mut();
     s.clear_subs();
     if let Some(iframe) = s.iframe.as_ref() {
-        let content = host.get_attribute("content").unwrap_or_default();
-        let base = space_base(&s);
-        let srcdoc = if host.has_attribute("runtime") {
-            bridge::bootstrap_srcdoc_with_runtime(&content, &base)
-        } else {
-            bridge::bootstrap_srcdoc(&content, &base)
-        };
-        let _ = iframe.set_attribute("srcdoc", &srcdoc);
+        let source = guest_source(host);
+        let html = guest_document(host, &s, source);
+        reload_guest(iframe, &html, source);
     }
+}
+
+/// The document that will own a guest mounted under `host`, and its window
+/// — the guest's CREATOR. In production that is the document this runtime
+/// runs in (the host lives there), so this equals the global `window`;
+/// resolving it through the host keeps the decision attached to the element
+/// rather than the global, which is also what lets a test hand in a host
+/// adopted into a nested frame.
+fn creator_document(host: &Element) -> Option<web_sys::Document> {
+    host.owner_document()
+        .or_else(|| window().and_then(|w| w.document()))
+}
+
+fn creator_window(host: &Element) -> Option<web_sys::Window> {
+    creator_document(host)
+        .and_then(|d| d.default_view())
+        .or_else(window)
+}
+
+/// Which [`GuestSource`] a guest mounted under `host` gets.
+///
+/// `window.parent !== window.top` in the creator means it is at least two
+/// frames deep, so a `srcdoc` child would be the third `about:srcdoc` in
+/// the chain — the one WebKit refuses. `parent` and `top` are readable
+/// across the sandbox boundary (identity only), so a sealed guest can
+/// answer this for itself.
+fn guest_source(host: &Element) -> GuestSource {
+    let Some(win) = creator_window(host) else {
+        return GuestSource::Srcdoc;
+    };
+    let parent: JsValue = win
+        .parent()
+        .ok()
+        .flatten()
+        .map(JsValue::from)
+        .unwrap_or(JsValue::NULL);
+    let top: JsValue = win
+        .top()
+        .ok()
+        .flatten()
+        .map(JsValue::from)
+        .unwrap_or(JsValue::NULL);
+    if parent == top {
+        GuestSource::Srcdoc
+    } else {
+        GuestSource::DataUrl
+    }
+}
+
+/// The complete guest document for `host`: the bridge bootstrap (plus the
+/// runtime bootstrap in `runtime` mode), the author `content`, and the
+/// `<base>` the guest resolves URLs against.
+///
+/// The base is the portal's per-space synthetic origin when it has one
+/// (see [`space_base`]). Without one, a `srcdoc` guest inherits the
+/// creator's base URL from the browser, but a `data:` document's base is the
+/// data URL itself — so for [`GuestSource::DataUrl`] the inherited value
+/// (the creator's `document.baseURI`) is written out explicitly, keeping
+/// link and request resolution identical between the two sources.
+fn guest_document(host: &Element, state: &PortalState, source: GuestSource) -> String {
+    let content = host.get_attribute("content").unwrap_or_default();
+    let mut base = space_base(state);
+    if base.is_empty() && source == GuestSource::DataUrl {
+        base = creator_document(host)
+            .and_then(|d| d.base_uri().ok().flatten())
+            .unwrap_or_default();
+    }
+    // In `runtime` mode the guest renders OUR elements (a real
+    // `<tonk-display>`): the bootstrap additionally pulls in the
+    // injected element runtime + CSS before `content` upgrades.
+    if host.has_attribute("runtime") {
+        bridge::bootstrap_srcdoc_with_runtime(&content, &base)
+    } else {
+        bridge::bootstrap_srcdoc(&content, &base)
+    }
+}
+
+/// First load of `html` into a freshly appended `iframe`. Either source
+/// navigates the frame away from its initial blank document, which the
+/// browser treats as a replacement — no joint-session-history entry.
+fn mount_guest(iframe: &HtmlIFrameElement, html: &str, source: GuestSource) {
+    match source {
+        GuestSource::Srcdoc => {
+            let _ = iframe.set_attribute("srcdoc", html);
+        }
+        GuestSource::DataUrl => {
+            let _ = iframe.set_attribute("src", &guest_data_url(html));
+        }
+    }
+}
+
+/// Reload a live `iframe` with new `html` (a `content` change).
+///
+/// A `srcdoc` guest is reloaded by reassigning the attribute, as before. A
+/// `data:` guest goes through the frame's own `location.replace()` rather
+/// than a fresh `src`: setting `src` on a live frame NAVIGATES it and a
+/// frame navigation appends a joint-session-history entry (see the
+/// teardown notes in `element.rs`), whereas `replace` swaps the entry in
+/// place. `location.replace()` is permitted across the sandbox boundary. The
+/// `src` attribute is left as the URL of the first load; the live document
+/// is the truth.
+fn reload_guest(iframe: &HtmlIFrameElement, html: &str, source: GuestSource) {
+    match source {
+        GuestSource::Srcdoc => {
+            let _ = iframe.set_attribute("srcdoc", html);
+        }
+        GuestSource::DataUrl => {
+            let url = guest_data_url(html);
+            match iframe.content_window() {
+                Some(frame_window) => {
+                    let _ = frame_window.location().replace(&url);
+                }
+                // No live window (never mounted): fall back to a first load.
+                None => {
+                    let _ = iframe.set_attribute("src", &url);
+                }
+            }
+        }
+    }
+}
+
+/// Wrap a guest document in a `data:text/html;charset=utf-8,…` URL that
+/// is unique to this load.
+///
+/// Unique, because WebKit's self-reference rule compares frame URLs: two
+/// guests with byte-identical documents in one ancestor chain would share
+/// a URL and trip it again. The marker is a trailing HTML comment — inert
+/// for the parser and invisible to the content. Percent-encoding (not
+/// base64) so the document decodes to exactly the string we built; it
+/// roughly doubles the size, well inside what browsers accept for a frame
+/// `src` (Chromium caps URLs at 2 MB; guest documents are tens of KB).
+pub(crate) fn guest_data_url(html: &str) -> String {
+    let nonce = format!(
+        "{:08x}{:08x}",
+        (js_sys::Math::random() * 4_294_967_296.0) as u32,
+        (js_sys::Math::random() * 4_294_967_296.0) as u32,
+    );
+    let marked = format!("{html}<!--tonk-guest:{nonce}-->");
+    format!(
+        "data:text/html;charset=utf-8,{}",
+        String::from(js_sys::encode_uri_component(&marked))
+    )
 }
 
 /// The per-space synthetic origin (`https://{label}.tonk.network/`) for this
@@ -193,4 +360,311 @@ pub(crate) fn install_method_delegates(host: &Element, state: &Rc<RefCell<Portal
         }));
     let _ = Reflect::set(host, &"__tonkError".into(), error.as_ref());
     error.forget();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasm_bindgen_futures::JsFuture;
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    use web_sys::{Document, MessageEvent};
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    const DATA_PREFIX: &str = "data:text/html;charset=utf-8,";
+
+    fn document() -> Document {
+        window().expect("window").document().expect("document")
+    }
+
+    /// A fresh sealed iframe appended to the body, exactly as
+    /// `connect_portal` sets one up (sandbox first, then attached).
+    fn sealed_iframe() -> HtmlIFrameElement {
+        let iframe = document()
+            .create_element("iframe")
+            .expect("create iframe")
+            .dyn_into::<HtmlIFrameElement>()
+            .expect("HtmlIFrameElement");
+        iframe
+            .set_attribute("sandbox", "allow-scripts allow-forms allow-downloads")
+            .expect("sandbox");
+        document()
+            .body()
+            .expect("body")
+            .append_child(&iframe)
+            .expect("attach");
+        iframe
+    }
+
+    /// Resolve to `true` when the bridge bootstrap inside `iframe` posts its
+    /// `hello` to this (parent) window, or `false` after a timeout. Install
+    /// BEFORE loading the guest — the bootstrap posts synchronously on load.
+    fn hello_from(iframe: &HtmlIFrameElement) -> JsFuture {
+        let target: JsValue = iframe.content_window().expect("contentWindow").into();
+        let promise = js_sys::Promise::new(&mut |resolve, _reject| {
+            let win = window().expect("window");
+            let target = target.clone();
+            let on_hello = resolve.clone();
+            let listener = Closure::wrap(Box::new(move |event: MessageEvent| {
+                let source = event.source().map(JsValue::from).unwrap_or(JsValue::NULL);
+                let kind = Reflect::get(&event.data(), &"type".into())
+                    .ok()
+                    .and_then(|v| v.as_string());
+                if source == target && kind.as_deref() == Some("hello") {
+                    let _ = on_hello.call1(&JsValue::NULL, &JsValue::TRUE);
+                }
+            }) as Box<dyn FnMut(MessageEvent)>);
+            let _ =
+                win.add_event_listener_with_callback("message", listener.as_ref().unchecked_ref());
+            listener.forget();
+
+            let on_timeout = resolve.clone();
+            let timeout = Closure::once_into_js(move || {
+                let _ = on_timeout.call1(&JsValue::NULL, &JsValue::FALSE);
+            });
+            let _ = win.set_timeout_with_callback_and_timeout_and_arguments_0(
+                timeout.unchecked_ref(),
+                8_000,
+            );
+        });
+        JsFuture::from(promise)
+    }
+
+    #[dialog_common::test]
+    fn a_top_level_document_loads_its_guests_through_srcdoc() {
+        // The test page is the top document: its guests are the first nested
+        // `about:srcdoc` level, which every engine allows.
+        let host: Element = document().body().expect("body").into();
+        assert_eq!(guest_source(&host), GuestSource::Srcdoc);
+    }
+
+    #[dialog_common::test]
+    fn a_guest_data_url_round_trips_the_document_and_is_unique_per_load() {
+        let html = "<base href=\"https://x.tonk.network/\"><script>1<2</script>\
+                    <p>hi &amp; <b>\"q\"</b> 100% #frag</p>";
+        let first = guest_data_url(html);
+        let second = guest_data_url(html);
+        assert!(first.starts_with(DATA_PREFIX), "got: {first}");
+        assert_ne!(
+            first, second,
+            "two loads of one document must never share a URL — WebKit's \
+             self-reference rule compares ancestor URLs"
+        );
+        let decoded = String::from(
+            js_sys::decode_uri_component(&first[DATA_PREFIX.len()..]).expect("decodes"),
+        );
+        assert!(
+            decoded.starts_with(html),
+            "the document must decode byte-for-byte; got: {decoded}"
+        );
+        assert!(
+            decoded[html.len()..].starts_with("<!--tonk-guest:"),
+            "the uniqueness marker is a trailing comment; got: {}",
+            &decoded[html.len()..]
+        );
+    }
+
+    #[dialog_common::test]
+    fn a_data_url_guest_writes_its_inherited_base_explicitly() {
+        let host = document().create_element("tonk-portal").expect("host");
+        host.set_attribute("content", "<p>hi</p>").expect("content");
+        // No `with`, so no space base — the case that used to rely on the
+        // browser's srcdoc base-URL inheritance.
+        let state = PortalState::new();
+
+        let as_srcdoc = guest_document(&host, &state, GuestSource::Srcdoc);
+        assert!(
+            !as_srcdoc.contains("<base "),
+            "a srcdoc guest inherits its base from the browser; got: {as_srcdoc}"
+        );
+
+        let as_data = guest_document(&host, &state, GuestSource::DataUrl);
+        let inherited = document().base_uri().expect("baseURI").expect("set");
+        assert!(
+            as_data.starts_with(&format!("<base href=\"{inherited}\">")),
+            "a data: guest must carry the creator's base URL explicitly; got: {}",
+            &as_data[..as_data.len().min(160)]
+        );
+        assert!(as_data.contains("<p>hi</p>"), "content survives");
+    }
+
+    /// The load path WebKit needs: a sealed guest handed over as a `data:`
+    /// URL still runs the bridge bootstrap (it posts `hello` to its parent),
+    /// and a reload through `location.replace()` runs it again.
+    #[dialog_common::test]
+    async fn a_data_url_guest_boots_the_bridge_and_reloads_in_place() {
+        let iframe = sealed_iframe();
+        let first = hello_from(&iframe);
+        mount_guest(
+            &iframe,
+            &bridge::bootstrap_srcdoc("<p>one</p>", ""),
+            GuestSource::DataUrl,
+        );
+        assert_eq!(
+            first.await.ok().and_then(|v| v.as_bool()),
+            Some(true),
+            "the data: guest must boot and greet its parent"
+        );
+        assert!(
+            iframe
+                .get_attribute("src")
+                .is_some_and(|src| src.starts_with(DATA_PREFIX)),
+            "the first load is the frame's `src`"
+        );
+        assert_eq!(iframe.get_attribute("srcdoc"), None);
+
+        let again = hello_from(&iframe);
+        reload_guest(
+            &iframe,
+            &bridge::bootstrap_srcdoc("<p>two</p>", ""),
+            GuestSource::DataUrl,
+        );
+        assert_eq!(
+            again.await.ok().and_then(|v| v.as_bool()),
+            Some(true),
+            "a reload must bring the guest back up"
+        );
+        iframe.remove();
+    }
+}
+
+/// The WebKit case, end to end, through the production mount path: a guest
+/// created from a document that is already TWO frames below the top must
+/// still boot. Safari refuses a third `about:srcdoc` frame outright (see the
+/// module docs), so without the `data:` source this test times out there and
+/// passes with it; Chrome loads either. Self-contained on purpose — it uses
+/// only `connect_portal`, so the very same test runs against the pre-fix
+/// code to show the red.
+///
+/// CI runs this in headless Chrome like every other test here. To see the
+/// Safari red/green locally (Safari ▸ Develop ▸ Allow Remote Automation):
+///
+/// ```text
+/// SAFARIDRIVER=/usr/bin/safaridriver \
+///   cargo test -p tonk-portal --target wasm32-unknown-unknown -- nested_tests
+/// ```
+#[cfg(test)]
+mod nested_tests {
+    use super::*;
+    use js_sys::Promise;
+    use wasm_bindgen_futures::JsFuture;
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    use web_sys::{Document, MessageEvent, Window};
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn document() -> Document {
+        window().expect("window").document().expect("document")
+    }
+
+    /// Append a `srcdoc` frame under `parent`'s body and wait for it to
+    /// load. Same-origin (`allow-same-origin`) so the test can reach inside
+    /// it; its URL is still `about:srcdoc`, which is all WebKit's
+    /// self-reference rule looks at.
+    async fn srcdoc_frame(parent: &Document) -> HtmlIFrameElement {
+        // `unchecked_into`, not `dyn_into`: an element created in a nested
+        // document belongs to that realm, and `dyn_into`'s `instanceof`
+        // checks against THIS realm's constructor — false across realms.
+        let iframe = parent
+            .create_element("iframe")
+            .expect("create iframe")
+            .unchecked_into::<HtmlIFrameElement>();
+        iframe
+            .set_attribute("sandbox", "allow-scripts allow-same-origin")
+            .expect("sandbox");
+        // `srcdoc` BEFORE insertion: an iframe inserted without one fires
+        // `load` for its initial about:blank, which would resolve this too
+        // early — before the srcdoc document (the one we hand back) exists.
+        iframe
+            .set_attribute("srcdoc", "<!doctype html><body></body>")
+            .expect("srcdoc");
+        let loaded = Promise::new(&mut |resolve, _reject| {
+            iframe.set_onload(Some(&resolve));
+        });
+        parent
+            .body()
+            .expect("parent body")
+            .append_child(&iframe)
+            .expect("attach");
+        let _ = JsFuture::from(loaded).await;
+        iframe
+    }
+
+    /// Resolve to `true` when a `hello` from the window `from` reaches
+    /// `on` (the guest's parent), or `false` after a timeout.
+    fn hello_on(on: &Window, from: &JsValue) -> JsFuture {
+        let from = from.clone();
+        let on = on.clone();
+        let promise = Promise::new(&mut |resolve, _reject| {
+            let from = from.clone();
+            let on_hello = resolve.clone();
+            let listener = Closure::wrap(Box::new(move |event: MessageEvent| {
+                let source = event.source().map(JsValue::from).unwrap_or(JsValue::NULL);
+                let kind = Reflect::get(&event.data(), &"type".into())
+                    .ok()
+                    .and_then(|v| v.as_string());
+                if source == from && kind.as_deref() == Some("hello") {
+                    let _ = on_hello.call1(&JsValue::NULL, &JsValue::TRUE);
+                }
+            }) as Box<dyn FnMut(MessageEvent)>);
+            let _ =
+                on.add_event_listener_with_callback("message", listener.as_ref().unchecked_ref());
+            listener.forget();
+
+            let on_timeout = resolve.clone();
+            let timeout = Closure::once_into_js(move || {
+                let _ = on_timeout.call1(&JsValue::NULL, &JsValue::FALSE);
+            });
+            let _ = on.set_timeout_with_callback_and_timeout_and_arguments_0(
+                timeout.unchecked_ref(),
+                8_000,
+            );
+        });
+        JsFuture::from(promise)
+    }
+
+    #[dialog_common::test]
+    async fn a_guest_created_two_frames_deep_still_boots() {
+        // top → A → B, both `about:srcdoc`: the real shape (shell site
+        // guest → space chrome's nested site) minus the element runtime.
+        let a = srcdoc_frame(&document()).await;
+        let a_doc = a.content_document().expect("A is same-origin");
+        let b = srcdoc_frame(&a_doc).await;
+        let b_doc = b.content_document().expect("B is same-origin");
+        let b_win = b.content_window().expect("B window");
+
+        // The portal host lives in B, so B is the guest's creator.
+        let host = b_doc
+            .create_element("div")
+            .expect("host")
+            .unchecked_into::<HtmlElement>();
+        host.set_attribute("content", "<p>deep</p>")
+            .expect("content");
+        b_doc
+            .body()
+            .expect("B body")
+            .append_child(&host)
+            .expect("attach host");
+
+        // The production mount path, exactly as `<tonk-portal>` calls it.
+        let cell: RefCell<Option<Rc<RefCell<PortalState>>>> = RefCell::new(None);
+        connect_portal(&host, &cell, None, Allow::none(), |_| {});
+        let guest = host
+            .query_selector("iframe")
+            .expect("query")
+            .expect("guest iframe mounted")
+            .unchecked_into::<HtmlIFrameElement>();
+        let guest_window: JsValue = guest.content_window().expect("guest window").into();
+
+        // The bootstrap posts `hello` to its parent — B's window — as its
+        // first act. No `hello` means the frame never loaded.
+        let booted = hello_on(&b_win, &guest_window).await;
+        assert_eq!(
+            booted.ok().and_then(|v| v.as_bool()),
+            Some(true),
+            "a guest two frames below the top must boot — WebKit refuses a \
+             third nested about:srcdoc frame, so it needs a different URL"
+        );
+        a.remove();
+    }
 }

--- a/rust/tonk-portal/src/shared.rs
+++ b/rust/tonk-portal/src/shared.rs
@@ -5,29 +5,32 @@
 //! iframe. This module provides the common setup path, parameterised by a
 //! caller-supplied style function.
 //!
-//! # How the guest document reaches its iframe
+//! # How the guest document gets into its iframe
 //!
-//! A guest is normally loaded through `srcdoc`, so its document URL is
-//! `about:srcdoc`. WebKit refuses to load a frame when TWO of its ancestors
-//! already carry the requested URL (`HTMLFrameOwnerElement::
-//! isProhibitedSelfReference` — "we allow one level of self-reference"), and
-//! every sealed guest is `about:srcdoc`, so the THIRD nested guest never
-//! loads on Safari: the frame silently stays at its blank initial document.
-//! The chain is exactly that deep in practice — the shell's `<tonk-site>`
-//! guest, the space chrome's nested `<tonk-site>`, then a text/html view's
-//! `<tonk-portal>` — which is why portal views render empty on Safari and
-//! iOS while `<tonk-view>` content renders fine. WebKit fixed this upstream
-//! (bugs.webkit.org/305276, 2026-01), but shipping Safari still refuses it.
+//! In the usual case the `srcdoc` attribute loads a guest. The document URL
+//! is then `about:srcdoc`. WebKit does not load a frame when two of its
+//! ancestors already have the requested URL. (See WebKit's
+//! `HTMLFrameOwnerElement::isProhibitedSelfReference`. It permits one level
+//! of self-reference, not two.) Each sealed guest is `about:srcdoc`. The
+//! third nested guest then does not load on Safari. The frame stays at its
+//! blank initial document and shows no error.
 //!
-//! So a guest created by a document that is itself nested below the top
-//! document ([`GuestSource::DataUrl`]) is loaded from a unique
-//! `data:text/html` URL instead. Same sandbox, same opaque origin, same
-//! bridge; only the document URL differs, and no two frames in one chain can
-//! share it. The top document and its direct guests keep `srcdoc`
-//! ([`GuestSource::Srcdoc`]), which is the path every other browser has
-//! always run. The one thing `srcdoc` gives a guest that a `data:` document
-//! lacks is the creator's base URL, so [`guest_document`] writes that out as
-//! an explicit `<base>` when the portal has no space base of its own.
+//! The chain in this app has exactly that depth. Level 1 is the shell's
+//! `<tonk-site>` guest. Level 2 is the space chrome's nested `<tonk-site>`.
+//! Level 3 is the `<tonk-portal>` of a text/html view. That is why portal
+//! views are empty on Safari and iOS while `<tonk-view>` content is correct.
+//! WebKit fixed the rule in January 2026 (bugs.webkit.org/305276). Released
+//! Safari still has the old rule.
+//!
+//! The fix: a document that is nested below the top document loads its
+//! guests from a unique `data:text/html` URL ([`GuestSource::DataUrl`]). The
+//! sandbox, the opaque origin, and the bridge do not change. Only the
+//! document URL changes, and no two frames in one chain can have the same
+//! URL. The top document and its direct guests keep `srcdoc`
+//! ([`GuestSource::Srcdoc`]). That is the path all other browsers have
+//! always used. A `srcdoc` guest inherits the creator's base URL. A `data:`
+//! document does not. For that reason [`guest_document`] writes an explicit
+//! `<base>` when the portal has no space base of its own.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -41,18 +44,18 @@ use web_sys::{Element, HtmlElement, HtmlIFrameElement, window};
 
 use crate::bridge::{self, PortalState};
 
-/// How a guest document is handed to its iframe. See the module docs for
-/// why two sources exist.
+/// How the guest document gets into its iframe. The module docs explain why
+/// there are two sources.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum GuestSource {
-    /// The `srcdoc` attribute: the guest's document URL is `about:srcdoc`
-    /// and it inherits the creator's base URL. Used by the top document and
-    /// by guests that are its direct children.
+    /// The `srcdoc` attribute. The guest's document URL is `about:srcdoc`,
+    /// and the guest inherits the creator's base URL. The top document and
+    /// its direct guests use this source.
     Srcdoc,
-    /// A unique `data:text/html;charset=utf-8,…` URL in `src`: sidesteps
-    /// WebKit's self-reference refusal for the third (and any deeper) nested
-    /// `about:srcdoc` frame. Used by any creator that is itself nested below
-    /// the top document.
+    /// A unique `data:text/html;charset=utf-8,…` URL in `src`. WebKit
+    /// refuses the third nested `about:srcdoc` frame and all deeper ones.
+    /// This URL does not have that problem. A creator that is nested below
+    /// the top document uses this source.
     DataUrl,
 }
 
@@ -120,9 +123,9 @@ pub(crate) fn connect_portal(
     bridge::register_portal(&iframe, &host, &state);
     install_method_delegates(&host, &state);
 
-    // Append before loading the document so `contentWindow` exists;
-    // the `hello` listener matches the live `contentWindow`, so the
-    // bootstrap script resolves this portal when it posts `hello`.
+    // Append the iframe before you load the document. Then `contentWindow`
+    // exists, and the `hello` listener can match the live `contentWindow`
+    // to this portal when the bootstrap posts `hello`.
     let _ = host.append_child(&iframe);
     let source = guest_source(&host);
     let html = guest_document(&host, &state.borrow(), source);
@@ -147,12 +150,11 @@ pub(crate) fn reload_portal(host: &Element, state: &Rc<RefCell<PortalState>>) {
     }
 }
 
-/// The document that will own a guest mounted under `host`, and its window
-/// — the guest's CREATOR. In production that is the document this runtime
-/// runs in (the host lives there), so this equals the global `window`;
-/// resolving it through the host keeps the decision attached to the element
-/// rather than the global, which is also what lets a test hand in a host
-/// adopted into a nested frame.
+/// The document that will own a guest mounted under `host`, and the window
+/// of that document. That document is the guest's CREATOR. In production it
+/// is the document this runtime runs in, because the host lives there. It is
+/// then equal to the global `window`. We resolve it through the host for one
+/// reason: a test can then give us a host that lives in a nested frame.
 fn creator_document(host: &Element) -> Option<web_sys::Document> {
     host.owner_document()
         .or_else(|| window().and_then(|w| w.document()))
@@ -164,13 +166,13 @@ fn creator_window(host: &Element) -> Option<web_sys::Window> {
         .or_else(window)
 }
 
-/// Which [`GuestSource`] a guest mounted under `host` gets.
+/// The [`GuestSource`] for a guest mounted under `host`.
 ///
-/// `window.parent !== window.top` in the creator means it is at least two
-/// frames deep, so a `srcdoc` child would be the third `about:srcdoc` in
-/// the chain — the one WebKit refuses. `parent` and `top` are readable
-/// across the sandbox boundary (identity only), so a sealed guest can
-/// answer this for itself.
+/// If `window.parent !== window.top` in the creator, the creator is two or
+/// more frames deep. A `srcdoc` child would then be the third `about:srcdoc`
+/// frame in the chain, and WebKit refuses that one. A sealed guest can read
+/// `parent` and `top` across the sandbox boundary (identity only). It can
+/// make this decision itself.
 fn guest_source(host: &Element) -> GuestSource {
     let Some(win) = creator_window(host) else {
         return GuestSource::Srcdoc;
@@ -194,16 +196,17 @@ fn guest_source(host: &Element) -> GuestSource {
     }
 }
 
-/// The complete guest document for `host`: the bridge bootstrap (plus the
-/// runtime bootstrap in `runtime` mode), the author `content`, and the
-/// `<base>` the guest resolves URLs against.
+/// The complete guest document for `host`. It contains the bridge
+/// bootstrap, the author `content`, and the `<base>` that the guest
+/// resolves URLs against. In `runtime` mode it also contains the runtime
+/// bootstrap.
 ///
-/// The base is the portal's per-space synthetic origin when it has one
-/// (see [`space_base`]). Without one, a `srcdoc` guest inherits the
-/// creator's base URL from the browser, but a `data:` document's base is the
-/// data URL itself — so for [`GuestSource::DataUrl`] the inherited value
-/// (the creator's `document.baseURI`) is written out explicitly, keeping
-/// link and request resolution identical between the two sources.
+/// The base is the portal's per-space synthetic origin when the portal has
+/// one (see [`space_base`]). When it has none, a `srcdoc` guest inherits the
+/// creator's base URL from the browser. A `data:` document does not: its
+/// base is the data URL itself. For [`GuestSource::DataUrl`] this function
+/// writes the inherited value (the creator's `document.baseURI`) explicitly.
+/// Link and request resolution are then identical for the two sources.
 fn guest_document(host: &Element, state: &PortalState, source: GuestSource) -> String {
     let content = host.get_attribute("content").unwrap_or_default();
     let mut base = space_base(state);
@@ -213,8 +216,8 @@ fn guest_document(host: &Element, state: &PortalState, source: GuestSource) -> S
             .unwrap_or_default();
     }
     // In `runtime` mode the guest renders OUR elements (a real
-    // `<tonk-display>`): the bootstrap additionally pulls in the
-    // injected element runtime + CSS before `content` upgrades.
+    // `<tonk-display>`). The bootstrap then also loads the injected element
+    // runtime and CSS before `content` upgrades.
     if host.has_attribute("runtime") {
         bridge::bootstrap_srcdoc_with_runtime(&content, &base)
     } else {
@@ -222,9 +225,10 @@ fn guest_document(host: &Element, state: &PortalState, source: GuestSource) -> S
     }
 }
 
-/// First load of `html` into a freshly appended `iframe`. Either source
-/// navigates the frame away from its initial blank document, which the
-/// browser treats as a replacement — no joint-session-history entry.
+/// The first load of `html` into an `iframe` that was just appended. With
+/// either source the frame navigates away from its initial blank document.
+/// The browser treats that as a replacement. It adds no
+/// joint-session-history entry.
 fn mount_guest(iframe: &HtmlIFrameElement, html: &str, source: GuestSource) {
     match source {
         GuestSource::Srcdoc => {
@@ -236,16 +240,16 @@ fn mount_guest(iframe: &HtmlIFrameElement, html: &str, source: GuestSource) {
     }
 }
 
-/// Reload a live `iframe` with new `html` (a `content` change).
+/// Reload a live `iframe` with new `html` (after a `content` change).
 ///
-/// A `srcdoc` guest is reloaded by reassigning the attribute, as before. A
-/// `data:` guest goes through the frame's own `location.replace()` rather
-/// than a fresh `src`: setting `src` on a live frame NAVIGATES it and a
-/// frame navigation appends a joint-session-history entry (see the
-/// teardown notes in `element.rs`), whereas `replace` swaps the entry in
-/// place. `location.replace()` is permitted across the sandbox boundary. The
-/// `src` attribute is left as the URL of the first load; the live document
-/// is the truth.
+/// A `srcdoc` guest reloads when we assign the attribute again, as before.
+/// A `data:` guest reloads through the frame's own `location.replace()`,
+/// not through a new `src`. A new `src` on a live frame NAVIGATES the frame,
+/// and a frame navigation adds a joint-session-history entry (see the
+/// teardown notes in `element.rs`). `replace` changes the entry in place.
+/// `location.replace()` is permitted across the sandbox boundary. The `src`
+/// attribute keeps the URL of the first load. The live document is the
+/// truth.
 fn reload_guest(iframe: &HtmlIFrameElement, html: &str, source: GuestSource) {
     match source {
         GuestSource::Srcdoc => {
@@ -257,7 +261,8 @@ fn reload_guest(iframe: &HtmlIFrameElement, html: &str, source: GuestSource) {
                 Some(frame_window) => {
                     let _ = frame_window.location().replace(&url);
                 }
-                // No live window (never mounted): fall back to a first load.
+                // There is no live window (the frame was never mounted). Do
+                // a first load.
                 None => {
                     let _ = iframe.set_attribute("src", &url);
                 }
@@ -266,16 +271,18 @@ fn reload_guest(iframe: &HtmlIFrameElement, html: &str, source: GuestSource) {
     }
 }
 
-/// Wrap a guest document in a `data:text/html;charset=utf-8,…` URL that
-/// is unique to this load.
+/// Wrap a guest document in a `data:text/html;charset=utf-8,…` URL that is
+/// unique to this load.
 ///
-/// Unique, because WebKit's self-reference rule compares frame URLs: two
-/// guests with byte-identical documents in one ancestor chain would share
-/// a URL and trip it again. The marker is a trailing HTML comment — inert
-/// for the parser and invisible to the content. Percent-encoding (not
-/// base64) so the document decodes to exactly the string we built; it
-/// roughly doubles the size, well inside what browsers accept for a frame
-/// `src` (Chromium caps URLs at 2 MB; guest documents are tens of KB).
+/// The URL must be unique because WebKit's self-reference rule compares
+/// frame URLs. Two guests with byte-identical documents in one ancestor
+/// chain would have the same URL, and the rule would refuse the second one.
+/// The marker is an HTML comment at the end. The parser ignores it, and the
+/// content cannot see it. We use percent-encoding, not base64. The document
+/// then decodes to exactly the string we built. The encoding makes the
+/// document about two times larger. That is well inside what browsers
+/// accept for a frame `src` (Chromium limits URLs to 2 MB; guest documents
+/// are tens of KB).
 pub(crate) fn guest_data_url(html: &str) -> String {
     let nonce = format!(
         "{:08x}{:08x}",
@@ -377,8 +384,8 @@ mod tests {
         window().expect("window").document().expect("document")
     }
 
-    /// A fresh sealed iframe appended to the body, exactly as
-    /// `connect_portal` sets one up (sandbox first, then attached).
+    /// A new sealed iframe appended to the body, set up as `connect_portal`
+    /// does it: sandbox first, then attached.
     fn sealed_iframe() -> HtmlIFrameElement {
         let iframe = document()
             .create_element("iframe")
@@ -396,9 +403,10 @@ mod tests {
         iframe
     }
 
-    /// Resolve to `true` when the bridge bootstrap inside `iframe` posts its
-    /// `hello` to this (parent) window, or `false` after a timeout. Install
-    /// BEFORE loading the guest — the bootstrap posts synchronously on load.
+    /// Resolves to `true` when the bridge bootstrap in `iframe` posts its
+    /// `hello` to this (parent) window. Resolves to `false` after a timeout.
+    /// Install it BEFORE you load the guest: the bootstrap posts `hello` as
+    /// soon as the document loads.
     fn hello_from(iframe: &HtmlIFrameElement) -> JsFuture {
         let target: JsValue = iframe.content_window().expect("contentWindow").into();
         let promise = js_sys::Promise::new(&mut |resolve, _reject| {
@@ -432,8 +440,8 @@ mod tests {
 
     #[dialog_common::test]
     fn a_top_level_document_loads_its_guests_through_srcdoc() {
-        // The test page is the top document: its guests are the first nested
-        // `about:srcdoc` level, which every engine allows.
+        // The test page is the top document. Its guests are the first nested
+        // `about:srcdoc` level. All engines permit that level.
         let host: Element = document().body().expect("body").into();
         assert_eq!(guest_source(&host), GuestSource::Srcdoc);
     }
@@ -468,8 +476,8 @@ mod tests {
     fn a_data_url_guest_writes_its_inherited_base_explicitly() {
         let host = document().create_element("tonk-portal").expect("host");
         host.set_attribute("content", "<p>hi</p>").expect("content");
-        // No `with`, so no space base — the case that used to rely on the
-        // browser's srcdoc base-URL inheritance.
+        // No `with` means no space base. This is the case that depended on
+        // the browser's srcdoc base-URL inheritance.
         let state = PortalState::new();
 
         let as_srcdoc = guest_document(&host, &state, GuestSource::Srcdoc);
@@ -488,9 +496,10 @@ mod tests {
         assert!(as_data.contains("<p>hi</p>"), "content survives");
     }
 
-    /// The load path WebKit needs: a sealed guest handed over as a `data:`
-    /// URL still runs the bridge bootstrap (it posts `hello` to its parent),
-    /// and a reload through `location.replace()` runs it again.
+    /// The load path that WebKit needs. A sealed guest that we load as a
+    /// `data:` URL still runs the bridge bootstrap: it posts `hello` to its
+    /// parent. A reload through `location.replace()` runs the bootstrap
+    /// again.
     #[dialog_common::test]
     async fn a_data_url_guest_boots_the_bridge_and_reloads_in_place() {
         let iframe = sealed_iframe();
@@ -528,16 +537,17 @@ mod tests {
     }
 }
 
-/// The WebKit case, end to end, through the production mount path: a guest
-/// created from a document that is already TWO frames below the top must
-/// still boot. Safari refuses a third `about:srcdoc` frame outright (see the
-/// module docs), so without the `data:` source this test times out there and
-/// passes with it; Chrome loads either. Self-contained on purpose — it uses
-/// only `connect_portal`, so the very same test runs against the pre-fix
-/// code to show the red.
+/// The WebKit case from end to end, through the production mount path. A
+/// guest created from a document that is already TWO frames below the top
+/// must still boot. Safari refuses a third `about:srcdoc` frame (see the
+/// module docs). Without the `data:` source this test times out there. With
+/// it, the test passes. Chrome loads both. The test uses only
+/// `connect_portal` on purpose. The same test then runs against the code
+/// before the fix and shows the failure.
 ///
-/// CI runs this in headless Chrome like every other test here. To see the
-/// Safari red/green locally (Safari ▸ Develop ▸ Allow Remote Automation):
+/// CI runs this test in headless Chrome, as it runs all tests here. To see
+/// the Safari failure and pass on your machine, enable Safari ▸ Develop ▸
+/// Allow Remote Automation, then run:
 ///
 /// ```text
 /// SAFARIDRIVER=/usr/bin/safaridriver \
@@ -557,14 +567,15 @@ mod nested_tests {
         window().expect("window").document().expect("document")
     }
 
-    /// Append a `srcdoc` frame under `parent`'s body and wait for it to
-    /// load. Same-origin (`allow-same-origin`) so the test can reach inside
-    /// it; its URL is still `about:srcdoc`, which is all WebKit's
-    /// self-reference rule looks at.
+    /// Append a `srcdoc` frame under the body of `parent` and wait until it
+    /// loads. The frame is same-origin (`allow-same-origin`), so the test
+    /// can reach into it. Its URL is still `about:srcdoc`. WebKit's
+    /// self-reference rule looks only at the URL.
     async fn srcdoc_frame(parent: &Document) -> HtmlIFrameElement {
-        // `unchecked_into`, not `dyn_into`: an element created in a nested
-        // document belongs to that realm, and `dyn_into`'s `instanceof`
-        // checks against THIS realm's constructor — false across realms.
+        // Use `unchecked_into`, not `dyn_into`. An element created in a
+        // nested document belongs to that realm. `dyn_into` does an
+        // `instanceof` check against the constructor of THIS realm, and that
+        // check is false across realms.
         let iframe = parent
             .create_element("iframe")
             .expect("create iframe")
@@ -572,9 +583,10 @@ mod nested_tests {
         iframe
             .set_attribute("sandbox", "allow-scripts allow-same-origin")
             .expect("sandbox");
-        // `srcdoc` BEFORE insertion: an iframe inserted without one fires
-        // `load` for its initial about:blank, which would resolve this too
-        // early — before the srcdoc document (the one we hand back) exists.
+        // Set `srcdoc` BEFORE insertion. An iframe inserted without it fires
+        // `load` for its initial about:blank. That would resolve the promise
+        // too early, before the srcdoc document exists. The srcdoc document
+        // is the one we return.
         iframe
             .set_attribute("srcdoc", "<!doctype html><body></body>")
             .expect("srcdoc");
@@ -590,8 +602,8 @@ mod nested_tests {
         iframe
     }
 
-    /// Resolve to `true` when a `hello` from the window `from` reaches
-    /// `on` (the guest's parent), or `false` after a timeout.
+    /// Resolves to `true` when a `hello` from the window `from` reaches the
+    /// window `on` (the guest's parent). Resolves to `false` after a timeout.
     fn hello_on(on: &Window, from: &JsValue) -> JsFuture {
         let from = from.clone();
         let on = on.clone();
@@ -625,15 +637,16 @@ mod nested_tests {
 
     #[dialog_common::test]
     async fn a_guest_created_two_frames_deep_still_boots() {
-        // top → A → B, both `about:srcdoc`: the real shape (shell site
-        // guest → space chrome's nested site) minus the element runtime.
+        // top → A → B, both `about:srcdoc`. This is the real shape (shell
+        // site guest → nested site of the space chrome) without the element
+        // runtime.
         let a = srcdoc_frame(&document()).await;
         let a_doc = a.content_document().expect("A is same-origin");
         let b = srcdoc_frame(&a_doc).await;
         let b_doc = b.content_document().expect("B is same-origin");
         let b_win = b.content_window().expect("B window");
 
-        // The portal host lives in B, so B is the guest's creator.
+        // The portal host lives in B. B is then the guest's creator.
         let host = b_doc
             .create_element("div")
             .expect("host")
@@ -646,7 +659,7 @@ mod nested_tests {
             .append_child(&host)
             .expect("attach host");
 
-        // The production mount path, exactly as `<tonk-portal>` calls it.
+        // The production mount path, called as `<tonk-portal>` calls it.
         let cell: RefCell<Option<Rc<RefCell<PortalState>>>> = RefCell::new(None);
         connect_portal(&host, &cell, None, Allow::none(), |_| {});
         let guest = host
@@ -656,8 +669,8 @@ mod nested_tests {
             .unchecked_into::<HtmlIFrameElement>();
         let guest_window: JsValue = guest.content_window().expect("guest window").into();
 
-        // The bootstrap posts `hello` to its parent — B's window — as its
-        // first act. No `hello` means the frame never loaded.
+        // The bootstrap posts `hello` to its parent (the window of B) as its
+        // first action. If no `hello` arrives, the frame did not load.
         let booted = hello_on(&b_win, &guest_window).await;
         assert_eq!(
             booted.ok().and_then(|v| v.as_bool()),

--- a/rust/tonk-portal/src/shared.rs
+++ b/rust/tonk-portal/src/shared.rs
@@ -23,14 +23,34 @@
 //! Safari still has the old rule.
 //!
 //! The fix: a document that is nested below the top document loads its
-//! guests from a unique `data:text/html` URL ([`GuestSource::DataUrl`]). The
-//! sandbox, the opaque origin, and the bridge do not change. Only the
-//! document URL changes, and no two frames in one chain can have the same
-//! URL. The top document and its direct guests keep `srcdoc`
-//! ([`GuestSource::Srcdoc`]). That is the path all other browsers have
-//! always used. A `srcdoc` guest inherits the creator's base URL. A `data:`
-//! document does not. For that reason [`guest_document`] writes an explicit
-//! `<base>` when the portal has no space base of its own.
+//! guests from a `blob:` URL ([`GuestSource::BlobUrl`]). The browser mints
+//! a unique URL for each load, so no two frames in one chain can have the
+//! same URL. The sandbox, the opaque origin, and the bridge do not change.
+//! Only the document URL changes. The top document and its direct guests
+//! keep `srcdoc` ([`GuestSource::Srcdoc`]). That is the path all other
+//! browsers have always used. A `srcdoc` guest inherits the creator's base
+//! URL. A `blob:` document does not. For that reason [`guest_document`]
+//! writes an explicit `<base>` when the portal has no space base of its own.
+//!
+//! Why `blob:` and not `data:`: a `data:` URL carries the whole document in
+//! the URL. Chromium rejects a URL above 2 MB, Firefox above 32 MB, and every
+//! engine must percent-encode and parse it. A portal document can be very
+//! large. A `blob:` URL is 46 characters, has no size limit, and needs no
+//! encoding. The code revokes each `blob:` URL as soon as it has started the
+//! navigation; see [`guest_blob_url`].
+//!
+//! # Known limits
+//!
+//! - The gate counts frames from the browser's top document, not from the
+//!   tonk shell. If another page embeds the tonk shell in an iframe, the
+//!   shell's level-2 guests (the space chrome's nested `<tonk-site>`) also
+//!   change to `blob:`. Those guests run the element runtime. That path has
+//!   no test. If you embed tonk as an iframe, expect problems.
+//! - WebKit's rule also applies to author content. Levels 1 and 2 are
+//!   `about:srcdoc`. An author `<iframe srcdoc>` inside a level-3 guest is
+//!   the third `about:srcdoc` in the chain, and Safari does not load it.
+//!   Author content below level 2 must use `src=` (a `blob:`, `data:`, or
+//!   http URL), not `srcdoc`.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -52,11 +72,11 @@ pub(crate) enum GuestSource {
     /// and the guest inherits the creator's base URL. The top document and
     /// its direct guests use this source.
     Srcdoc,
-    /// A unique `data:text/html;charset=utf-8,…` URL in `src`. WebKit
-    /// refuses the third nested `about:srcdoc` frame and all deeper ones.
-    /// This URL does not have that problem. A creator that is nested below
-    /// the top document uses this source.
-    DataUrl,
+    /// A `blob:` URL in `src`. The browser mints a unique URL for each load,
+    /// so WebKit's self-reference rule never matches. WebKit refuses the
+    /// third nested `about:srcdoc` frame and all deeper ones. A creator
+    /// below the top document uses this source.
+    BlobUrl,
 }
 
 /// Create and wire up the portal iframe, then store the resulting state.
@@ -192,7 +212,7 @@ fn guest_source(host: &Element) -> GuestSource {
     if parent == top {
         GuestSource::Srcdoc
     } else {
-        GuestSource::DataUrl
+        GuestSource::BlobUrl
     }
 }
 
@@ -203,14 +223,14 @@ fn guest_source(host: &Element) -> GuestSource {
 ///
 /// The base is the portal's per-space synthetic origin when the portal has
 /// one (see [`space_base`]). When it has none, a `srcdoc` guest inherits the
-/// creator's base URL from the browser. A `data:` document does not: its
-/// base is the data URL itself. For [`GuestSource::DataUrl`] this function
-/// writes the inherited value (the creator's `document.baseURI`) explicitly.
-/// Link and request resolution are then identical for the two sources.
+/// creator's base URL from the browser. A `blob:` document does not: its URL
+/// cannot be a base. For [`GuestSource::BlobUrl`] this function writes the
+/// inherited value (the creator's `document.baseURI`) explicitly. Link and
+/// request resolution are then identical for the two sources.
 fn guest_document(host: &Element, state: &PortalState, source: GuestSource) -> String {
     let content = host.get_attribute("content").unwrap_or_default();
     let mut base = space_base(state);
-    if base.is_empty() && source == GuestSource::DataUrl {
+    if base.is_empty() && source == GuestSource::BlobUrl {
         base = creator_document(host)
             .and_then(|d| d.base_uri().ok().flatten())
             .unwrap_or_default();
@@ -234,16 +254,25 @@ fn mount_guest(iframe: &HtmlIFrameElement, html: &str, source: GuestSource) {
         GuestSource::Srcdoc => {
             let _ = iframe.set_attribute("srcdoc", html);
         }
-        GuestSource::DataUrl => {
-            let _ = iframe.set_attribute("src", &guest_data_url(html));
-        }
+        GuestSource::BlobUrl => match guest_blob_url(html) {
+            Some(url) => {
+                let _ = iframe.set_attribute("src", &url);
+                revoke_guest_url(&url);
+            }
+            // The browser could not mint a URL. Use `srcdoc` instead of
+            // nothing. That works everywhere except in deep chains on WebKit.
+            None => {
+                tonk_common::log!("tonk-portal: createObjectURL failed; falling back to srcdoc");
+                let _ = iframe.set_attribute("srcdoc", html);
+            }
+        },
     }
 }
 
 /// Reload a live `iframe` with new `html` (after a `content` change).
 ///
 /// A `srcdoc` guest reloads when we assign the attribute again, as before.
-/// A `data:` guest reloads through the frame's own `location.replace()`,
+/// A `blob:` guest reloads through the frame's own `location.replace()`,
 /// not through a new `src`. A new `src` on a live frame NAVIGATES the frame,
 /// and a frame navigation adds a joint-session-history entry (see the
 /// teardown notes in `element.rs`). `replace` changes the entry in place.
@@ -255,11 +284,23 @@ fn reload_guest(iframe: &HtmlIFrameElement, html: &str, source: GuestSource) {
         GuestSource::Srcdoc => {
             let _ = iframe.set_attribute("srcdoc", html);
         }
-        GuestSource::DataUrl => {
-            let url = guest_data_url(html);
+        GuestSource::BlobUrl => {
+            let Some(url) = guest_blob_url(html) else {
+                tonk_common::log!("tonk-portal: createObjectURL failed; falling back to srcdoc");
+                let _ = iframe.set_attribute("srcdoc", html);
+                return;
+            };
             match iframe.content_window() {
                 Some(frame_window) => {
-                    let _ = frame_window.location().replace(&url);
+                    if let Err(error) = frame_window.location().replace(&url) {
+                        // The browser refused the in-place navigation. Load
+                        // through `src`, so that the new content still shows.
+                        // This adds one history entry. The log says so.
+                        tonk_common::log!(
+                            "tonk-portal: location.replace failed ({error:?}); reloading via src"
+                        );
+                        let _ = iframe.set_attribute("src", &url);
+                    }
                 }
                 // There is no live window (the frame was never mounted). Do
                 // a first load.
@@ -267,33 +308,45 @@ fn reload_guest(iframe: &HtmlIFrameElement, html: &str, source: GuestSource) {
                     let _ = iframe.set_attribute("src", &url);
                 }
             }
+            revoke_guest_url(&url);
         }
     }
 }
 
-/// Wrap a guest document in a `data:text/html;charset=utf-8,…` URL that is
-/// unique to this load.
+/// Put a guest document into a `blob:` URL that the frame can load.
 ///
-/// The URL must be unique because WebKit's self-reference rule compares
-/// frame URLs. Two guests with byte-identical documents in one ancestor
-/// chain would have the same URL, and the rule would refuse the second one.
-/// The marker is an HTML comment at the end. The parser ignores it, and the
-/// content cannot see it. We use percent-encoding, not base64. The document
-/// then decodes to exactly the string we built. The encoding makes the
-/// document about two times larger. That is well inside what browsers
-/// accept for a frame `src` (Chromium limits URLs to 2 MB; guest documents
-/// are tens of KB).
-pub(crate) fn guest_data_url(html: &str) -> String {
-    let nonce = format!(
-        "{:08x}{:08x}",
-        (js_sys::Math::random() * 4_294_967_296.0) as u32,
-        (js_sys::Math::random() * 4_294_967_296.0) as u32,
-    );
-    let marked = format!("{html}<!--tonk-guest:{nonce}-->");
-    format!(
-        "data:text/html;charset=utf-8,{}",
-        String::from(js_sys::encode_uri_component(&marked))
-    )
+/// The browser mints a unique URL for each call. WebKit's self-reference
+/// rule compares frame URLs, so it never matches an ancestor. The blob holds
+/// the document bytes as they are: no encoding, no size limit, and a
+/// 46-character URL. Returns `None` when the browser cannot make the URL.
+///
+/// The caller must call [`revoke_guest_url`] after it has started the
+/// navigation. A `blob:` URL keeps its bytes in memory until the code
+/// revokes it.
+pub(crate) fn guest_blob_url(html: &str) -> Option<String> {
+    let parts = js_sys::Array::of1(&JsValue::from_str(html));
+    let options = web_sys::BlobPropertyBag::new();
+    options.set_type("text/html;charset=utf-8");
+    let blob = web_sys::Blob::new_with_str_sequence_and_options(&parts, &options).ok()?;
+    web_sys::Url::create_object_url_with_blob(&blob).ok()
+}
+
+/// Revoke a guest `blob:` URL directly after the navigation to it has
+/// started.
+///
+/// This is safe. The HTML "navigate" algorithm resolves a `blob:` URL when
+/// the navigation starts. The browser then keeps the bytes alive until the
+/// load completes. Chromium takes a blob token at navigation start. WebKit
+/// keeps a scheduled blob navigation alive since bug 243936 (2022). We
+/// confirmed both with a 24 MB document three frames deep: a first load
+/// through `src`, and a reload through `location.replace()`.
+///
+/// Because the code revokes at once, it holds no URL state and needs no
+/// `load` listener. The iframe's `load` event is not a usable signal. An
+/// iframe appended without `src` fires `load` for its initial blank
+/// document. A "revoke on next load" would then revoke too early.
+pub(crate) fn revoke_guest_url(url: &str) {
+    let _ = web_sys::Url::revoke_object_url(url);
 }
 
 /// The per-space synthetic origin (`https://{label}.tonk.network/`) for this
@@ -378,10 +431,19 @@ mod tests {
 
     wasm_bindgen_test_configure!(run_in_browser);
 
-    const DATA_PREFIX: &str = "data:text/html;charset=utf-8,";
+    const BLOB_PREFIX: &str = "blob:";
 
     fn document() -> Document {
         window().expect("window").document().expect("document")
+    }
+
+    /// Fetch `url` from this page and return the body as text. Returns `Err`
+    /// when the fetch fails. For a `blob:` URL that means the URL is revoked.
+    async fn fetch_text(url: &str) -> Result<String, JsValue> {
+        let response = JsFuture::from(window().expect("window").fetch_with_str(url)).await?;
+        let response: web_sys::Response = response.dyn_into()?;
+        let text = JsFuture::from(response.text()?).await?;
+        Ok(text.as_string().unwrap_or_default())
     }
 
     /// A new sealed iframe appended to the body, set up as `connect_portal`
@@ -447,33 +509,32 @@ mod tests {
     }
 
     #[dialog_common::test]
-    fn a_guest_data_url_round_trips_the_document_and_is_unique_per_load() {
+    async fn a_guest_blob_url_serves_the_document_and_is_unique_per_load() {
         let html = "<base href=\"https://x.tonk.network/\"><script>1<2</script>\
-                    <p>hi &amp; <b>\"q\"</b> 100% #frag</p>";
-        let first = guest_data_url(html);
-        let second = guest_data_url(html);
-        assert!(first.starts_with(DATA_PREFIX), "got: {first}");
+                    <p>hi &amp; <b>\"q\"</b> 100% #frag ünïcödé</p>";
+        let first = guest_blob_url(html).expect("a blob URL");
+        let second = guest_blob_url(html).expect("a blob URL");
+        assert!(first.starts_with(BLOB_PREFIX), "got: {first}");
         assert_ne!(
             first, second,
             "two loads of one document must never share a URL — WebKit's \
              self-reference rule compares ancestor URLs"
         );
-        let decoded = String::from(
-            js_sys::decode_uri_component(&first[DATA_PREFIX.len()..]).expect("decodes"),
-        );
+        let served = fetch_text(&first)
+            .await
+            .expect("the blob URL serves the document");
+        assert_eq!(served, html, "the document must arrive byte-for-byte");
+
+        revoke_guest_url(&first);
+        revoke_guest_url(&second);
         assert!(
-            decoded.starts_with(html),
-            "the document must decode byte-for-byte; got: {decoded}"
-        );
-        assert!(
-            decoded[html.len()..].starts_with("<!--tonk-guest:"),
-            "the uniqueness marker is a trailing comment; got: {}",
-            &decoded[html.len()..]
+            fetch_text(&first).await.is_err(),
+            "a revoked URL serves nothing; the bytes are free"
         );
     }
 
     #[dialog_common::test]
-    fn a_data_url_guest_writes_its_inherited_base_explicitly() {
+    fn a_blob_url_guest_writes_its_inherited_base_explicitly() {
         let host = document().create_element("tonk-portal").expect("host");
         host.set_attribute("content", "<p>hi</p>").expect("content");
         // No `with` means no space base. This is the case that depended on
@@ -486,53 +547,60 @@ mod tests {
             "a srcdoc guest inherits its base from the browser; got: {as_srcdoc}"
         );
 
-        let as_data = guest_document(&host, &state, GuestSource::DataUrl);
+        let as_blob = guest_document(&host, &state, GuestSource::BlobUrl);
         let inherited = document().base_uri().expect("baseURI").expect("set");
         assert!(
-            as_data.starts_with(&format!("<base href=\"{inherited}\">")),
-            "a data: guest must carry the creator's base URL explicitly; got: {}",
-            &as_data[..as_data.len().min(160)]
+            as_blob.starts_with(&format!("<base href=\"{inherited}\">")),
+            "a blob: guest must carry the creator's base URL explicitly; got: {}",
+            &as_blob[..as_blob.len().min(160)]
         );
-        assert!(as_data.contains("<p>hi</p>"), "content survives");
+        assert!(as_blob.contains("<p>hi</p>"), "content survives");
     }
 
-    /// The load path that WebKit needs. A sealed guest that we load as a
-    /// `data:` URL still runs the bridge bootstrap: it posts `hello` to its
+    /// The load path that WebKit needs. A sealed guest that we load from a
+    /// `blob:` URL still runs the bridge bootstrap: it posts `hello` to its
     /// parent. A reload through `location.replace()` runs the bootstrap
-    /// again.
+    /// again. The code revokes each URL as soon as the navigation has
+    /// started. Both loads still succeed. After the load, the URL serves
+    /// nothing.
     #[dialog_common::test]
-    async fn a_data_url_guest_boots_the_bridge_and_reloads_in_place() {
+    async fn a_blob_url_guest_boots_the_bridge_reloads_in_place_and_revokes_its_url() {
         let iframe = sealed_iframe();
         let first = hello_from(&iframe);
         mount_guest(
             &iframe,
             &bridge::bootstrap_srcdoc("<p>one</p>", ""),
-            GuestSource::DataUrl,
+            GuestSource::BlobUrl,
         );
         assert_eq!(
             first.await.ok().and_then(|v| v.as_bool()),
             Some(true),
-            "the data: guest must boot and greet its parent"
+            "the blob: guest must boot and greet its parent"
         );
-        assert!(
-            iframe
-                .get_attribute("src")
-                .is_some_and(|src| src.starts_with(DATA_PREFIX)),
-            "the first load is the frame's `src`"
-        );
+        let src = iframe
+            .get_attribute("src")
+            .expect("the first load is the frame's `src`");
+        assert!(src.starts_with(BLOB_PREFIX), "got: {src}");
         assert_eq!(iframe.get_attribute("srcdoc"), None);
+        assert!(
+            fetch_text(&src).await.is_err(),
+            "the URL is revoked once the navigation has started"
+        );
 
         let again = hello_from(&iframe);
         reload_guest(
             &iframe,
             &bridge::bootstrap_srcdoc("<p>two</p>", ""),
-            GuestSource::DataUrl,
+            GuestSource::BlobUrl,
         );
         assert_eq!(
             again.await.ok().and_then(|v| v.as_bool()),
             Some(true),
             "a reload must bring the guest back up"
         );
+        // `replace` keeps `src` at the first URL. The live document is the
+        // truth.
+        assert_eq!(iframe.get_attribute("src").as_deref(), Some(src.as_str()));
         iframe.remove();
     }
 }
@@ -540,14 +608,17 @@ mod tests {
 /// The WebKit case from end to end, through the production mount path. A
 /// guest created from a document that is already TWO frames below the top
 /// must still boot. Safari refuses a third `about:srcdoc` frame (see the
-/// module docs). Without the `data:` source this test times out there. With
+/// module docs). Without the `blob:` source this test times out there. With
 /// it, the test passes. Chrome loads both. The test uses only
 /// `connect_portal` on purpose. The same test then runs against the code
 /// before the fix and shows the failure.
 ///
-/// CI runs this test in headless Chrome, as it runs all tests here. To see
-/// the Safari failure and pass on your machine, enable Safari ▸ Develop ▸
-/// Allow Remote Automation, then run:
+/// CI runs this test in headless Chrome, as it runs all tests here. Chrome
+/// loads a third `about:srcdoc` frame, so the boot alone cannot catch a
+/// broken gate there. For that reason the test also asserts the mechanism:
+/// a guest created two frames deep has a `blob:` `src`. To see the Safari
+/// failure and pass on your machine, enable Safari ▸ Develop ▸ Allow Remote
+/// Automation, then run:
 ///
 /// ```text
 /// SAFARIDRIVER=/usr/bin/safaridriver \
@@ -668,6 +739,18 @@ mod nested_tests {
             .expect("guest iframe mounted")
             .unchecked_into::<HtmlIFrameElement>();
         let guest_window: JsValue = guest.content_window().expect("guest window").into();
+
+        // The mechanism. This assertion fails on every engine if the gate
+        // breaks, so CI (Chrome) catches that too.
+        assert!(
+            guest
+                .get_attribute("src")
+                .is_some_and(|src| src.starts_with("blob:")),
+            "a guest created two frames deep must load from a blob: URL, not srcdoc; \
+             got src={:?} srcdoc={:?}",
+            guest.get_attribute("src"),
+            guest.get_attribute("srcdoc").map(|s| s.len())
+        );
 
         // The bootstrap posts `hello` to its parent (the window of B) as its
         // first action. If no `hello` arrives, the frame did not load.


### PR DESCRIPTION
## Problem

WebKit does not load a frame when two of its ancestors already have the requested URL (`HTMLFrameOwnerElement::isProhibitedSelfReference`). It permits one level of self-reference, not two. Each sealed guest is `about:srcdoc`. The real chain is three deep: the shell `<tonk-site>` guest, the space chrome's nested `<tonk-site>`, and a text/html view's `<tonk-portal>`. On Safari and iOS the third frame stays blank and shows no error. Hub tab views and full-portal spots render empty, while `<tonk-view>` content is correct. WebKit fixed the rule in January 2026 ([bug 305276](https://bugs.webkit.org/show_bug.cgi?id=305276)). Safari 26.5 still has the old rule.

## Change

`rust/tonk-portal/src/shared.rs`: a guest whose creator is nested below the top document (`window.parent !== window.top`) loads from a `blob:` URL, not from `srcdoc`. The browser mints a unique URL for each load, so no two frames in one chain share a URL. The sandbox, the opaque origin, and the bridge do not change. Levels 1 and 2 keep `srcdoc`. No UA sniffing.

- A `srcdoc` guest inherits the creator's base URL. A `blob:` guest does not. The code writes the inherited value as an explicit `<base>` when the portal has no space base.
- A reload of a `blob:` guest uses `location.replace()`. That adds no history entry.
- The code revokes each `blob:` URL as soon as the navigation has started. The HTML "navigate" algorithm resolves the URL at that point. Chrome 151 and Safari 26.5 load a 24 MB document three frames deep this way.
- Why `blob:` and not `data:`: Chromium rejects a URL above 2 MB, and a `data:` URL holds the whole document in `location.href`. A portal document can be very large.

`rust/tonk-portal/src/bridge.rs`: `build_context` forwards `path`, `search`, and `hash` from the parent context, the same as `origin`. A nested host must not read its own location. That location is `about:srcdoc` or a `blob:` URL, not the page the user is on.

## Known limits

- The gate counts frames from the browser's top document, not from the tonk shell. If another page embeds tonk in an iframe, the level-2 guests also change to `blob:`. That path has no test. Expect problems if you embed tonk as an iframe.
- WebKit's rule also applies to author content. An author `<iframe srcdoc>` inside a level-3 portal is the third `about:srcdoc` in the chain. Safari does not load it. Author content below level 2 must use `src=`, not `srcdoc`.

## Tests

`shared::nested_tests::a_guest_created_two_frames_deep_still_boots` builds top → srcdoc → srcdoc and runs the production `connect_portal` from the innermost document. It passes only if the guest's bootstrap posts `hello`. It also asserts that the guest `src` starts with `blob:`. That assertion fails on every engine if the gate breaks, so CI (Chrome) catches that too.

| code | Safari 26.5 | Chrome 151 |
|---|---|---|
| `staging` | **FAIL** (8 s, no `hello`) | ok |
| this branch | ok | ok |

Three more tests cover the `blob:` path: the URL serves the document and is unique per load; a `blob:` guest writes its inherited `<base>`; a `blob:` guest boots, reloads in place, and its URL is revoked after the load. One test covers the context forwarding. The crate's 42 tests pass in headless Chrome (CI) and in Safari 26.5 (local: `SAFARIDRIVER=/usr/bin/safaridriver cargo test -p tonk-portal --target wasm32-unknown-unknown`).

## To verify after deploy

Open a full-portal spot and a hub tab in Safari and on iOS. Press a copy button inside a portal view.
