### PR TITLE
feat(worker): profile roster as facts; one member-name projection

### DIFF
--- a/plan/roster-as-facts.md
+++ b/plan/roster-as-facts.md
@@ -78,3 +78,27 @@ sealed secrets, and branches of one repository share blocks, so sharing
 any branch of it with a space is sharing block reachability with that
 space. If a readable card is wanted, it should be its own small
 repository, not a branch of the account's.
+
+## Status (2026-08-24)
+
+Shipped on `feat/roster-as-facts`:
+
+- The profile roster is facts: `RosterProfile` (storage name, label) with
+  `RosterAccount` and `RosterEmail` stamps, on a `roster` branch of the
+  registry profile's repository that has no upstream. Signing out retracts
+  the stamps and keeps the entry. `last_active_at` is gone.
+- The active-profile pointer stays a credential, deliberately. Boot reads
+  it before any operator exists, and a fact needs an operator to read; a
+  pointer in a DB you need an operator to open is the same problem the
+  pointer already solved one level down. It is single-writer per device,
+  so the merge argument does not apply to it.
+- The rename projects `MemberName` to every reachable space at the moment
+  it happens and queues each for sync; the sweep runs the same idempotent
+  projection as catch-up. The convergence report and its retry
+  bookkeeping are gone; a space the projection cannot reach is logged and
+  left for the next sweep.
+
+Not yet: the switcher as a subscription (the sealed UI has no path to
+the registry db; it still fetches `/api/profiles`), the per-space name
+override policy (representable, no UI asks for it), and email as an
+account-space fact (waits on the summary proxy retiring).

--- a/rust/tonk-schema/src/domain.rs
+++ b/rust/tonk-schema/src/domain.rs
@@ -641,6 +641,40 @@ pub mod profile {
     pub struct DisplayName(pub String);
 }
 
+/// Attributes on the device-local roster of profiles this browser knows,
+/// kept in the registry profile's repository on a branch that never syncs.
+/// One entity per profile storage name; the account, provider, and email
+/// stamps are absent for a local workspace.
+pub mod roster {
+    use super::{Attribute, Entity};
+
+    /// The storage name the profile opens under: the activation handle.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.roster")]
+    pub struct Name(pub String);
+
+    /// The display label as of the last refresh: the profile's display
+    /// name, cached so a closed profile can be rendered without opening it.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.roster")]
+    pub struct Label(pub String);
+
+    /// The account root the profile is attached to.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.roster")]
+    pub struct Account(pub Entity);
+
+    /// The attached provider base URL.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.roster")]
+    pub struct Provider(pub String);
+
+    /// The account email, captured best-effort at link time.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.roster")]
+    pub struct Email(pub String);
+}
+
 /// Root-owned account state replicated through the hidden account repository.
 pub mod account {
     use super::Attribute;

--- a/rust/tonk-schema/src/lib.rs
+++ b/rust/tonk-schema/src/lib.rs
@@ -107,5 +107,8 @@ pub use site::{Route, Site};
 mod identity;
 pub use identity::{ProfileIdentity, ProfileName};
 
+mod roster;
+pub use roster::{RosterAccount, RosterEmail, RosterProfile};
+
 mod petname;
 pub use petname::petname;

--- a/rust/tonk-schema/src/roster.rs
+++ b/rust/tonk-schema/src/roster.rs
@@ -1,0 +1,155 @@
+//! The device-local roster of profiles this browser knows: one entity per
+//! profile storage name, with the attachment and email as stamps.
+//!
+//! The switcher has to describe profiles it has not opened, and opening
+//! each one just to render a row would cost key-material load per profile
+//! per render. So each entry caches what a row needs and nothing more: the
+//! storage name to activate, a display label, and the attachment that
+//! decides between "Signed in" and "Local workspace". Identity fields keep
+//! their one home in the account space; the label is a cache of it,
+//! refreshed at the moments the worker already has the facts in hand.
+//!
+//! Facts rather than one serialized blob so concurrent writers merge per
+//! entity instead of racing a whole-roster read-modify-write.
+
+// The `#[derive(Concept)]` macro generates helper types without doc
+// comments; suppress `missing_docs` like the sibling concept modules.
+#![allow(missing_docs)]
+
+use dialog_artifacts::Entity;
+use dialog_query::Concept;
+use dialog_varsig::Did;
+use serde::Serialize;
+
+use crate::domain::roster::{Account, Email, Label, Name, Provider};
+use crate::prelude::*;
+
+/// One profile this browser knows, keyed by its storage name.
+///
+/// The entity is content-derived from the storage name, so a refresh
+/// from any moment (boot, link, rename, switch) converges on the same
+/// entity. `label` is cardinality-one: the latest refresh wins.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RosterProfile {
+    /// The entry's entity. Derived from `name`.
+    pub this: Entity,
+    /// Storage name the profile opens under.
+    pub name: Name,
+    /// Display label as of the last refresh.
+    pub label: Label,
+}
+
+/// Hash input for [`RosterProfile::this`]. Single-variant enum tags the
+/// CBOR encoding with the concept name so equal field data under a
+/// different concept hashes differently.
+#[derive(Debug, Clone, Serialize)]
+enum This<'a> {
+    RosterProfile { name: &'a str },
+}
+
+impl RosterProfile {
+    /// The entry for the profile stored under `name`, labelled `label`.
+    pub fn new(name: String, label: String) -> Self {
+        Self {
+            this: Self::entity(&name),
+            name: Name(name),
+            label: Label(label),
+        }
+    }
+
+    /// The entity of the entry for the profile stored under `name`.
+    pub fn entity(name: &str) -> Entity {
+        Entity::of(&This::RosterProfile { name })
+    }
+
+    /// The entry's entity.
+    pub fn this(&self) -> &Entity {
+        &self.this
+    }
+}
+
+/// The account a roster profile is attached to, stamped onto its entity.
+/// Absent for a local workspace: never signed in, or signed out. Signing
+/// out retracts the stamp and keeps the entry, which is how a row is
+/// demoted without deleting anything.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RosterAccount {
+    /// The roster entry being stamped.
+    pub this: Entity,
+    /// The account root the profile is attached to.
+    pub account: Account,
+    /// The attached provider base URL.
+    pub provider: Provider,
+}
+
+impl RosterAccount {
+    /// Stamp the entry at `entry` as attached to `account` through `provider`.
+    pub fn new(entry: Entity, account: &Did, provider: String) -> Self {
+        Self {
+            this: entry,
+            account: Account(account.this()),
+            provider: Provider(provider),
+        }
+    }
+}
+
+/// The account email of a roster profile, stamped onto its entity.
+/// Captured best-effort at link time and carried until the summary proxy
+/// retires in favour of an account-space fact; may lag.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RosterEmail {
+    /// The roster entry being stamped.
+    pub this: Entity,
+    /// The account email.
+    pub email: Email,
+}
+
+impl RosterEmail {
+    /// Stamp the entry at `entry` with `email`.
+    pub fn new(entry: Entity, email: String) -> Self {
+        Self {
+            this: entry,
+            email: Email(email),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dialog_varsig::did;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[dialog_common::test]
+    fn it_derives_the_same_entity_for_the_same_storage_name() {
+        let a = RosterProfile::new("tonk".into(), "Alice".into());
+        let b = RosterProfile::new("tonk".into(), "Renamed".into());
+        assert_eq!(
+            a.this, b.this,
+            "a refresh converges on the entry it refreshes"
+        );
+        assert_eq!(RosterProfile::entity("tonk"), a.this);
+    }
+
+    #[dialog_common::test]
+    fn it_derives_different_entities_for_different_storage_names() {
+        let a = RosterProfile::new("tonk".into(), "Alice".into());
+        let b = RosterProfile::new("tonk-0a".into(), "Alice".into());
+        assert_ne!(a.this, b.this);
+    }
+
+    #[dialog_common::test]
+    fn it_stamps_the_entry_with_its_attachment() {
+        let entry = RosterProfile::entity("tonk");
+        let account = did!("key:zAccount");
+        let stamp = RosterAccount::new(entry.clone(), &account, "https://accounts.example".into());
+        assert_eq!(stamp.this, entry);
+        assert_eq!(stamp.account.0, account.this());
+        assert_eq!(stamp.provider.0, "https://accounts.example");
+        let email = RosterEmail::new(entry.clone(), "person@example.com".into());
+        assert_eq!(email.this, entry);
+    }
+}

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -2408,7 +2408,6 @@ mod tests {
                     provider: Some("https://accounts.example".into()),
                     email: Some("person@example.com".into()),
                     display_name: Some("Alice".into()),
-                    last_active_at: 1_754_380_800,
                     active: true,
                 },
                 tonk_worker_api::ProfileRosterEntry {
@@ -2417,7 +2416,6 @@ mod tests {
                     provider: None,
                     email: None,
                     display_name: Some("brave-otter".into()),
-                    last_active_at: 1_754_000_000,
                     active: false,
                 },
             ],

--- a/rust/tonk-worker-api/src/account.rs
+++ b/rust/tonk-worker-api/src/account.rs
@@ -146,26 +146,12 @@ pub struct AccountDisplayNameRequest {
     pub name: String,
 }
 
-/// Durable projections changed by account-state convergence.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AccountConvergenceReport {
-    /// Whether the device-local profile name cache changed.
-    pub profile_changed: bool,
-    /// Real-space routing keys whose durable roster changed.
-    pub changed_keys: Vec<String>,
-    /// Real-space routing keys that could not be checked or updated.
-    pub failed_keys: Vec<String>,
-}
-
 /// Result of an authoritative account display-name write.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountDisplayNameResponse {
     /// Name committed to the account repository.
     pub name: String,
-    /// Idempotent projection work completed after the account commit.
-    pub convergence: AccountConvergenceReport,
 }
 
 /// One device authorized under this profile's account, read from the
