### PR TITLE
Pin the worker's HTTP route table

### DIFF
--- a/.claude/skills/commands-not-routes/SKILL.md
+++ b/.claude/skills/commands-not-routes/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: commands-not-routes
+description: How to add an operation to the tonk worker — define a COMMAND (transient concept + registered handler + outcomes as facts), not a new HTTP route in router.rs. Use whenever about to add `.route(` to rust/tonk-worker/src/router.rs, a `reqwest` call to tonk-ui/src/api.rs, or a request/response DTO to tonk-worker-api for something a page or the FAB triggers.
+allowed-tools: Read, Bash, Glob, Grep
+---
+
+# Commands, not routes
+
+The worker's HTTP surface is pinned: `rust/tonk-worker/src/router/route_table.rs` lists every route, and `it_adds_no_http_routes_without_editing_the_pinned_table` fails when `router.rs` gains one. That is deliberate. The route table is the data plane (branch `query`, `transact`, `evaluate`, `blob`, `sync`, and a few identity/site probes); everything a user *does* is a command.
+
+## Why
+
+- A route is one handler reachable by one caller over one transport. A command is a fact: the FAB, a YAML view, the CLI, a test, and another command can all assert it, and it rides the same `/transact` path everything else uses.
+- A route answers with a response body one caller reads once. A command's outcome lands as facts on a branch the page already subscribes to, so every element showing that state updates, on every tab, with no polling and no "reshape the bar after the POST" code.
+- Routes accumulate a parallel API in three places (`router.rs`, `tonk-worker-api`, `tonk-ui/src/api.rs`) that nothing keeps consistent. Commands live in one place: `tonk-schema`.
+- Capability is a compile-time gate: a command only registers if `CommandEnv: Provider<C>`. A route has no equivalent.
+
+Roughly half of today's 61 routes are commands wearing HTTP (`/api/account/*`, `/api/profile/{join,visit}`, `/api/repository/{repo}/{invite,membership}`, `/api/custody/*`, `/api/customer/*`). Do not add to that half; migrate from it when you touch it.
+
+## What a command is
+
+1. **A transient concept** in `rust/tonk-schema/src/command.rs`, with its attributes in `domain.rs` under `command::<name>`. It is asserted with `kind: transient`, so it never persists; the commit sweeps it after the handler fires. Implement `Command` on it.
+
+   ```rust
+   #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+   pub struct PromoteMember {
+       pub this: Entity,
+       pub member: crate::domain::command::promote::Promote,
+   }
+   impl Command for PromoteMember { type Input = Self; type Output = (); }
+   ```
+
+2. **A handler** in the worker implementing `crate::reactor::CommandHandler<CommandEnv>`: `trigger_attributes` (from `Decode::trigger_attributes()`), `matches`, and `run`. `run` gets a `CommandEnv`: the `AppState` plus the origin repo/branch the transient was committed in, and the originating client when a page effect is needed. Register it in `command_registry()` in `rust/tonk-worker/src/router/command.rs`. Look at `router/members.rs` (`PromoteMemberHandler`, `ExpelMemberHandler`) for the smallest complete example.
+
+3. **A trigger.** Two forms, both already wired:
+   - Declarative, in a view: `command!: &member/promote` in `rust/tonk-core/assets/library/core.yaml`, bound to a form or `onclick=command`. Fields read `dom.event.*` attributes.
+   - Programmatic, from a Rust element: build the same transient as a `TransactRequest` claim and dispatch through `window.tonk.transact(...)`. See `invite_claim_json` / `enable_sync_claim_json` in `rust/tonk-fab/src/logic.rs`.
+
+4. **Outcomes as facts.** The handler asserts durable facts (a `MemberRole` stamp, a `Membership` row, an `Invitation`) or overlay facts (`state:*` entities for per-session, unreplicated state such as a refusal the share control echoes). The page reads them through the subscription it already has. If the page must be told something that no branch can carry (navigate, set title), post to `env.origin().client` as `tonk:join` does; do not invent a response body.
+
+## When a route is actually right
+
+- Raw data plane: bytes in, bytes out, no user intent (`blob`, `import`/`export`, `sync/*`).
+- Something the service worker must answer *before* the page has a branch to subscribe to (`/api/identify`, `/api/site`, `/api/identity/root`).
+- A debug/inspection surface (`/api/inspect/*`).
+
+If you believe you have one of these, add it to `ROUTES` in `route_table.rs` in the same change and say in the PR why a command could not carry it. Reviewers will push back on "the UI needs a response".
+
+## Checklist before writing `.route(`
+
+- Is this triggered by a user or a page? Then it is a command.
+- Does it need to answer the caller? Ask what fact the caller would subscribe to instead.
+- Does it need the page to do something (navigate, open)? Post to the originating client from the handler.
+- Is the same operation needed from the CLI? A command is asserted the same way from `tonk eval`; a route is not.

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -113,6 +113,8 @@ mod command;
 pub use command::{CommandEnv, CommandOrigin, command_registry, dispatch};
 
 #[cfg(test)]
