### PR TITLE
Custody space and invite seeds under the account's X25519 key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5036,6 +5036,7 @@ dependencies = [
  "aes-gcm",
  "anyhow",
  "blake3",
+ "bs58",
  "dialog-common",
  "dialog-credentials",
  "dialog-ucan-core",
@@ -5058,6 +5059,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
+ "x25519-dalek",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,6 +181,7 @@ web-time = "1"
 webbrowser = "1.0"
 worker = "0.8.5"
 worker-macros = "0.8.5"
+x25519-dalek = { version = "2", features = ["static_secrets"] }
 zeroize = "1"
 
 js-sys = "0.3"

--- a/plan/authority-facts.md
+++ b/plan/authority-facts.md
@@ -131,33 +131,109 @@ devices.
 The worker's label is coarser — no `platform`, no touch-point count — so
 browser and OS come from the user agent alone.
 
-## Wrapped keys
+## Wrapped keys (2026-08-25)
 
 Not a delegation, so not this entity. A sealed space seed is its own
-concept, keyed by the DID it derives:
+concept, and it is sealed to a **public key**, not wrapped under the
+account KEK.
+
+The KEK derives from the account secret, and the account secret only
+materialises inside a passkey ceremony. A CLI device holds a delegation
+from the root, never the secret, so a symmetric wrap at account clearance
+would make every space creation a browser-only act. Sealing to a public
+key splits the two halves: anything holding the account DB can *seal*,
+only a ceremony can *open*.
+
+### The account encryption key
+
+`AccountSecret::encryption_key()` derives an X25519 key from the account
+secret (`HKDF(secret, info = "tonk/account/encryption/v1")`), the same
+way `signer()` derives the Ed25519 one. Its public half is a `did:key`
+under the `x25519-pub` multicodec (`0xec`, `did:key:z6LS…`), so a
+recipient is an `Entity` like every other reference. Published on the
+account subject entity, next to `AccountDisplayName`:
 
 ```
-CustodiedSeed   this = hash(subject)
-                subject    → the space or invite DID
-                envelope   → sealed bytes, clearance = account
-                generation → which account secret sealed it
+{account DID}
+  xyz.tonk.account/encryption-key   did:key:z6LS…   cardinality one
 ```
 
-It sits *beside* the ownership delegation rather than on it: the
+`AccountEncryptionKey`, written by the custody ceremony at account
+creation, by onboarding-account creation (it has a secret too), and by
+rotation. Cardinality one: rotation overwrites, and sealed rows name their
+own recipient, so nothing is lost by that.
+
+### The sealed seed
+
+One row per `(subject, recipient)`, content-derived like `Membership`:
+
+```
+CustodiedSeed   this = Entity::of(CustodiedSeed { subject, recipient })
+  xyz.tonk.custody/subject     the space DID, or the invite principal DID
+  xyz.tonk.custody/kind        tonk:space | tonk:invite
+  xyz.tonk.custody/recipient   the did:key:z6LS… it is sealed to
+  xyz.tonk.custody/sealed      the envelope bytes
+```
+
+A row per pair rather than a stamp on the directory entity, because
+rotation adds a row for the new recipient and retracts the old one rather
+than overwriting in place, and sealing a space seed to an admin's account
+as a recovery custodian (see `space-admins.md`) is just another row with
+another recipient. `subject` and `kind` repeat the hash inputs as
+queryable attributes so rotation can enumerate everything sealed to the
+old key and a recovering device can find the seed for a space without
+knowing the entity.
+
+### The envelope
+
+`version (1) ‖ algorithm (1) ‖ ephemeral X25519 pub (32) ‖ nonce (12) ‖
+ciphertext`. Shared secret = ECDH(ephemeral, recipient); AEAD key =
+`HKDF(shared, salt = ephemeral_pub ‖ recipient_pub, info =
+"tonk/custody/v1")`; AES-256-GCM, as `Envelope` already uses. Associated
+data is the header plus the recipient DID plus the subject DID, so a blob
+cannot be re-pointed at another space or another recipient.
+`seal(recipient, seed, subject)` needs no secret; `open(encryption_key,
+sealed, subject)` needs the ceremony.
+
+### Writers and readers
+
+- Space create (worker and CLI): after `retain_space_delegation`, read
+  `AccountEncryptionKey`, seal, assert `CustodiedSeed`. Best-effort like
+  retain; an account with no key yet logs and skips.
+- Invite mint: the same, `kind = tonk:invite`.
+- A sweep on the account-ready path: every locally held signer with no
+  `CustodiedSeed` for the current recipient gets sealed. This repairs
+  accounts that predate the key and re-seals after rotation on devices
+  that still hold plaintext.
+- Rotation (browser): open every row sealed to the old recipient,
+  re-issue `space → new-root`, re-seal to the new recipient, retract the
+  old rows.
+- Recovery on a new device (browser): open the row for the space and
+  reconstruct the signer into the local credential store.
+- The CLI only ever seals.
+
+The seed sits *beside* the ownership delegation rather than on it: the
 delegation says who may act for the space, the seed says how to re-issue
-it. They have different lifetimes — rotation replaces the delegation and
-re-wraps the seed — so one entity carrying both would make every rotation
-a read-modify-write of the ownership record.
+it. They have different lifetimes, so one entity carrying both would make
+every rotation a read-modify-write of the ownership record. Join on the
+DID when both are needed: `CustodiedSeed.subject` equals the delegation's
+`dialog.ucan/subject`.
 
-Join on the DID when both are needed: `CustodiedSeed.subject` equals the
-delegation's `dialog.ucan/subject`.
+Clearance is unchanged: sealing is public, opening is Recovery-gated. A
+device compromise leaks nothing it did not already hold; an account
+compromise costs the seeds, which `onboarding-accreditation.md` already
+accepts. `vault-key.md` describes wrappings addressed to public keys
+enumerable from the account space; this is that primitive with the
+account as the only addressee, and the vault should share it.
 
 ## Where these live
 
-Profile main, which replicates through the account upstream. Both the
-authority and the sealed seed must reach every device on the account —
-that is what makes a space usable on a second device and re-issuable
-after a lost one.
+The account space `main`, which replicates to every linked device and is
+readable only by the account. Both the authority and the sealed seed must
+reach every device on the account — that is what makes a space usable on
+a second device and re-issuable after a lost one. The plaintext signer
+stays in the creating device's local credential store; the fact is the
+recovery copy.
 
 ## Relationship to #748 (feat/ucan-revocations)
 
@@ -184,11 +260,12 @@ service would otherwise be the only source of.
 
 1. ~~`SpaceFounded` on the directory entity~~ — DONE.
 2. ~~`DeviceLink` on the powerline~~ — DONE.
-3. **`CustodiedSeed`** — the concept and the seal-on-create path, with
-   space keys generated extractable and their seeds sealed under the
-   account KEK.
-4. **Rotation** consumes all three: re-wrap seeds, re-issue ownership
-   delegations, retract the old device link.
+3. **`AccountEncryptionKey` + `CustodiedSeed`** — the X25519 key derived
+   from the account secret and published as a fact; the `Sealed`
+   envelope in tonk-identity; the concept; seal-on-create in the worker
+   and the CLI for spaces and invites; the backfill sweep.
+4. **Rotation and recovery** consume all three: open and re-seal seeds,
+   re-issue ownership delegations, retract the old device link.
 
 ## Open
 

--- a/plan/authority-facts.md
+++ b/plan/authority-facts.md
@@ -200,7 +200,11 @@ sealed, subject)` needs the ceremony.
 - Space create (worker and CLI): after `retain_space_delegation`, read
   `AccountEncryptionKey`, seal, assert `CustodiedSeed`. Best-effort like
   retain; an account with no key yet logs and skips.
-- Invite mint: the same, `kind = tonk:invite`.
+- Join through an open invite: the joiner seals the invite principal's
+  seed, `kind = tonk:invite`. The membership hangs off that principal,
+  so it is the joiner's account that must re-issue `principal → new
+  root` at rotation; the inviter holds `/` on the space and can always
+  mint another invite, so nothing is sealed at mint.
 - A sweep on the account-ready path: every locally held signer with no
   `CustodiedSeed` for the current recipient gets sealed. This repairs
   accounts that predate the key and re-seals after rotation on devices

--- a/plan/onboarding-accreditation.md
+++ b/plan/onboarding-accreditation.md
@@ -93,8 +93,9 @@ makes re-tagging one fail as tampering.
    the interim account's encryption key and store it as a `CustodiedSeed` fact
    in the account DB, keyed by the derived `did:key`.
 4. Delegate full authority from every space to the interim account.
-5. For every invite, seal the invitation secret the same way, as a
-   `CustodiedSeed` with `kind = tonk:invite`.
+5. For every open invite joined, seal the invitation secret the same way, as
+   a `CustodiedSeed` with `kind = tonk:invite`: the membership hangs off
+   that principal, so re-issuing it at rotation is the joiner's job.
 6. Delegate full authority from the invite key to the interim account key.
 
 ## Accreditation (= account rotation)

--- a/plan/onboarding-accreditation.md
+++ b/plan/onboarding-accreditation.md
@@ -48,7 +48,7 @@ compromise costs is exactly the subtree beneath the key that leaked.
 | Level | Key comes from | Wraps | Compromise costs |
 |---|---|---|---|
 | **Recovery** | passkey PRF, recovery phrase, or the pre-passkey custodian | the account secret | everything |
-| **Account** | `HKDF(account secret)` | space seeds, invite seeds | spaces and invites, not the account |
+| **Account** | `HKDF(account secret)`: the account KEK, and the X25519 encryption key seeds are sealed to | space seeds, invite seeds | spaces and invites, not the account |
 
 ```mermaid
 flowchart TB
@@ -89,12 +89,12 @@ makes re-tagging one fail as tampering.
 1. Generate an **interim account secret**, same shape as an account secret but
    in non-extractable form.
 2. Delegate through the powerline from interim to the account key.
-3. For every new space, generate a secret to derive its keys from. Store it
-   under interim account custody, encrypted, as a credential keyed by the
-   derived `did:key`.
+3. For every new space, generate a secret to derive its keys from. Seal it to
+   the interim account's encryption key and store it as a `CustodiedSeed` fact
+   in the account DB, keyed by the derived `did:key`.
 4. Delegate full authority from every space to the interim account.