@@ -276,17 +262,10 @@ mod tests {
     fn it_serializes_display_name_results_in_camel_case() {
         let value = serde_json::to_value(AccountDisplayNameResponse {
             name: "Alice".into(),
-            convergence: AccountConvergenceReport {
-                profile_changed: true,
-                changed_keys: vec!["one".into()],
-                failed_keys: vec!["two".into()],
-            },
         })
         .unwrap();
         assert_eq!(value["name"], "Alice");
-        assert_eq!(value["convergence"]["profileChanged"], true);
-        assert_eq!(value["convergence"]["changedKeys"][0], "one");
-        assert_eq!(value["convergence"]["failedKeys"][0], "two");
+        assert!(value.get("convergence").is_none());
     }
 
     #[dialog_common::test]

--- a/rust/tonk-worker-api/src/lib.rs
+++ b/rust/tonk-worker-api/src/lib.rs
@@ -29,10 +29,10 @@ pub mod share;
 mod sync;
 
 pub use account::{
-    AccountConvergenceReport, AccountDeletionPlan, AccountDeletionRequest, AccountDeletionResult,
-    AccountDeletionSpace, AccountDevice, AccountDisplayNameRequest, AccountDisplayNameResponse,
-    AccountLinkRequest, AccountSpaceDeletionRequest, AccountStatus, AccountSummary,
-    HostedSpaceDeletionResult, RevokeDeviceAcknowledgement, RevokeDeviceRequest,
+    AccountDeletionPlan, AccountDeletionRequest, AccountDeletionResult, AccountDeletionSpace,
+    AccountDevice, AccountDisplayNameRequest, AccountDisplayNameResponse, AccountLinkRequest,
+    AccountSpaceDeletionRequest, AccountStatus, AccountSummary, HostedSpaceDeletionResult,
+    RevokeDeviceAcknowledgement, RevokeDeviceRequest,
 };
 pub use claim::{ClaimResponse, QueryResponse};
 pub use conclusion::{Conclusion, Frame};

--- a/rust/tonk-worker-api/src/profiles.rs
+++ b/rust/tonk-worker-api/src/profiles.rs
@@ -18,8 +18,6 @@ pub struct ProfileRosterEntry {
     pub email: Option<String>,
     /// Display name at last refresh.
     pub display_name: Option<String>,
-    /// When the profile was last activated, seconds since the epoch.
-    pub last_active_at: u64,
     /// Whether this entry is the profile currently being served.
     pub active: bool,
 }
@@ -54,14 +52,12 @@ mod tests {
             provider: Some("https://accounts.example".into()),
             email: Some("person@example.com".into()),
             display_name: Some("Alice".into()),
-            last_active_at: 1_754_380_800,
             active: true,
         })
         .unwrap();
         assert_eq!(json["profileName"], "tonk");
         assert_eq!(json["rootDid"], "did:key:root");
         assert_eq!(json["displayName"], "Alice");
-        assert_eq!(json["lastActiveAt"], 1_754_380_800u64);
         assert_eq!(json["active"], true);
         assert!(json.get("profile_name").is_none());
     }
@@ -76,7 +72,6 @@ mod tests {
                 provider: None,
                 email: None,
                 display_name: None,
-                last_active_at: 0,
                 active: false,
             }],
         };

--- a/rust/tonk-worker/src/device.rs
+++ b/rust/tonk-worker/src/device.rs
@@ -20,12 +20,15 @@
 
 use dialog_effects::storage::Directory;
 use dialog_operator::Profile;
+use dialog_query::{Output as _, Query, Term};
+use dialog_repository::{Branch, Repository};
 use dialog_storage::provider::storage::Storage;
-use serde::{Deserialize, Serialize};
+use dialog_varsig::Did;
 use tonk_common::log;
+use tonk_schema::{RosterAccount, RosterEmail, RosterProfile};
 
 use crate::TonkWorkerError;
-use crate::worker::DefaultSpace;
+use crate::worker::{DefaultOperator, DefaultSpace};
 
 /// The profile that holds the pointer to the active one. Fixed, because
 /// boot has to find it without being told where to look.
@@ -39,15 +42,22 @@ pub const REGISTRY_PROFILE: &str = "tonk";
 /// name as UTF-8.
 const ACTIVE_PROFILE_SITE: &str = "tonk-active-profile-v1";
 
