### PR TITLE
fix: allow same-account login after logout

### DIFF
--- a/plan/logout-login-conflicting-state.md
+++ b/plan/logout-login-conflicting-state.md
@@ -1,0 +1,32 @@
+# Browser logout/login conflicting-state fix
+
+## Observed failure
+
+- Browser sign-out clears only the local provider attachment and preserves the
+  profile root, device DID, spaces, and server-side device registration.
+- Logging back in with the same passkey submits `/devices/link` for the same
+  account root and device DID with a freshly minted root-to-device delegation.
+- `register_device` always inserts a fresh active row, so the
+  `devices_one_active_did` index rejects the request and the account service
+  returns `conflicts with existing state`.
+
+## Plan
+
+- [x] Add regressions proving same-account browser re-login returns the existing
+  active attachment without adding device history.
+- [x] Make root-authorized browser re-login reuse an active same-account device
+  while retaining strict fresh-generation semantics for ordinary registration.
+- [x] Reattach the browser with its preserved local grant when the service
+  reuses that active generation.
+- [x] Run focused account-service tests, formatting, and relevant broader
+  checks.
+
+## Verification
+
+- Full account-service suite: 50 unit tests and 11 HTTP tests passed.
+- Full tonk-ui Wasm unit suite: 31 tests passed.
+- Native browser regression for logout followed by same-account login passed.
+- `cargo fmt --all -- --check`, account-service Clippy, isolated tonk-ui
+  Clippy, and `git diff --check` passed.
+- Dependency-inclusive tonk-ui Clippy remains blocked by six existing
+  `arc_with_non_send_sync` errors in `rust/dialog-reactor` on Wasm.

--- a/rust/tonk-account-service/src/core/devices.rs
+++ b/rust/tonk-account-service/src/core/devices.rs
@@ -53,10 +53,45 @@ pub async fn list_devices<S: Store>(
         .collect())
 }
 
-/// Register a new device under an account.
+/// Reuse the active generation after a root-authorized browser re-login.
+fn reuse_linked_device(existing: Device, account: &Account) -> Result<String, CeremonyError> {
+    if existing.account_id != account.id {
+        return Err(CeremonyError::Conflict(
+            "this device is already active on another account".to_string(),
+        ));
+    }
+    Ok(existing.attachment_id)
+}
+
 /// Generate a random 32-byte lowercase hex attachment identifier.
 pub fn random_attachment_id() -> String {
     hex::encode(rand::random::<[u8; 32]>())
+}
+
+async fn insert_device_registration<S: Store>(
+    store: &S,
+    account: &Account,
+    device_did: &str,
+    device_name: &str,
+    delegation_cid: String,
+    delegation_hex: String,
+    now: u64,
+) -> Result<String, StoreError> {
+    let attachment_id = random_attachment_id();
+    store
+        .insert_device(&Device {
+            id: 0,
+            account_id: account.id,
+            device_did: device_did.to_string(),
+            attachment_id: attachment_id.clone(),
+            delegation_cid,
+            delegation_hex,
+            name: device_name.to_string(),
+            status: DeviceStatus::Active,
+            created_at: now,
+        })
+        .await?;
+    Ok(attachment_id)
 }
 
 /// Register a fresh globally active attachment generation.
