### PR TITLE
fix(cli): do not lose a completed link to deployment discovery

### DIFF
--- a/rust/tonk-cli/src/account.rs
+++ b/rust/tonk-cli/src/account.rs
@@ -179,6 +179,13 @@ pub struct LinkOutcome {
     pub account_state: AccountStateStatus,
     /// Diagnostic when the persisted link remains unhydrated.
     pub warning: Option<String>,
+    /// Account service this device attached to.
+    ///
+    /// The page's own deployment when it named one, and only otherwise the
+    /// flag — the same precedence the attachment itself was recorded under,
+    /// so a caller matching endpoints against a provider matches the one
+    /// this device actually uses.
+    pub service_url: String,
 }
 
 async fn decode_provider(
@@ -572,6 +579,7 @@ async fn link_via_callback(
         device_did: profile.did().to_string(),
         account_state,
         warning,
+        service_url: provider_url,
     })
 }
 

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -1431,6 +1431,12 @@ async fn print_customer_line(
 /// Refuses while another account is still signed in: one account at a time is
 /// the whole model, and silently swapping would leave the spaces of the
 /// account being replaced looking broken rather than simply not-yours.
+///
+/// The registry row is written whether or not the deployment answers with
+/// its content endpoints. By the time they are asked for, the grant is
+/// installed and the session active, so refusing to record the account
+/// would leave `status` and the registry disagreeing about whether this
+/// device is signed in.
 async fn link_account(
     store: &tonk_cli::spot::SpotStore,
     name: Option<String>,
@@ -1475,14 +1481,12 @@ async fn link_account(
     .await
     {
         Ok(outcome) => {
-            let defaults = match tonk_cli::deployment::discover(&ceremony_page, &service_url).await
-            {
-                Ok(defaults) => defaults,
-                Err(error) => return print_failure(error),
-            };
-            let mut record = tonk_cli::spot::AccountRecord::new(&outcome.root_did);
-            record.ceremony_origin = Some(defaults.ceremony_origin.to_string());
-            record.access_remote = Some(defaults.access_remote.to_string());
+            let discovery = tonk_cli::deployment::discover(&ceremony_page, &service_url).await;
+            let record = tonk_cli::deployment::account_record(
+                &outcome.root_did,
+                &ceremony_page,
+                discovery.as_ref().ok(),
+            );
             if let Err(error) = store.set_account(Some(record)) {
                 return print_failure(error);
             }
@@ -1494,6 +1498,17 @@ async fn link_account(
             );
             if let Some(warning) = outcome.warning {
                 eprintln!("warning: account repository is not synchronized: {warning}");
+            }
+            // The device is signed in either way. Say what is missing and
+            // what restores it, rather than reporting a failure for a link
+            // the account service has already granted.
+            if let Err(error) = discovery {
+                eprintln!(
+                    "warning: {ceremony_page} did not answer with its content endpoints: {error:#}"
+                );
+                eprintln!(
+                    "spaces stay local-only until `tonk account logout` and `tonk account link` reach it"
+                );
             }
             print_customer_line(&profile, store).await;
             ExitCode::Success

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -1481,7 +1481,12 @@ async fn link_account(
     .await
     {
         Ok(outcome) => {
-            let discovery = tonk_cli::deployment::discover(&ceremony_page, &service_url).await;
+            // Matched against the provider the page delivered rather than
+            // the flag: the ceremony records whichever service its own
+            // deployment named, while the flag's default says production
+            // wherever it ran.
+            let discovery =
+                tonk_cli::deployment::discover(&ceremony_page, &outcome.service_url).await;
             let record = tonk_cli::deployment::account_record(
                 &outcome.root_did,
                 &ceremony_page,

--- a/rust/tonk-cli/src/deployment.rs
+++ b/rust/tonk-cli/src/deployment.rs
@@ -66,6 +66,38 @@ pub async fn discover(
     })
 }
 
+/// The registry record for a freshly linked account.
+///
+/// Discovery enriches this record; it does not gate it. The link is already
+/// complete by the time discovery runs — the grant is installed, the
+/// provider attachment persisted, the session active — so a deployment that
+/// cannot be reached leaves the endpoints unset rather than costing the
+/// account its only registry row. Every reader of those endpoints already
+/// answers "sign in again" when they are missing, which is a state the
+/// device can act on; a missing record is one where `status` and the
+/// registry disagree about whether this device is signed in at all.
+pub fn account_record(
+    root_did: &str,
+    ceremony_page: &str,
+    defaults: Option<&DeploymentDefaults>,
+) -> crate::spot::AccountRecord {
+    let mut record = crate::spot::AccountRecord::new(root_did);
+    match defaults {
+        Some(defaults) => {
+            record.ceremony_origin = Some(defaults.ceremony_origin.to_string());
+            record.access_remote = Some(defaults.access_remote.to_string());
+        }
+        // The origin is the one part discovery never needed the network
+        // for, and it is what a later sign-in reads to know where to ask.
+        None => {
+            record.ceremony_origin = ceremony_origin(ceremony_page)
+                .ok()
+                .map(|origin| origin.to_string());
+        }
+    }
+    record
+}
+
 /// Validate a ceremony URL and return only its origin for safe persistence.
 pub fn ceremony_origin(account_url: &str) -> Result<Url> {
     let ceremony = validated_http_url(account_url, "account ceremony URL")?;
@@ -162,6 +194,50 @@ mod tests {
                 .expect_err("unsafe URL must be rejected");
             assert!(!error.to_string().is_empty());
         }
+    }
+
+    #[dialog_common::test]
+    async fn it_records_every_endpoint_the_deployment_advertised() -> Result<()> {
+        let (origin, server) = deployment_server("/accounts/").await?;
+        let page = format!("{origin}/account/link?intent=login");
+        let defaults = discover(&page, &format!("{origin}/accounts")).await?;
+        let record = account_record("did:key:zRoot", &page, Some(&defaults));
+        assert_eq!(record.root, "did:key:zRoot");
+        assert_eq!(
+            record.ceremony_origin.as_deref(),
+            Some(&*format!("{origin}/"))
+        );
+        assert_eq!(
+            record.access_remote.as_deref(),
+            Some(&*format!("{origin}/ucan/"))
+        );
+        server.abort();
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_records_the_ceremony_origin_when_discovery_fails() -> Result<()> {
+        let record = account_record(
+            "did:key:zRoot",
+            "https://deployment.example/account/link?intent=login",
+            None,
+        );
+        assert_eq!(record.root, "did:key:zRoot");
+        assert_eq!(
+            record.ceremony_origin.as_deref(),
+            Some("https://deployment.example/")
+        );
+        assert_eq!(record.access_remote, None);
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_records_the_root_alone_when_the_ceremony_url_is_unusable() -> Result<()> {
+        let record = account_record("did:key:zRoot", "not-a-url", None);
+        assert_eq!(record.root, "did:key:zRoot");
+        assert_eq!(record.ceremony_origin, None);
+        assert_eq!(record.access_remote, None);
+        Ok(())
     }
 
     #[tokio::test]

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -1317,7 +1317,6 @@ mod tests {
         let origin = url::Url::parse(&format!("{}/", env.tonk_web.origin().ascii_serialization()))?;
         assert_eq!(endpoint("ceremonyOrigin")?, origin);
         assert_eq!(endpoint("accessRemote")?, origin.join("/ucan/")?);
-        endpoint("revocationRelay")?;
 
         driver.quit().await?;
         Ok(())

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -446,6 +446,17 @@ mod tests {
         link: CliOutput,
     }
 
+    /// Where the CLI learns which account service the link belongs to.
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum AccountService {
+        /// Named on the command line, as staging and local development do.
+        Named,
+        /// Left to the ceremony page. The hidden flag then keeps its
+        /// production default, so anything matched against it instead of
+        /// against what the page delivered names the wrong deployment.
+        FromThePage,
+    }
+
     async fn link_cli(driver: &WebDriver, env: &TestEnvironment) -> Result<LinkedCli> {
         link_cli_with(driver, env, false).await
     }
@@ -455,20 +466,30 @@ mod tests {
         env: &TestEnvironment,
         register_first: bool,
     ) -> Result<LinkedCli> {
+        link_cli_using(driver, env, register_first, AccountService::Named).await
+    }
+
+    async fn link_cli_using(
+        driver: &WebDriver,
+        env: &TestEnvironment,
+        register_first: bool,
+        service: AccountService,
+    ) -> Result<LinkedCli> {
         let profile = tempfile::tempdir()?;
         let mut command = tonk_command_in(env, &profile);
+        command.args([
+            "account",
+            "link",
+            "--name",
+            "e2e terminal",
+            "--no-open",
+            "--via",
+            env.tonk_web.join("account/link")?.as_str(),
+        ]);
+        if service == AccountService::Named {
+            command.args(["--service-url", env.account_service.as_str()]);
+        }
         command
-            .args([
-                "account",
-                "link",
-                "--name",
-                "e2e terminal",
-                "--no-open",
-                "--service-url",
-                env.account_service.as_str(),
-                "--via",
-                env.tonk_web.join("account/link")?.as_str(),
-            ])
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
@@ -1245,6 +1266,58 @@ mod tests {
             "the link reports the registration the signup performed: {}",
             linked.link.stdout
         );
+
+        driver.quit().await?;
+        Ok(())
+    }
+
+    /// Linking without naming the account service records the deployment
+    /// the ceremony actually ran on.
+    ///
+    /// The page delivers its own service URL and the CLI attaches to that,
+    /// so the endpoints it discovers must be matched against the same
+    /// value. Matched against the flag instead, every ceremony outside
+    /// production disagrees with its own deployment, because the flag is
+    /// hidden and defaults to production.
+    #[dialog_common::test]
+    async fn it_links_without_being_told_the_account_service(env: TestEnvironment) -> Result<()> {
+        let driver = driver_with_prf(&env).await?;
+        sign_up(&driver, &env, EMAIL).await?;
+        let linked = link_cli_using(&driver, &env, false, AccountService::FromThePage).await?;
+
+        let status = run_cli(
+            &env,
+            &linked.profile,
+            &["account".to_string(), "status".to_string()],
+        )
+        .await?;
+        let provider = status
+            .stdout
+            .lines()
+            .find_map(|line| line.strip_prefix("account service: "))
+            .context("status output omitted the account service")?;
+        assert_eq!(url::Url::parse(provider)?, env.account_service);
+
+        // The endpoints are what `space new` and `space link` need; the
+        // registry is where they are read from, and status does not print
+        // them.
+        let registry: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(
+            linked.profile.path().join("spots").join("spots.json"),
+        )?)?;
+        let account = registry
+            .get("account")
+            .context("the registry recorded no account")?;
+        let endpoint = |field: &str| -> Result<url::Url> {
+            let value = account
+                .get(field)
+                .and_then(serde_json::Value::as_str)
+                .with_context(|| format!("the account record omitted {field}"))?;
+            Ok(url::Url::parse(value)?)
+        };
+        let origin = url::Url::parse(&format!("{}/", env.tonk_web.origin().ascii_serialization()))?;
+        assert_eq!(endpoint("ceremonyOrigin")?, origin);
+        assert_eq!(endpoint("accessRemote")?, origin.join("/ucan/")?);
+        endpoint("revocationRelay")?;
 
         driver.quit().await?;
         Ok(())


### PR DESCRIPTION
Stacked on #739, which is stacked on #738.

`tonk account link` asked the ceremony's deployment for its content endpoints and treated a failed answer as a failed link. By the time discovery runs the link is already complete — grant installed, provider attachment persisted, session active, account repository synced — so the abort skipped only the last write, `store.set_account`, and left the three stores disagreeing:

| Command | Reads | Said |
|---|---|---|
| `tonk account status` | profile credentials | `signed in: yes` |
| `tonk account link` (retry) | session sidecar | "an account is already active; run `tonk account logout`" |
| `tonk account spaces` | `spots.json` | "no account is signed in; run `tonk account link`" |

`tonk space new` reads the registry too, so it quietly made a **local-only** space on a device that was signed in — the surprise its own guard exists to prevent, which could not fire because the record was missing rather than stale.

## What changed

**Discovery enriches the record; it no longer gates it.** The row is written either way, carrying the ceremony origin (the one part needing no network) plus the endpoints when the deployment answered. Every reader of those endpoints already answers "sign in again" when they are missing — a state the device can act on. The failure is reported as a warning naming the deployment, with the full error chain rather than the top context alone.

**Endpoints are matched against the service the page named.** The page delivers the account service its own deployment uses, and `link` deliberately prefers that over `--service-url`, whose default names production wherever the ceremony ran. Discovery matched against the flag anyway, so linking through a staging or local page without the hidden flag failed every time, after the grant was installed. `LinkOutcome` now carries the service the attachment was recorded under. The check still catches a page whose delivered service disagrees with its own deployment config.

## Tests

- Three unit tests over the new record builder: endpoints recorded when discovery answered, ceremony origin alone when it did not, root alone when the ceremony URL is unusable.
- One browser e2e case linking with no `--service-url`, asserting the recorded endpoints belong to the harness deployment rather than production. It fails without the second commit. Every other test still names the service, so both paths stay covered.
- `cargo clippy --workspace --all-targets --all-features` and `cargo fmt --all --check` clean.

## Not done here

When the endpoints are missing, the advice is `tonk account logout` then `tonk account link`, because a second `link` on a signed-in device is refused. Teaching that refusal to complete the discovery instead — repairing the record without a fresh ceremony — would remove the logout, and is a larger behavior change than this fix needs.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `tonk-cli` and related modules by introducing a `service_url` field to account records, refining how account services are linked, and ensuring that deployments are accurately recorded. It also improves error handling and adds tests for these functionalities.

### Detailed summary
- Added `service_url` field in `AccountRecord` in `rust/tonk-cli/src/account.rs`.
- Updated `link_account` function to use `service_url` for discovery.
- Improved error messages related to account linking.
- Added tests for account record creation and linking behavior in `rust/tonk-cli/src/deployment.rs` and `rust/tonk-ui/src/account_flow.rs`.
- Introduced `AccountService` enum to differentiate between named and page-derived services.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->