-5. For every invite, put the invitation secret under account custody the same
-   way: encrypted, credential keyed by its derived `did:key`.
+5. For every invite, seal the invitation secret the same way, as a
+   `CustodiedSeed` with `kind = tonk:invite`.
 6. Delegate full authority from the invite key to the interim account key.
 
 ## Accreditation (= account rotation)
@@ -106,7 +106,8 @@ makes re-tagging one fail as tampering.
 4. Delegate through the powerline from the new account to the passkey DID.
 5. Re-issue every space and invite under the new account: because their secrets
    are custodied, this mints `space -> account2` directly rather than appending
-   `account1 -> account2`. Move custody from credentials into the account DB.
+   `account1 -> account2`. Open every seed sealed to the old encryption key,
+   re-seal to the new one, retract the old rows.
 6. Revoke the old account's delegation to the profile.
 7. Create a delegation from the new account to the profile.
 8. Delete every space and invite key from credentials, and the old account key.
@@ -129,22 +130,31 @@ enable account key rotation — or to drop them and let chains grow a hop when a
 re-root is needed. Dropping that ability is a one-way door; retaining it is not.
 
 > [!note]
-> Space seeds are wrapped bytes under the account KEK, not non-extractable
-> handles. Non-extractable would be stronger against on-device code execution,
-> but it is also non-replicable: only the device that generated a space could
-> ever re-issue it, and a second device could never hold the origin authority.
-> Wrapping keeps the seeds replicable and re-issuable, which is what account
-> rotation needs. The one non-extractable key we keep is the pre-passkey
-> custodian, because it stands in for a passkey and must be as uncopyable as
-> one.
+> Space seeds are sealed bytes, not non-extractable handles. Non-extractable
+> would be stronger against on-device code execution, but it is also
+> non-replicable: only the device that generated a space could ever re-issue
+> it, and a second device could never hold the origin authority. Sealing keeps
+> the seeds replicable and re-issuable, which is what account rotation needs.
+> The one non-extractable key we keep is the pre-passkey custodian, because it
+> stands in for a passkey and must be as uncopyable as one.
+
+> [!important]
+> Seeds are sealed to the account's **X25519 public key** (2026-08-25), not
+> wrapped under the account KEK. The KEK only exists inside a passkey ceremony,
+> and a CLI device never has one, so a symmetric wrap would make space creation
+> browser-only. Sealing to a public key lets any device holding the account DB
+> seal, while opening still needs the ceremony. The key, the envelope, and the
+> `CustodiedSeed` fact are specified in `authority-facts.md`.
 
 ## Not yet built
 
 - **Destroying the onboarding custodian.** Demotion (overwriting the key record
   with its own public half) is the mechanism, since the credential API has no
   retract for keys. It belongs with step 8 and lands when accreditation does.
-- **Account-clearance wrapping.** `AccountSecret::account_kek` exists; nothing
-  wraps a space or invite seed with it yet.
+- **Seed custody.** `AccountSecret::account_kek` exists; the X25519 encryption
+  key, the `Sealed` envelope, `AccountEncryptionKey`, `CustodiedSeed`, and the
+  seal-on-create writers are step 3 of `authority-facts.md` and not yet landed.
+  Until then a space's secret lives only on the device that created it.
 
 ## Ordering
 

--- a/rust/tonk-identity/Cargo.toml
+++ b/rust/tonk-identity/Cargo.toml
@@ -10,6 +10,7 @@ description = "Root identity derived from a passkey: PRF-derived root key and th
 aes-gcm = { workspace = true }
 anyhow = { workspace = true }
 blake3 = { workspace = true }
+bs58 = { workspace = true }
 dialog-credentials = { workspace = true }
 dialog-ucan-core = { workspace = true }
 dialog-varsig = { workspace = true }
@@ -22,6 +23,7 @@ serde_ipld_dagcbor = { workspace = true }
 sha2_0_10 = { workspace = true }
 thiserror = { workspace = true }
 tonk-account = { workspace = true }
+x25519-dalek = { workspace = true }
 zeroize = { workspace = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]

--- a/rust/tonk-identity/src/ceremony.rs
+++ b/rust/tonk-identity/src/ceremony.rs
@@ -48,6 +48,10 @@ pub struct RootCeremony {
     pub delegation_hex: String,
     /// Creation details when this ceremony created the passkey.
     pub passkey: Option<PasskeyCreationMetadata>,
+    /// The account's X25519 recipient (`did:key:z6LS…`) when this
+    /// ceremony held the secret, for the worker to publish as
+    /// `AccountEncryptionKey`.
+    pub encryption_key: Option<String>,
 }
 
 /// A fresh account, its first custody passkey, and its creation
@@ -87,6 +91,7 @@ async fn root_ceremony(
     credential_id: String,
     device_did: dialog_varsig::Did,
     passkey: Option<PasskeyCreationMetadata>,
+    encryption_key: Option<String>,
 ) -> Result<RootCeremony> {
     let root_did = root.did().to_string();
     let delegation = mint_device_delegation(root, &device_did).await?;
@@ -103,6 +108,7 @@ async fn root_ceremony(
         delegation_cid,
         delegation_hex,
         passkey,
+        encryption_key,
     })
 }
 
@@ -277,11 +283,13 @@ pub async fn create_custody_account(
         Some(service) => mint_service_deposits(&root, service).await?,
         None => Vec::new(),
     };
+    let encryption_key = secret.encryption_key().recipient().did().to_string();
     let root_ceremony = root_ceremony(
         root.clone(),
         credential_id.clone(),
         device_did.clone(),
         passkey.clone(),
+        Some(encryption_key),
     )
     .await?;
     let account = create_account(
@@ -496,6 +504,9 @@ pub struct CustodyUnlock {
     /// Hex-encoded account-signed access-service deposits, when the
     /// caller named the service; empty otherwise.
     pub deposits_hex: Vec<String>,
+    /// The account's X25519 recipient (`did:key:z6LS…`), for the worker
+    /// to publish as `AccountEncryptionKey`.
+    pub encryption_key: String,
 }
 
 /// Unlock the account with a custody passkey on a fresh browser: one
@@ -511,6 +522,7 @@ pub async fn unlock_account(
 ) -> Result<CustodyUnlock> {
     let (secret, credential_id) = assert_unlock(endpoint).await?;
     let root = secret.signer().await?;
+    let encryption_key = secret.encryption_key().recipient().did().to_string();
     let deposits_hex = match service {
         Some(service) => mint_service_deposits(&root, service).await?,
         None => Vec::new(),
@@ -520,6 +532,7 @@ pub async fn unlock_account(
         account,
         credential_id,
         deposits_hex,
+        encryption_key,
     })
 }
 

--- a/rust/tonk-identity/src/envelope.rs
+++ b/rust/tonk-identity/src/envelope.rs
@@ -22,9 +22,10 @@ use crate::clearance::{Account, Clearance, Recovery};
 /// version is a deliberate account rotation, never a routine change.
 pub const SIGNING_CONTEXT: &[u8] = b"tonk/sign/v1";
 
-/// HKDF info reserved for the X25519 encryption root when E2EE lands.
-/// No derivation function exists yet on purpose: reserving the domain
-/// is the reason the *secret* is wrapped rather than the signing key.
+/// HKDF info for the account's X25519 encryption key, the recipient
+/// every device seals custodied seeds to (see [`crate::sealed`]).
+/// Having a second root derive from the same secret is the reason the
+/// *secret* is wrapped rather than the signing key.
 pub const ENCRYPTION_CONTEXT: &[u8] = b"tonk/enc/v1";
 
 /// Entry-function salt that seeds the custody keypair. Evaluated as
@@ -99,6 +100,13 @@ impl AccountSecret {
     /// the new one.
     pub fn account_kek(&self) -> Kek<Account> {
         Kek(expand(&self.0, Account::CONTEXT), PhantomData)
+    }
+
+    /// The account's X25519 encryption key, via [`ENCRYPTION_CONTEXT`].
+    /// Its public half is the recipient every device seals custodied
+    /// seeds to; the private half only exists inside a ceremony.
+    pub fn encryption_key(&self) -> crate::sealed::EncryptionKey {
+        crate::sealed::EncryptionKey::from_bytes(expand(&self.0, ENCRYPTION_CONTEXT))
     }
 
     /// The account signer. On the web target the key imports into

--- a/rust/tonk-identity/src/install.rs
+++ b/rust/tonk-identity/src/install.rs
@@ -135,6 +135,9 @@ fn root_result(ceremony: crate::ceremony::RootCeremony) -> Result<JsValue, JsVal
         Reflect::set(&metadata, &"createdOn".into(), &passkey.created_on.into())?;
         Reflect::set(&result, &"passkey".into(), &metadata)?;
     }
+    if let Some(encryption_key) = ceremony.encryption_key {
+        Reflect::set(&result, &"encryptionKey".into(), &encryption_key.into())?;
+    }
     Ok(result.into())
 }
 
@@ -291,6 +294,11 @@ async fn unlock_with_passkey(input: JsValue) -> Result<JsValue, JsValue> {
         &result,
         &"credentialId".into(),
         &unlock.credential_id.into(),
+    )?;
+    Reflect::set(
+        &result,
+        &"encryptionKey".into(),
+        &unlock.encryption_key.into(),
     )?;
     set_deposits(&result, &unlock.deposits_hex)?;
     Ok(result)

--- a/rust/tonk-identity/src/lib.rs
+++ b/rust/tonk-identity/src/lib.rs
@@ -20,6 +20,7 @@ mod install;
 pub mod passkey;
 pub mod request;
 pub mod revocation;
+pub mod sealed;
 pub mod session;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]

