### PR TITLE
fix(cli): allow accountless invite claims

### DIFF
--- a/rust/tonk-cli/Cargo.toml
+++ b/rust/tonk-cli/Cargo.toml
@@ -26,6 +26,10 @@ name = "site"
 path = "tests/site.rs"
 
 [[test]]
+name = "join_profile"
+path = "tests/join_profile.rs"
+
+[[test]]
 name = "invite_revocation"
 path = "tests/invite_revocation.rs"
 

--- a/rust/tonk-cli/src/account.rs
+++ b/rust/tonk-cli/src/account.rs
@@ -200,16 +200,8 @@ async fn decode_provider(
         .context("stored account provider is unusable")
 }
 
-/// Load the provider attachment through an already-mounted site operator.
-pub(crate) async fn stored_provider_with_operator(
-    profile: &Profile,
-    operator: &dialog_operator::Operator<NativeSpace>,
-) -> Result<Option<AccountProviderRecord>> {
-    let store = crate::space::SpaceStore::open().context("failed to locate account state")?;
-    stored_provider_for_store(profile, operator, &store).await
-}
-
-/// [`stored_provider_with_operator`] against a caller-supplied store.
+/// Load the provider attachment through an already-mounted site operator and
+/// caller-supplied profile store.
 pub(crate) async fn stored_provider_in(
     profile: &Profile,
     operator: &dialog_operator::Operator<NativeSpace>,
@@ -251,23 +243,6 @@ async fn stored_provider_for_store(
 /// authority. Names the one command that provisions both the root and the
 /// account it belongs to.
 const ACCOUNT_REQUIRED: &str = "A Tonk account is required; run `tonk account login`";
-
-/// Refuse unless this profile holds an account.
-///
-/// The precondition every durable operation shares, in the shape the browser
-/// worker uses it (`router::account::require_account`): durable authority is
-/// only ever issued to an account, so what it mints stays revocable and what
-/// it creates gets backed up. `Unhydrated` and `Unconfigured` accounts pass —
-/// an account that exists but has not synchronized is still an account.
-pub(crate) async fn require_account_with_operator(
-    profile: &Profile,
-    operator: &dialog_operator::Operator<NativeSpace>,
-) -> Result<()> {
-    match stored_provider_with_operator(profile, operator).await? {
-        Some(_) => Ok(()),
-        None => bail!(ACCOUNT_REQUIRED),
-    }
-}
 
 /// Refuse unless one explicit profile store holds an account attachment.
 pub(crate) async fn require_account_with_operator_in(
@@ -1306,22 +1281,26 @@ mod tests {
         std::fs::write(&sentinel, b"keep").unwrap();
 
         assert!(
-            stored_provider_with_operator(&profile, &operator)
+            stored_provider_in(&profile, &operator, &store)
                 .await
                 .unwrap()
                 .is_some()
         );
 
-        logout_with_operator(&profile, &operator).await.unwrap();
+        logout_with_operator_in(&profile, &operator, &store)
+            .await
+            .unwrap();
 
         assert!(
-            stored_provider_with_operator(&profile, &operator)
+            stored_provider_in(&profile, &operator, &store)
                 .await
                 .unwrap()
                 .is_none()
         );
 
-        logout_with_operator(&profile, &operator).await.unwrap();
+        logout_with_operator_in(&profile, &operator, &store)
+            .await
+            .unwrap();
 
         assert_eq!(
             profile

--- a/rust/tonk-cli/src/invite.rs
+++ b/rust/tonk-cli/src/invite.rs
@@ -405,24 +405,20 @@ pub async fn claim(
         .await
         .map_err(|e| InviteError::Io(e.to_string()))?;
 
-    let local_root = crate::identity::local_root_with_operator(&profile, &operator)
+    // An invite already carries the authority needed to join. A linked
+    // profile claims to its durable account root; before linking, the
+    // persistent profile DID is the stable identity available on this device.
+    // The later profile↔account union carries profile-held spaces forward.
+    let member = match crate::identity::local_root_with_operator(&profile, &operator)
         .await
-        .map_err(|e| InviteError::Io(e.to_string()))?;
-    // Claiming an invite is what makes this device a member, and a member is
-    // what a later `tonk invite` delegates from. Rooting that chain in an
-    // anonymous key leaves it with no owner and nothing able to revoke it.
-    if config.require_account {
-        crate::account::require_account_with_operator(&profile, &operator)
-            .await
-            .map_err(|e| InviteError::Io(e.to_string()))?;
-    }
-    let member = local_root
-        .ok_or_else(|| {
-            InviteError::Io("local root provisioning did not produce a record".to_string())
-        })?
-        .root_did
-        .parse()
-        .map_err(|e| InviteError::Io(format!("stored root DID is invalid: {e}")))?;
+        .map_err(|e| InviteError::Io(e.to_string()))?
+    {
+        Some(root) => root
+            .root_did
+            .parse()
+            .map_err(|e| InviteError::Io(format!("stored root DID is invalid: {e}")))?,
+        None => profile.did(),
+    };
     let claimed = invite
         .claim(&member)
         .await

--- a/rust/tonk-cli/src/site.rs
+++ b/rust/tonk-cli/src/site.rs
@@ -19,7 +19,6 @@ use std::sync::LazyLock;
 use anyhow::{Context, Result, bail};
 use dialog_capability::Subject;
 use dialog_credentials::{Credential, Ed25519Signer, Ed25519Verifier};
-use dialog_effects::Use;
 use dialog_effects::space::{Space, SpaceExt as _};
 use dialog_effects::storage::Directory;
 use dialog_operator::{DeriveOperator, Operator, Profile};
@@ -648,8 +647,10 @@ pub async fn mount_delegated_at(
 
 /// Mount with profile/operator state already prepared by the invite parser.
 ///
-/// Existing invites can contain subject-open device authority. It remains
-/// usable for this mount but is never persisted as a reusable account backup.
+/// An invite supplies its own authority, so this path does not impose the
+/// account precondition used when restoring an account-root prefix. Before an
+/// account is linked, a valid profile-ending prefix remains reusable on this
+/// device and can be connected to an account by the later profile union.
 pub(crate) async fn mount_delegated_with(
     root: &Path,
     profile: Profile,
@@ -668,10 +669,9 @@ async fn mount_delegated_inner(
     config: SiteConfig,
     require_reusable: bool,
 ) -> Result<TonkSite> {
-    let local_root = crate::identity::local_root_with_operator(&profile, &operator)
-        .await?
-        .context("local root provisioning did not produce a record")?;
-    if config.require_account {
+    let local_root = crate::identity::local_root_with_operator(&profile, &operator).await?;
+    let require_account = config.require_account && require_reusable;
+    if require_account {
         crate::account::require_account_with_operator_in(
             &profile,
             &operator,
@@ -679,10 +679,16 @@ async fn mount_delegated_inner(
         )
         .await?;
     }
-    let account_root: Did = local_root
-        .root_did
-        .parse()
-        .context("stored root DID is invalid")?;
+    let authority_root: Did = match local_root {
+        Some(root) => root
+            .root_did
+            .parse()
+            .context("stored root DID is invalid")?,
+        None if require_reusable => {
+            bail!("local root provisioning did not produce a record")
+        }
+        None => profile.did(),
+    };
     let subject = chain
         .subject()
         .cloned()
@@ -690,7 +696,7 @@ async fn mount_delegated_inner(
     let chain_bytes = chain
         .to_bytes()
         .context("failed to serialize delegated authority")?;
-    let reusable = verify_prefix(&chain_bytes, &account_root).await;
+    let reusable = verify_prefix(&chain_bytes, &authority_root).await;
     if require_reusable && let Err(error) = &reusable {
         anyhow::bail!("delegated prefix is not reusable account-root authority: {error}");
     }
@@ -708,7 +714,7 @@ async fn mount_delegated_inner(
             .context("failed to serialize delegated prefix")?;
         profile
             .credential()
-            .site(space_root_site(&subject, &account_root))
+            .site(space_root_site(&subject, &authority_root))
             .save(prefix_bytes)
             .perform(&operator)
             .await
@@ -737,7 +743,7 @@ async fn mount_delegated_inner(
         operator,
         profile.clone(),
         config.account_store.clone(),
-        config.require_account,
+        require_account,
     )
     .await?;
     Ok(TonkSite {
@@ -787,17 +793,14 @@ async fn optional_credential(
     }
 }
 
-/// Resolve the reusable `subject → … → account_root` prefix, minting it
-/// when this profile holds the subject's authority but no chain to the
-/// account reaches it yet.
+/// Resolve the reusable `subject → … → account_root` prefix, recovering it
+/// from retained delegations when no validated credential is stored yet.
 ///
 /// Every path that authorizes a remote request for a space needs this exact
-/// prefix, so all of them recover the same way. A space created before the
-/// account existed — or by a release that stored no prefix at all — has
-/// repository authority that stops at the profile, and refusing it would
-/// strand data the device demonstrably owns. Extending that authority to
-/// the account root is local bookkeeping: it delegates to the root this
-/// profile already holds a grant from, and publishes nothing.
+/// prefix, so all of them recover the same way. Authority claimed before the
+/// account existed stops at the profile until linking retains the profile →
+/// account union. Recovery composes that existing path without minting a new
+/// ownership edge; explicit ownership adoption remains a separate operation.
 pub async fn load_account_root_prefix_for(
     profile: &Profile,
     operator: &Operator<NativeSpace>,
@@ -897,48 +900,50 @@ async fn save_prefix(
     Ok(())
 }
 
-/// Rebuild the prefix from certificates this profile already holds.
+/// Rebuild the prefix from delegations the profile's access branch retains.
+///
+/// Ask the branch prover for the account root directly. Proving as the
+/// profile would stop at the shorter `subject → … → profile` path and omit
+/// the union edge needed by account-bound authorization.
 pub(crate) async fn recover_prefix(
     profile: &Profile,
     operator: &Operator<NativeSpace>,
     subject: &Did,
     account_root: &Did,
 ) -> Result<Option<DelegationChain>> {
-    let proof = profile
-        .access()
-        .prove(Subject::from(subject.clone()).attenuate(Use))
+    let access = Repository::from(profile)
+        .branch(dialog_repository::ACCESS_BRANCH)
+        .open()
         .perform(operator)
         .await
-        .context("failed to recover repository authority")?;
-    let delegations: Vec<_> = proof
+        .context("failed to open the profile access branch")?;
+    let proof = match access
+        .delegations()
+        .prove(
+            account_root.clone(),
+            dialog_ucan::Scope {
+                subject: dialog_ucan_core::subject::Subject::Specific(subject.clone()),
+                command: dialog_ucan_core::command::Command::parse("/use")
+                    .expect("the use command is valid"),
+                parameters: dialog_ucan::Parameters::default(),
+            },
+        )
+        .perform(operator)
+        .await
+    {
+        Ok(proof) => proof,
+        Err(dialog_capability::access::AuthorizeError::UnprovenSubject { .. }) => return Ok(None),
+        Err(error) => return Err(error).context("failed to recover repository authority"),
+    };
+    let delegations = proof
         .proofs
         .into_iter()
         .map(|certificate| certificate.0)
-        .collect();
-    // Assemble `subject → … → account_root` by issuer/audience links:
-    // the prover's proof ordering is not guaranteed to start at the
-    // subject, and a chain sliced by position can drag device/session
-    // proofs past the root into what must stay a reusable prefix.
-    let mut chain = Vec::new();
-    let mut cursor = subject.clone();
-    while &cursor != account_root {
-        let Some(next) = delegations
-            .iter()
-            .find(|delegation| delegation.issuer() == &cursor)
-        else {
-            return Ok(None);
-        };
-        chain.push(next.clone());
-        cursor = next.audience().clone();
-        if chain.len() > delegations.len() {
-            // A cycle cannot reach the root.
-            return Ok(None);
-        }
-    }
-    if chain.is_empty() {
+        .collect::<Vec<_>>();
+    if delegations.is_empty() {
         return Ok(None);
     }
-    DelegationChain::try_from(chain)
+    DelegationChain::try_from(delegations)
         .context("recovered repository authority is not a valid chain")
         .map(Some)
 }

--- a/rust/tonk-cli/tests/account_authority.rs
+++ b/rust/tonk-cli/tests/account_authority.rs
@@ -276,6 +276,87 @@ async fn it_installs_authority_from_a_callback_authorization(
     Ok(())
 }
 
+/// A profile can accept space authority before it has an account. Linking
+/// later adds the profile-to-account half of the union, so the same local
+/// space can authorize account-bound sync without being re-claimed or moved.
+#[dialog_common::test]
+async fn it_syncs_a_claimed_space_after_linking_an_account(
+    env: AccessServiceAddress,
+) -> Result<()> {
+    let remote = format!("{}/", env.access_service_url.trim_end_matches('/'));
+    let account_owner = common::AccountFixture::with_account_remote(&remote).await?;
+    account_owner.activate_with(&env).await?;
+    let owner_operator = account_owner.pre_account_site.operator.inner();
+    let owner_account =
+        tonk_cli::account_state::open_account_branch(&account_owner.profile, owner_operator)
+            .await?
+            .expect("the account owner is hydrated");
+    owner_account.push().perform(owner_operator).await?;
+
+    let inviter = common::TestSite::new().await?;
+    let invitation = tonk_cli::invite::mint(&inviter.site, None, None).await?;
+    let claimer_tmp = tempfile::tempdir()?;
+    let claimer_parent = claimer_tmp.path().canonicalize()?;
+    let claimer_config = common::isolated_config(&claimer_parent)?;
+    let joined_root = claimer_parent.join("claimed-before-link");
+    let mut production_config = claimer_config.clone();
+    production_config.require_account = true;
+    let claimed =
+        tonk_cli::invite::claim(&joined_root, &invitation.url, production_config.clone()).await?;
+
+    let joined = TonkSite::open_with(&joined_root, production_config.clone()).await?;
+    assert_eq!(
+        tonk_cli::site::member_did(&joined).await?,
+        joined.profile.did(),
+        "the pre-link invite must terminate at the persistent profile"
+    );
+    let page = common::authorizing_page(account_owner.root_signer().await?, remote.clone()).await?;
+    let (announce, mut announced) = tokio::sync::mpsc::unbounded_channel();
+    let approving = tokio::spawn(async move {
+        if let Some(url) = announced.recv().await {
+            let _ = reqwest::Client::new().get(&url).send().await;
+        }
+    });
+    let linked = tonk_cli::account::link_with_operator(
+        &joined.profile,
+        joined.operator.inner(),
+        &tonk_cli::account::LinkOptions {
+            service_url: remote,
+            device_name: "pre-link-claimer".to_owned(),
+            open_browser: false,
+            via: Some(page.url.clone()),
+            announce: Some(announce),
+            store: Some(claimer_config.account_store.clone()),
+        },
+    )
+    .await?;
+    approving.await?;
+    assert_eq!(
+        linked.account_state,
+        tonk_account::AccountStateStatus::Ready,
+        "linking must hydrate the account: {:?}",
+        linked.warning
+    );
+    let account_root: dialog_varsig::Did = linked.root_did.parse()?;
+    tonk_cli::site::load_account_root_prefix_for(
+        &joined.profile,
+        joined.operator.inner(),
+        &claimed.subject,
+        &account_root,
+    )
+    .await
+    .context("linking must make the profile-ending invite chain reach the account root")?;
+
+    let joined = TonkSite::open_with(&joined_root, production_config).await?;
+    configure_upstream(&joined, &env.access_service_url).await?;
+    env.provision_subject(claimed.subject.as_str()).await?;
+    tonk_cli::sync::push(&joined)
+        .await
+        .context("the linked account must authorize the profile's pre-link invite")?;
+
+    Ok(())
+}
+
 /// Discovering a space through the account: the flow that makes linking
 /// worth anything.
 ///

--- a/rust/tonk-cli/tests/join_profile.rs
+++ b/rust/tonk-cli/tests/join_profile.rs
@@ -1,0 +1,53 @@
+//! Accountless invite claims use the persistent local profile directly.
+
+mod common;
+
+use anyhow::Result;
+use tonk_cli::inventory;
+use tonk_cli::invite;
+use tonk_cli::site::TonkSite;
+
+/// An invite already carries the authority needed to join. Before this
+/// profile is linked to an account, that authority terminates at the
+/// persistent profile DID; linking later connects the same profile to an
+/// account without changing the local membership identity.
+#[dialog_common::test]
+async fn it_claims_to_the_profile_without_a_linked_account() -> Result<()> {
+    let inviter = common::TestSite::new().await?;
+    let invite = invite::mint(&inviter.site, None, None).await?;
+
+    let claimer_tmp = tempfile::tempdir()?;
+    let claimer_parent = claimer_tmp.path().canonicalize()?;
+    let claimer_root = claimer_parent.join("joined-site");
+    let mut claimer_config = common::isolated_config(&claimer_parent)?;
+    // Match production's account precondition while keeping every file in
+    // the fixture. Claiming is not an account-owned creation operation.
+    claimer_config.require_account = true;
+
+    // SAFETY: this integration-test binary contains exactly one test, so no
+    // other thread can observe the process-wide store override.
+    unsafe {
+        std::env::set_var(
+            tonk_cli::space::STATE_ENV,
+            claimer_config.account_store.root(),
+        );
+    }
+
+    let claimed = invite::claim(&claimer_root, &invite.url, claimer_config.clone()).await;
+    // SAFETY: paired with the single-test process override above.
+    unsafe {
+        std::env::remove_var(tonk_cli::space::STATE_ENV);
+    }
+    claimed?;
+
+    let joined = TonkSite::open_with(&claimer_root, claimer_config.clone()).await?;
+    assert_eq!(
+        tonk_cli::site::member_did(&joined).await?,
+        joined.profile.did(),
+        "claiming must not fabricate an anonymous membership root"
+    );
+    let roster = inventory::read_roster(&joined).await?;
+    assert_eq!(roster.members.len(), 1);
+    assert_eq!(roster.members[0].did, joined.profile.did().to_string());
+    Ok(())
+}

--- a/rust/tonk-cli/tests/site.rs
+++ b/rust/tonk-cli/tests/site.rs
@@ -350,6 +350,49 @@ mod when_shortening_an_invite {
     }
 }
 
+mod when_claiming_before_account_linking {
+    #[cfg(feature = "integration-tests")]
+    use anyhow::Result;
+    #[cfg(feature = "integration-tests")]
+    use tonk_access_service::helpers::AccessServiceAddress;
+    #[cfg(feature = "integration-tests")]
+    use tonk_cli::{invite, remote, sync};
+
+    #[cfg(feature = "integration-tests")]
+    use crate::common;
+
+    /// The invite's profile-ending chain, not an account session, authorizes
+    /// the initial pull. Account linking later makes the profile portable; it
+    /// is not a precondition for receiving the shared space.
+    #[cfg(feature = "integration-tests")]
+    #[dialog_common::test]
+    async fn it_pulls_with_invite_authority(env: AccessServiceAddress) -> Result<()> {
+        let endpoint = env.access_service_url.as_str();
+        let inviter = common::TestSite::new().await?;
+        env.provision_subject(inviter.site.repository.did().as_str())
+            .await?;
+        remote::add(&inviter.site, "origin", endpoint, None).await?;
+        remote::set_upstream(&inviter.site, "origin").await?;
+        sync::push(&inviter.site).await?;
+
+        let base = format!("{endpoint}/join");
+        let invitation = invite::mint(&inviter.site, Some(&base), Some(endpoint)).await?;
+        let claimer_tmp = tempfile::tempdir()?;
+        let claimer_parent = claimer_tmp.path().canonicalize()?;
+        let claimer_root = claimer_parent.join("joined-site");
+        let mut claimer_config = common::isolated_config(&claimer_parent)?;
+        claimer_config.require_account = true;
+
+        let outcome = invite::claim(&claimer_root, &invitation.url, claimer_config).await?;
+
+        assert!(
+            outcome.synced,
+            "the invite authority should pull before any account is linked"
+        );
+        Ok(())
+    }
+}
+
 /// The library's own copy of what the binary no longer enforces: a mint that
 /// embeds a remote used to be refused unless the remote named a relay for its
 /// revocations. A revocation is an ordinary `ucan/revoke` invocation now,


### PR DESCRIPTION
## Summary

- claim invitations with the persistent local profile when no Tonk account is linked
- authorize mounting and the initial pull with the profile-ending invite delegation
- compose that delegation with a later account link so claimed spaces can sync through the account
- cover accountless claim, initial pull, and claim-link-push behavior with regressions

## Testing

- cargo test -p tonk-cli --quiet
- cargo test -p tonk-cli --features integration-tests --test account_authority
- cargo test -p tonk-cli --features integration-tests --test site it_pulls_with_invite_authority -- --nocapture
- cargo clippy -p tonk-cli --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- git diff --check

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces new tests and modifies existing code to enhance the handling of invites and accounts in the `tonk-cli` application, emphasizing the ability to claim invites without requiring a linked account.

### Detailed summary
- Added a new test for claiming invites without a linked account in `tests/join_profile.rs`.
- Introduced a test for pulling with invite authority in `tests/site.rs`.
- Updated `rust/tonk-cli/src/invite.rs` to streamline invite claiming logic.
- Refactored account provider functions in `rust/tonk-cli/src/account.rs`.
- Improved handling of local root provisioning and authority in `rust/tonk-cli/src/site.rs`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->