@@ -70,21 +105,60 @@ pub async fn register_device<S: Store>(
 ) -> Result<String, CeremonyError> {
     let delegation_cid =
         check_device_delegation(delegation_hex, &account.root_did, device_did).await?;
-    let attachment_id = random_attachment_id();
-    store
-        .insert_device(&Device {
-            id: 0,
-            account_id: account.id,
-            device_did: device_did.to_string(),
-            attachment_id: attachment_id.clone(),
-            delegation_cid,
-            delegation_hex: delegation_hex.to_string(),
-            name: device_name.to_string(),
-            status: DeviceStatus::Active,
-            created_at: now,
-        })
-        .await?;
-    Ok(attachment_id)
+    insert_device_registration(
+        store,
+        account,
+        device_did,
+        device_name,
+        delegation_cid,
+        delegation_hex.to_string(),
+        now,
+    )
+    .await
+    .map_err(Into::into)
+}
+
+/// Link a browser after a root-authorized passkey ceremony.
+///
+/// Browser sign-out is intentionally local-only. If the same account root
+/// later links the same device DID, its earlier server attachment is still
+/// active and is recovered instead of replaced. The fresh ceremony grant is
+/// still validated, but the browser continues using its preserved local grant.
+pub async fn link_device<S: Store>(
+    store: &S,
+    account: &Account,
+    device_did: &str,
+    device_name: &str,
+    delegation_hex: &str,
+    now: u64,
+) -> Result<String, CeremonyError> {
+    let delegation_cid =
+        check_device_delegation(delegation_hex, &account.root_did, device_did).await?;
+    if let Some(existing) = store.active_device_by_did(device_did).await? {
+        return reuse_linked_device(existing, account);
+    }
+    match insert_device_registration(
+        store,
+        account,
+        device_did,
+        device_name,
+        delegation_cid,
+        delegation_hex.to_string(),
+        now,
+    )
+    .await
+    {
+        Ok(attachment_id) => Ok(attachment_id),
+        // Close the check-then-insert race for concurrent re-login requests.
+        Err(StoreError::Conflict(detail)) => {
+            if let Some(existing) = store.active_device_by_did(device_did).await? {
+                reuse_linked_device(existing, account)
+            } else {
+                Err(StoreError::Conflict(detail).into())
+            }
+        }
+        Err(error) => Err(error.into()),
+    }
 }
 
 /// Terminal result of processing a signed generation-bound detach intent.
