### PR TITLE
feat: promote via a page-minted, root-signed hop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5149,8 +5149,13 @@ dependencies = [
 name = "tonk-portal"
 version = "0.6.8"
 dependencies = [
+ "anyhow",
+ "bs58",
  "custom-elements",
  "dialog-common",
+ "dialog-credentials",
+ "dialog-ucan-core",
+ "dialog-varsig",
  "indexmap",
  "ipld-core",
  "js-sys",
@@ -5160,6 +5165,7 @@ dependencies = [
  "tonk-common",
  "tonk-display",
  "tonk-host",
+ "tonk-identity",
  "tonk-worker-api",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/plan/space-admins.md
+++ b/plan/space-admins.md
@@ -126,10 +126,16 @@ Admin therefore has to be decided by what a chain covers:
   CLI classification exist. The join retains the claimed chain into the
   space's content branch so a member's own hop is individually
   revocable.
-- `member/promote` and `member/expel` are commands (transients on the
-  space branch, run by worker handlers after the commit, like
-  `tonk:invite`): promote mints a `/` chain to the member's account,
-  retains it in the space db and stamps the role; expel proves the
-  member's own hop, revokes it under the remover's `/` chain, records it
-  at the access service and retracts the roster rows. No HTTP endpoints.
-  The roster row does not offer the forms yet.
+- `member/promote` and `member/expel` are commands run by worker handlers
+  after the commit, like `tonk:invite`. Expel is a form on the space
+  branch: it proves the member's own hop, revokes it under the remover's
+  `/` chain, records it at the access service and retracts the roster
+  rows. Promote is dispatched by the FAB's roster: the guest asks the
+  outer page to delegate `/` on the space to the member's account
+  (`window.tonk.delegate`), the page runs the passkey ceremony inside
+  the click's activation and answers with the root-signed hop, and the
+  command carries it. The worker proves the promoter's own `/` chain,
+  appends the hop, checks issuer, audience, subject and command, retains
+  it beside the invites and stamps the role. No device key sits in an
+  admin chain, so signing a device out never takes its promotions with
+  it. No HTTP endpoints.

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -586,23 +586,13 @@ concept!: &member
 # The role badge label comes from CSS `::after` keyed on `data-role`, so the
 # raw `tonk:founder` / `tonk:member` URI never shows; the raw {role} text is
 # kept (visually hidden) only to drive the attribute.
-# Membership management. Each is a single matched field, so the attribute
-# is the command's shape as well as its payload: `dataset/promote` and
-# `dataset/expel` are read by no other command. Both act on the space
-# they fire in. The worker's handlers do the chain work; the service
-# refuses a removal minted under a member's `/use` chain, so holding the
-# space is what makes it take effect, not the role on the roster.
-command!: &member/promote
-  description: Promote a member of this space to admin.
-  with:
-    member:
-      description: The DID of the member to promote, read from `data-promote`.
-      the: dom.event.current-target.dataset/promote
-      as: entity
-    prevent-default:
-      description: Stop the form submission from reloading the page
-      the: dom.event.do/prevent-default
-
+# Removing a member. A single matched field, so the attribute is the
+# command's shape as well as its payload: `dataset/expel` is read by no
+# other command. Acts on the space it fires in. The worker's handler does
+# the chain work; the service refuses a removal minted under a member's
+# `/use` chain, so holding the space is what makes it take effect, not the
+# role on the roster. Promotion is not a form: the FAB dispatches it after
+# the page mints the admin hop under the passkey.
 command!: &member/expel
   description: Remove a member from this space.
   with:

--- a/rust/tonk-fab/src/logic.rs
+++ b/rust/tonk-fab/src/logic.rs
@@ -357,6 +357,38 @@ pub fn dock_claim_json(dock: Dock) -> Value {
     })
 }
 
+/// Build a `TransactRequest` JSON body for the `member/promote` command.
+///
+/// Asserted once the page has minted the admin hop under the passkey:
+/// `member` is the DID the membership is keyed on, `space` the space, and
+/// `chain` the base58 hop `promoter-account -> member`. Routeless like
+/// `pause_claim_json`: the worker reads `space` off the command.
+pub fn promote_claim_json(space: &str, member: &str, chain: &str) -> Value {
+    json!({
+        "claims": [{
+            "op": "assert",
+            "application": {
+                "predicate": {
+                    "kind": "transient",
+                    "concept": {
+                        "description": "Promote a member of a space to admin.",
+                        "with": {
+                            "member": { "the": "xyz.tonk.promote/member", "cardinality": "one", "as": "Entity" },
+                            "space": { "the": "xyz.tonk.promote/space", "cardinality": "one", "as": "Entity" },
+                            "chain": { "the": "xyz.tonk.promote/chain", "cardinality": "one", "as": "Text" }
+                        }
+                    }
+                },
+                "parameters": {
+                    "member": member,
+                    "space": space,
+                    "chain": chain
+                }
+            }
+        }]
+    })
+}
+
 /// Build a `TransactRequest` JSON body for the `tonk:pause-sync` command.
 ///
 /// A transient command asserting the target `space` (the DID to pause) with a
@@ -1074,6 +1106,25 @@ pub fn member_roster_query_body() -> String {
         }
     })
     .to_string()
+}
+
+#[cfg(test)]
+mod promote {
+    use super::*;
+
+    #[test]
+    fn it_names_the_space_member_and_chain_on_the_promote_command() {
+        let body = promote_claim_json("did:key:zSpace", "did:key:zMember", "3vQB7B6MrGQZaxCu");
+        let claim = &body["claims"][0];
+        assert_eq!(claim["op"], "assert");
+        assert_eq!(claim["application"]["predicate"]["kind"], "transient");
+        let parameters = &claim["application"]["parameters"];
+        assert_eq!(parameters["space"], "did:key:zSpace");
+        assert_eq!(parameters["member"], "did:key:zMember");
+        assert_eq!(parameters["chain"], "3vQB7B6MrGQZaxCu");
+        let with = &claim["application"]["predicate"]["concept"]["with"];
+        assert_eq!(with["chain"]["the"], "xyz.tonk.promote/chain");
+    }
 }
 
 #[cfg(test)]

--- a/rust/tonk-fab/src/logic.rs
+++ b/rust/tonk-fab/src/logic.rs
@@ -1108,6 +1108,77 @@ pub fn member_roster_query_body() -> String {
     .to_string()
 }
 