-/// Credential site on the registry profile holding the roster of every
-/// profile this browser knows, as a JSON-serialized `Vec<RosterEntry>`.
+/// Branch of the registry profile's repository holding the roster of
+/// every profile this browser knows, one [`RosterProfile`] entity per
+/// storage name with its attachment and email as stamps.
 ///
 /// A switcher menu has to describe profiles it has not opened, and
 /// opening each one just to render a row would cost key-material load
-/// and credential reads per profile per render. The roster is one
-/// credential load, maintained by the worker at the moments it already
-/// has the facts in hand (boot, link, unlink, rename, switch).
-const PROFILE_ROSTER_SITE: &str = "tonk-profile-roster-v1";
+/// and credential reads per profile per render. The roster is maintained
+/// by the worker at the moments it already has the facts in hand (boot,
+/// link, unlink, rename, switch). Facts rather than one serialized blob:
+/// concurrent refreshes merge per entity instead of racing a
+/// read-modify-write of the whole roster.
+///
+/// Never upstreamed, so it stays on this device: the registry profile's
+/// `main` is an account branch that syncs, and the roster is not the
+/// account's business.
+const ROSTER_BRANCH: &str = "roster";
 
 /// One profile this browser knows about, as the switcher renders it.
 ///
@@ -55,7 +65,7 @@ const PROFILE_ROSTER_SITE: &str = "tonk-profile-roster-v1";
 /// active profile's entry is refreshed from live state. A display name
 /// renamed on another device converges the next time that account's
 /// profile is activated here.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct RosterEntry {
     /// Storage name the profile opens under.
     pub profile_name: String,
@@ -67,9 +77,15 @@ pub(crate) struct RosterEntry {
     /// Account email, captured best-effort at link time. May lag.
     pub email: Option<String>,
     /// Display name at last refresh.
-    pub display_name: Option<String>,
-    /// When the profile was last activated, unix seconds.
-    pub last_active_at: u64,
+    pub display_name: String,
+}
+
+/// The stamps currently on one roster entry, as read back for a refresh:
+/// what a refresh must retract when the attachment or email goes away.
+#[derive(Default)]
+struct Stamps {
+    account: Vec<RosterAccount>,
+    email: Vec<RosterEmail>,
 }
 
 /// Where the pointer lives: a profile name and the directory it is
@@ -209,67 +225,193 @@ impl Registry {
             })
     }
 
-    /// The stored roster, or empty when none was ever written.
+    /// The roster branch, opened fresh: it has no upstream and no
+    /// subscribers, so a handle per operation is the simplest thing that
+    /// cannot go stale.
+    ///
+    /// The registry profile is opened through `storage` so its space is
+    /// loaded in the pool the operator routes through; the branch itself
+    /// is read and written through `operator`, whichever profile it was
+    /// derived from. Local reads and commits are not authorized against
+    /// the branch's subject, and the roster belongs to the device, not to
+    /// whichever profile happens to be active.
+    async fn roster_branch(
+        &self,
+        storage: &Storage<DefaultSpace>,
+        operator: &DefaultOperator,
+    ) -> Result<Branch, TonkWorkerError> {
+        let registry = self.open_self(storage).await?;
+        Repository::from(&registry)
+            .branch(ROSTER_BRANCH)
+            .open()
+            .perform(operator)
+            .await
+            .map_err(|error| {
+                TonkWorkerError::Internal(format!("failed to open the profile roster: {error}"))
+            })
+    }
+
+    /// The stored roster, ordered by storage name; empty when no entry was
+    /// ever written.
     pub(crate) async fn read_roster(
         &self,
         storage: &Storage<DefaultSpace>,
+        operator: &DefaultOperator,
     ) -> Result<Vec<RosterEntry>, TonkWorkerError> {
-        let registry = self.open_self(storage).await?;
-        let bytes = match registry
-            .credential()
-            .site(PROFILE_ROSTER_SITE)
-            .load::<Vec<u8>>()
-            .perform(storage)
+        let branch = self.roster_branch(storage, operator).await?;
+        let profiles: Vec<RosterProfile> = branch
+            .query()
+            .select(Query::<RosterProfile> {
+                this: Term::var("this"),
+                name: Term::var("name"),
+                label: Term::var("label"),
+            })
+            .perform(operator)
+            .try_vec()
             .await
-        {
-            Ok(bytes) => bytes,
-            Err(error) if crate::credential::is_missing(&error) => return Ok(Vec::new()),
-            Err(error) => {
-                return Err(TonkWorkerError::Internal(format!(
-                    "failed to read the profile roster: {error}"
-                )));
-            }
-        };
-        if bytes.is_empty() {
-            return Ok(Vec::new());
-        }
-        serde_json::from_slice(&bytes).map_err(|error| {
-            TonkWorkerError::Internal(format!("stored profile roster is malformed: {error}"))
-        })
+            .map_err(|error| {
+                TonkWorkerError::Internal(format!("failed to read the profile roster: {error:?}"))
+            })?;
+        let accounts: Vec<RosterAccount> = branch
+            .query()
+            .select(Query::<RosterAccount> {
+                this: Term::var("this"),
+                account: Term::var("account"),
+                provider: Term::var("provider"),
+            })
+            .perform(operator)
+            .try_vec()
+            .await
+            .map_err(|error| {
+                TonkWorkerError::Internal(format!(
+                    "failed to read the profile roster attachments: {error:?}"
+                ))
+            })?;
+        let emails: Vec<RosterEmail> = branch
+            .query()
+            .select(Query::<RosterEmail> {
+                this: Term::var("this"),
+                email: Term::var("email"),
+            })
+            .perform(operator)
+            .try_vec()
+            .await
+            .map_err(|error| {
+                TonkWorkerError::Internal(format!(
+                    "failed to read the profile roster emails: {error:?}"
+                ))
+            })?;
+
+        let mut roster: Vec<RosterEntry> = profiles
+            .into_iter()
+            .map(|profile| {
+                let account = accounts.iter().find(|stamp| stamp.this == profile.this);
+                let email = emails.iter().find(|stamp| stamp.this == profile.this);
+                RosterEntry {
+                    profile_name: profile.name.0,
+                    root_did: account.map(|stamp| stamp.account.0.to_string()),
+                    provider: account.map(|stamp| stamp.provider.0.clone()),
+                    email: email.map(|stamp| stamp.email.0.clone()),
+                    display_name: profile.label.0,
+                }
+            })
+            .collect();
+        roster.sort_by(|a, b| a.profile_name.cmp(&b.profile_name));
+        Ok(roster)
+    }
+
+    /// The stamps currently on the entry for `name`.
+    async fn stamps(
+        branch: &Branch,
+        operator: &DefaultOperator,
+        name: &str,
+    ) -> Result<Stamps, TonkWorkerError> {
+        let entry = RosterProfile::entity(name);
+        let account = branch
+            .query()
+            .select(Query::<RosterAccount> {
+                this: Term::from(entry.clone()),
+                account: Term::var("account"),
+                provider: Term::var("provider"),
+            })
+            .perform(operator)
+            .try_vec()
+            .await
+            .map_err(|error| {
+                TonkWorkerError::Internal(format!(
+                    "failed to read the roster attachment of '{name}': {error:?}"
+                ))
+            })?;
+        let email = branch
+            .query()
+            .select(Query::<RosterEmail> {
+                this: Term::from(entry),
+                email: Term::var("email"),
+            })
+            .perform(operator)
+            .try_vec()
+            .await
+            .map_err(|error| {
+                TonkWorkerError::Internal(format!(
+                    "failed to read the roster email of '{name}': {error:?}"
+                ))
+            })?;
+        Ok(Stamps { account, email })
     }
 
     /// Insert or replace the roster entry named by `entry.profile_name`.
