### PR TITLE
fix: joining a spot twice no longer breaks its sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,7 +986,7 @@ dependencies = [
 [[package]]
 name = "dialog-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-08-23#c0506b41f38cac2338f9e2eb9a3686ec4c7e10e2"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=4eefa898c942ae4d12310de9225e6371ca816253#4eefa898c942ae4d12310de9225e6371ca816253"
 dependencies = [
  "arrayref",
  "async-stream",
@@ -1025,7 +1025,7 @@ dependencies = [
 [[package]]
 name = "dialog-capability"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-08-23#c0506b41f38cac2338f9e2eb9a3686ec4c7e10e2"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=4eefa898c942ae4d12310de9225e6371ca816253#4eefa898c942ae4d12310de9225e6371ca816253"
 dependencies = [
  "async-trait",
  "base58",
@@ -1048,7 +1048,7 @@ dependencies = [
 [[package]]
 name = "dialog-common"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-08-23#c0506b41f38cac2338f9e2eb9a3686ec4c7e10e2"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=4eefa898c942ae4d12310de9225e6371ca816253#4eefa898c942ae4d12310de9225e6371ca816253"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1076,7 +1076,7 @@ dependencies = [
 [[package]]
 name = "dialog-credentials"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-08-23#c0506b41f38cac2338f9e2eb9a3686ec4c7e10e2"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=4eefa898c942ae4d12310de9225e6371ca816253#4eefa898c942ae4d12310de9225e6371ca816253"
 dependencies = [
  "async-trait",
  "base58",
@@ -1097,7 +1097,7 @@ dependencies = [
 [[package]]
 name = "dialog-csv"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-08-23#c0506b41f38cac2338f9e2eb9a3686ec4c7e10e2"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=4eefa898c942ae4d12310de9225e6371ca816253#4eefa898c942ae4d12310de9225e6371ca816253"
 dependencies = [
  "async-trait",
  "base58",
@@ -1112,7 +1112,7 @@ dependencies = [
 [[package]]
 name = "dialog-did-web"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-08-23#c0506b41f38cac2338f9e2eb9a3686ec4c7e10e2"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=4eefa898c942ae4d12310de9225e6371ca816253#4eefa898c942ae4d12310de9225e6371ca816253"
 dependencies = [
  "async-trait",
  "base58",
@@ -1135,7 +1135,7 @@ dependencies = [
 [[package]]
 name = "dialog-effects"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-08-23#c0506b41f38cac2338f9e2eb9a3686ec4c7e10e2"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=4eefa898c942ae4d12310de9225e6371ca816253#4eefa898c942ae4d12310de9225e6371ca816253"
 dependencies = [
  "async-trait",
  "base58",
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "dialog-identity"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-08-23#c0506b41f38cac2338f9e2eb9a3686ec4c7e10e2"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=4eefa898c942ae4d12310de9225e6371ca816253#4eefa898c942ae4d12310de9225e6371ca816253"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1167,7 +1167,7 @@ dependencies = [
 [[package]]
 name = "dialog-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-08-23#c0506b41f38cac2338f9e2eb9a3686ec4c7e10e2"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=4eefa898c942ae4d12310de9225e6371ca816253#4eefa898c942ae4d12310de9225e6371ca816253"
 dependencies = [
  "blake3",
  "convert_case",
@@ -1179,7 +1179,7 @@ dependencies = [
 [[package]]
 name = "dialog-network"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-08-23#c0506b41f38cac2338f9e2eb9a3686ec4c7e10e2"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=4eefa898c942ae4d12310de9225e6371ca816253#4eefa898c942ae4d12310de9225e6371ca816253"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1194,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "dialog-operator"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-08-23#c0506b41f38cac2338f9e2eb9a3686ec4c7e10e2"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=4eefa898c942ae4d12310de9225e6371ca816253#4eefa898c942ae4d12310de9225e6371ca816253"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1232,7 +1232,7 @@ dependencies = [
 [[package]]
 name = "dialog-query"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-08-23#c0506b41f38cac2338f9e2eb9a3686ec4c7e10e2"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=4eefa898c942ae4d12310de9225e6371ca816253#4eefa898c942ae4d12310de9225e6371ca816253"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1292,7 +1292,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-fs"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-08-23#c0506b41f38cac2338f9e2eb9a3686ec4c7e10e2"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=4eefa898c942ae4d12310de9225e6371ca816253#4eefa898c942ae4d12310de9225e6371ca816253"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1309,7 +1309,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-08-23#c0506b41f38cac2338f9e2eb9a3686ec4c7e10e2"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=4eefa898c942ae4d12310de9225e6371ca816253#4eefa898c942ae4d12310de9225e6371ca816253"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1348,7 +1348,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-ucan-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-08-23#c0506b41f38cac2338f9e2eb9a3686ec4c7e10e2"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=4eefa898c942ae4d12310de9225e6371ca816253#4eefa898c942ae4d12310de9225e6371ca816253"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1385,7 +1385,7 @@ dependencies = [
 [[package]]
 name = "dialog-repository"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-08-23#c0506b41f38cac2338f9e2eb9a3686ec4c7e10e2"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=4eefa898c942ae4d12310de9225e6371ca816253#4eefa898c942ae4d12310de9225e6371ca816253"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1424,7 +1424,7 @@ dependencies = [
 [[package]]
 name = "dialog-search-tree"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-08-23#c0506b41f38cac2338f9e2eb9a3686ec4c7e10e2"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=4eefa898c942ae4d12310de9225e6371ca816253#4eefa898c942ae4d12310de9225e6371ca816253"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1454,7 +1454,7 @@ dependencies = [
 [[package]]
 name = "dialog-storage"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-08-23#c0506b41f38cac2338f9e2eb9a3686ec4c7e10e2"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=4eefa898c942ae4d12310de9225e6371ca816253#4eefa898c942ae4d12310de9225e6371ca816253"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1501,7 +1501,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-08-23#c0506b41f38cac2338f9e2eb9a3686ec4c7e10e2"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=4eefa898c942ae4d12310de9225e6371ca816253#4eefa898c942ae4d12310de9225e6371ca816253"
 dependencies = [
  "async-trait",
  "base58",
@@ -1522,7 +1522,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan-core"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-08-23#c0506b41f38cac2338f9e2eb9a3686ec4c7e10e2"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=4eefa898c942ae4d12310de9225e6371ca816253#4eefa898c942ae4d12310de9225e6371ca816253"
 dependencies = [
  "dialog-varsig",
  "futures",
@@ -1548,7 +1548,7 @@ dependencies = [
 [[package]]
 name = "dialog-varsig"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-08-23#c0506b41f38cac2338f9e2eb9a3686ec4c7e10e2"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=4eefa898c942ae4d12310de9225e6371ca816253#4eefa898c942ae4d12310de9225e6371ca816253"
 dependencies = [
  "dialog-common",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,22 +186,22 @@ wasm-bindgen-test = "0.3"
 web-sys = { version = "0.3" }
 
 # Dialog DB
-dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-08-23" }
-dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-08-23" }
-dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-08-23" }
-dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-08-23" }
-dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-08-23" }
-dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-08-23" }
-dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-08-23" }
-dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-08-23" }
-dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-08-23" }
-dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-08-23" }
-dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-08-23" }
-dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-08-23" }
-dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-08-23" }
-dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-08-23" }
-dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-08-23" }
-dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-08-23" }
+dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", rev = "4eefa898c942ae4d12310de9225e6371ca816253" }
+dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", rev = "4eefa898c942ae4d12310de9225e6371ca816253" }
+dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", rev = "4eefa898c942ae4d12310de9225e6371ca816253" }
+dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", rev = "4eefa898c942ae4d12310de9225e6371ca816253" }
+dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", rev = "4eefa898c942ae4d12310de9225e6371ca816253" }
+dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", rev = "4eefa898c942ae4d12310de9225e6371ca816253" }
+dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", rev = "4eefa898c942ae4d12310de9225e6371ca816253" }
+dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", rev = "4eefa898c942ae4d12310de9225e6371ca816253" }
+dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", rev = "4eefa898c942ae4d12310de9225e6371ca816253" }
+dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", rev = "4eefa898c942ae4d12310de9225e6371ca816253" }
+dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", rev = "4eefa898c942ae4d12310de9225e6371ca816253" }
+dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", rev = "4eefa898c942ae4d12310de9225e6371ca816253" }
+dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", rev = "4eefa898c942ae4d12310de9225e6371ca816253" }
+dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", rev = "4eefa898c942ae4d12310de9225e6371ca816253" }
+dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", rev = "4eefa898c942ae4d12310de9225e6371ca816253" }
+dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", rev = "4eefa898c942ae4d12310de9225e6371ca816253" }
 
 [profile.dev]
 opt-level = 1

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -1311,6 +1311,43 @@ async fn prepare_join(
     let remote_url = invite.remote_url.as_ref().map(url::Url::to_string);
     let revocation_url = invite.revocation_url.as_ref().map(url::Url::to_string);
 
+    let existing = find_replica_for_subject(tonk, &subject)
+        .await
+        .map_err(|error| {
+            JoinFailure::claim_failed(format!("failed to look up the local replica: {error}"))
+        })?;
+    let guest = guest_url(tonk, &subject)
+        .await
+        .map_err(|error| {
+            JoinFailure::claim_failed(format!("failed to read the guest record: {error}"))
+        })?
+        .is_some();
+
+    // A spot this profile already holds durably is never re-entered as a
+    // guest, however the invite arrives. A visit mints its authority
+    // bounded to [`VISIT_TTL_SECONDS`] and files it under the same
+    // audience the durable route already resolves to; the proof walk
+    // chooses between the two without consulting the clock (see
+    // [`crate::session`]), so once the visit's hour is up, every walk
+    // that picks the bounded one presents a lapsed chain and the remote
+    // refuses it. Re-opening a link the recipient has already redeemed
+    // is a renewal, which is what [`JoinResponse::Renewed`] has always
+    // described.
+    //
+    // Conditioned on an account, because that is what a durable claim
+    // terminates at: a profile without one has nowhere to root a
+    // membership, and refusing its visit outright would be a worse
+    // answer than the bounded access it asked for.
+    let mode = if mode == JoinMode::GuestVisit
+        && existing
+        && !guest
+        && crate::router::account::require_account(tonk).await.is_ok()
+    {
+        JoinMode::Durable
+    } else {
+        mode
+    };
+
     // Audience: an open invite redelegates to whoever redeems it; a
     // targeted one only ever redeems for the DID it names.
     let (member, chain) = match mode {
@@ -1354,18 +1391,6 @@ async fn prepare_join(
             (Some(member), Some(claimed.chain))
         }
     };
-
-    let existing = find_replica_for_subject(tonk, &subject)
-        .await
-        .map_err(|error| {
-            JoinFailure::claim_failed(format!("failed to look up the local replica: {error}"))
-        })?;
-    let guest = guest_url(tonk, &subject)
-        .await
-        .map_err(|error| {
-            JoinFailure::claim_failed(format!("failed to read the guest record: {error}"))
-        })?
-        .is_some();
 
     Ok(PreparedJoin {
         mode,
@@ -3872,6 +3897,57 @@ mod tests {
             Some(tonk_schema::Replica::INITIALIZED),
             "the visibility commit stamps initialized, never blank",
         );
+    }
+
+    /// Re-opening an invite link for a spot this profile already holds
+    /// durably must not re-route the authority its sync presigns with.
+    ///
+    /// The `/join` route runs every open invite as a guest visit, and a
+    /// guest visit installs an `invite -> operator` grant bounded to
+    /// [`VISIT_TTL_SECONDS`](tonk_invite::VISIT_TTL_SECONDS) under the
+    /// same audience the durable route already resolves to. The
+    /// certificate walk never consults the clock (see
+    /// [`crate::session`]), so from then on it picks between a live
+    /// 12-hour route and one that lapses in an hour — and once that hour
+    /// is up, the pulls that pick the lapsed one fail with
+    /// `Authorization(Expired)`.
+    #[dialog_common::test]
+    async fn it_keeps_a_durable_members_authority_when_the_invite_is_reopened() {
+        let (app, state, _lsp) = api_router_with_state(test_state().await);
+        let (url, key) = handcrafted_invite_url(90, 91).await;
+        let subject: dialog_varsig::Did = key.parse().unwrap();
+
+        assert_eq!(post_join(&app, &url).await, StatusCode::CREATED);
+        let durable = proof_window(&state, &subject).await;
+
+        assert_eq!(post_visit(&app, &url).await, StatusCode::OK);
+
+        assert_eq!(
+            proof_window(&state, &subject).await,
+            durable,
+            "re-opening the invite bounded the durable member's own authority",
+        );
+        assert!(
+            !snapshot(&state, &key).await.guest,
+            "re-opening the invite demoted a durable member to a guest",
+        );
+    }
+
+    /// When the presign path's proof for `subject` lapses, if ever.
+    async fn proof_window(
+        state: &crate::router::AppState,
+        subject: &dialog_varsig::Did,
+    ) -> Option<u64> {
+        let tonk = state.read().await;
+        tonk.profile
+            .access()
+            .prove(dialog_capability::Subject::from(subject.clone()))
+            .audience(&tonk.operator)
+            .perform(&tonk.operator)
+            .await
+            .expect("the durable member stays authorized")
+            .duration
+            .expiration
     }
 
     /// The second attempt at the same invite renews rather than


### PR DESCRIPTION
Reported: clicking a join link for a spot you had already joined broke
that spot's sync, about an hour later, with

```
Pull failed: main@did:key:z6Mkn…:
  Pull(FetchRemoteBranch(Resolve(Authorization(Expired { expiration: 1787490822, at: 1787496714 }))))
background sync of did:key:z6Mkn…/main failed: Upstream service returned HTTP 502
```

## What happens

`run_join` maps every open invite to a guest visit, whatever membership
the profile already holds. On a spot you joined durably, that installs a
second route to the same subject: the visit mints authority bounded to
`VISIT_TTL_SECONDS` (one hour) and files it under the same audience —
the current operator — that the durable route already resolves to. It
also writes a guest record, so `GET /membership` starts reporting a
durable member as a `guest`.

The proof walk never consults the clock. It filters candidates by
whether their window covers the *requested* one, and the presign path
requests nothing — an unbounded requirement that every window satisfies,
including one that closed an hour ago (this is what
`rust/tonk-worker/src/session.rs` already documents as the reason
session renewal rotates the operator key instead of re-minting under the
same audience). Candidate order follows content hashes, so the walk
picks between the live 12-hour route and the one-hour route
arbitrarily, and once that hour is up, every pick of the bounded one
presents a lapsed chain. The responder checks the clock, refuses it, and the
client re-raises the refusal verbatim — the `at` in the report is the
*server's* clock. (Since #748 that check lives in dialog's authorizer,
`dialog-remote-ucan-s3/src/authorizer.rs`, which maps
`TimeBoundError::Expired` to the same `AuthorizeError::Expired`; tonk's
own `expiry.rs` screen was deleted as redundant.)

It does not reliably heal: rotation only fires for a still-renewable
guest lease inside its five-minute margin, and a promotion calls
`clear_guest`, deleting the lease that would have driven rotation while
the lapsed certificate stays in a store that has no delete.

## The fix

**Here.** `prepare_join` resolves the replica and guest state before
choosing a mode, and an open invite for a subject this profile already
holds durably runs as a durable renewal — the `Renewed` outcome the API
already described — instead of a guest visit. A profile with no account
still gets its bounded visit, since a durable claim has nowhere to root
without one. This also stops the guest demotion.

**In dialog-db** (dialog-db/dialog-db#462, pinned by rev off
`tonk-2026-08-23` — the tag staging moved to in #748): the presign path asks for authority good at the
instant it presents, and a memoized chain is retired once it has lapsed.
That half matters for profiles already carrying a lapsed certificate —
they cannot delete it, so without this it stays selectable until the
operator rotates. With it, they heal on upgrade.

## Tests

`it_keeps_a_durable_members_authority_when_the_invite_is_reopened`
(`rust/tonk-worker/src/router/join.rs`) durably joins, re-posts the same
invite, and asserts neither the resolved proof window nor durable
membership moved. Before the fix it recorded

```
durable=Some(now+43199)    # 12h, the session bound
after_visit=Some(now+3600) # 1h, the visit TTL
guest=true
```

and failed 6 runs out of 8 — the coin flip is real. It passes 4/4 now.
dialog-db#462 carries three tests of its own, each confirmed to fail
without its change.

Green: tonk worker wasm 289/289 against the final pin, tonk native
workspace (113 suites), the dialog operator / remote-ucan-s3 / ucan /
capability / repository suites, `cargo fmt --check` and clippy on the
touched crates.

Two run notes, for honesty rather than concern:

- `tonk-cli`'s `it_removes_the_source_when_moving` (a tempdir migration
  test, no proof resolution) failed once under full-workspace
  parallelism and passed standalone and on two clean full-suite reruns.
- The e2e `it_backs_up_a_claimed_spot_for_another_account_device` fails
  at its last step on this machine: a spawned CLI child cannot reach
  `https://tonk.network:PORT/ucan/` through Caddy's locally-issued cert
  — a transport error before any UCAN is evaluated, not verified against
  a baseline run. Everything before it passed live against the access
  service (create, push, mint invite, guest visit, promotion), and a
  browser-only e2e passes.

## Not covered

Callers that mint a delegation without bounds — invite minting in
particular — still resolve unbounded and can select a lapsed chain,
producing an invite that is dead on arrival. Closing that means either
bounding those call sites too or making an unbounded request mean "valid
now" at the walk, which is a larger semantic change to dialog.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the dependency references in `Cargo.toml` from using tags to specific commit hashes (revisions) for various `dialog-db` components. It also modifies the logic in `tonk-worker/src/router/join.rs` to handle guest visits and durable memberships more effectively.

### Detailed summary
- Changed dependency references in `Cargo.toml` from `tag` to `rev` for multiple `dialog-db` components.
- Enhanced logic in `prepare_join` function to determine membership mode based on existing replicas and guest status.
- Added a new test function to verify durable membership authority when an invite link is reopened.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->