+mod route_table;
+#[cfg(test)]
 mod wire_compat;
 
 /// Shared application state containing profile and operator.

--- a/rust/tonk-worker/src/router/route_table.rs
+++ b/rust/tonk-worker/src/router/route_table.rs
@@ -1,0 +1,139 @@
+//! The worker's HTTP route table, pinned.
+//!
+//! Every path registered in `router.rs` is listed here, and the test
+//! fails when the two disagree. The point is not the list; it is that
+//! adding a route becomes a deliberate edit to this file, reviewed as
+//! such, rather than a drive-by `.route(...)`. Most things that feel
+//! like they need an endpoint are commands: a transient concept the page
+//! asserts, a handler the worker registers, and outcomes that land as
+//! facts the page already subscribes to. See
+//! `.claude/skills/commands-not-routes/SKILL.md` before adding a line.
+
+/// Every route the worker serves, sorted. The data plane (branch query,
+/// transact, evaluate, blob, sync) belongs here; account, membership,
+/// invite, and custody operations are commands or are on their way to
+/// becoming ones.
+const ROUTES: &[&str] = &[
+    "/api",
+    "/api/account",
+    "/api/account/attach",
+    "/api/account/delete",
+    "/api/account/deletion/plan",
+    "/api/account/devices",
+    "/api/account/devices/register",
+    "/api/account/devices/revoke",
+    "/api/account/display-name",
+    "/api/account/spaces/delete",
+    "/api/account/summary",
+    "/api/custody/provision",
+    "/api/custody/queue",
+    "/api/customer",
+    "/api/customer/enroll",
+    "/api/customer/pending",
+    "/api/customer/pending/custody",
+    "/api/identify",
+    "/api/identity/root",
+    "/api/inspect/repository/{repo}/archive/index/{hash}",
+    "/api/inspect/repository/{repo}/branch/{branch}",
+    "/api/inspect/repository/{repo}/remote/{remote}",
+    "/api/inspect/repository/{repo}/remote/{remote}/archive/index/{hash}",
+    "/api/inspect/repository/{repo}/remote/{remote}/branch/{branch}",
+    "/api/migrate/repo-vs-profile",
+    "/api/profile",
+    "/api/profile/branch/{branch}/evaluate",
+    "/api/profile/branch/{branch}/query",
+    "/api/profile/branch/{branch}/site",
+    "/api/profile/branch/{branch}/transact",
+    "/api/profile/join",
+    "/api/profile/repository",
+    "/api/profile/visit",
+    "/api/profiles",
+    "/api/profiles/activate",
+    "/api/profiles/add",
+    "/api/repository/{repo}",
+    "/api/repository/{repo}/branch/{branch}/blob",
+    "/api/repository/{repo}/branch/{branch}/blob/{entity}",
+    "/api/repository/{repo}/branch/{branch}/claim/assert/{entity}/{attr_ns}/{attr_name}",
+    "/api/repository/{repo}/branch/{branch}/claim/retract/{entity}/{attr_ns}/{attr_name}",
+    "/api/repository/{repo}/branch/{branch}/claim/select",
+    "/api/repository/{repo}/branch/{branch}/evaluate",
+    "/api/repository/{repo}/branch/{branch}/export",
+    "/api/repository/{repo}/branch/{branch}/host/{host}/{entity}",
+    "/api/repository/{repo}/branch/{branch}/import",
+    "/api/repository/{repo}/branch/{branch}/query",
+    "/api/repository/{repo}/branch/{branch}/site",
+    "/api/repository/{repo}/branch/{branch}/sync",
+    "/api/repository/{repo}/branch/{branch}/sync/pull",
+    "/api/repository/{repo}/branch/{branch}/sync/push",
+    "/api/repository/{repo}/branch/{branch}/sync/status",
+    "/api/repository/{repo}/branch/{branch}/transact",
+    "/api/repository/{repo}/invite",
+    "/api/repository/{repo}/invites",
+    "/api/repository/{repo}/invites/{target_cid}/revoke",
+    "/api/repository/{repo}/membership",
+    "/api/repository/{repo}/remote",
+    "/api/site",
+    "/api/spaces",
+    "/api/sync",
+];
+
+/// Every path literal passed to `.route(` in `router.rs`, sorted.
+///
+/// Read from the source rather than the built `Router` because axum
+/// does not expose its route table. A source scan is enough: routes are
+/// only ever registered through `.route("literal", ...)`, and the test
+/// below fails loudly if that stops being true.
+fn registered_routes() -> Vec<String> {
+    const SOURCE: &str = include_str!("../router.rs");
+    const CALL: &str = ".route(";
+    let mut routes = Vec::new();
+    let mut rest = SOURCE;
+    while let Some(at) = rest.find(CALL) {
+        rest = &rest[at + CALL.len()..];
+        let literal = rest.trim_start();
+        let Some(literal) = literal.strip_prefix('"') else {
+            panic!(
+                "every `.route(` in router.rs must take a string literal path; found `{}`",
+                literal.chars().take(40).collect::<String>()
+            );
+        };
+        let end = literal.find('"').expect("an unterminated string literal");
+        routes.push(literal[..end].to_owned());
+    }
+    routes.sort_unstable();
+    routes
+}
+
+#[dialog_common::test]
+fn it_adds_no_http_routes_without_editing_the_pinned_table() {
+    let registered = registered_routes();
+    let pinned: Vec<String> = ROUTES.iter().map(|route| (*route).to_owned()).collect();
+    let added: Vec<&String> = registered
+        .iter()
+        .filter(|route| !pinned.contains(route))
+        .collect();
+    let removed: Vec<&String> = pinned
+        .iter()
+        .filter(|route| !registered.contains(route))
+        .collect();
+    assert!(
+        added.is_empty() && removed.is_empty(),
+        "the worker's HTTP route table changed.\n\
+         added: {added:?}\n\
+         removed: {removed:?}\n\n\
+         A new route is almost always the wrong shape: define a command instead \
+         (a transient concept in tonk-schema, a handler registered in \
+         router/command.rs, outcomes as facts the page subscribes to). See \
+         .claude/skills/commands-not-routes/SKILL.md. If this really is data \
+         plane, update ROUTES in router/route_table.rs in the same change and \
+         say why in the PR.",
+    );
+}
+
+#[dialog_common::test]
+fn it_pins_a_sorted_deduplicated_table() {
+    let mut sorted = ROUTES.to_vec();
+    sorted.sort_unstable();
+    sorted.dedup();
+    assert_eq!(ROUTES, sorted.as_slice(), "keep ROUTES sorted and unique");
+}


### PR DESCRIPTION
Routes keep getting added where a command was wanted: 31 of the worker's 61 routes are account, membership, invite, and custody operations that the page triggers and reads back over `reqwest`, next to the command path (`tonk:join`, `member/promote`, `member/expel`) that already does the same job as facts.

This makes adding a route a deliberate, reviewed act. `router/route_table.rs` pins every registered path; `it_adds_no_http_routes_without_editing_the_pinned_table` scans `router.rs` and fails on any difference, with a message pointing at the alternative. The new `.claude/skills/commands-not-routes` skill spells that alternative out: the transient concept, the handler registration in `command_registry()`, the declarative and programmatic triggers, and outcomes as facts, plus the short list of cases where a route is actually right.

No routes were added or removed; the pinned table is the current one.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR emphasizes the distinction between commands and routes in the `tonk-worker` system, advocating for commands as transient concepts instead of adding new HTTP routes. It introduces documentation and tests to ensure route management aligns with this philosophy.

### Detailed summary
- Added a new module `route_table` for testing route management.
- Introduced `SKILL.md` to guide adding operations as commands instead of routes.
- Updated `route_table.rs` with a comprehensive list of HTTP routes and their management.
- Implemented tests to ensure routes remain consistent and sorted.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->