--- a/rust/tonk-identity/src/sealed.rs
+++ b/rust/tonk-identity/src/sealed.rs
@@ -1,0 +1,348 @@
+//! Sealing a seed to the account's public encryption key.
+//!
+//! The account KEK ([`crate::envelope::Kek`]) only exists inside a
+//! ceremony, and a CLI device never runs one, so wrapping a space seed
+//! under it would make space creation a browser-only act. Instead every
+//! device seals to the account's X25519 public key, which it already
+//! holds from the account space, and only a ceremony, which derives the
+//! private half from the account secret, can open. Design:
+//! `plan/authority-facts.md`, "Wrapped keys".
+//!
+//! Sealing is public, opening is recovery-gated, so the clearance model
+//! is unchanged: a device compromise leaks nothing it did not already
+//! hold, an account compromise costs the seeds.
+
+use aes_gcm::aead::{Aead, Payload};
+use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+use anyhow::Result;
+use dialog_varsig::Did;
+use hkdf::Hkdf;
+use sha2_0_10::Sha256;
+use x25519_dalek::{PublicKey, StaticSecret};
+use zeroize::Zeroizing;
+
+/// HKDF info for the AEAD key derived from the ECDH shared secret.
+pub const SEAL_CONTEXT: &[u8] = b"tonk/seal/v1";
+
+/// Multicodec `x25519-pub` (`0xec`) as an unsigned varint: the
+/// `did:key` prefix for an X25519 public key.
+const X25519_PUB_CODEC: [u8; 2] = [0xec, 0x01];
+
+const VERSION: u8 = 1;
+const ALGORITHM_X25519_AES_256_GCM: u8 = 0;
+const KEY_LEN: usize = 32;
+const NONCE_LEN: usize = 12;
+/// version + algorithm + ephemeral public key.
+const HEADER_LEN: usize = 1 + 1 + KEY_LEN;
+
+/// What can go wrong opening or parsing a sealed blob. Decryption
+/// failures are opaque on purpose: a wrong key, a wrong subject, and a
+/// tampered blob are indistinguishable by design.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum SealedError {
+    /// The blob is shorter than a well-formed sealed seed can be.
+    #[error("the sealed seed is truncated")]
+    Truncated,
+    /// The version byte names a format this build does not read.
+    #[error("unsupported sealed seed version {0}")]
+    UnsupportedVersion(u8),
+    /// The algorithm byte names no known scheme.
+    #[error("unknown sealed seed algorithm {0}")]
+    UnknownAlgorithm(u8),
+    /// The key does not open this blob for this subject, or the blob
+    /// was altered.
+    #[error("the sealed seed did not open")]
+    Sealed,
+    /// The DID is not a `did:key` carrying an X25519 public key.
+    #[error("not an X25519 did:key: {0}")]
+    NotAnX25519Key(String),
+}
+
+/// The account's X25519 private key: what opens a [`Sealed`] seed.
+/// Derived from the account secret inside a ceremony, never stored.
+pub struct EncryptionKey(StaticSecret);
+
+impl EncryptionKey {
+    /// Adopt 32 secret bytes as an X25519 key. The bytes are clamped
+    /// by the curve as usual.
+    pub fn from_bytes(bytes: Zeroizing<[u8; 32]>) -> Self {
+        Self(StaticSecret::from(*bytes))
+    }
+
+    /// The public half: the recipient every device seals to.
+    pub fn recipient(&self) -> RecipientKey {
+        RecipientKey(PublicKey::from(&self.0))
+    }
+
+    /// Open a seed sealed to this key for `subject`. Fails as
+    /// [`SealedError::Sealed`] for another key, another subject, and a
+    /// tampered blob alike.
+    pub fn open(&self, sealed: &Sealed, subject: &Did) -> Result<Zeroizing<[u8; 32]>, SealedError> {
+        let recipient = self.recipient();
+        let shared = Zeroizing::new(self.0.diffie_hellman(&sealed.ephemeral).to_bytes());
+        let cipher = cipher(&shared, &sealed.ephemeral, &recipient.0);
+        let plaintext = cipher
+            .decrypt(
+                &Nonce::from(sealed.nonce),
+                Payload {
+                    msg: &sealed.ciphertext,
+                    aad: &sealed.associated_data(&recipient, subject),
+                },
+            )
+            .map_err(|_| SealedError::Sealed)?;
+        let mut plaintext = Zeroizing::new(plaintext);
+        let bytes: [u8; 32] = plaintext
+            .as_slice()
+            .try_into()
+            .map_err(|_| SealedError::Sealed)?;
+        plaintext.as_mut_slice().fill(0);
+        Ok(Zeroizing::new(bytes))
+    }
+}
+
+/// An X25519 public key: the addressee of a [`Sealed`] seed. Carried
+/// in facts as a `did:key` under the `x25519-pub` multicodec
+/// (`did:key:z6LS…`), so a recipient is an entity like any other
+/// reference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RecipientKey(PublicKey);
+
+impl RecipientKey {
+    /// The `did:key:z6LS…` form.
+    pub fn did(&self) -> Did {
+        let mut bytes = Vec::with_capacity(X25519_PUB_CODEC.len() + KEY_LEN);
+        bytes.extend_from_slice(&X25519_PUB_CODEC);
+        bytes.extend_from_slice(self.0.as_bytes());
+        let encoded = bs58::encode(bytes).into_string();
+        format!("did:key:z{encoded}")
+            .parse()
+            .expect("a did:key with a method and identifier")
+    }
+
+    /// Parse a `did:key:z6LS…`.
+    pub fn from_did(did: &Did) -> Result<Self, SealedError> {
+        let invalid = || SealedError::NotAnX25519Key(did.to_string());
+        let encoded = did.as_str().strip_prefix("did:key:z").ok_or_else(invalid)?;
+        let bytes = bs58::decode(encoded).into_vec().map_err(|_| invalid())?;
+        let key = bytes
+            .strip_prefix(&X25519_PUB_CODEC[..])
+            .ok_or_else(invalid)?;
+        let key: [u8; KEY_LEN] = key.try_into().map_err(|_| invalid())?;
+        Ok(Self(PublicKey::from(key)))
+    }
+
+    /// Seal a 32-byte seed for `subject` to this recipient. Needs no
+    /// secret: a fresh ephemeral X25519 key is agreed against the
+    /// recipient and discarded.
+    pub fn seal(&self, seed: &Zeroizing<[u8; 32]>, subject: &Did) -> Result<Sealed> {
+        let mut ephemeral_bytes = Zeroizing::new([0u8; 32]);
+        getrandom::fill(ephemeral_bytes.as_mut())
+            .map_err(|error| anyhow::anyhow!("no entropy for an ephemeral key: {error}"))?;
+        let ephemeral_secret = StaticSecret::from(*ephemeral_bytes);
+        let ephemeral = PublicKey::from(&ephemeral_secret);
+        let shared = Zeroizing::new(ephemeral_secret.diffie_hellman(&self.0).to_bytes());
+
+        let mut nonce = [0u8; NONCE_LEN];
+        getrandom::fill(&mut nonce)
+            .map_err(|error| anyhow::anyhow!("no entropy for a seal nonce: {error}"))?;
+        let mut sealed = Sealed {
+            ephemeral,
+            nonce,
+            ciphertext: Vec::new(),
+        };
+        sealed.ciphertext = cipher(&shared, &ephemeral, &self.0)
+            .encrypt(
+                &Nonce::from(nonce),
+                Payload {
+                    msg: seed.as_ref(),
+                    aad: &sealed.associated_data(self, subject),
+                },
+            )
+            .map_err(|_| anyhow::anyhow!("failed to seal the seed"))?;
+        Ok(sealed)
+    }
+}
+
+/// The AEAD key for one seal: `HKDF(shared, salt = ephemeral ‖
+/// recipient, info = SEAL_CONTEXT)`. Both public keys go into the salt so
+/// the key is bound to this exact agreement.
+fn cipher(shared: &Zeroizing<[u8; 32]>, ephemeral: &PublicKey, recipient: &PublicKey) -> Aes256Gcm {
+    let mut salt = [0u8; KEY_LEN * 2];
+    salt[..KEY_LEN].copy_from_slice(ephemeral.as_bytes());
+    salt[KEY_LEN..].copy_from_slice(recipient.as_bytes());
+    let hkdf = Hkdf::<Sha256>::new(Some(&salt), shared.as_ref());
+    let mut okm = Zeroizing::new([0u8; 32]);
+    hkdf.expand(SEAL_CONTEXT, okm.as_mut())
+        .expect("32 bytes is a valid HKDF-SHA256 output length");
+    Aes256Gcm::new_from_slice(okm.as_ref()).expect("32 bytes is the AES-256 key length")
+}
+
+/// A seed sealed to one recipient for one subject: `version (1) ‖
+/// algorithm (1) ‖ ephemeral public key (32) ‖ nonce (12) ‖
+/// ciphertext`. The header, the recipient DID, and the subject DID are
+/// the associated data, so a blob cannot be re-pointed at another space
+/// or another account without refusing to open.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Sealed {
+    ephemeral: PublicKey,
+    nonce: [u8; NONCE_LEN],
+    ciphertext: Vec<u8>,
+}
+
+impl Sealed {
+    fn header(&self) -> [u8; HEADER_LEN] {
+        let mut header = [0u8; HEADER_LEN];
+        header[0] = VERSION;
+        header[1] = ALGORITHM_X25519_AES_256_GCM;
+        header[2..].copy_from_slice(self.ephemeral.as_bytes());
+        header
+    }
+
+    fn associated_data(&self, recipient: &RecipientKey, subject: &Did) -> Vec<u8> {
+        let recipient = recipient.did();
+        let mut aad =
+            Vec::with_capacity(HEADER_LEN + recipient.as_str().len() + subject.as_str().len());
+        aad.extend_from_slice(&self.header());
+        aad.extend_from_slice(recipient.as_str().as_bytes());
+        aad.extend_from_slice(subject.as_str().as_bytes());
+        aad
+    }
+
+    /// The wire form.
+    pub fn encode(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(HEADER_LEN + NONCE_LEN + self.ciphertext.len());
+        bytes.extend_from_slice(&self.header());
+        bytes.extend_from_slice(&self.nonce);
+        bytes.extend_from_slice(&self.ciphertext);
+        bytes
+    }
+
+    /// Parse a sealed seed, rejecting anything this build cannot open.
+    pub fn decode(bytes: &[u8]) -> Result<Self, SealedError> {
+        if bytes.len() < HEADER_LEN + NONCE_LEN {
+            return Err(SealedError::Truncated);
+        }
+        if bytes[0] != VERSION {
+            return Err(SealedError::UnsupportedVersion(bytes[0]));
+        }
+        if bytes[1] != ALGORITHM_X25519_AES_256_GCM {
+            return Err(SealedError::UnknownAlgorithm(bytes[1]));
+        }
+        let ephemeral: [u8; KEY_LEN] = bytes[2..HEADER_LEN].try_into().expect("32 bytes");
+        let mut nonce = [0u8; NONCE_LEN];
+        nonce.copy_from_slice(&bytes[HEADER_LEN..HEADER_LEN + NONCE_LEN]);
+        Ok(Self {
+            ephemeral: PublicKey::from(ephemeral),
+            nonce,
+            ciphertext: bytes[HEADER_LEN + NONCE_LEN..].to_vec(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::AccountSecret;
+    use dialog_varsig::did;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn account(byte: u8) -> EncryptionKey {
+        AccountSecret::from_bytes(Zeroizing::new([byte; 32])).encryption_key()
+    }
+
+    fn seed(byte: u8) -> Zeroizing<[u8; 32]> {
+        Zeroizing::new([byte; 32])
+    }
+
+    #[dialog_common::test]
+    fn it_seals_to_the_recipient_and_opens_with_the_account_key() {
+        let key = account(1);
+        let subject = did!("key:z6MkSpace");
+        let sealed = key.recipient().seal(&seed(7), &subject).unwrap();
+        let opened = key.open(&sealed, &subject).unwrap();
+        assert_eq!(*opened, [7u8; 32]);
+    }
+
+    #[dialog_common::test]
+    fn it_survives_the_wire() {
+        let key = account(1);
+        let subject = did!("key:z6MkSpace");
+        let sealed = key.recipient().seal(&seed(7), &subject).unwrap();
+        let decoded = Sealed::decode(&sealed.encode()).unwrap();
+        assert_eq!(decoded, sealed);
+        assert_eq!(*key.open(&decoded, &subject).unwrap(), [7u8; 32]);
+    }
+
+    #[dialog_common::test]
+    fn it_refuses_another_account_key() {
+        let subject = did!("key:z6MkSpace");
+        let sealed = account(1).recipient().seal(&seed(7), &subject).unwrap();
+        assert_eq!(account(2).open(&sealed, &subject), Err(SealedError::Sealed));
+    }
+
+    #[dialog_common::test]
+    fn it_refuses_another_subject() {
+        let key = account(1);
+        let sealed = key
+            .recipient()
+            .seal(&seed(7), &did!("key:z6MkSpace"))
+            .unwrap();
+        assert_eq!(
+            key.open(&sealed, &did!("key:z6MkOther")),
+            Err(SealedError::Sealed)
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_refuses_a_tampered_blob() {
+        let key = account(1);
+        let subject = did!("key:z6MkSpace");
+        let mut bytes = key.recipient().seal(&seed(7), &subject).unwrap().encode();
+        let last = bytes.len() - 1;
+        bytes[last] ^= 1;
+        let sealed = Sealed::decode(&bytes).unwrap();
+        assert_eq!(key.open(&sealed, &subject), Err(SealedError::Sealed));
+    }
+
+    #[dialog_common::test]
+    fn it_names_the_recipient_as_an_x25519_did_key() {
+        let recipient = account(1).recipient();
+        let did = recipient.did();
+        assert!(did.as_str().starts_with("did:key:z6LS"), "{did}");
+        assert_eq!(RecipientKey::from_did(&did).unwrap(), recipient);
+    }
+
+    #[dialog_common::test]
+    fn it_refuses_an_ed25519_did_key_as_a_recipient() {
+        let ed25519 = did!("key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK");
+        assert!(matches!(
+            RecipientKey::from_did(&ed25519),
+            Err(SealedError::NotAnX25519Key(_))
+        ));
+    }
+
+    #[dialog_common::test]
+    fn it_derives_the_same_recipient_from_the_same_secret() {
+        assert_eq!(account(1).recipient(), account(1).recipient());
+        assert_ne!(account(1).recipient(), account(2).recipient());
+    }
+
+    #[dialog_common::test]
+    fn it_rejects_malformed_blobs() {
+        assert_eq!(Sealed::decode(&[1, 0]), Err(SealedError::Truncated));
+        let mut bytes = vec![9u8; HEADER_LEN + NONCE_LEN];
+        assert_eq!(
+            Sealed::decode(&bytes),
+            Err(SealedError::UnsupportedVersion(9))
+        );
+        bytes[0] = VERSION;
+        assert_eq!(
+            Sealed::decode(&bytes),
+            Err(SealedError::UnknownAlgorithm(9))
+        );
+    }
+}

--- a/rust/tonk-schema/src/account.rs
+++ b/rust/tonk-schema/src/account.rs
@@ -3,7 +3,7 @@
 use dialog_artifacts::Entity;
 use dialog_query::Concept;
 
-use crate::domain::account::{DisplayName, PasskeyCreatedAt, PasskeyCreatedOn};
+use crate::domain::account::{DisplayName, EncryptionKey, PasskeyCreatedAt, PasskeyCreatedOn};
 
 /// The account-wide display name, keyed by the immutable account subject.
 ///
@@ -69,6 +69,32 @@ impl AccountPasskeyCreated {
     /// Unix seconds, back in the integer form the wire DTO carries.
     pub fn seconds(&self) -> u64 {
         self.created_at.0 as u64
+    }
+}
+
+/// The account's public encryption key, keyed by the immutable account
+/// subject: the recipient every device seals a [`CustodiedSeed`] to.
+///
+/// Written by the ceremony that creates the account secret and again at
+/// rotation. Any device holding the account space can read it and seal;
+/// only a ceremony, which derives the private half, can open.
+///
+/// [`CustodiedSeed`]: crate::CustodiedSeed
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AccountEncryptionKey {
+    /// The immutable account subject.
+    pub this: Entity,
+    /// The X25519 `did:key:z6LS…`.
+    pub key: EncryptionKey,
+}
+
+impl AccountEncryptionKey {
+    /// Publish `key` as the account's encryption key.
+    pub fn new(account: Entity, key: Entity) -> Self {
+        Self {
+            this: account,
+            key: EncryptionKey(key),
+        }
     }
 }
 

--- a/rust/tonk-schema/src/custody.rs
+++ b/rust/tonk-schema/src/custody.rs
@@ -1,0 +1,222 @@
+//! [`CustodiedSeed`] — a space or invite seed sealed to an account.
+
+use dialog_artifacts::Entity;
+use dialog_query::Concept;
+use dialog_varsig::Did;
+use serde::Serialize;
+
+use crate::domain::custody::{Kind, Recipient, Sealed, Subject};
+use crate::prelude::*;
+
+/// A seed sealed to one recipient for one subject, in the account space.
+///
+/// The `this` entity is content-derived from the `(subject, recipient)`
+/// pair, so re-sealing the same seed to the same account converges on
+/// one row, while rotation adds a row for the new recipient and retracts
+/// the old one rather than overwriting in place. Sealing a space seed to
+/// another account (an admin as recovery custodian) is another row with
+/// another recipient, no schema change.
+///
+/// `subject`, `kind`, and `recipient` repeat the hash inputs as
+/// queryable attributes: rotation enumerates everything sealed to the
+/// old recipient, and a recovering device finds the seed for a space
+/// without knowing the entity. The sealed bytes are a
+/// `tonk_identity::sealed::Sealed` envelope, which binds the recipient
+/// and subject DIDs as associated data, so a row cannot be re-pointed.
+///
+/// The seed sits beside the ownership delegation rather than on it: the
+/// delegation says who may act for the space, the seed says how to
+/// re-issue it. Design: `plan/authority-facts.md`, "Wrapped keys".
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CustodiedSeed {
+    /// The row's entity. Derived from `(subject, recipient)`.
+    pub this: Entity,
+    /// The DID the seed derives.
+    pub subject: Subject,
+    /// What the subject is: [`SeedKind::Space`] or [`SeedKind::Invite`].
+    pub kind: Kind,
+    /// The X25519 `did:key` the seed is sealed to.
+    pub recipient: Recipient,
+    /// The sealed envelope bytes.
+    pub sealed: Sealed,
+}
+
+/// What a custodied seed derives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SeedKind {
+    /// A space's signing key.
+    Space,
+    /// An invite principal's signing key.
+    Invite,
+}
+
+impl SeedKind {
+    /// `kind` URI for a space seed.
+    pub const SPACE: &'static str = "tonk:space";
+    /// `kind` URI for an invite seed.
+    pub const INVITE: &'static str = "tonk:invite";
+
+    /// The URI this kind is stored as.
+    pub fn uri(self) -> &'static str {
+        match self {
+            Self::Space => Self::SPACE,
+            Self::Invite => Self::INVITE,
+        }
+    }
+
+    /// The stored [`Kind`]. The URIs are constants, so the parse cannot
+    /// fail.
+    pub fn kind(self) -> Kind {
+        Kind(self.uri().parse().expect("a constant kind URI parses"))
+    }
+}
+
+/// Hash input for [`CustodiedSeed::this`]. Single-variant enum tags the
+/// CBOR encoding with the concept name so equal field data under a
+/// different concept hashes differently.
+#[derive(Debug, Clone, Serialize)]
+enum This<'a> {
+    CustodiedSeed {
+        subject: &'a Did,
+        recipient: &'a Did,
+    },
+}
+
+impl CustodiedSeed {
+    /// A seed for `subject`, sealed to `recipient`.
+    pub fn new(subject: Did, kind: SeedKind, recipient: Did, sealed: Vec<u8>) -> Self {
+        Self {
+            this: Entity::of(&This::CustodiedSeed {
+                subject: &subject,
+                recipient: &recipient,
+            }),
+            subject: Subject(subject.this()),
+            kind: kind.kind(),
+            recipient: Recipient(recipient.this()),
+            sealed: Sealed(sealed),
+        }
+    }
+
+    /// The row's entity.
+    pub fn this(&self) -> &Entity {
+        &self.this
+    }
+}
+
+impl AsRef<Entity> for CustodiedSeed {
+    fn as_ref(&self) -> &Entity {
+        &self.this
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use dialog_operator::helpers;
+    use dialog_query::{Output as _, Query, Term};
+    use dialog_varsig::did;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[dialog_common::test]
+    fn it_derives_the_same_entity_for_the_same_subject_and_recipient() {
+        let a = CustodiedSeed::new(did!("test:s"), SeedKind::Space, did!("test:r"), vec![1]);
+        let b = CustodiedSeed::new(did!("test:s"), SeedKind::Space, did!("test:r"), vec![2]);
+        assert_eq!(a.this, b.this);
+    }
+
+    #[dialog_common::test]
+    fn it_derives_different_entities_per_recipient_and_subject() {
+        let base = CustodiedSeed::new(did!("test:s"), SeedKind::Space, did!("test:r1"), vec![]);
+        let other_recipient =
+            CustodiedSeed::new(did!("test:s"), SeedKind::Space, did!("test:r2"), vec![]);
+        let other_subject =
+            CustodiedSeed::new(did!("test:s2"), SeedKind::Space, did!("test:r1"), vec![]);
+        assert_ne!(base.this, other_recipient.this);
+        assert_ne!(base.this, other_subject.this);
+    }
+
+    #[dialog_common::test]
+    fn it_reflects_the_inputs_as_attributes() {
+        let row = CustodiedSeed::new(
+            did!("test:space"),
+            SeedKind::Invite,
+            did!("test:recipient"),
+            vec![7, 8],
+        );
+        assert_eq!(row.subject.0.to_string(), "did:test:space");
+        assert_eq!(row.recipient.0.to_string(), "did:test:recipient");
+        assert_eq!(row.kind.0.to_string(), SeedKind::INVITE);
+        assert_eq!(row.sealed.0, vec![7, 8]);
+    }
+
+    #[dialog_common::test]
+    async fn it_round_trips_through_a_branch_and_finds_rows_by_recipient() -> Result<()> {
+        let (operator, profile) = helpers::test_operator_with_profile().await;
+        let repository = helpers::test_repo(&operator, &profile).await;
+        let branch = repository.branch("main").open().perform(&operator).await?;
+
+        let old = did!("test:old-recipient");
+        let new = did!("test:new-recipient");
+        branch
+            .transaction()
+            .assert(CustodiedSeed::new(
+                did!("test:space-a"),
+                SeedKind::Space,
+                old.clone(),
+                vec![1],
+            ))
+            .assert(CustodiedSeed::new(
+                did!("test:space-b"),
+                SeedKind::Space,
+                old.clone(),
+                vec![2],
+            ))
+            .assert(CustodiedSeed::new(
+                did!("test:space-a"),
+                SeedKind::Space,
+                new.clone(),
+                vec![3],
+            ))
+            .commit()
+            .perform(&operator)
+            .await?;
+
+        let sealed_to_old: Vec<CustodiedSeed> = branch
+            .query()
+            .select(Query::<CustodiedSeed> {
+                this: Term::var("this"),
+                subject: Term::var("subject"),
+                kind: Term::var("kind"),
+                recipient: Term::from(Recipient(old.this())),
+                sealed: Term::var("sealed"),
+            })
+            .perform(&operator)
+            .try_vec()
+            .await?;
+        let mut subjects: Vec<String> = sealed_to_old
+            .iter()
+            .map(|row| row.subject.0.to_string())
+            .collect();
+        subjects.sort();
+        assert_eq!(subjects, vec!["did:test:space-a", "did:test:space-b"]);
+
+        let for_space_a: Vec<CustodiedSeed> = branch
+            .query()
+            .select(Query::<CustodiedSeed> {
+                this: Term::var("this"),
+                subject: Term::from(Subject(did!("test:space-a").this())),
+                kind: Term::var("kind"),
+                recipient: Term::var("recipient"),
+                sealed: Term::var("sealed"),
+            })
+            .perform(&operator)
+            .try_vec()
+            .await?;
+        assert_eq!(for_space_a.len(), 2, "one row per recipient");
+        Ok(())
+    }
+}

--- a/rust/tonk-schema/src/domain.rs
+++ b/rust/tonk-schema/src/domain.rs
@@ -706,7 +706,7 @@ pub mod roster {
 
 /// Root-owned account state replicated through the hidden account repository.
 pub mod account {
-    use super::Attribute;
+    use super::{Attribute, Entity};
 
     /// The account-wide display name. Cardinality-one merge semantics choose a
     /// deterministic winner when linked devices write concurrently.
@@ -733,6 +733,46 @@ pub mod account {
     #[domain("xyz.tonk.account")]
     #[cardinality(one)]
     pub struct PasskeyCreatedOn(pub String);
+
+    /// The account's X25519 public key as a `did:key:z6LS…` entity: the
+    /// recipient every device seals custodied seeds to. Derived from the
+    /// account secret, so rotation publishes a new one; cardinality-one
+    /// because sealed rows name their own recipient and need no history
+    /// here.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.account")]
+    #[cardinality(one)]
+    pub struct EncryptionKey(pub Entity);
+}
+
+/// Attributes of a seed sealed to an account, in the account space. One
+/// row per `(subject, recipient)`; see [`crate::CustodiedSeed`].
+pub mod custody {
+    use super::{Attribute, Entity};
+
+    /// The DID the seed derives: a space's, or an invite principal's.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.custody")]
+    #[cardinality(one)]
+    pub struct Subject(pub Entity);
+
+    /// What the subject is: `tonk:space` or `tonk:invite`.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.custody")]
+    #[cardinality(one)]
+    pub struct Kind(pub Entity);
+
+    /// The X25519 `did:key` the seed is sealed to.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.custody")]
+    #[cardinality(one)]
+    pub struct Recipient(pub Entity);
+
+    /// The sealed envelope bytes (`tonk_identity::sealed::Sealed`).
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.custody")]
+    #[cardinality(one)]
+    pub struct Sealed(pub Vec<u8>);
 }
 
 /// Attributes that describe a repository on its content branch, keyed by the

--- a/rust/tonk-schema/src/lib.rs
+++ b/rust/tonk-schema/src/lib.rs
@@ -64,7 +64,10 @@ pub mod sync;
 pub use sync::*;
 
 pub mod account;
-pub use account::{AccountDisplayName, AccountPasskeyCreated};
+pub use account::{AccountDisplayName, AccountEncryptionKey, AccountPasskeyCreated};
+
+pub mod custody;
+pub use custody::{CustodiedSeed, SeedKind};
 
 pub mod device_link;
 pub mod replica;

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -1168,6 +1168,7 @@ async fn persist(
             root.credential_id.to_string(),
             root.delegation_hex.to_string(),
             None,
+            ceremony.encryption_key.clone(),
         )
         .await
         .map_err(|error| error.to_string())?;
@@ -1469,6 +1470,7 @@ fn bind(host: &HtmlElement) {
                     created.credential_id.clone(),
                     created.delegation_hex.clone(),
                     created.passkey.clone(),
+                    created.encryption_key.clone(),
                 )
                 .await
                 .map_err(|error| error.to_string())?;
@@ -1478,6 +1480,7 @@ fn bind(host: &HtmlElement) {
                     delegation_hex: created.delegation_hex,
                     invocation_hex: created.invocation_hex,
                     deposits_hex: created.deposits_hex,
+                    encryption_key: created.encryption_key,
                 };
                 set_busy(&host, true, "Creating your account…");
                 complete_remote(&host, "/accounts", ceremony, true, Some(&email)).await?;
@@ -1589,6 +1592,7 @@ fn bind(host: &HtmlElement) {
                         created_at: (js_sys::Date::now() / 1000.0) as u64,
                         created_on: crate::device_name::current(),
                     }),
+                    None,
                 )
                 .await
                 .map_err(|error| error.to_string())?;

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -2345,6 +2345,7 @@ mod tests {
             delegation_hex: "11".into(),
             invocation_hex: "22".into(),
             deposits_hex: Vec::new(),
+            encryption_key: None,
         };
 
         assert_eq!(
@@ -2374,6 +2375,7 @@ mod tests {
             delegation_hex: "11".into(),
             invocation_hex: "22".into(),
             deposits_hex: Vec::new(),
+            encryption_key: None,
         };
 
         assert_eq!(

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -660,7 +660,26 @@ mod tests {
             .await?;
         // The callback answers the form POST with a redirect back to the
         // account page, which renders the outcome in its own styling.
-        element(driver, "tonk-account[data-mode=\"success\"]").await?;
+        if let Err(wait_error) = element(driver, "tonk-account[data-mode=\"success\"]").await {
+            // Say WHERE the approval stopped, not just that it did: the
+            // panel's mode, its error line, and its status line are what
+            // separate a ceremony that failed from a callback that never
+            // redirected.
+            let host = element(driver, "tonk-account").await?;
+            let mode = host.attr("data-mode").await?.unwrap_or_default();
+            let error = match driver.find(By::Css("#account-error")).await {
+                Ok(element) => element.text().await.unwrap_or_default(),
+                Err(_) => String::new(),
+            };
+            let working = match driver.find(By::Css("#account-working")).await {
+                Ok(element) => element.text().await.unwrap_or_default(),
+                Err(_) => String::new(),
+            };
+            let url = driver.current_url().await?;
+            return Err(wait_error).context(format!(
+                "approval stopped in mode {mode:?} at {url}; error={error:?}; status={working:?}"
+            ));
+        }
         wait_for_text(
             driver,
             "#account-success-message",

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -496,6 +496,7 @@ pub async fn save_root(
     credential_id: String,
     delegation_hex: String,
     passkey: Option<tonk_worker_api::PasskeyMetadata>,
+    encryption_key: Option<String>,
 ) -> Result<RootStatus, TonkUiError> {
     tonk_host::ready::wait().await;
     let response = reqwest::Client::new()
@@ -504,6 +505,7 @@ pub async fn save_root(
             credential_id,
             delegation_hex,
             passkey,
+            encryption_key,
         })
         .send()
         .await

--- a/rust/tonk-ui/src/identity_bridge.rs
+++ b/rust/tonk-ui/src/identity_bridge.rs
@@ -39,6 +39,9 @@ pub(crate) struct CreateAccountOutput {
     pub invocation_hex: String,
     #[serde(default)]
     pub passkey: Option<tonk_worker_api::PasskeyMetadata>,
+    /// The account's X25519 recipient, published as `AccountEncryptionKey`.
+    #[serde(default)]
+    pub encryption_key: Option<String>,
     #[serde(default)]
     pub deposits_hex: Vec<String>,
     pub custody_did: String,
@@ -101,6 +104,9 @@ pub(crate) struct CeremonyOutput {
     /// input named the service.
     #[serde(default)]
     pub deposits_hex: Vec<String>,
+    /// The account's X25519 recipient, when the ceremony held the secret.
+    #[serde(default)]
+    pub encryption_key: Option<String>,
 }
 
 /// Verification-only assertion input: the account passkey to assert

--- a/rust/tonk-worker-api/src/identity.rs
+++ b/rust/tonk-worker-api/src/identity.rs
@@ -56,6 +56,11 @@ pub struct SaveRootRequest {
     /// Creation details when this request follows passkey creation.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub passkey: Option<PasskeyMetadata>,
+    /// The account's X25519 recipient (`did:key:z6LS…`) when the
+    /// ceremony held the secret, for the worker to publish as
+    /// `AccountEncryptionKey`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encryption_key: Option<String>,
 }
 
 /// Request to create a durable space through the local root.

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -609,6 +609,7 @@ pub mod tests {
                 credential_id: "test-credential".to_string(),
                 delegation_hex: hex::encode(grant.to_bytes().unwrap()),
                 passkey: None,
+                encryption_key: None,
             },
         )
         .await
@@ -906,6 +907,7 @@ pub mod tests {
                 credential_id: "test-credential".to_string(),
                 delegation_hex: hex::encode(grant.to_bytes().unwrap()),
                 passkey: None,
+                encryption_key: None,
             },
         )
         .await

--- a/rust/tonk-worker/src/router/account_state.rs
+++ b/rust/tonk-worker/src/router/account_state.rs
@@ -20,7 +20,12 @@ use tonk_account::{
     probe_remote_main, publish_genesis_if_absent,
 };
 use tonk_common::log;
-use tonk_schema::{AccountPasskeyCreated, Replica, prelude::DidExt as _};
+use tonk_identity::sealed::RecipientKey;
+use tonk_schema::{
+    AccountEncryptionKey, AccountPasskeyCreated, CustodiedSeed, Replica, SeedKind,
+    prelude::DidExt as _,
+};
+use zeroize::Zeroizing;
 
 use crate::TonkWorkerError;
 use crate::worker::TonkState;
@@ -538,6 +543,9 @@ async fn sync_ready(tonk: &TonkState, _key: &str) -> Result<(), String> {
     if seed_passkey_facts(tonk).await {
         log!("recorded this device's passkey creation facts in the account space");
     }
+    if seed_encryption_key(tonk).await {
+        log!("published the account's encryption key in the account space");
+    }
     describe_own_device(tonk).await;
     if let Err(error) = converge_account_state(tonk).await {
         log!("account-state convergence after sync failed: {error}");
@@ -626,6 +634,9 @@ pub(crate) async fn ensure_account_state_swept(
                     // ready sweep above has not run yet.
                     if seed_passkey_facts(tonk).await {
                         log!("recorded this device's passkey creation facts in the account space");
+                    }
+                    if seed_encryption_key(tonk).await {
+                        log!("published the account's encryption key in the account space");
                     }
                     describe_own_device(tonk).await;
                     if let Err(error) = converge_account_state(tonk).await {
@@ -945,6 +956,151 @@ pub(crate) async fn seed_passkey_facts(tonk: &TonkState) -> bool {
         .await
     {
         log!("commit account passkey creation facts: {error}");
+        return false;
+    }
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    tonk.sync_queue.mark_dirty(&ready.key, js_sys::Date::now());
+    true
+}
+
+/// The account's published encryption key, when the account is ready and
+/// has one.
+pub(crate) async fn read_encryption_key(
+    tonk: &TonkState,
+    ready: &ReadyAccountBranch,
+) -> Result<Option<dialog_varsig::Did>, TonkWorkerError> {
+    let branch = tonk
+        .reactor
+        .profile_repository()
+        .branch(tonk_account::MAIN_BRANCH)
+        .acquire(&tonk.operator)
+        .await
+        .map_err(|error| TonkWorkerError::Internal(format!("open ready account state: {error}")))?;
+    let rows: Vec<AccountEncryptionKey> = branch
+        .handle()
+        .query()
+        .select(Query::<AccountEncryptionKey> {
+            this: Term::from(ready.subject.this()),
+            key: Term::var("key"),
+        })
+        .perform(&tonk.operator)
+        .try_vec()
+        .await
+        .map_err(|error| {
+            TonkWorkerError::Internal(format!("read account encryption key: {error:?}"))
+        })?;
+    rows.into_iter()
+        .next()
+        .map(|row| {
+            row.key.0.to_string().parse().map_err(|error| {
+                TonkWorkerError::Internal(format!(
+                    "the published account encryption key is not a DID: {error}"
+                ))
+            })
+        })
+        .transpose()
+}
+
+/// Publish the recipient the root record carries as the account's
+/// encryption key, when the account space does not already say so.
+/// Returns whether it wrote.
+///
+/// Only a ceremony that held the secret records a recipient, so a
+/// device that merely links has nothing to contribute and returns
+/// `false`. A differing published key is replaced: the record comes
+/// from the most recent ceremony, and rotation is what changes it.
+pub(crate) async fn seed_encryption_key(tonk: &TonkState) -> bool {
+    let Ok(ready) = require_ready_account_state(tonk).await else {
+        return false;
+    };
+    let Ok(root) = super::identity::local_root(tonk).await else {
+        return false;
+    };
+    let Some(recipient) = root.encryption_key else {
+        return false;
+    };
+    match read_encryption_key(tonk, &ready).await {
+        Ok(Some(published)) if published == recipient => return false,
+        Ok(_) => {}
+        Err(error) => {
+            log!("account encryption key unreadable before seeding: {error}");
+            return false;
+        }
+    }
+    if let Err(error) = tonk
+        .reactor
+        .profile_repository()
+        .branch(tonk_account::MAIN_BRANCH)
+        .transaction()
+        .assert(AccountEncryptionKey::new(
+            ready.subject.this(),
+            recipient.this(),
+        ))
+        .commit()
+        .perform(&tonk.operator)
+        .await
+    {
+        log!("commit account encryption key: {error}");
+        return false;
+    }
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    tonk.sync_queue.mark_dirty(&ready.key, js_sys::Date::now());
+    true
+}
+
+/// Seal `seed` (the signing seed `subject` derives from) to the account's
+/// published encryption key and record it as a [`CustodiedSeed`] in the
+/// account space, so any device on the account can re-issue the subject
+/// after a passkey ceremony opens it. Returns whether it wrote.
+///
+/// Best-effort, like [`retain_space_delegation`]: the subject is usable
+/// the moment its signer exists locally, and an account that has not
+/// published a key yet (one predating the key, or not ready) is logged
+/// and left for the next sweep rather than failing the caller.
+pub(crate) async fn custody_seed(
+    tonk: &TonkState,
+    subject: &dialog_varsig::Did,
+    kind: SeedKind,
+    seed: Zeroizing<[u8; 32]>,
+) -> bool {
+    let Ok(ready) = require_ready_account_state(tonk).await else {
+        return false;
+    };
+    let recipient = match read_encryption_key(tonk, &ready).await {
+        Ok(Some(recipient)) => recipient,
+        Ok(None) => {
+            log!("seed for {subject} not custodied: the account has published no encryption key");
+            return false;
+        }
+        Err(error) => {
+            log!("seed for {subject} not custodied: {error}");
+            return false;
+        }
+    };
+    let sealed = match RecipientKey::from_did(&recipient) {
+        Ok(key) => match key.seal(&seed, subject) {
+            Ok(sealed) => sealed.encode(),
+            Err(error) => {
+                log!("seed for {subject} not custodied: {error}");
+                return false;
+            }
+        },
+        Err(error) => {
+            log!("seed for {subject} not custodied: {error}");
+            return false;
+        }
+    };
+    if let Err(error) = tonk
+        .reactor
+        .profile_repository()
+        .branch(tonk_account::MAIN_BRANCH)
+        .transaction()
+        .assert(CustodiedSeed::new(subject.clone(), kind, recipient, sealed))
+        .commit()
+        .perform(&tonk.operator)
+        .await
+    {
+        log!("commit custodied seed for {subject}: {error}");
         return false;
     }
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -1498,6 +1654,7 @@ mod tests {
                 credential_id: credential_id.clone(),
                 delegation_hex: delegation_hex.clone(),
                 passkey,
+                encryption_key: None,
             },
         )
         .await
@@ -1594,6 +1751,86 @@ mod tests {
         assert_eq!(again.len(), 1);
         assert_eq!(again[0].seconds(), 1_754_380_800);
         assert_eq!(again[0].created_on.0, "Chrome on macOS");
+
+        service.stop().await.unwrap();
+        discard(state, &ready.key);
+    }
+
+    /// The recipient a ceremony recorded on the local root is published
+    /// as the account's encryption key, and a seed sealed to it lands as
+    /// a `CustodiedSeed` row that the account's own key opens.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[dialog_common::test]
+    async fn it_publishes_the_encryption_key_and_custodies_a_seed() {
+        use tonk_identity::envelope::AccountSecret;
+        use tonk_identity::sealed::Sealed;
+
+        let (state, service, _descriptor, root, _remote) = ready_account_state(None).await;
+        assert_eq!(
+            ensure_account_state(&state).await,
+            AccountStateStatus::Ready
+        );
+        let ready = require_ready_account_state(&state).await.unwrap();
+
+        // A device that only linked recorded no recipient: nothing to seed.
+        assert!(!seed_encryption_key(&state).await);
+        assert_eq!(read_encryption_key(&state, &ready).await.unwrap(), None);
+        let subject: dialog_varsig::Did = "did:key:z6MkSpaceUnderTest".parse().unwrap();
+        assert!(!custody_seed(&state, &subject, SeedKind::Space, Zeroizing::new([7u8; 32])).await);
+
+        // A ceremony that held the secret re-saves the root with the recipient.
+        let account = AccountSecret::from_bytes(Zeroizing::new([5u8; 32]));
+        let recipient = account.encryption_key().recipient().did();
+        let grant =
+            tonk_identity::delegation::mint_device_delegation(root.clone(), &state.profile.did())
+                .await
+                .unwrap();
+        crate::router::identity::persist_root(
+            &state,
+            tonk_worker_api::SaveRootRequest {
+                credential_id: "credential".to_string(),
+                delegation_hex: hex::encode(grant.to_bytes().unwrap()),
+                passkey: None,
+                encryption_key: Some(recipient.to_string()),
+            },
+        )
+        .await
+        .unwrap();
+        assert!(seed_encryption_key(&state).await);
+        assert!(!seed_encryption_key(&state).await, "already published");
+        assert_eq!(
+            read_encryption_key(&state, &ready).await.unwrap(),
+            Some(recipient.clone())
+        );
+
+        assert!(custody_seed(&state, &subject, SeedKind::Space, Zeroizing::new([7u8; 32])).await);
+        let branch = state
+            .reactor
+            .profile_repository()
+            .branch(tonk_account::MAIN_BRANCH)
+            .acquire(&state.operator)
+            .await
+            .unwrap();
+        let rows: Vec<CustodiedSeed> = branch
+            .handle()
+            .query()
+            .select(Query::<CustodiedSeed> {
+                this: Term::var("this"),
+                subject: Term::from(tonk_schema::domain::custody::Subject(subject.this())),
+                kind: Term::var("kind"),
+                recipient: Term::var("recipient"),
+                sealed: Term::var("sealed"),
+            })
+            .perform(&state.operator)
+            .try_vec()
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].kind.0.to_string(), SeedKind::SPACE);
+        assert_eq!(rows[0].recipient.0, recipient.this());
+        let sealed = Sealed::decode(&rows[0].sealed.0).unwrap();
+        let opened = account.encryption_key().open(&sealed, &subject).unwrap();
+        assert_eq!(*opened, [7u8; 32]);
 
         service.stop().await.unwrap();
         discard(state, &ready.key);

--- a/rust/tonk-worker/src/router/create_invite.rs
+++ b/rust/tonk-worker/src/router/create_invite.rs
@@ -32,8 +32,9 @@ use dialog_varsig::{Did, Principal};
 use tokio::sync::oneshot;
 use tonk_common::log;
 use tonk_invite::{Invite, InviteAudience, shortcut::ShortcutRequest};
-use tonk_schema::{Invitation, InvitationExecution, Remote as RemoteConcept};
+use tonk_schema::{Invitation, InvitationExecution, Remote as RemoteConcept, SeedKind};
 use url::Url;
+use zeroize::Zeroizing;
 
 pub use tonk_worker_api::{CreateInviteRequest, CreateInviteResponse};
 
@@ -198,6 +199,19 @@ pub async fn create_invite(
         .map_err(|e| TonkWorkerError::Internal(format!("failed to record invitation: {e}")))?;
 
     retain_invite_authority(&tonk, &repo_name, &invite.chain).await?;
+
+    // The recovery copy of the invite principal: sealed to the account,
+    // so the account can re-issue from it after a ceremony. Best effort;
+    // the invite works without it.
+    if let InviteAudience::Open { seed } = &invite.audience {
+        super::account_state::custody_seed(
+            &tonk,
+            &audience_did,
+            SeedKind::Invite,
+            Zeroizing::new(*seed),
+        )
+        .await;
+    }
 
     let url_str = invite
         .to_url(base_url.as_str())

--- a/rust/tonk-worker/src/router/create_invite.rs
+++ b/rust/tonk-worker/src/router/create_invite.rs
@@ -32,9 +32,8 @@ use dialog_varsig::{Did, Principal};
 use tokio::sync::oneshot;
 use tonk_common::log;
 use tonk_invite::{Invite, InviteAudience, shortcut::ShortcutRequest};
-use tonk_schema::{Invitation, InvitationExecution, Remote as RemoteConcept, SeedKind};
+use tonk_schema::{Invitation, InvitationExecution, Remote as RemoteConcept};
 use url::Url;
-use zeroize::Zeroizing;
 
 pub use tonk_worker_api::{CreateInviteRequest, CreateInviteResponse};
 
@@ -199,19 +198,6 @@ pub async fn create_invite(
         .map_err(|e| TonkWorkerError::Internal(format!("failed to record invitation: {e}")))?;
 
     retain_invite_authority(&tonk, &repo_name, &invite.chain).await?;
-
-    // The recovery copy of the invite principal: sealed to the account,
-    // so the account can re-issue from it after a ceremony. Best effort;
-    // the invite works without it.
-    if let InviteAudience::Open { seed } = &invite.audience {
-        super::account_state::custody_seed(
-            &tonk,
-            &audience_did,
-            SeedKind::Invite,
-            Zeroizing::new(*seed),
-        )
-        .await;
-    }
 
     let url_str = invite
         .to_url(base_url.as_str())

--- a/rust/tonk-worker/src/router/identity.rs
+++ b/rust/tonk-worker/src/router/identity.rs
@@ -22,6 +22,8 @@ pub(crate) struct LocalRootRecord {
     delegation: Vec<u8>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     passkey: Option<PasskeyMetadata>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    encryption_key: Option<String>,
 }
 
 /// A validated local root record.
@@ -39,6 +41,10 @@ pub(crate) struct LocalRoot {
     pub bytes: Vec<u8>,
     /// Informational creation details recorded by the creating browser.
     pub passkey: Option<PasskeyMetadata>,
+    /// The account's X25519 recipient, when the ceremony that wrote this
+    /// record held the secret. Published to the account space by
+    /// `seed_encryption_key`.
+    pub encryption_key: Option<dialog_varsig::Did>,
 }
 
 pub(crate) async fn validate_grant(
@@ -115,6 +121,11 @@ pub(crate) async fn local_root(state: &TonkState) -> Result<LocalRoot, TonkWorke
         .ok_or(TonkWorkerError::RootRequired)?;
     let device_did = state.profile.did();
     let delegation = validate_grant(record.delegation.clone(), &device_did).await?;
+    let encryption_key = record
+        .encryption_key
+        .as_deref()
+        .map(parse_encryption_key)
+        .transpose()?;
     Ok(LocalRoot {
         root_did: delegation.issuer().clone(),
         device_did,
@@ -122,6 +133,7 @@ pub(crate) async fn local_root(state: &TonkState) -> Result<LocalRoot, TonkWorke
         delegation,
         bytes: record.delegation,
         passkey: record.passkey,
+        encryption_key,
     })
 }
 
@@ -183,16 +195,31 @@ pub(crate) async fn persist_root(
             Ok(metadata)
         })
         .transpose()?;
+    request
+        .encryption_key
+        .as_deref()
+        .map(parse_encryption_key)
+        .transpose()?;
     let bytes = hex::decode(&request.delegation_hex)
         .map_err(|error| TonkWorkerError::Router(format!("invalid delegation hex: {error}")))?;
     let chain = validate_grant(bytes.clone(), &state.profile.did()).await?;
-    let record = LocalRootRecord {
+    let mut record = LocalRootRecord {
         version: 1,
         credential_id: request.credential_id,
         delegation: bytes.clone(),
         passkey,
+        encryption_key: request.encryption_key,
     };
     if let Some(existing) = load_record(state).await? {
+        let stored_root = DelegationChain::try_from(existing.delegation.as_slice())
+            .ok()
+            .map(|stored| stored.issuer().clone());
+        // Only a ceremony that held the secret records the recipient, so
+        // a re-save from one that did not (a link, a re-minted grant)
+        // keeps the one already recorded for this root.
+        if stored_root.as_ref() == Some(chain.issuer()) && record.encryption_key.is_none() {
+            record.encryption_key = existing.encryption_key.clone();
+        }
         if existing == record {
             return Ok(status(local_root(state).await?));
         }
@@ -213,9 +240,6 @@ pub(crate) async fn persist_root(
         // or signed in, this profile's spaces and delegations hang off
         // the stored root, and a different account arrives through
         // add-account, never by rebinding this profile.
-        let stored_root = DelegationChain::try_from(existing.delegation.as_slice())
-            .ok()
-            .map(|stored| stored.issuer().clone());
         if stored_root.as_ref() != Some(chain.issuer()) {
             if super::account::has_attachment_history(state).await {
                 return Err(TonkWorkerError::Conflict(
@@ -266,7 +290,24 @@ pub(crate) async fn persist_root(
         delegation: chain,
         bytes,
         passkey: record.passkey,
+        encryption_key: record
+            .encryption_key
+            .as_deref()
+            .map(parse_encryption_key)
+            .transpose()?,
     }))
+}
+
+/// Parse a ceremony-supplied recipient, refusing anything that is not
+/// an X25519 `did:key`: a record holding an Ed25519 DID here would seal
+/// every seed to a key nothing can open.
+fn parse_encryption_key(did: &str) -> Result<dialog_varsig::Did, TonkWorkerError> {
+    let did: dialog_varsig::Did = did
+        .parse()
+        .map_err(|error| TonkWorkerError::Router(format!("invalid encryptionKey: {error}")))?;
+    tonk_identity::sealed::RecipientKey::from_did(&did)
+        .map_err(|error| TonkWorkerError::Router(format!("invalid encryptionKey: {error}")))?;
+    Ok(did)
 }
 
 /// `POST /api/identity/root`.
@@ -283,6 +324,9 @@ pub async fn save(
     // enrollment immediately. Idempotent and best-effort.
     if super::account_state::seed_passkey_facts(&state).await {
         tonk_common::log!("recorded this device's passkey creation facts in the account space");
+    }
+    if super::account_state::seed_encryption_key(&state).await {
+        tonk_common::log!("published the account's encryption key in the account space");
     }
     Ok(Json(status))
 }
@@ -313,6 +357,7 @@ mod tests {
                 credential_id: format!("credential-{root_seed}"),
                 delegation_hex: hex::encode(grant.to_bytes().unwrap()),
                 passkey: None,
+                encryption_key: None,
             },
             grant,
         )
@@ -354,6 +399,54 @@ mod tests {
         let result = serde_json::to_value(result).unwrap();
         assert_eq!(result["passkey"]["createdAt"], 1_754_380_800u64);
         assert_eq!(result["passkey"]["createdOn"], "Chrome on macOS");
+    }
+
+    fn recipient_did(byte: u8) -> dialog_varsig::Did {
+        tonk_identity::envelope::AccountSecret::from_bytes(zeroize::Zeroizing::new([byte; 32]))
+            .encryption_key()
+            .recipient()
+            .did()
+    }
+
+    #[dialog_common::test]
+    async fn it_keeps_the_encryption_key_with_the_local_root() {
+        let state = Arc::new(RwLock::new(test_state_without_root().await));
+        let device = state.read().await.profile.did();
+        let recipient = recipient_did(1);
+        let (mut request, _) = request_for(1, &device).await;
+        request.encryption_key = Some(recipient.to_string());
+        let _ = save(State(state.clone()), Json(request)).await.unwrap();
+        assert_eq!(
+            local_root(&*state.read().await)
+                .await
+                .unwrap()
+                .encryption_key,
+            Some(recipient.clone())
+        );
+
+        // A later ceremony on the same root that did not hold the secret
+        // (a re-minted grant) leaves the recorded recipient in place.
+        let (again, _) = request_for(1, &device).await;
+        let _ = save(State(state.clone()), Json(again)).await.unwrap();
+        assert_eq!(
+            local_root(&*state.read().await)
+                .await
+                .unwrap()
+                .encryption_key,
+            Some(recipient)
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_an_encryption_key_that_is_not_x25519() {
+        let state = Arc::new(RwLock::new(test_state_without_root().await));
+        let device = state.read().await.profile.did();
+        let (mut request, grant) = request_for(1, &device).await;
+        request.encryption_key = Some(grant.issuer().to_string());
+        assert!(matches!(
+            save(State(state), Json(request)).await,
+            Err(TonkWorkerError::Router(_))
+        ));
     }
 
     #[dialog_common::test]
@@ -457,6 +550,7 @@ mod tests {
             credential_id: "renewed-credential".to_string(),
             delegation_hex: hex::encode(grant.to_bytes().unwrap()),
             passkey: None,
+            encryption_key: None,
         };
 
         let _ = super::super::account::unlink(State(state.clone()))

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -87,9 +87,10 @@ use tonk_common::log;
 use tonk_invite::{Invite, InviteAudience};
 use tonk_schema::{
     Invitation, InvitationExecution, InvitedVia, MemberName, MemberRole, Membership, Replica,
-    RepositoryName, prelude::DidExt as _,
+    RepositoryName, SeedKind, prelude::DidExt as _,
 };
 use tonk_worker_api::JoinFailureKind;
+use zeroize::Zeroizing;
 
 use self::staging::Staging;
 use super::AppState;
@@ -1550,6 +1551,21 @@ async fn commit_join(tonk: &TonkState, staged: StagedJoin) -> Result<JoinOutcome
                 Err(error) => {
                     log!("claimed space directory record skipped: {error}");
                 }
+            }
+            // The membership hangs off the invite principal, so the
+            // account keeps that principal's seed: at rotation it mints
+            // `principal -> new root` itself instead of needing a fresh
+            // invite. A targeted invite carries no seed and its chain is
+            // rooted at the account already. Best-effort, like the
+            // directory record above.
+            if let InviteAudience::Open { seed } = &prepared.invite.audience {
+                super::account_state::custody_seed(
+                    tonk,
+                    prepared.invite.chain.audience(),
+                    SeedKind::Invite,
+                    Zeroizing::new(*seed),
+                )
+                .await;
             }
         }
     }

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -20,7 +20,7 @@ use ::axum::{
     http::{HeaderMap, StatusCode},
 };
 use axum_wasm_macros::wasm_compat;
-use dialog_credentials::SignerCredential;
+use dialog_credentials::{Ed25519Signer, SignerCredential};
 use dialog_query::{Output as _, Query, Term};
 use dialog_repository::{
     RemoteRepository, Repository, RepositoryExt as _, Revision, SiteAddress, Upstream,
@@ -2682,12 +2682,16 @@ pub async fn create_repository(
     // repository's own `tonk/repository` concept. Generating the signer
     // first (rather than letting `.create()` mint one) is what lets the
     // name derive from the DID instead of the other way around.
-    // Extractable, so the seed can be sealed to the account below; the
-    // signer itself is stored as the repository's credential as before.
-    let (signer, seed) = super::create_invite::generate_ephemeral()
+    // The seed is drawn here rather than inside `generate`, so it can be
+    // sealed to the account below; the signer imports from it the same
+    // way an account root does (non-extractable on the web target), so
+    // the credential the repository stores is the shape it always was.
+    let mut seed = Zeroizing::new([0u8; 32]);
+    getrandom::fill(seed.as_mut())
+        .map_err(|e| RepositoryError::Internal(format!("Failed to generate signer: {}", e)))?;
+    let signer = Ed25519Signer::import(&*seed)
         .await
         .map_err(|e| RepositoryError::Internal(format!("Failed to generate signer: {}", e)))?;
-    let seed = Zeroizing::new(seed);
     let did = signer.did();
     let key = did.repo_key();
 

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -20,7 +20,7 @@ use ::axum::{
     http::{HeaderMap, StatusCode},
 };
 use axum_wasm_macros::wasm_compat;
-use dialog_credentials::{Ed25519Signer, SignerCredential};
+use dialog_credentials::SignerCredential;
 use dialog_query::{Output as _, Query, Term};
 use dialog_repository::{
     RemoteRepository, Repository, RepositoryExt as _, Revision, SiteAddress, Upstream,
@@ -37,9 +37,10 @@ use tonk_common::log;
 use tonk_schema::prelude::DidExt as _;
 use tonk_schema::{
     Branch as MetaBranch, Invitation, InvitedVia, MemberName, MemberRole, Membership, Remote,
-    RemoteExecution, Replica, RepositoryName, SpaceStatus, TrackingBranch,
+    RemoteExecution, Replica, RepositoryName, SeedKind, SpaceStatus, TrackingBranch,
 };
 use url::Url;
+use zeroize::Zeroizing;
 
 use super::AppState;
 use crate::{Notification, RepositoryError, TonkWorkerError, broadcast, worker::TonkState};
@@ -2681,9 +2682,12 @@ pub async fn create_repository(
     // repository's own `tonk/repository` concept. Generating the signer
     // first (rather than letting `.create()` mint one) is what lets the
     // name derive from the DID instead of the other way around.
-    let signer = Ed25519Signer::generate()
+    // Extractable, so the seed can be sealed to the account below; the
+    // signer itself is stored as the repository's credential as before.
+    let (signer, seed) = super::create_invite::generate_ephemeral()
         .await
         .map_err(|e| RepositoryError::Internal(format!("Failed to generate signer: {}", e)))?;
+    let seed = Zeroizing::new(seed);
     let did = signer.did();
     let key = did.repo_key();
 
@@ -2748,6 +2752,10 @@ pub async fn create_repository(
         .map_err(|error| {
             RepositoryError::Internal(format!("Failed to persist space root delegation: {error}"))
         })?;
+    // The recovery copy: the seed sealed to the account, so any device
+    // on the account can re-issue this space after a ceremony. Best
+    // effort like the retain above; the space is usable without it.
+    super::account_state::custody_seed(tonk, &repository.did(), SeedKind::Space, seed).await;
 
     // 3-7. Wire up the meta branch and register the replica. The
     // replica is a name-less membership index; its identity (`subject`)


### PR DESCRIPTION
The plans (`onboarding-accreditation.md`, `authority-facts.md` step 3) call for every space and invite seed to be custodied under the account so a space can be re-issued after rotation or a lost device. Nothing did that: a created space's secret lived only in the creating device's credential store, and an invite principal was consumed for one hop and dropped.

Wrapping under the account KEK would have made space creation a browser-only act, since the KEK only exists inside a passkey ceremony and the CLI never runs one. So seeds are sealed to a **public** X25519 key instead, derived from the account secret under the already-reserved `tonk/enc/v1` context and published as a `did:key` under the `x25519-pub` (`0xec`) codec. Any device holding the account DB can seal; only a ceremony can open.

- `tonk-identity::sealed`: `EncryptionKey` / `RecipientKey` and a `Sealed` envelope (ephemeral X25519 + HKDF + AES-256-GCM, recipient and subject DIDs bound as associated data).
- `tonk-schema`: `AccountEncryptionKey` on the account subject; `CustodiedSeed`, one row per `(subject, recipient)` with subject, kind, and recipient repeated as queryable attributes so rotation and recovery can enumerate rows.
- Creation and unlock ceremonies return the recipient with the root; the worker keeps it on the local root record (a re-save from a ceremony that did not hold the secret inherits it) and publishes it on the account sweep.
- Space create seals its seed (`tonk:space`); a durable join through an open invite seals the invite principal's seed (`tonk:invite`), since the membership hangs off that principal and the joiner's account is what re-issues it at rotation. Both are best-effort like `retain_space_delegation`.
- The space signer now imports from a seed drawn up front, so the stored credential keeps its shape; an extractable WebCrypto key stored as the credential cannot be reloaded.

Not in this PR: the CLI writer (CLI spaces do not delegate to the account yet), the backfill sweep for spaces created before the key existed, and rotation/recovery consuming the rows (authority-facts step 4). Plans updated to match.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for X25519 encryption keys in the `tonk` project, enhancing security by allowing devices to seal seeds to a public key. It includes updates across various modules to incorporate the new encryption functionality and related data structures.

### Detailed summary
- Added `x25519-dalek` dependency in `Cargo.toml`.
- Introduced `sealed` module in `tonk-identity`.
- Updated `AccountEncryptionKey` structure in `tonk-schema`.
- Incorporated `encryption_key` in multiple structs and functions across modules.
- Implemented sealing and opening of seeds using X25519 keys.
- Enhanced tests to ensure encryption key functionality and validation.
- Updated relevant documentation to reflect changes in key management.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->