+    ///
+    /// A stamp the entry no longer carries is retracted rather than left
+    /// behind: an unlinked profile has to render as a local workspace.
     pub(crate) async fn upsert_roster(
         &self,
         storage: &Storage<DefaultSpace>,
+        operator: &DefaultOperator,
         entry: RosterEntry,
     ) -> Result<(), TonkWorkerError> {
-        let mut roster = self.read_roster(storage).await?;
-        match roster
-            .iter_mut()
-            .find(|existing| existing.profile_name == entry.profile_name)
-        {
-            Some(existing) => *existing = entry,
-            None => roster.push(entry),
-        }
-        self.write_roster(storage, &roster).await
-    }
+        let branch = self.roster_branch(storage, operator).await?;
+        let current = Self::stamps(&branch, operator, &entry.profile_name).await?;
+        let this = RosterProfile::entity(&entry.profile_name);
 
-    async fn write_roster(
-        &self,
-        storage: &Storage<DefaultSpace>,
-        roster: &[RosterEntry],
-    ) -> Result<(), TonkWorkerError> {
-        let bytes = serde_json::to_vec(roster).map_err(|error| {
-            TonkWorkerError::Internal(format!("failed to serialize the profile roster: {error}"))
-        })?;
-        let registry = self.open_self(storage).await?;
-        registry
-            .credential()
-            .site(PROFILE_ROSTER_SITE)
-            .save(bytes)
-            .perform(storage)
+        let mut transaction = branch.transaction().assert(RosterProfile::new(
+            entry.profile_name.clone(),
+            entry.display_name.clone(),
+        ));
+        match (&entry.root_did, &entry.provider) {
+            (Some(root), Some(provider)) => {
+                let account: Did = root.parse().map_err(|error| {
+                    TonkWorkerError::Internal(format!(
+                        "roster entry '{}' names an unparseable account root: {error:?}",
+                        entry.profile_name
+                    ))
+                })?;
+                transaction = transaction.assert(RosterAccount::new(
+                    this.clone(),
+                    &account,
+                    provider.clone(),
+                ));
+            }
+            _ => {
+                for stale in current.account {
+                    transaction = transaction.retract(stale);
+                }
+            }
+        }
+        match &entry.email {
+            Some(email) => {
+                transaction = transaction.assert(RosterEmail::new(this, email.clone()));
+            }
+            None => {
+                for stale in current.email {
+                    transaction = transaction.retract(stale);
+                }
+            }
+        }
+        transaction
+            .commit()
+            .perform(operator)
             .await
+            .map(|_| ())
             .map_err(|error| {
                 TonkWorkerError::Internal(format!("failed to save the profile roster: {error}"))
             })
@@ -338,6 +480,7 @@ pub async fn rotate(storage: &Storage<DefaultSpace>) -> Result<(String, Profile)
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dialog_varsig::Principal as _;
 
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test_configure;
@@ -411,45 +554,114 @@ mod tests {
             root_did: None,
             provider: None,
             email: None,
-            display_name: Some(display_name.to_string()),
-            last_active_at: 0,
+            display_name: display_name.to_string(),
         }
+    }
+
+    /// An operator to read and write the roster through: the registry's
+    /// own, as a device that never rotated would use.
+    async fn operator(registry: &Registry, storage: &Storage<DefaultSpace>) -> DefaultOperator {
+        let profile = registry.open_self(storage).await.unwrap();
+        crate::session::open(&profile, storage)
+            .await
+            .unwrap()
+            .operator
     }
 
     #[dialog_common::test]
     async fn it_reads_an_empty_roster_before_any_entry_is_written() {
         let registry = scratch();
         let storage = Storage::<DefaultSpace>::default();
+        let operator = operator(&registry, &storage).await;
 
-        assert_eq!(registry.read_roster(&storage).await.unwrap(), Vec::new());
+        assert_eq!(
+            registry.read_roster(&storage, &operator).await.unwrap(),
+            Vec::new()
+        );
     }
 
     #[dialog_common::test]
     async fn it_upserts_a_roster_entry_by_profile_name() {
         let registry = scratch();
         let storage = Storage::<DefaultSpace>::default();
+        let operator = operator(&registry, &storage).await;
 
         registry
-            .upsert_roster(&storage, entry("one", "first"))
+            .upsert_roster(&storage, &operator, entry("one", "first"))
             .await
             .unwrap();
         registry
-            .upsert_roster(&storage, entry("two", "second"))
+            .upsert_roster(&storage, &operator, entry("two", "second"))
             .await
             .unwrap();
         registry
-            .upsert_roster(&storage, entry("one", "renamed"))
+            .upsert_roster(&storage, &operator, entry("one", "renamed"))
             .await
             .unwrap();
 
-        let roster = registry.read_roster(&storage).await.unwrap();
+        let roster = registry.read_roster(&storage, &operator).await.unwrap();
         assert_eq!(roster.len(), 2, "an upsert replaces, never duplicates");
         assert_eq!(
-            roster[0].display_name.as_deref(),
-            Some("renamed"),
-            "the entry keeps its position and takes the new value"
+            roster[0].display_name, "renamed",
+            "the entry takes the new value"
         );
         assert_eq!(roster[1].profile_name, "two");
+    }
+
+    #[dialog_common::test]
+    async fn it_retracts_the_attachment_when_an_entry_is_demoted() {
+        let registry = scratch();
+        let storage = Storage::<DefaultSpace>::default();
+        let operator = operator(&registry, &storage).await;
+        let root = dialog_credentials::Ed25519Signer::generate().await.unwrap();
+
+        let attached = RosterEntry {
+            root_did: Some(root.did().to_string()),
+            provider: Some("https://accounts.example".to_string()),
+            email: Some("person@example.com".to_string()),
+            ..entry("one", "first")
+        };
+        registry
+            .upsert_roster(&storage, &operator, attached.clone())
+            .await
+            .unwrap();
+        assert_eq!(
+            registry.read_roster(&storage, &operator).await.unwrap(),
+            vec![attached]
+        );
+
+        registry
+            .upsert_roster(&storage, &operator, entry("one", "first"))
+            .await
+            .unwrap();
+        assert_eq!(
+            registry.read_roster(&storage, &operator).await.unwrap(),
+            vec![entry("one", "first")],
+            "a signed-out profile carries no attachment or email"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_serves_the_roster_to_another_profiles_operator() {
+        let registry = scratch();
+        let storage = Storage::<DefaultSpace>::default();
+        let operator = operator(&registry, &storage).await;
+        registry
+            .upsert_roster(&storage, &operator, entry("one", "first"))
+            .await
+            .unwrap();
+
+        // A rotated device reads the roster through the profile it now
+        // signs as, not the registry's key.
+        let (_, rotated) = registry.rotate(&storage).await.unwrap();
+        let other = crate::session::open(&rotated, &storage)
+            .await
+            .unwrap()
+            .operator;
+        assert_eq!(
+            registry.read_roster(&storage, &other).await.unwrap(),
+            vec![entry("one", "first")]
+        );
     }
 
     #[dialog_common::test]

--- a/rust/tonk-worker/src/router/account.rs
+++ b/rust/tonk-worker/src/router/account.rs
@@ -304,7 +304,6 @@ pub async fn set_display_name(
         Some(response) => Ok(Json(response)),
         None => Ok(Json(AccountDisplayNameResponse {
             name: crate::router::profile_name::resolve_display_name(&tonk).await,
-            convergence: Default::default(),
         })),
     }
 }
@@ -557,7 +556,11 @@ mod tests {
         let _ = link(State(state.clone()), Json(request)).await.unwrap();
         {
             let tonk = state.read().await;
-            let roster = tonk.registry.read_roster(&tonk.storage).await.unwrap();
+            let roster = tonk
+                .registry
+                .read_roster(&tonk.storage, &tonk.operator)
+                .await
+                .unwrap();
             let entry = roster
                 .iter()
                 .find(|entry| entry.profile_name == tonk.profile_name)
@@ -569,7 +572,11 @@ mod tests {
         let _ = unlink(State(state.clone())).await.unwrap();
 
         let tonk = state.read().await;
-        let roster = tonk.registry.read_roster(&tonk.storage).await.unwrap();
+        let roster = tonk
+            .registry
+            .read_roster(&tonk.storage, &tonk.operator)
+            .await
+            .unwrap();
         let entry = roster
             .iter()
             .find(|entry| entry.profile_name == tonk.profile_name)

--- a/rust/tonk-worker/src/router/account_state.rs
+++ b/rust/tonk-worker/src/router/account_state.rs
@@ -952,14 +952,17 @@ pub(crate) async fn seed_passkey_facts(tonk: &TonkState) -> bool {
     true
 }
 
-/// Project the authoritative account display name into local caches and every
-/// known real-space roster.
+/// Project the authoritative account display name into the local profile
+/// name cache and every known real-space roster.
+///
+/// The idempotent catch-up: a rename projects at the moment it happens,
+/// and this runs on every sweep for whatever that moment could not reach
+/// (a space that was unmounted, a name another device chose). Every
+/// space is checked and written independently; a failure is logged and
+/// left for the next sweep rather than failing the others.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-pub(crate) async fn converge_account_state(
-    tonk: &TonkState,
-) -> Result<tonk_worker_api::AccountConvergenceReport, TonkWorkerError> {
-    use tonk_schema::{AccountDisplayName, MemberName, Membership, ProfileName};
-    use tonk_worker_api::AccountConvergenceReport;
+pub(crate) async fn converge_account_state(tonk: &TonkState) -> Result<(), TonkWorkerError> {
+    use tonk_schema::{AccountDisplayName, ProfileName};
 
     let ready = require_ready_account_state(tonk).await?;
     let account = tonk
@@ -983,7 +986,7 @@ pub(crate) async fn converge_account_state(
             TonkWorkerError::Internal(format!("read account display name: {error:?}"))
         })?;
     let Some(name) = names.into_iter().next().map(|name| name.name.0) else {
-        return Ok(AccountConvergenceReport::default());
+        return Ok(());
     };
 
     let profile_entity = tonk.profile.did().this();
@@ -1020,117 +1023,47 @@ pub(crate) async fn converge_account_state(
             })?;
     }
 
-    let member = ready.subject;
-    let device = tonk.profile.did();
-    let mut report = AccountConvergenceReport {
-        profile_changed,
-        ..AccountConvergenceReport::default()
-    };
+    project_member_names(tonk, &ready.subject, &name, profile_changed).await;
+    Ok(())
+}
+
+/// Project `name` onto `member`'s row in every known real space's roster,
+/// queueing each space that changed for sync. `republish` also refreshes
+/// the self-identity overlay of the spaces that did not change, for a
+/// profile-name cache that did.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn project_member_names(
+    tonk: &TonkState,
+    member: &dialog_varsig::Did,
+    name: &str,
+    republish: bool,
+) {
     for key in crate::router::profile_name::real_space_keys(tonk).await {
-        let result = async {
-            let session = tonk
-                .reactor
-                .repository(&key)
-                .branch(tonk_account::MAIN_BRANCH)
-                .acquire(&tonk.operator)
-                .await
-                .map_err(|error| {
-                    TonkWorkerError::Internal(format!("open projection target '{key}': {error}"))
-                })?;
-            let subject = session.handle().of().clone();
-            let membership = Membership::new(member.clone(), subject.clone());
-            let current: Vec<MemberName> = session
-                .handle()
-                .query()
-                .select(Query::<MemberName> {
-                    this: Term::from(membership.this().clone()),
-                    name: Term::var("name"),
-                })
-                .perform(&tonk.operator)
-                .try_vec()
-                .await
-                .map_err(|error| {
-                    TonkWorkerError::Internal(format!(
-                        "read account member name in '{key}': {error:?}"
-                    ))
-                })?;
-            let root_stale = current.first().is_none_or(|row| row.name.0 != name);
-
-            let mut obsolete = Vec::new();
-            if device != member {
-                let device_membership = Membership::new(device.clone(), subject);
-                obsolete = session
-                    .handle()
-                    .query()
-                    .select(Query::<MemberName> {
-                        this: Term::from(device_membership.this().clone()),
-                        name: Term::var("name"),
-                    })
-                    .perform(&tonk.operator)
-                    .try_vec()
-                    .await
-                    .map_err(|error| {
-                        TonkWorkerError::Internal(format!(
-                            "read obsolete member name in '{key}': {error:?}"
-                        ))
-                    })?;
-            }
-
-            if !root_stale && obsolete.is_empty() {
-                return Ok(false);
-            }
-            let mut transaction = tonk
-                .reactor
-                .repository(&key)
-                .branch(tonk_account::MAIN_BRANCH)
-                .transaction();
-            if root_stale {
-                transaction =
-                    transaction.assert(MemberName::new(membership.this().clone(), name.clone()));
-            }
-            for stale in obsolete {
-                transaction = transaction.retract(stale);
-            }
-            transaction
-                .commit()
-                .perform(&tonk.operator)
-                .await
-                .map_err(|error| {
-                    TonkWorkerError::Internal(format!(
-                        "project account member name to '{key}': {error}"
-                    ))
-                })?;
-            Ok::<bool, TonkWorkerError>(true)
-        }
-        .await;
-
-        let changed = match result {
+        let changed = match crate::router::profile_name::project_member_name(
+            tonk, &key, member, name,
+        )
+        .await
+        {
             Ok(changed) => {
                 if changed {
                     tonk.sync_queue.mark_dirty(&key, js_sys::Date::now());
-                    report.changed_keys.push(key.clone());
                 }
                 changed
             }
             Err(error) => {
-                log!("account-name projection for '{key}' failed: {error}");
-                report.failed_keys.push(key.clone());
+                log!("member name projection for '{key}' failed: {error}");
                 false
             }
         };
-        if changed || profile_changed {
+        if changed || republish {
             crate::router::sync::publish_self_identity(tonk, &key, tonk_account::MAIN_BRANCH).await;
         }
     }
-
-    Ok(report)
 }
 
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-pub(crate) async fn converge_account_state(
-    _tonk: &TonkState,
-) -> Result<tonk_worker_api::AccountConvergenceReport, TonkWorkerError> {
-    Ok(Default::default())
+pub(crate) async fn converge_account_state(_tonk: &TonkState) -> Result<(), TonkWorkerError> {
+    Ok(())
 }
 
 fn account_state_unavailable() -> TonkWorkerError {
@@ -1165,10 +1098,11 @@ async fn adopt_account_display_name(
         })?;
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     tonk.sync_queue.mark_dirty(&ready.key, js_sys::Date::now());
-    let convergence = converge_account_state(tonk).await?;
+    // The rename's own fan-out: every space this device can reach gets
+    // the name now and is queued for sync; the sweep catches up the rest.
+    converge_account_state(tonk).await?;
     Ok(tonk_worker_api::AccountDisplayNameResponse {
         name: name.to_string(),
-        convergence,
     })
 }
 
@@ -1206,10 +1140,9 @@ pub(crate) async fn initialize_display_name(
             TonkWorkerError::Internal(format!("read initial account display name: {error:?}"))
         })?;
     if let Some(existing) = existing.into_iter().next() {
-        let convergence = converge_account_state(tonk).await?;
+        converge_account_state(tonk).await?;
         return Ok(tonk_worker_api::AccountDisplayNameResponse {
             name: existing.name.0,
-            convergence,
         });
     }
 
@@ -1224,7 +1157,7 @@ pub(crate) async fn rename_display_name(
     name: &str,
 ) -> Result<Option<tonk_worker_api::AccountDisplayNameResponse>, TonkWorkerError> {
     use tonk_schema::{ProfileName, prelude::DidExt as _};
-    use tonk_worker_api::{AccountConvergenceReport, AccountDisplayNameResponse};
+    use tonk_worker_api::AccountDisplayNameResponse;
 
     let name = name.trim();
     if name.is_empty() {
@@ -1254,25 +1187,12 @@ pub(crate) async fn rename_display_name(
             TonkWorkerError::Internal(format!("failed to persist profile name override: {error}"))
         })?;
 
-    let convergence = AccountConvergenceReport {
-        profile_changed: true,
-        ..AccountConvergenceReport::default()
-    };
+    // Keyed the way the membership rows were written: on the persisted
+    // root when there is one, else on the device.
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-    let mut convergence = convergence;
-    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-    for key in crate::router::profile_name::real_space_keys(tonk).await {
-        match crate::router::profile_name::restamp_member_name(tonk, &key, name).await {
-            Ok(()) => {
-                tonk.sync_queue.mark_dirty(&key, js_sys::Date::now());
-                convergence.changed_keys.push(key.clone());
-            }
-            Err(error) => {
-                log!("restamp MemberName for space '{key}' failed: {error}");
-                convergence.failed_keys.push(key.clone());
-            }
-        }
-        crate::router::sync::publish_self_identity(tonk, &key, tonk_account::MAIN_BRANCH).await;
+    {
+        let member = super::account::member_did(tonk).await?;
+        project_member_names(tonk, &member, name, true).await;
     }
 
     // Roster upkeep: the switcher row shows the new name.
@@ -1280,7 +1200,6 @@ pub(crate) async fn rename_display_name(
 
     Ok(Some(AccountDisplayNameResponse {
         name: name.to_string(),
-        convergence,
     }))
 }
 
@@ -1314,7 +1233,7 @@ mod tests {
 
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     #[dialog_common::test]
-    async fn it_projects_each_space_independently_and_retries_only_failures() {
+    async fn it_projects_the_name_to_each_space_and_catches_up_the_ones_it_could_not_reach() {
         use dialog_capability::Subject;
         use dialog_credentials::{Credential, Ed25519Verifier};
         use dialog_effects::space::{Space, SpaceExt as _};
@@ -1376,10 +1295,23 @@ mod tests {
                 .await
                 .unwrap()
                 .unwrap();
-            assert!(response.convergence.profile_changed);
-            assert!(response.convergence.changed_keys.contains(&key_a));
-            assert!(response.convergence.changed_keys.contains(&key_c));
-            assert_eq!(response.convergence.failed_keys, vec![missing_key.clone()]);
+            assert_eq!(response.name, "shared-name");
+        }
+        // The rename projected to the spaces it could reach, and the one
+        // it could not is left for the sweep rather than failing the rest.
+        let member_name = |names: Vec<tonk_schema::MemberName>| {
+            names
+                .into_iter()
+                .map(|row| row.name.0)
+                .find(|name| name == "shared-name")
+        };
+        for key in [&key_a, &key_c] {
+            assert_eq!(
+                member_name(crate::router::tests::content_member_names(&state, key).await)
+                    .as_deref(),
+                Some("shared-name"),
+                "the rename projects to a mounted space"
+            );
         }
 
         let (before_a, before_c) = {
@@ -1422,15 +1354,34 @@ mod tests {
                 .await
                 .unwrap();
 
-            let retry = converge_account_state(&tonk).await.unwrap();
-            assert!(!retry.profile_changed);
-            assert_eq!(retry.changed_keys, vec![missing_key.clone()]);
-            assert!(retry.failed_keys.is_empty());
+            // The sweep's catch-up reaches the space the rename could not.
+            converge_account_state(&tonk).await.unwrap();
+            let caught_up = tonk
+                .reactor
+                .repository(&missing_key)
+                .branch(tonk_account::MAIN_BRANCH)
+                .acquire(&tonk.operator)
+                .await
+                .unwrap()
+                .handle()
+                .revision();
+            assert!(
+                caught_up.is_some(),
+                "the catch-up writes the name into the space it reached"
+            );
 
-            let no_op = converge_account_state(&tonk).await.unwrap();
-            assert!(!no_op.profile_changed);
-            assert!(no_op.changed_keys.is_empty());
-            assert!(no_op.failed_keys.is_empty());
+            // Idempotent: a second pass finds nothing stale and writes nothing.
+            converge_account_state(&tonk).await.unwrap();
+            let settled = tonk
+                .reactor
+                .repository(&missing_key)
+                .branch(tonk_account::MAIN_BRANCH)
+                .acquire(&tonk.operator)
+                .await
+                .unwrap()
+                .handle()
+                .revision();
+            assert_eq!(caught_up, settled, "a converged space receives no write");
 
             let after_a = tonk
                 .reactor

--- a/rust/tonk-worker/src/router/profile_name.rs
+++ b/rust/tonk-worker/src/router/profile_name.rs
@@ -178,13 +178,23 @@ pub(crate) async fn real_space_keys(tonk: &TonkState) -> Vec<String> {
     keys
 }
 
-/// Re-stamp the self member's `MemberName` on a space's content branch.
+/// Project `name` onto `member`'s `MemberName` in one space's roster.
+///
+/// Idempotent: reads the roster first and commits only when the row is
+/// missing or stale, so the sweep can run it on every pass without
+/// touching the branch. A linked profile's rename also clears the
+/// device-keyed row a pre-link join left behind (cardinality-one on a
+/// different entity, so the assert alone would not overwrite it).
+///
+/// Returns whether anything was written, so the caller knows to queue
+/// the space for sync.
 #[cfg(target_arch = "wasm32")]
-pub(crate) async fn restamp_member_name(
+pub(crate) async fn project_member_name(
     tonk: &TonkState,
     key: &str,
+    member: &dialog_varsig::Did,
     name: &str,
-) -> Result<(), RepositoryError> {
+) -> Result<bool, RepositoryError> {
     // The repo (subject) DID identifies the membership entity. Read it
     // from the acquired content-branch handle (`of()` is the subject),
     // matching how sync.rs derives the replica subject.
@@ -196,50 +206,52 @@ pub(crate) async fn restamp_member_name(
         .await
         .map_err(|e| RepositoryError::Internal(format!("acquire content branch '{key}': {e}")))?;
     let repo_did = session.handle().of().clone();
-
-    let member = crate::router::account::member_did(tonk)
-        .await
-        .map_err(|error| match error {
-            crate::TonkWorkerError::RootRequired => RepositoryError::RootRequired,
-            error => RepositoryError::Internal(error.to_string()),
-        })?;
     let membership = Membership::new(member.clone(), repo_did.clone());
+    let names: Vec<MemberName> = session
+        .handle()
+        .query()
+        .select(Query::<MemberName> {
+            this: Term::var("this"),
+            name: Term::var("name"),
+        })
+        .perform(&tonk.operator)
+        .try_vec()
+        .await
+        .map_err(|e| RepositoryError::Internal(format!("name query '{key}': {e:?}")))?;
+
+    let stale = !names
+        .iter()
+        .any(|row| row.this == *membership.this() && row.name.0 == name);
+    let device = tonk.profile.did();
+    let obsolete: Vec<MemberName> = if *member == device {
+        Vec::new()
+    } else {
+        let device_entity = Membership::new(device, repo_did).this().clone();
+        names
+            .into_iter()
+            .filter(|row| row.this == device_entity)
+            .collect()
+    };
+    if !stale && obsolete.is_empty() {
+        return Ok(false);
+    }
 
     let mut txn = tonk
         .reactor
         .repository(key)
         .branch(CONTENT_BRANCH)
-        .transaction()
-        .assert(MemberName::new(membership.this().clone(), name.to_string()));
-
-    // Linked profiles: a rename must also clear the orphaned device-keyed
-    // name row (cardinality-one on a different entity, so the assert above
-    // won't overwrite it).
-    let device = tonk.profile.did();
-    if member != device {
-        let device_membership = Membership::new(device, repo_did);
-        let device_entity = device_membership.this().clone();
-        let names: Vec<MemberName> = session
-            .handle()
-            .query()
-            .select(Query::<MemberName> {
-                this: Term::var("this"),
-                name: Term::var("name"),
-            })
-            .perform(&tonk.operator)
-            .try_vec()
-            .await
-            .map_err(|e| RepositoryError::Internal(format!("name query '{key}': {e:?}")))?;
-        for stale in names.into_iter().filter(|n| n.this == device_entity) {
-            txn = txn.retract(stale);
-        }
+        .transaction();
+    if stale {
+        txn = txn.assert(MemberName::new(membership.this().clone(), name.to_string()));
     }
-
+    for row in obsolete {
+        txn = txn.retract(row);
+    }
     txn.commit()
         .perform(&tonk.operator)
         .await
-        .map_err(|e| RepositoryError::Internal(format!("restamp member name for '{key}': {e}")))?;
-    Ok(())
+        .map_err(|e| RepositoryError::Internal(format!("project member name to '{key}': {e}")))?;
+    Ok(true)
 }
 
 #[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
@@ -342,7 +354,7 @@ mod tests {
     /// A rename after linking a device to an account root must move the
     /// space's roster row rather than duplicate it: the founder membership
     /// was stamped on the device DID (the account was unlinked when the
-    /// space was created), so [`restamp_member_name`] has to key the new
+    /// space was created), so [`project_member_name`] has to key the new
     /// `MemberName` on the root and retract the now-orphaned device-keyed
     /// row.
     #[dialog_common::test]
@@ -386,9 +398,13 @@ mod tests {
         };
 
         let tonk = state.read().await;
-        restamp_member_name(&tonk, &key, "brave-lynx")
-            .await
-            .expect("restamp succeeds");
+        let root_did: Did = root_did_str.parse().unwrap();
+        assert!(
+            project_member_name(&tonk, &key, &root_did, "brave-lynx")
+                .await
+                .expect("projection succeeds"),
+            "a rekey is a write"
+        );
 
         let session = tonk
             .reactor
@@ -398,7 +414,6 @@ mod tests {
             .await
             .unwrap();
         let repo_did = session.handle().of().clone();
-        let root_did: Did = root_did_str.parse().unwrap();
         let root_entity = Membership::new(root_did, repo_did.clone()).this().clone();
         let device_entity = Membership::new(device_did, repo_did).this().clone();
 

--- a/rust/tonk-worker/src/router/profiles.rs
+++ b/rust/tonk-worker/src/router/profiles.rs
@@ -24,13 +24,6 @@ use crate::TonkWorkerError;
 use crate::device::RosterEntry;
 use crate::worker::{DefaultSpace, TonkState};
 
-fn now_unix() -> u64 {
-    web_time::SystemTime::now()
-        .duration_since(web_time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs()
-}
-
 /// The active profile's roster entry, rebuilt from live state.
 ///
 /// The account fields all derive from the provider attachment: an
@@ -63,11 +56,7 @@ async fn refreshed_entry(
         root_did,
         provider,
         email,
-        display_name: Some(super::profile_name::resolve_display_name(tonk).await),
-        last_active_at: existing
-            .map(|entry| entry.last_active_at)
-            .filter(|&at| at > 0)
-            .unwrap_or_else(now_unix),
+        display_name: super::profile_name::resolve_display_name(tonk).await,
     }
 }
 
@@ -87,12 +76,17 @@ async fn try_upsert_active_entry(
     tonk: &TonkState,
     email: Option<String>,
 ) -> Result<(), TonkWorkerError> {
-    let roster = tonk.registry.read_roster(&tonk.storage).await?;
+    let roster = tonk
+        .registry
+        .read_roster(&tonk.storage, &tonk.operator)
+        .await?;
     let existing = roster
         .iter()
         .find(|entry| entry.profile_name == tonk.profile_name);
     let entry = refreshed_entry(tonk, existing, email).await;
-    tonk.registry.upsert_roster(&tonk.storage, entry).await
+    tonk.registry
+        .upsert_roster(&tonk.storage, &tonk.operator, entry)
+        .await
 }
 
 fn response_from(active: &str, roster: Vec<RosterEntry>) -> ProfilesResponse {
@@ -106,8 +100,7 @@ fn response_from(active: &str, roster: Vec<RosterEntry>) -> ProfilesResponse {
                 root_did: entry.root_did,
                 provider: entry.provider,
                 email: entry.email,
-                display_name: entry.display_name,
-                last_active_at: entry.last_active_at,
+                display_name: Some(entry.display_name),
             })
             .collect(),
     }
@@ -117,7 +110,10 @@ fn response_from(active: &str, roster: Vec<RosterEntry>) -> ProfilesResponse {
 /// written back so the stored roster converges as a side effect.
 /// Inactive entries are served as-of their profile's last activation.
 async fn refreshed_response(tonk: &TonkState) -> Result<ProfilesResponse, TonkWorkerError> {
-    let mut roster = tonk.registry.read_roster(&tonk.storage).await?;
+    let mut roster = tonk
+        .registry
+        .read_roster(&tonk.storage, &tonk.operator)
+        .await?;
     let existing = roster
         .iter()
         .find(|entry| entry.profile_name == tonk.profile_name)
@@ -125,7 +121,7 @@ async fn refreshed_response(tonk: &TonkState) -> Result<ProfilesResponse, TonkWo
     let entry = refreshed_entry(tonk, existing.as_ref(), None).await;
     if existing.as_ref() != Some(&entry) {
         tonk.registry
-            .upsert_roster(&tonk.storage, entry.clone())
+            .upsert_roster(&tonk.storage, &tonk.operator, entry.clone())
             .await?;
     }
     match roster
@@ -163,7 +159,7 @@ pub async fn activate(
         if name != tonk.registry.initial_profile()
             && !tonk
                 .registry
-                .read_roster(&tonk.storage)
+                .read_roster(&tonk.storage, &tonk.operator)
                 .await?
                 .iter()
                 .any(|entry| entry.profile_name == name)
@@ -234,15 +230,16 @@ async fn finish_swap(
 ) -> Result<Json<ProfilesResponse>, TonkWorkerError> {
     let name = new_state.profile_name.clone();
     let registry = new_state.registry.clone();
-    let mut roster = registry.read_roster(&new_state.storage).await?;
+    let mut roster = registry
+        .read_roster(&new_state.storage, &new_state.operator)
+        .await?;
     let existing = roster
         .iter()
         .find(|entry| entry.profile_name == name)
         .cloned();
-    let mut entry = refreshed_entry(&new_state, existing.as_ref(), None).await;
-    entry.last_active_at = now_unix();
+    let entry = refreshed_entry(&new_state, existing.as_ref(), None).await;
     registry
-        .upsert_roster(&new_state.storage, entry.clone())
+        .upsert_roster(&new_state.storage, &new_state.operator, entry.clone())
         .await?;
     match roster
         .iter_mut()

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -1827,7 +1827,11 @@ pub(crate) async fn remove_space_inner(
     // too, since sharing can't be ruled out.
     let other_profiles = {
         let tonk = state.read().await;
-        match tonk.registry.read_roster(&tonk.storage).await {
+        match tonk
+            .registry
+            .read_roster(&tonk.storage, &tonk.operator)
+            .await
+        {
             Ok(roster) => roster.len() > 1,
             Err(error) => {
                 log!("profile roster unreadable before storage delete: {error}");


### PR DESCRIPTION
Stacked on #745. Implements `plan/roster-as-facts.md`.

The switcher's roster was one JSON blob in a credential site: every refresh read, modified, and rewrote the whole thing, so concurrent worker writes raced and lost updates. It is now facts in the registry profile's own db, on a `roster` branch that has no upstream: one `RosterProfile` entity per storage name (name, label) with `RosterAccount` and `RosterEmail` stamps. Signing out retracts the stamps and keeps the entry, which is how a row is demoted without deleting anything. `last_active_at` is gone; it churned the store on every switch and nothing rendered it. The branch is opened fresh per operation and read or written through whichever profile's operator is active: it has no subscribers and no upstream, so nothing can go stale, and the roster belongs to the device rather than to the active profile.

One deliberate deviation from the plan: the active-profile pointer stays a credential. Boot reads it before any operator exists, and reading a fact needs one (queries carry fork bounds), so a pointer in a db you need an operator to open is the same problem the pointer solved one level down. It is single-writer per device, so the merge argument does not apply to it.

On the membership side, the rename used to fan out through the sweep's convergence and report changed and failed keys back, and the unattached rename had a second, unconditional restamp. Both now run one idempotent projection per space that reads the roster and writes only when the row is missing or stale, queueing the space for sync when it does; the sweep runs the same projection as catch-up for whatever a rename could not reach. The convergence report and its retry bookkeeping go with it.

Still open, noted in the plan: the switcher as a subscription (the sealed UI has no path to the registry db yet), the per-space name override policy, and email as an account-space fact once the summary proxy retires.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces new modules and features across various components of the Tonk project, enhancing functionality related to onboarding, clearance, and device management, while also refining error handling and testing setups.

### Detailed summary
- Added `onboarding` module in `rust/tonk-worker/src/lib.rs`.
- Introduced `clearance` and `device_label` modules in `rust/tonk-identity/src/lib.rs` and `rust/tonk-common/src/lib.rs`, respectively.
- Enhanced error handling in `rust/tonk-host/src/http.rs`.
- Updated `Registration` struct to include revocation checks in `rust/tonk-access-service/src/registration.rs`.
- Improved handling of transient claims in `rust/tonk-worker/src/router/transact.rs`.
- Added tests for error handling and subscription management in various modules.
- Updated `Cargo.toml` files to include new dependencies and test configurations.
- Modified CSS in `rust/tonk-fab/src/fab.css` for improved UI behavior.

> The following files were skipped due to too many changes: `rust/dialog-reactor/src/lib.rs`, `Cargo.toml`, `rust/tonk-ui/src/account_flow.rs`, `rust/tonk-core/assets/library/profile.yaml`, `rust/tonk-schema/src/domain.rs`, `rust/tonk-worker/src/router/profile_name.rs`, `rust/tonk-schema/src/device_link.rs`, `rust/tonk-schema/src/roster.rs`, `rust/tonk-display/src/state.rs`, `plan/roster-as-facts.md`, `rust/tonk-worker/src/session.rs`, `plan/vault-key.md`, `rust/tonk-worker-api/src/account.rs`, `plan/profile-db.md`, `rust/tonk-fab/src/element.rs`, `rust/tonk-cli/src/account_state.rs`, `rust/tonk-worker/src/router/repository.rs`, `rust/tonk-worker/src/router/query.rs`, `rust/tonk-worker/src/router/join.rs`, `plan/onboarding-accreditation.md`, `plan/authority-facts.md`, `rust/tonk-cli/tests/revoked_device.rs`, `Cargo.lock`, `rust/tonk-worker/src/device.rs`, `rust/tonk-worker/src/router/account_state.rs`, `rust/tonk-ui/src/account.rs`, `rust/tonk-identity/src/envelope.rs`, `rust/tonk-worker/src/router/sync.rs`, `rust/tonk-cli/src/account.rs`, `rust/tonk-worker/src/router/account_devices.rs`, `rust/tonk-worker/src/onboarding.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->