+/// The one-shot query body for the signed-in member's own profile DID.
+///
+/// Reads the PROFILE branch's replica records by raw attribute: every
+/// replica there carries `xyz.tonk.replica/profile`, the profile that owns
+/// it, so any row answers. Directory mode (`this` unbound). Routeless from
+/// the FAB, whose host mounts `with="main@profile:tonk"`.
+pub fn self_did_query_body() -> String {
+    json!({
+        "predicate": { "with": {
+            "profile": { "the": "xyz.tonk.replica/profile", "as": "Entity", "cardinality": "one" }
+        } },
+        "terms": {
+            "this":    { "?": { "name": "this" } },
+            "profile": { "?": { "name": "profile" } }
+        }
+    })
+    .to_string()
+}
+
+/// The profile DID from a `Conclusion[]` answer to [`self_did_query_body`]:
+/// the first row's `profile` field. `None` for an empty answer.
+pub fn self_did_from_conclusions(rows: &Value) -> Option<String> {
+    rows.as_array()?.iter().find_map(|row| {
+        row.get("fields")
+            .and_then(|fields| fields.get("profile"))
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+    })
+}
+
+/// Whether a member holding `role` runs the space: founders and admins
+/// may promote (and expel) other members; the worker refuses everyone
+/// else, so the roster offers those controls only to them.
+pub fn role_manages_members(role: &str) -> bool {
+    role == "tonk:founder" || role == "tonk:admin"
+}
+
+#[cfg(test)]
+mod self_did {
+    use super::*;
+
+    #[test]
+    fn it_queries_the_replica_profile_by_raw_attribute() {
+        let body = self_did_query_body();
+        assert!(body.contains("xyz.tonk.replica/profile"));
+        assert!(body.contains("\"this\":{\"?\""));
+        assert!(!body.contains("tonk:profile"));
+    }
+
+    #[test]
+    fn it_reads_the_profile_off_the_first_row() {
+        let rows = json!([
+            { "this": "r1", "fields": { "profile": "did:key:zMe" } },
+            { "this": "r2", "fields": { "profile": "did:key:zMe" } }
+        ]);
+        assert_eq!(
+            self_did_from_conclusions(&rows).as_deref(),
+            Some("did:key:zMe")
+        );
+        assert_eq!(self_did_from_conclusions(&json!([])), None);
+    }
+
+    #[test]
+    fn it_lets_founders_and_admins_manage_members() {
+        assert!(role_manages_members("tonk:founder"));
+        assert!(role_manages_members("tonk:admin"));
+        assert!(!role_manages_members("tonk:member"));
+        assert!(!role_manages_members(""));
+    }
+}
+
 #[cfg(test)]
 mod promote {
     use super::*;

--- a/rust/tonk-fab/src/member_roster.rs
+++ b/rust/tonk-fab/src/member_roster.rs
@@ -28,7 +28,9 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::{JsFuture, spawn_local};
 use web_sys::{Element, HtmlElement, window};
 
-use crate::logic::member_roster_query_body;
+use crate::logic::{
+    member_roster_query_body, role_manages_members, self_did_from_conclusions, self_did_query_body,
+};
 use crate::subscribing;
 
 const SUB_TAG: &str = "ui-member-roster";
@@ -40,6 +42,10 @@ pub struct UiMemberRosterElement {
     /// delta can upsert/retract individual rows rather than needing a full
     /// snapshot every time. Order is insertion order.
     members: Rc<RefCell<Vec<Member>>>,
+    /// The signed-in member's own profile DID, resolved once from the
+    /// profile branch. Which roster row is "me" decides whether the
+    /// management controls render at all.
+    viewer: Rc<RefCell<Option<String>>>,
 }
 
 impl CustomElement for UiMemberRosterElement {
@@ -56,8 +62,12 @@ impl CustomElement for UiMemberRosterElement {
     fn connected_callback(&mut self, this: &HtmlElement) {
         let behaviour: Rc<dyn subscribing::Subscribing> = Rc::new(MemberRosterBehaviour {
             members: self.members.clone(),
+            viewer: self.viewer.clone(),
         });
         self.scaffold.connect(this, behaviour);
+        if self.viewer.borrow().is_none() {
+            resolve_viewer(this, self.members.clone(), self.viewer.clone());
+        }
     }
 
     fn attribute_changed_callback(
@@ -76,6 +86,7 @@ impl CustomElement for UiMemberRosterElement {
         self.scaffold.disconnect();
         let behaviour: Rc<dyn subscribing::Subscribing> = Rc::new(MemberRosterBehaviour {
             members: self.members.clone(),
+            viewer: self.viewer.clone(),
         });
         self.scaffold.connect(this, behaviour);
     }
@@ -99,6 +110,7 @@ struct Member {
 /// roster query, and rendering delivered frames as member spans.
 struct MemberRosterBehaviour {
     members: Rc<RefCell<Vec<Member>>>,
+    viewer: Rc<RefCell<Option<String>>>,
 }
 
 impl subscribing::Subscribing for MemberRosterBehaviour {
@@ -118,7 +130,7 @@ impl subscribing::Subscribing for MemberRosterBehaviour {
                 members.push(row);
             }
         }
-        render_spans(host, &members);
+        render_spans(host, &members, self.viewer.borrow().as_deref());
     }
 
     fn render_update(&self, host: &HtmlElement, payload: &JsValue) {
@@ -146,7 +158,7 @@ impl subscribing::Subscribing for MemberRosterBehaviour {
             }
         }
 
-        render_spans(host, &members);
+        render_spans(host, &members, self.viewer.borrow().as_deref());
     }
 
     fn tag(&self) -> &'static str {
@@ -178,11 +190,11 @@ fn read_row(row: &JsValue) -> Option<Member> {
 }
 
 /// Rebuild the host's children as one member span per row, in `members`'
-/// order — the markup the deleted `fab-roster` view used to supply. A
-/// member who is not already an admin or the founder gets a "Make admin"
-/// button; the worker refuses the rest, but there is no point offering
-/// what it will refuse.
-fn render_spans(host: &HtmlElement, members: &[Member]) {
+/// order — the markup the deleted `fab-roster` view used to supply. When
+/// the viewer's own row is the founder or an admin, every member who is
+/// not already one gets a "Make admin" button; the worker refuses the
+/// rest, but there is no point offering what it will refuse.
+fn render_spans(host: &HtmlElement, members: &[Member], viewer: Option<&str>) {
     while let Some(child) = host.first_child() {
         let _ = host.remove_child(&child);
     }
@@ -190,6 +202,9 @@ fn render_spans(host: &HtmlElement, members: &[Member]) {
         return;
     };
     let space = host.get_attribute("space").unwrap_or_default();
+    let manages = viewer
+        .and_then(|viewer| members.iter().find(|member| member.did == viewer))
+        .is_some_and(|me| role_manages_members(&me.role));
     for member in members {
         let Ok(span) = document.create_element("span") else {
             continue;
@@ -197,7 +212,7 @@ fn render_spans(host: &HtmlElement, members: &[Member]) {
         let _ = span.set_attribute("class", "fab__menu-item fab__menu-item--member");
         let _ = span.set_attribute("data-role", &member.role);
         span.set_text_content(Some(&member.name));
-        if !space.is_empty() && member.role != "tonk:founder" && member.role != "tonk:admin" {
+        if manages && !space.is_empty() && !role_manages_members(&member.role) {
             if let Ok(button) = document.create_element("button") {
                 let _ = button.set_attribute("type", "button");
                 let _ = button.set_attribute("class", "fab__member-promote");
@@ -210,6 +225,61 @@ fn render_spans(host: &HtmlElement, members: &[Member]) {
         }
         let _ = host.append_child(&span);
     }
+}
+
+/// Resolve the viewer's own profile DID with a one-shot, routeless
+/// `window.tonk.query` (the FAB mounts on the profile branch), then
+/// re-render so the management controls appear once "me" is known. A
+/// failed or empty answer leaves the roster read-only.
+fn resolve_viewer(
+    host: &HtmlElement,
+    members: Rc<RefCell<Vec<Member>>>,
+    viewer: Rc<RefCell<Option<String>>>,
+) {
+    let Some(win) = window() else { return };
+    let Some(tonk) = Reflect::get(&win, &"tonk".into())
+        .ok()
+        .and_then(|v| v.dyn_into::<Object>().ok())
+    else {
+        return;
+    };
+    let Some(query) = Reflect::get(&tonk, &"query".into())
+        .ok()
+        .and_then(|v| v.dyn_into::<Function>().ok())
+    else {
+        return;
+    };
+    let Ok(body) = js_sys::JSON::parse(&self_did_query_body()) else {
+        return;
+    };
+    let Some(promise) = query
+        .call1(&tonk, &body)
+        .ok()
+        .and_then(|v| v.dyn_into::<js_sys::Promise>().ok())
+    else {
+        return;
+    };
+    let host = host.clone();
+    spawn_local(async move {
+        let rows = match JsFuture::from(promise).await {
+            Ok(rows) => rows,
+            Err(error) => {
+                log!("{SUB_TAG}: the profile query failed: {error:?}");
+                return;
+            }
+        };
+        let json = js_sys::JSON::stringify(&rows)
+            .ok()
+            .and_then(|s| s.as_string())
+            .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok());
+        let Some(did) = json.as_ref().and_then(self_did_from_conclusions) else {
+            return;
+        };
+        *viewer.borrow_mut() = Some(did);
+        if host.is_connected() {
+            render_spans(&host, &members.borrow(), viewer.borrow().as_deref());
+        }
+    });
 }
 
 /// Wire a "Make admin" button: on click, ask the outer page to delegate

--- a/rust/tonk-fab/src/member_roster.rs
+++ b/rust/tonk-fab/src/member_roster.rs
@@ -22,9 +22,11 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use custom_elements::CustomElement;
-use js_sys::Reflect;
+use js_sys::{Function, Object, Reflect};
+use tonk_common::log;
 use wasm_bindgen::prelude::*;
-use web_sys::{HtmlElement, window};
+use wasm_bindgen_futures::{JsFuture, spawn_local};
+use web_sys::{Element, HtmlElement, window};
 
 use crate::logic::member_roster_query_body;
 use crate::subscribing;
@@ -37,7 +39,7 @@ pub struct UiMemberRosterElement {
     /// The live member set, keyed by each row's entity `this` so an `update`
     /// delta can upsert/retract individual rows rather than needing a full
     /// snapshot every time. Order is insertion order.
-    members: Rc<RefCell<Vec<(String, String)>>>,
+    members: Rc<RefCell<Vec<Member>>>,
 }
 
 impl CustomElement for UiMemberRosterElement {
@@ -83,10 +85,20 @@ impl CustomElement for UiMemberRosterElement {
     }
 }
 
+/// One roster row: the membership entity, the name shown, the DID the
+/// membership is keyed on, and the role stamped on it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Member {
+    this: String,
+    name: String,
+    did: String,
+    role: String,
+}
+
 /// This element's [`subscribing::Subscribing`] behaviour: the directory-mode
 /// roster query, and rendering delivered frames as member spans.
 struct MemberRosterBehaviour {
-    members: Rc<RefCell<Vec<(String, String)>>>,
+    members: Rc<RefCell<Vec<Member>>>,
 }
 
 impl subscribing::Subscribing for MemberRosterBehaviour {
@@ -116,20 +128,20 @@ impl subscribing::Subscribing for MemberRosterBehaviour {
 
         let retracted_rows = js_sys::Array::from(&retracted);
         for i in 0..retracted_rows.length() {
-            if let Some((id, _)) = read_row(&retracted_rows.get(i)) {
-                members.retain(|(existing_id, _)| existing_id != &id);
+            if let Some(row) = read_row(&retracted_rows.get(i)) {
+                members.retain(|existing| existing.this != row.this);
             }
         }
 
         let asserted_rows = js_sys::Array::from(&asserted);
         for i in 0..asserted_rows.length() {
-            if let Some((id, name)) = read_row(&asserted_rows.get(i)) {
+            if let Some(row) = read_row(&asserted_rows.get(i)) {
                 match members
                     .iter_mut()
-                    .find(|(existing_id, _)| existing_id == &id)
+                    .find(|existing| existing.this == row.this)
                 {
-                    Some(existing) => existing.1 = name,
-                    None => members.push((id, name)),
+                    Some(existing) => *existing = row,
+                    None => members.push(row),
                 }
             }
         }
@@ -146,34 +158,124 @@ impl subscribing::Subscribing for MemberRosterBehaviour {
 /// a missing/empty row, a missing entity id, or a missing/non-string name —
 /// mirroring the query's requirement that all three fields (and so the row's
 /// `this`) are present for a row to appear at all.
-fn read_row(row: &JsValue) -> Option<(String, String)> {
+fn read_row(row: &JsValue) -> Option<Member> {
     if row.is_undefined() || row.is_null() {
         return None;
     }
     let this_id = Reflect::get(row, &"this".into()).ok()?.as_string()?;
-    let name = Reflect::get(row, &"fields".into())
-        .ok()
-        .and_then(|fields| Reflect::get(&fields, &"name".into()).ok())
-        .and_then(|v| v.as_string())?;
-    Some((this_id, name))
+    let fields = Reflect::get(row, &"fields".into()).ok()?;
+    let field = |name: &str| {
+        Reflect::get(&fields, &name.into())
+            .ok()
+            .and_then(|value| value.as_string())
+    };
+    Some(Member {
+        this: this_id,
+        name: field("name")?,
+        did: field("member")?,
+        role: field("role").unwrap_or_default(),
+    })
 }
 
 /// Rebuild the host's children as one member span per row, in `members`'
-/// order — the markup the deleted `fab-roster` view used to supply.
-fn render_spans(host: &HtmlElement, members: &[(String, String)]) {
+/// order — the markup the deleted `fab-roster` view used to supply. A
+/// member who is not already an admin or the founder gets a "Make admin"
+/// button; the worker refuses the rest, but there is no point offering
+/// what it will refuse.
+fn render_spans(host: &HtmlElement, members: &[Member]) {
     while let Some(child) = host.first_child() {
         let _ = host.remove_child(&child);
     }
     let Some(document) = window().and_then(|w| w.document()) else {
         return;
     };
-    for (_, name) in members {
+    let space = host.get_attribute("space").unwrap_or_default();
+    for member in members {
         let Ok(span) = document.create_element("span") else {
             continue;
         };
         let _ = span.set_attribute("class", "fab__menu-item fab__menu-item--member");
-        span.set_text_content(Some(name));
+        let _ = span.set_attribute("data-role", &member.role);
+        span.set_text_content(Some(&member.name));
+        if !space.is_empty() && member.role != "tonk:founder" && member.role != "tonk:admin" {
+            if let Ok(button) = document.create_element("button") {
+                let _ = button.set_attribute("type", "button");
+                let _ = button.set_attribute("class", "fab__member-promote");
+                let _ =
+                    button.set_attribute("aria-label", &format!("Make {} an admin", member.name));
+                button.set_text_content(Some("Make admin"));
+                install_promote(&button, space.clone(), member.did.clone());
+                let _ = span.append_child(&button);
+            }
+        }
         let _ = host.append_child(&span);
+    }
+}
+
+/// Wire a "Make admin" button: on click, ask the outer page to delegate
+/// `/` on the space to the member's account (the passkey ceremony runs
+/// there, inside this click's activation), then dispatch `member/promote`
+/// carrying the hop it minted. Errors are logged; the roster shows the
+/// outcome when the role row arrives through the subscription.
+fn install_promote(button: &Element, space: String, member: String) {
+    let on_click = Closure::<dyn FnMut(web_sys::Event)>::new(move |_event: web_sys::Event| {
+        let space = space.clone();
+        let member = member.clone();
+        spawn_local(async move {
+            match delegate(&space, "/", &member).await {
+                Ok(chain) => transact(&crate::logic::promote_claim_json(&space, &member, &chain)),
+                Err(error) => log!("member/promote: the page did not delegate: {error:?}"),
+            }
+        });
+    });
+    let _ = button.add_event_listener_with_callback("click", on_click.as_ref().unchecked_ref());
+    on_click.forget();
+}
+
+/// `window.tonk.delegate({subject, command, audience})`: the outer page
+/// mints `root -> audience` under the passkey and answers with the base58
+/// chain.
+async fn delegate(subject: &str, command: &str, audience: &str) -> Result<String, JsValue> {
+    let win = window().ok_or_else(|| JsValue::from_str("no window"))?;
+    let tonk = Reflect::get(&win, &"tonk".into())?
+        .dyn_into::<Object>()
+        .map_err(|_| JsValue::from_str("no window.tonk"))?;
+    let delegate = Reflect::get(&tonk, &"delegate".into())?
+        .dyn_into::<Function>()
+        .map_err(|_| JsValue::from_str("window.tonk.delegate is missing"))?;
+    let request = Object::new();
+    Reflect::set(&request, &"subject".into(), &JsValue::from_str(subject))?;
+    Reflect::set(&request, &"command".into(), &JsValue::from_str(command))?;
+    Reflect::set(&request, &"audience".into(), &JsValue::from_str(audience))?;
+    let promise: js_sys::Promise = delegate.call1(&tonk, &request)?.dyn_into()?;
+    let answer = JsFuture::from(promise).await?;
+    answer
+        .as_string()
+        .ok_or_else(|| JsValue::from_str("the page answered without a chain"))
+}
+
+/// Dispatch a `TransactRequest` JSON body via `window.tonk.transact(...)`,
+/// routeless, so it lands on the FAB portal's own context where the
+/// command lives.
+fn transact(claim: &serde_json::Value) {
+    let Ok(json) = serde_json::to_string(claim) else {
+        return;
+    };
+    let Some(win) = window() else { return };
+    let Some(tonk) = Reflect::get(&win, &"tonk".into())
+        .ok()
+        .and_then(|v| v.dyn_into::<Object>().ok())
+    else {
+        return;
+    };
+    let Some(transact) = Reflect::get(&tonk, &"transact".into())
+        .ok()
+        .and_then(|v| v.dyn_into::<Function>().ok())
+    else {
+        return;
+    };
+    if let Ok(request) = js_sys::JSON::parse(&json) {
+        let _ = transact.call1(&tonk, &request);
     }
 }
 

--- a/rust/tonk-portal/Cargo.toml
+++ b/rust/tonk-portal/Cargo.toml
@@ -17,7 +17,13 @@ js-sys = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde-wasm-bindgen = { workspace = true }
 serde_json = { workspace = true }
+anyhow = { workspace = true }
+bs58 = { workspace = true }
+dialog-credentials = { workspace = true }
+dialog-ucan-core = { workspace = true }
+dialog-varsig = { workspace = true }
 tonk-common = { workspace = true }
+tonk-identity = { workspace = true }
 tonk-host = { workspace = true }
 tonk-worker-api = { workspace = true }
 wasm-bindgen = { workspace = true }

--- a/rust/tonk-portal/src/bridge.rs
+++ b/rust/tonk-portal/src/bridge.rs
@@ -241,6 +241,12 @@ const BOOTSTRAP_JS: &str = r#"(function(){
     // {document, transact}; the parent relays it to the installed host's
     // consumer path, which performs the typed evaluate and returns its parsed result.
     evaluate:function(detail){return call("evaluate",{document:(detail&&detail.document)||"",transact:!(detail&&detail.transact===false)});},
+    // Ask the HOST page to delegate: the account root lives behind the
+    // passkey, and WebAuthn exists only on the top-level window, inside a
+    // user gesture. A guest click posts {subject, command, audience} here;
+    // the parent runs the ceremony and answers with the minted hop (base58
+    // of the serialized chain), or rejects with the reason.
+    delegate:function(request){return call("delegate",request||{});},
     // Navigate the HOST page: the opaque guest can't touch parent.location
     // and has no router, so a link click posts its href here and the parent
     // performs the real navigation. Fire-and-forget (no response).
@@ -304,6 +310,10 @@ const BOOTSTRAP_JS: &str = r#"(function(){
         var h=pending.get(env.id); if(!h) return; pending.delete(env.id);
         h.resolve(env.result); return;
       }
+      case "delegate-result": {
+        var h=pending.get(env.id); if(!h) return; pending.delete(env.id);
+        h.resolve(env.delegation); return;
+      }
       case "fetch-result": {
         var h=pending.get(env.id); if(!h) return; pending.delete(env.id);
         // Rebuild a real Response from the status/headers the host captured
@@ -360,7 +370,7 @@ const BOOTSTRAP_JS: &str = r#"(function(){
         h.resolve(rebuilt);
         return;
       }
-      case "query-error": case "transact-error": case "evaluate-error": case "fetch-error": {
+      case "query-error": case "transact-error": case "evaluate-error": case "fetch-error": case "delegate-error": {
         var h=pending.get(env.id); if(!h) return; pending.delete(env.id);
         h.reject(new Error(env.error)); return;
       }
@@ -1546,6 +1556,7 @@ fn make_dispatcher(
             "title" => handle_title(&data),
             "open" => handle_open(&state, &data),
             "fetch" => handle_host_fetch(&state, &port, &data),
+            "delegate" => handle_delegate(&port, &data),
             _ => {}
         }
     }) as Box<dyn FnMut(MessageEvent)>)
@@ -1860,6 +1871,77 @@ fn title_text(data: &JsValue) -> Option<String> {
 /// and no `allow-top-navigation`, so it cannot open anything itself; it posts
 /// the raw href and `tonk_host::open_external` — running on the page, which is
 /// the only place that can both resolve and open it — decides what happens.
+/// Mint a delegation under the passkey on the guest's behalf.
+///
+/// The guest asks `{ subject, command, audience }`; the account root that
+/// signs it lives behind the passkey, which exists only on this top-level
+/// window and only inside a user gesture. The guest's click propagates its
+/// activation to this frame, so the ceremony runs here immediately and the
+/// prompt is the user's own gesture. The hop minted is `root -> audience`
+/// over `subject` at `command`; the guest carries it to the worker, which
+/// checks it against what it composes it with. Answered with
+/// `delegate-result` carrying the base58 chain, or `delegate-error`.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+fn handle_delegate(port: &MessagePort, data: &JsValue) {
+    let Some(id) = get_str(data, "id") else {
+        return;
+    };
+    let request = (
+        get_str(data, "subject").unwrap_or_default(),
+        get_str(data, "command").unwrap_or_default(),
+        get_str(data, "audience").unwrap_or_default(),
+    );
+    let port = port.clone();
+    wasm_bindgen_futures::spawn_local(async move {
+        match mint_delegation(&request.0, &request.1, &request.2).await {
+            Ok(encoded) => post_result(
+                &port,
+                "delegate-result",
+                &id,
+                "delegation",
+                &JsValue::from_str(&encoded),
+            ),
+            Err(error) => post_error(&port, "delegate-error", &id, &format!("{error:#}")),
+        }
+    });
+}
+
+/// Run the passkey ceremony and mint `root -> audience` over `subject` at
+/// `command`, returning the serialized chain as base58.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn mint_delegation(subject: &str, command: &str, audience: &str) -> anyhow::Result<String> {
+    use dialog_ucan_core::command::Command;
+    use dialog_ucan_core::subject::Subject as UcanSubject;
+    use dialog_ucan_core::{DelegationBuilder, DelegationChain};
+    use dialog_varsig::Did;
+
+    let subject: Did = subject
+        .parse()
+        .map_err(|error| anyhow::anyhow!("the subject is not a DID: {error:?}"))?;
+    let audience: Did = audience
+        .parse()
+        .map_err(|error| anyhow::anyhow!("the audience is not a DID: {error:?}"))?;
+    let command = Command::parse(command)
+        .map_err(|error| anyhow::anyhow!("the command does not parse: {error}"))?;
+    // The custody endpoint the page's other ceremonies use: the account
+    // service is served under `/ucan/` on the page's own origin.
+    let origin = web_sys::window()
+        .and_then(|window| window.location().origin().ok())
+        .ok_or_else(|| anyhow::anyhow!("window origin is unavailable"))?;
+    let endpoint = format!("{}/ucan/", origin.trim_end_matches('/'));
+    let root = tonk_identity::ceremony::unlock_root(&endpoint).await?;
+    let delegation = DelegationBuilder::new()
+        .issuer(dialog_credentials::Signer::from(root))
+        .audience(&audience)
+        .subject(UcanSubject::Specific(subject))
+        .command(command.segments().clone())
+        .try_build()
+        .await
+        .map_err(|error| anyhow::anyhow!("failed to mint the delegation: {error}"))?;
+    let bytes = DelegationChain::new(delegation).to_bytes()?;
+    Ok(bs58::encode(bytes).into_string())
+}
+
 fn handle_open(state: &Rc<RefCell<PortalState>>, data: &JsValue) {
     let Some(href) = open_href(data) else {
         return;

--- a/rust/tonk-schema/src/command.rs
+++ b/rust/tonk-schema/src/command.rs
@@ -312,20 +312,29 @@ impl Command for RemoveSpace {
     type Output = ();
 }
 
-/// Promote a member of the space this command fires in to admin.
+/// Promote a member of a space to admin.
 ///
-/// Asserted transiently by the roster row's promote form; the worker's
-/// handler mints a `/` chain to the member's account, retains it in the
-/// space db beside the invites, and stamps `MemberRole::admin`. The
-/// target space is the dispatch origin, as for `tonk:invite`. A single
-/// matched field, like [`RemoveSpace`]: `dataset/promote` is read by no
-/// other command, so it is the command's shape as well as its payload.
+/// Dispatched by the FAB's roster after the page minted the admin hop
+/// under the passkey: the guest asks the outer page to delegate `/` on
+/// the space to the member's account, and the page answers with the hop
+/// signed by the promoter's account root. The worker's handler proves the
+/// promoter's own `/` chain from the space db, appends the hop, checks it
+/// is the one asked for, retains the chain beside the invites, and stamps
+/// `MemberRole::admin`. No device key sits in the admin chain, so signing
+/// a device out never takes the admins it promoted with it.
+///
+/// Routeless like `tonk:pause-sync`: the command names its `space` rather
+/// than firing on it, so the FAB needs nothing seeded per space.
 #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PromoteMember {
     /// The command entity (a fresh id per invocation).
     pub this: Entity,
-    /// The DID the member's membership is keyed on, from `data-promote`.
-    pub member: crate::domain::command::promote::Promote,
+    /// The DID the member's membership is keyed on.
+    pub member: crate::domain::command::promote::Member,
+    /// The space the promotion is in.
+    pub space: crate::domain::command::promote::Space,
+    /// The page-minted `promoter-account -> member` hop, base58.
+    pub chain: crate::domain::command::promote::Chain,
 }
 
 impl Command for PromoteMember {

--- a/rust/tonk-schema/src/domain.rs
+++ b/rust/tonk-schema/src/domain.rs
@@ -594,19 +594,29 @@ pub mod command {
         pub struct Remove(pub Entity);
     }
 
-    /// Attributes of the `member/promote` command.
+    /// Attributes of the `member/promote` command, dispatched by the FAB's
+    /// roster once the page has minted the admin hop.
     pub mod promote {
         use super::super::Entity;
         use super::Attribute;
 
-        /// The DID of the member to promote to admin, read from the roster
-        /// row's `data-promote`. The distinctly named attribute is both the
-        /// payload and the command's unique shape, as with
-        /// [`super::remove::Remove`]. An `Entity` because a DID carries a
-        /// `:`. Derived attribute: `dom.event.current-target.dataset/promote`.
+        /// The DID the member's membership is keyed on. Derived attribute:
+        /// `xyz.tonk.promote/member`.
         #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
-        #[domain("dom.event.current-target.dataset")]
-        pub struct Promote(pub Entity);
+        #[domain("xyz.tonk.promote")]
+        pub struct Member(pub Entity);
+
+        /// The space the promotion is in: dispatched routeless from the FAB,
+        /// the command names its target rather than firing on it.
+        #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        #[domain("xyz.tonk.promote")]
+        pub struct Space(pub Entity);
+
+        /// The hop the page minted under the passkey, `promoter-account ->
+        /// member` over the space at `/`, as base58 of the serialized chain.
+        #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        #[domain("xyz.tonk.promote")]
+        pub struct Chain(pub String);
     }
 
     /// Attributes of the `member/expel` command.

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -660,7 +660,26 @@ mod tests {
             .await?;
         // The callback answers the form POST with a redirect back to the
         // account page, which renders the outcome in its own styling.
-        element(driver, "tonk-account[data-mode=\"success\"]").await?;
+        if let Err(wait_error) = element(driver, "tonk-account[data-mode=\"success\"]").await {
+            // Say WHERE the approval stopped, not just that it did: the
+            // panel's mode, its error line, and its status line are what
+            // separate a ceremony that failed from a callback that never
+            // redirected.
+            let host = element(driver, "tonk-account").await?;
+            let mode = host.attr("data-mode").await?.unwrap_or_default();
+            let error = match driver.find(By::Css("#account-error")).await {
+                Ok(element) => element.text().await.unwrap_or_default(),
+                Err(_) => String::new(),
+            };
+            let working = match driver.find(By::Css("#account-working")).await {
+                Ok(element) => element.text().await.unwrap_or_default(),
+                Err(_) => String::new(),
+            };
+            let url = driver.current_url().await?;
+            return Err(wait_error).context(format!(
+                "approval stopped in mode {mode:?} at {url}; error={error:?}; status={working:?}"
+            ));
+        }
         wait_for_text(
             driver,
             "#account-success-message",

--- a/rust/tonk-worker/src/router/members.rs
+++ b/rust/tonk-worker/src/router/members.rs
@@ -17,10 +17,8 @@
 //! authority question is answered by what the chain covers, not by the
 //! role fact. See `plan/space-admins.md`.
 
-use dialog_capability::Subject;
 use dialog_query::{Output as _, Query, Term};
 use dialog_repository::RepositoryExt as _;
-use dialog_ucan::UcanDelegation;
 use dialog_ucan_core::DelegationChain;
 use dialog_varsig::Did;
 use ipld_core::cid::Cid;
@@ -198,18 +196,21 @@ pub(crate) async fn expel_member(
     Ok(receipt)
 }
 
-/// Promote `member` of the space at `repo` to admin.
+/// Admit `member` of the space at `repo` as admin, with the hop the page
+/// minted under the passkey.
 ///
-/// Mints a `/` chain from this profile's authority for the space down to
-/// the member's account, exactly as a scoped invite is minted but without
-/// the attenuation, retains it in the space db beside the invites, and
-/// stamps the role. The member's devices find the chain where every
-/// other member proof is found; nothing is sent to them. Returns the CID
-/// of the chain's leaf: the hop a demotion revokes.
-pub(crate) async fn promote_member(
+/// The promoter's own `/` chain for the space (an admin chain retained in
+/// the space db, or the creation prefix for a founder) ends at their
+/// account; `hop` must be that account's delegation of `/` on the space to
+/// the member, and nothing else: issued by the account, to the member, over
+/// this space, unattenuated. The composed chain is retained beside the
+/// invites, where the member's devices prove from, and the role is
+/// stamped. Returns the CID of the hop: what a demotion revokes.
+pub(crate) async fn admit_member(
     tonk: &TonkState,
     repo: &str,
     member: &Did,
+    hop: DelegationChain,
 ) -> Result<Cid, TonkWorkerError> {
     let session = tonk
         .reactor
@@ -243,17 +244,40 @@ pub(crate) async fn promote_member(
         Some(_) => {}
     }
 
-    let delegation: UcanDelegation = tonk
-        .profile
-        .access()
-        .claim(Subject::from(subject.clone()))
-        .delegate(member.clone())
-        .perform(&tonk.operator)
-        .await
-        .map_err(|error| {
-            TonkWorkerError::Forbidden(format!("cannot mint an admin chain: {error}"))
-        })?;
-    let chain = delegation.into_chain();
+    let authority =
+        super::revoke_invite::account_authority(tonk, session.handle(), &subject).await?;
+    let hops: Vec<_> = hop.proofs().collect();
+    let [delegation] = hops.as_slice() else {
+        return Err(TonkWorkerError::Forbidden(
+            "the page must answer with exactly one hop".to_string(),
+        ));
+    };
+    if delegation.issuer() != authority.audience() {
+        return Err(TonkWorkerError::Forbidden(format!(
+            "the hop is issued by {}, not by this profile's account {}",
+            delegation.issuer(),
+            authority.audience()
+        )));
+    }
+    if delegation.audience() != member {
+        return Err(TonkWorkerError::Forbidden(format!(
+            "the hop admits {}, not {member}",
+            delegation.audience()
+        )));
+    }
+    if !delegation.subject().allows(&subject) {
+        return Err(TonkWorkerError::Forbidden(
+            "the hop is over another subject than this space".to_string(),
+        ));
+    }
+    if !delegation.command().segments().is_empty() {
+        return Err(TonkWorkerError::Forbidden(
+            "an admin holds the whole space; the hop is attenuated".to_string(),
+        ));
+    }
+    let chain = authority.push((*delegation).clone()).map_err(|error| {
+        TonkWorkerError::Forbidden(format!("the hop does not chain onto the account: {error}"))
+    })?;
     let target = leaf_cid(&chain)?;
     super::create_invite::retain_invite_authority(tonk, repo, &chain).await?;
 
@@ -284,8 +308,8 @@ where
         .and_then(|command| member(&command).parse::<Did>().ok())
 }
 
-/// Runs `member/promote`: the roster row's promote form on the space the
-/// command fires in.
+/// Runs `member/promote`: dispatched by the FAB's roster with the hop the
+/// page minted, naming its space.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) struct PromoteMemberHandler {
     attributes: Vec<String>,
@@ -302,16 +326,28 @@ impl PromoteMemberHandler {
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+fn decode_promotion(facts: &crate::reactor::EntityFacts) -> Option<(String, Did, DelegationChain)> {
+    use crate::reactor::Decode as _;
+    use tonk_schema::prelude::DidExt as _;
+    let command = facts
+        .first()
+        .map(|artifact| artifact.of.clone())
+        .and_then(|entity| tonk_schema::command::PromoteMember::decode(entity, facts))?;
+    let space: Did = command.space.0.to_string().parse().ok()?;
+    let member: Did = command.member.0.to_string().parse().ok()?;
+    let bytes = bs58::decode(&command.chain.0).into_vec().ok()?;
+    let hop = DelegationChain::try_from(bytes.as_slice()).ok()?;
+    Some((space.repo_key().to_owned(), member, hop))
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl crate::reactor::CommandHandler<crate::router::CommandEnv> for PromoteMemberHandler {
     fn trigger_attributes(&self) -> &[String] {
         &self.attributes
     }
 
     fn matches(&self, facts: &crate::reactor::EntityFacts) -> bool {
-        member_of::<tonk_schema::command::PromoteMember>(facts, |command| {
-            command.member.0.to_string()
-        })
-        .is_some()
+        decode_promotion(facts).is_some()
     }
 
     fn run(
@@ -319,18 +355,15 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for PromoteMember
         facts: &crate::reactor::EntityFacts,
         env: &crate::router::CommandEnv,
     ) -> crate::reactor::RunFuture {
-        let member = member_of::<tonk_schema::command::PromoteMember>(facts, |command| {
-            command.member.0.to_string()
-        });
+        let decoded = decode_promotion(facts);
         let env = env.clone();
         Box::pin(async move {
-            let Some(member) = member else {
-                log!("member/promote: no/unparseable member, skipping");
+            let Some((repo, member, hop)) = decoded else {
+                log!("member/promote: no/unparseable member, space, or chain; skipping");
                 return;
             };
-            let repo = env.origin().repo.clone();
             let tonk = env.state().read().await;
-            match promote_member(&tonk, &repo, &member).await {
+            match admit_member(&tonk, &repo, &member, hop).await {
                 Ok(target) => log!("member/promote: {member} is an admin of {repo} ({target})"),
                 Err(error) => log!("member/promote for {member} on {repo} failed: {error}"),
             }
@@ -526,33 +559,63 @@ mod tests {
         );
     }
 
-    /// Promotion stamps the role and leaves a `/` chain to the member's
-    /// account in the space db, where any member can prove it.
+    /// The hop the page mints under the passkey: this profile's account root
+    /// delegating `/` on the space to the member.
+    async fn root_hop(
+        state: &crate::router::AppState,
+        subject: &Did,
+        member: &Did,
+        issuer: Option<Ed25519Signer>,
+    ) -> DelegationChain {
+        use dialog_ucan_core::DelegationBuilder;
+        let issuer = match issuer {
+            Some(issuer) => issuer,
+            None => {
+                let seed = crate::router::tests::test_root_seed(&state.read().await.profile_name);
+                Ed25519Signer::import(&seed).await.unwrap()
+            }
+        };
+        let delegation = DelegationBuilder::new()
+            .issuer(dialog_credentials::Signer::from(issuer))
+            .audience(member)
+            .subject(UcanSubject::Specific(subject.clone()))
+            .command(vec![])
+            .try_build()
+            .await
+            .unwrap();
+        DelegationChain::new(delegation)
+    }
+
+    async fn seed_member(state: &crate::router::AppState, key: &str, member: &Did, subject: &Did) {
+        let tonk = state.read().await;
+        let membership = Membership::new(member.clone(), subject.clone());
+        tonk.reactor
+            .repository(key)
+            .branch(CONTENT_BRANCH)
+            .transaction()
+            .assert(membership.clone())
+            .assert(MemberRole::member(membership.this().clone()))
+            .commit()
+            .perform(&tonk.operator)
+            .await
+            .unwrap();
+    }
+
+    /// Admitting stamps the role and leaves a `/` chain to the member's
+    /// account in the space db, where any member can prove it, with no
+    /// device key in it.
     #[dialog_common::test]
-    async fn it_promotes_a_member_with_a_full_chain_retained_in_the_space() {
+    async fn it_admits_a_member_with_a_root_signed_chain_retained_in_the_space() {
         let (app, state, _lsp) = api_router_with_state(test_state().await);
         let key = put_repo(&app, "members-promote").await;
         let (branch, subject) = open_content(&state, &key).await;
         let member = Ed25519Signer::generate().await.unwrap().did();
-        // Seed the roster as a claim would.
-        {
-            let tonk = state.read().await;
-            let membership = Membership::new(member.clone(), subject.clone());
-            tonk.reactor
-                .repository(&key)
-                .branch(CONTENT_BRANCH)
-                .transaction()
-                .assert(membership.clone())
-                .assert(MemberRole::member(membership.this().clone()))
-                .commit()
-                .perform(&tonk.operator)
-                .await
-                .unwrap();
-        }
+        seed_member(&state, &key, &member, &subject).await;
+        let hop = root_hop(&state, &subject, &member, None).await;
 
         let target = {
             let tonk = state.read().await;
-            promote_member(&tonk, &key, &member).await.unwrap()
+            admit_member(&tonk, &key, &member, hop).await.unwrap()
         };
 
         let roles = content_member_roles(&state, &key).await;
@@ -567,6 +630,7 @@ mod tests {
         );
 
         let tonk = state.read().await;
+        let device = tonk.profile.did();
         let full = Scope {
             subject: UcanSubject::Specific(subject.clone()),
             command: Command::parse("/").unwrap(),
@@ -583,6 +647,52 @@ mod tests {
             target,
             "the returned target is the chain's leaf"
         );
+        assert!(
+            proof
+                .proofs
+                .iter()
+                .all(|certificate| certificate.0.issuer() != &device),
+            "no device key issues a hop of the admin chain"
+        );
+    }
+
+    /// A hop signed by anything but this profile's account is refused,
+    /// whatever it says.
+    #[dialog_common::test]
+    async fn it_refuses_a_hop_the_account_did_not_sign() {
+        let (app, state, _lsp) = api_router_with_state(test_state().await);
+        let key = put_repo(&app, "members-forged").await;
+        let (_, subject) = open_content(&state, &key).await;
+        let member = Ed25519Signer::generate().await.unwrap().did();
+        seed_member(&state, &key, &member, &subject).await;
+        let forger = Ed25519Signer::generate().await.unwrap();
+        let hop = root_hop(&state, &subject, &member, Some(forger)).await;
+
+        let tonk = state.read().await;
+        let error = admit_member(&tonk, &key, &member, hop).await.unwrap_err();
+        assert!(
+            matches!(error, TonkWorkerError::Forbidden(_)),
+            "got {error:?}"
+        );
+    }
+
+    /// A hop the account signed for someone else does not admit this member.
+    #[dialog_common::test]
+    async fn it_refuses_a_hop_to_another_audience() {
+        let (app, state, _lsp) = api_router_with_state(test_state().await);
+        let key = put_repo(&app, "members-audience").await;
+        let (_, subject) = open_content(&state, &key).await;
+        let member = Ed25519Signer::generate().await.unwrap().did();
+        let other = Ed25519Signer::generate().await.unwrap().did();
+        seed_member(&state, &key, &member, &subject).await;
+        let hop = root_hop(&state, &subject, &other, None).await;
+
+        let tonk = state.read().await;
+        let error = admit_member(&tonk, &key, &member, hop).await.unwrap_err();
+        assert!(
+            matches!(error, TonkWorkerError::Forbidden(_)),
+            "got {error:?}"
+        );
     }
 
     /// A stranger cannot be promoted: promotion describes a member.
@@ -591,8 +701,10 @@ mod tests {
         let (app, state, _lsp) = api_router_with_state(test_state().await);
         let key = put_repo(&app, "members-stranger").await;
         let stranger = Ed25519Signer::generate().await.unwrap().did();
+        let (_, subject) = open_content(&state, &key).await;
+        let hop = root_hop(&state, &subject, &stranger, None).await;
         let tonk = state.read().await;
-        let error = promote_member(&tonk, &key, &stranger).await.unwrap_err();
+        let error = admit_member(&tonk, &key, &stranger, hop).await.unwrap_err();
         assert!(
             matches!(error, TonkWorkerError::NotFound(_)),
             "got {error:?}"

--- a/rust/tonk-worker/src/router/revoke_invite.rs
+++ b/rust/tonk-worker/src/router/revoke_invite.rs
@@ -219,17 +219,15 @@ pub async fn revoke(
     Ok(Json(receipt))
 }
 
-/// This device's authority to revoke under the space: a `/` chain from the
-/// space down to this device.
+/// This profile's account's authority over the space: a `/` chain from the
+/// space down to the account.
 ///
-/// Searched on the space's own branch first, proving as this profile's
-/// account: that is where an admin's chain lives, retained by whoever
-/// promoted them. The creation prefix persisted at space creation is the
-/// fallback, for a founder whose space db holds no chains yet. Either way
-/// the chain reaches the account, so the root-to-device grant is pushed on
-/// top: that is the pair every other invocation on a space subject presents.
+/// Searched on the space's own branch first, proving as the account: that
+/// is where an admin's chain lives, retained by whoever promoted them. The
+/// creation prefix persisted at space creation is the fallback, for a
+/// founder whose space db holds no chains yet.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-async fn revoking_authority(
+pub(super) async fn account_authority(
     tonk: &TonkState,
     branch: &dialog_repository::Branch,
     subject: &Did,
@@ -240,7 +238,7 @@ async fn revoking_authority(
         command: Command::parse("/").expect("the root command always parses"),
         parameters: Parameters::default(),
     };
-    let mut authority = match branch
+    match branch
         .delegations()
         .prove(root.root_did.clone(), full)
         .perform(&tonk.operator)
@@ -258,13 +256,26 @@ async fn revoking_authority(
                             ))
                         })?;
                     }
-                    chain
+                    Ok(chain)
                 }
-                None => super::repository::space_root_prefix(tonk, subject).await?,
+                None => super::repository::space_root_prefix(tonk, subject).await,
             }
         }
-        Err(_) => super::repository::space_root_prefix(tonk, subject).await?,
-    };
+        Err(_) => super::repository::space_root_prefix(tonk, subject).await,
+    }
+}
+
+/// This device's authority to revoke under the space: the account's chain
+/// with the root-to-device grant pushed on top, the pair every other
+/// invocation on a space subject presents.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn revoking_authority(
+    tonk: &TonkState,
+    branch: &dialog_repository::Branch,
+    subject: &Did,
+) -> Result<DelegationChain, TonkWorkerError> {
+    let root = super::identity::local_root(tonk).await?;
+    let mut authority = account_authority(tonk, branch, subject).await?;
     for delegation in root.delegation.proofs() {
         authority = authority.push(delegation.clone()).map_err(|error| {
             TonkWorkerError::Internal(format!(


### PR DESCRIPTION
An admin's chain for a space must not run through the account's device key: `/` is what lets an admin revoke other members, and a chain that carries the device key dies with that device when it is signed out. Promotion therefore needs the passkey, and passkeys only work on the top-level page.

The FAB's roster (sealed guest) asks the outer page for the hop through the portal bridge: `window.tonk.delegate({subject, command: "/", audience})`. The page runs the custody ceremony (`ceremony::unlock_root`) inside the click's user activation, which propagates across the frame boundary, so no extra prompt or safeguard fires. It answers with the root-signed `account -> member` delegation, and the guest dispatches `member/promote` carrying it (member, space, chain). The `member/promote` form leaves `core.yaml`; `member/expel` stays as it was.

The worker handler (`admit_member`) proves its own `/` chain for the space, requires the hop to be a single delegation issued by that chain's audience to the member over the space with an empty command, appends it, retains the joined chain in the space beside the invites and stamps `tonk:admin`. Founders and non-members are refused.

Tests: `router::members::` covers the retained chain, a hop the account did not sign, a hop to another audience and a non-member; `tonk-fab` covers the command payload.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements and fixes related to member promotion and management within a space, focusing on the delegation process and error handling. It refines the `member/promote` command and its associated logic, ensuring proper handling of roles and delegation chains.

### Detailed summary
- Added dependencies: `anyhow`, `bs58`, `dialog-credentials`, `dialog-ucan-core`, `dialog-varsig`, `tonk-identity`.
- Updated error handling in `rust/tonk-ui/src/account_flow.rs` to provide more context on failure.
- Refined documentation for `member/promote` command attributes in `rust/tonk-schema/src/domain.rs`.
- Changed `promote_member` to `admit_member`, updating logic to validate delegation chains.
- Improved `handle_delegate` function to mint delegation under the passkey.
- Enhanced `UiMemberRosterElement` to manage member roles and viewer's profile.
- Added tests for member admission and delegation to ensure correct behavior and error handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->