@@ -438,6 +512,124 @@ mod tests {
         let listed = list_devices(&store, &account).await.unwrap();
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].delegation_cid, device.delegation_cid);
+    }
+
+    /// Browser sign-out is local-only, so signing back in with the same
+    /// passkey presents the same account and device with a freshly minted
+    /// grant while the first attachment is still active. That root-authorized
+    /// re-login recovers the existing generation.
+    #[dialog_common::test]
+    async fn it_reuses_an_active_device_when_the_same_account_links_again() {
+        let store = SqliteStore::in_memory().unwrap();
+        let (mut account, device, root, first_grant) = fixture().await;
+        account.id = store
+            .create_account(
+                &account.email,
+                &account.root_did,
+                &account.credential_id,
+                account.created_at,
+            )
+            .await
+            .unwrap();
+        let device_did = device.device_did.parse().unwrap();
+        let second_grant = tonk_identity::delegation::mint_device_delegation(root, &device_did)
+            .await
+            .unwrap();
+        assert_ne!(
+            second_grant.proof_cids()[0],
+            first_grant.proof_cids()[0],
+            "each passkey login proposes a fresh grant"
+        );
+
+        let first = link_device(
+            &store,
+            &account,
+            &device.device_did,
+            &device.name,
+            &hex::encode(first_grant.to_bytes().unwrap()),
+            device.created_at,
+        )
+        .await
+        .unwrap();
+        let second = link_device(
+            &store,
+            &account,
+            &device.device_did,
+            &device.name,
+            &hex::encode(second_grant.to_bytes().unwrap()),
+            device.created_at + 1,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(second, first, "the same active generation is recovered");
+        let listed = store.devices(account.id).await.unwrap();
+        assert_eq!(listed.len(), 1, "re-login adds no device history");
+    }
+
+    #[dialog_common::test]
+    async fn it_does_not_reuse_an_active_device_for_another_account() {
+        let store = SqliteStore::in_memory().unwrap();
+        let (mut first_account, device, _, first_grant) = fixture().await;
+        first_account.id = store
+            .create_account(
+                &first_account.email,
+                &first_account.root_did,
+                &first_account.credential_id,
+                first_account.created_at,
+            )
+            .await
+            .unwrap();
+        link_device(
+            &store,
+            &first_account,
+            &device.device_did,
+            &device.name,
+            &hex::encode(first_grant.to_bytes().unwrap()),
+            device.created_at,
+        )
+        .await
+        .unwrap();
+
+        let second_root = Ed25519Signer::import(&[13u8; 32]).await.unwrap();
+        let mut second_account = Account {
+            id: 0,
+            email: "b@x.com".into(),
+            root_did: second_root.did().to_string(),
+            credential_id: "other-cred".into(),
+            repository_descriptor: None,
+            passkey_created_at: None,
+            passkey_created_on: None,
+            created_at: 3,
+        };
+        second_account.id = store
+            .create_account(
+                &second_account.email,
+                &second_account.root_did,
+                &second_account.credential_id,
+                second_account.created_at,
+            )
+            .await
+            .unwrap();
+        let device_did = device.device_did.parse().unwrap();
+        let second_grant =
+            tonk_identity::delegation::mint_device_delegation(second_root, &device_did)
+                .await
+                .unwrap();
+
+        assert!(matches!(
+            link_device(
+                &store,
+                &second_account,
+                &device.device_did,
+                &device.name,
+                &hex::encode(second_grant.to_bytes().unwrap()),
+                4,
+            )
+            .await,
+            Err(CeremonyError::Conflict(detail))
+                if detail == "this device is already active on another account"
+        ));
     }
 
     struct SpyProjection {

--- a/rust/tonk-account-service/src/handlers/devices.rs
+++ b/rust/tonk-account-service/src/handlers/devices.rs
@@ -7,7 +7,7 @@ use crate::auth::{
     authorize, authorize_root, optional_revocation, required_string, string_argument,
 };
 use crate::core::devices::{
-    DeviceView, detach_device, list_devices, register_device, revoke_device,
+    DeviceView, detach_device, link_device, list_devices, register_device, revoke_device,
 };
 use crate::error::{ErrorCode, ServiceError};
 use crate::handlers::{build_store, ceremony_error, read_body, with_cors_headers};
@@ -122,7 +122,7 @@ async fn handle_link_inner(
     let descriptor_hex = hex::encode(descriptor);
     let now = Date::now().as_millis() / 1000;
 
-    let attachment_id = register_device(
+    let attachment_id = link_device(
         &store,
         &account,
         &device_did,

--- a/rust/tonk-account-service/src/helpers/server.rs
+++ b/rust/tonk-account-service/src/helpers/server.rs
@@ -31,7 +31,7 @@ use crate::core::codes::{generate_code, request_code};
 use crate::core::deletion::delete_account;
 use crate::core::descriptor::establish_descriptor;
 use crate::core::devices::{
-    DeviceView, detach_device, list_devices, register_device, revoke_device,
+    DeviceView, detach_device, link_device, list_devices, register_device, revoke_device,
 };
 use crate::email::CapturedEmail;
 use crate::error::{ErrorCode, ServiceError};
@@ -411,7 +411,7 @@ async fn devices_link_route(
     })?;
     let descriptor_hex = hex::encode(descriptor);
 
-    let attachment_id = register_device(
+    let attachment_id = link_device(
         &backends.store,
         &account,
         &device_did,

--- a/rust/tonk-account-service/tests/service.rs
+++ b/rust/tonk-account-service/tests/service.rs
@@ -652,13 +652,34 @@ async fn it_drives_the_full_ceremony_over_http() {
         dialog_ucan_core::DelegationChain::try_from(second_grant_bytes.as_slice()).unwrap();
     let response = client
         .post(format!("{base}/devices/link"))
-        .body(hex::decode(ceremony.invocation_hex).unwrap())
+        .body(hex::decode(&ceremony.invocation_hex).unwrap())
         .send()
         .await
         .unwrap();
     assert_eq!(response.status(), 200);
     let linked: serde_json::Value = response.json().await.unwrap();
     assert_eq!(linked["descriptorHex"], expected_descriptor);
+    let second_attachment = linked["attachmentId"].as_str().unwrap();
+
+    // Browser sign-out leaves the account-service attachment active. A later
+    // login with the same passkey mints a new invocation and nonce-bearing
+    // root-to-device grant, but must recover the active generation.
+    let root = dialog_credentials::Ed25519Signer::import(&ROOT_PRF)
+        .await
+        .unwrap();
+    let relink = tonk_identity::ceremony::link_device(root, second.did(), "phone".into())
+        .await
+        .unwrap();
+    assert_ne!(relink.delegation_hex, ceremony.delegation_hex);
+    let response = client
+        .post(format!("{base}/devices/link"))
+        .body(hex::decode(relink.invocation_hex).unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    let relinked: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(relinked["attachmentId"], second_attachment);
 
     // POST /devices/list -> the newly registered device shows up.
     let body = container_with_link(

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -1162,10 +1162,11 @@ async fn persist(
     let root_status = crate::api::root_status()
         .await
         .map_err(|error| error.to_string())?;
-    if root_needs_persist(&root_status, &ceremony.root_did) {
+    let root = root_for_link(&root_status, ceremony);
+    if root.needs_persist {
         crate::api::save_root(
-            ceremony.credential_id.clone(),
-            ceremony.delegation_hex.clone(),
+            root.credential_id.to_string(),
+            root.delegation_hex.to_string(),
             None,
         )
         .await
@@ -1173,9 +1174,9 @@ async fn persist(
     }
     crate::api::save_account_link(
         provider.to_string(),
-        ceremony.root_did.clone(),
-        ceremony.credential_id.clone(),
-        ceremony.delegation_hex.clone(),
+        root.root_did.to_string(),
+        root.credential_id.to_string(),
+        root.delegation_hex.to_string(),
         descriptor_hex,
         initialize_name,
     )
@@ -1183,12 +1184,41 @@ async fn persist(
     .map_err(|error| error.to_string())
 }
 
-fn root_needs_persist(status: &tonk_worker_api::RootStatus, root_did: &str) -> bool {
+#[derive(Debug, PartialEq, Eq)]
+struct LinkRoot<'a> {
+    root_did: &'a str,
+    credential_id: &'a str,
+    delegation_hex: &'a str,
+    needs_persist: bool,
+}
+
+/// Select the grant the worker should attach after a remote link succeeds.
+///
+/// A same-root browser re-login reuses the still-active server generation, so
+/// it must also reuse the local grant that generation records. A missing or
+/// different root continues through the normal root-persistence boundary.
+fn root_for_link<'a>(
+    status: &'a tonk_worker_api::RootStatus,
+    ceremony: &'a CeremonyOutput,
+) -> LinkRoot<'a> {
     match status {
-        tonk_worker_api::RootStatus::Missing { .. } => true,
         tonk_worker_api::RootStatus::Ready {
-            root_did: current, ..
-        } => current != root_did,
+            root_did,
+            credential_id,
+            delegation_hex,
+            ..
+        } if root_did == &ceremony.root_did => LinkRoot {
+            root_did,
+            credential_id,
+            delegation_hex,
+            needs_persist: false,
+        },
+        _ => LinkRoot {
+            root_did: &ceremony.root_did,
+            credential_id: &ceremony.credential_id,
+            delegation_hex: &ceremony.delegation_hex,
+            needs_persist: true,
+        },
     }
 }
 
@@ -2296,7 +2326,7 @@ mod tests {
     }
 
     #[dialog_common::test]
-    fn it_persists_a_different_passkey_root_after_signing_out() {
+    fn it_selects_the_new_ceremony_when_the_root_differs() {
         let status = tonk_worker_api::RootStatus::Ready {
             root_did: "did:key:zOldRoot".into(),
             device_did: "did:key:zDevice".into(),
@@ -2305,9 +2335,52 @@ mod tests {
             delegation_hex: "00".into(),
             passkey: None,
         };
+        let ceremony = CeremonyOutput {
+            root_did: "did:key:zNewRoot".into(),
+            credential_id: "new-credential".into(),
+            delegation_hex: "11".into(),
+            invocation_hex: "22".into(),
+            deposits_hex: Vec::new(),
+        };
 
-        assert!(root_needs_persist(&status, "did:key:zNewRoot"));
-        assert!(!root_needs_persist(&status, "did:key:zOldRoot"));
+        assert_eq!(
+            root_for_link(&status, &ceremony),
+            LinkRoot {
+                root_did: "did:key:zNewRoot",
+                credential_id: "new-credential",
+                delegation_hex: "11",
+                needs_persist: true,
+            }
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_reuses_the_stored_grant_when_the_same_root_links_again() {
+        let status = tonk_worker_api::RootStatus::Ready {
+            root_did: "did:key:zRoot".into(),
+            device_did: "did:key:zDevice".into(),
+            credential_id: "stored-credential".into(),
+            delegation_cid: "bafystored".into(),
+            delegation_hex: "00".into(),
+            passkey: None,
+        };
+        let ceremony = CeremonyOutput {
+            root_did: "did:key:zRoot".into(),
+            credential_id: "ceremony-credential".into(),
+            delegation_hex: "11".into(),
+            invocation_hex: "22".into(),
+            deposits_hex: Vec::new(),
+        };
+
+        assert_eq!(
+            root_for_link(&status, &ceremony),
+            LinkRoot {
+                root_did: "did:key:zRoot",
+                credential_id: "stored-credential",
+                delegation_hex: "00",
+                needs_persist: false,
+            }
+        );
     }
 
     #[dialog_common::test]

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -289,6 +289,45 @@ mod tests {
     }
 
     #[dialog_common::test]
+    async fn it_signs_back_into_the_same_account_after_signing_out(
+        env: TestEnvironment,
+    ) -> Result<()> {
+        let driver = driver_with_prf(&env).await?;
+        sign_up(&driver, &env, EMAIL).await?;
+
+        driver.goto(env.tonk_web.join("account")?.as_str()).await?;
+        element(&driver, "tonk-account[data-mode=\"success\"]").await?;
+        click(&driver, "#account-unlink").await?;
+        driver.accept_alert().await?;
+        element(&driver, "tonk-account[data-mode=\"choice\"]").await?;
+
+        click(&driver, "#account-choose-link").await?;
+        click(&driver, "#account-link-submit").await?;
+        if let Err(wait_error) = element(&driver, "tonk-account[data-mode=\"success\"]").await {
+            let host = element(&driver, "tonk-account").await?;
+            let mode = host.attr("data-mode").await?.unwrap_or_default();
+            let error = element(&driver, "#account-error").await?.text().await?;
+            return Err(wait_error).context(format!(
+                "same-account re-login stopped in mode {mode:?}: {error:?}"
+            ));
+        }
+
+        let summary = get_json(&driver, "/api/account/summary").await?;
+        assert_eq!(
+            successful_body("account summary after re-login", &summary)["email"],
+            EMAIL
+        );
+        let devices = get_json(&driver, "/api/account/devices").await?;
+        let devices = successful_body("device list after re-login", &devices)
+            .as_array()
+            .context("device list was not an array")?;
+        assert_eq!(devices.len(), 1, "re-login must not duplicate the device");
+
+        driver.quit().await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
     async fn it_reports_an_existing_email_and_recovers_with_another_address(
         env: TestEnvironment,
     ) -> Result<()> {


### PR DESCRIPTION
## Summary

- recover the existing active attachment when the same account root links the same browser device after local logout
- keep ordinary device registration and cross-account device ownership strict
- reattach the UI with the preserved local grant that matches the recovered server generation
- add account-service, Wasm, HTTP, and real-browser regressions

## Test plan

- cargo test -p tonk-account-service --features helpers
- cargo test -p tonk-ui --target wasm32-unknown-unknown --no-run
- wasm-bindgen-test-runner target/wasm32-unknown-unknown/debug/deps/tonk_ui-0b7bd60ee674182c.wasm --nocapture
- cargo test -p tonk-ui --features integration-tests it_signs_back_into_the_same_account_after_signing_out -- --nocapture
- cargo clippy -p tonk-account-service --features helpers --all-targets -- -D warnings
- cargo clippy -p tonk-ui --target wasm32-unknown-unknown --all-targets --no-deps -- -D warnings
- cargo fmt --all -- --check
- git diff --check

## Known check gap

Dependency-inclusive tonk-ui Wasm Clippy stops on six existing arc_with_non_send_sync errors in rust/dialog-reactor. The isolated tonk-ui Clippy run passes.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the device linking functionality in the `tonk-account-service`, enhancing how devices are registered and linked after user sign-out, and ensuring that active devices are reused correctly without duplicating device history.

### Detailed summary
- Replaced `register_device` with `link_device` in several locations to improve device linking logic.
- Introduced a new function `reuse_linked_device` to manage existing device links.
- Updated `insert_device_registration` to handle device registration.
- Added tests to ensure correct behavior during re-login and device linking.
- Modified the handling of device delegation to prevent conflicts when devices are linked to different accounts.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->