### PR TITLE
feat(cli): improve declarative authoring

### DIFF
--- a/rust/tonk-analyzer/src/analyzer.rs
+++ b/rust/tonk-analyzer/src/analyzer.rs
@@ -157,6 +157,7 @@ pub fn analyze_local(syntax: &Syntax) -> Result<Tree<Syntax>, AnalyzeError> {
     let scope = Scope::new();
     let graph = graph::push(syntax)?;
     let resolved = poll_ready(graph.resolve(syntax, &scope, &graph::LocalOnly))?;
+    rule::check_overlapping_transient_rule_triggers(syntax, &scope)?;
     expand(syntax, &scope, resolved)
 }
 
@@ -222,6 +223,7 @@ impl<'s, 'a> Analyze<'s, 'a> {
         let graph = graph::push(syntax)?;
         let resolver = graph::BranchResolver::new(source, env);
         let resolved = graph.resolve(syntax, &scope, &resolver).await?;
+        rule::check_overlapping_transient_rule_triggers(syntax, &scope)?;
         expand(syntax, &scope, resolved)
     }
 }

--- a/rust/tonk-analyzer/src/analyzer/error.rs
+++ b/rust/tonk-analyzer/src/analyzer/error.rs
@@ -511,6 +511,20 @@ pub enum AnalyzeErrorKind {
         /// Underlying message from dialog's compiler.
         reason: String,
     },
+    /// Two differently named transient commands used as positive rule
+    /// triggers have equal or subset required-attribute shapes, so one event
+    /// can satisfy both rules.
+    #[error(
+        "an event intended for transient command {event_command:?} also satisfies {also_matches:?} because their required attributes overlap ({shared_attributes}); give each command verb-specific `the:` paths such as `dataset/toggle` and `dataset/remove`"
+    )]
+    OverlappingTransientCommands {
+        /// The narrower command (or the later command when shapes are equal).
+        event_command: String,
+        /// The broader command the same event also satisfies.
+        also_matches: String,
+        /// Stable, sorted list of the attributes shared by both shapes.
+        shared_attributes: String,
+    },
 }
 
 impl AnalyzeErrorKind {
@@ -543,6 +557,7 @@ impl AnalyzeErrorKind {
             Self::ProtectedUri { .. } => "E_PROTECTED_URI",
             Self::IncompleteAssertion { .. } => "E_INCOMPLETE_ASSERTION",
             Self::RuleCompileFailed { .. } => "E_RULE_COMPILE_FAILED",
+            Self::OverlappingTransientCommands { .. } => "E_OVERLAPPING_TRANSIENT_COMMANDS",
         }
     }
 }

--- a/rust/tonk-analyzer/src/analyzer/rule.rs
+++ b/rust/tonk-analyzer/src/analyzer/rule.rs
@@ -18,6 +18,8 @@
 //! transient-trigger check runs separately at the evaluator's
 //! commit step where a branch is available.
 
+use std::collections::{BTreeSet, HashSet};
+
 use dialog_query::concept::query::ConceptQuery;
 use dialog_query::constraint::Constraint;
 use dialog_query::formula::query::FormulaQuery;
@@ -26,7 +28,8 @@ use dialog_query::{
     DeductiveRule as CompiledDeductiveRule, InductiveRule, Negation, Parameters, Proposition, Term,
 };
 use tonk_notation::{
-    Application as SyntaxApplication, FieldValue, Premise as NotationPremise, Scalar,
+    Application as SyntaxApplication, Expression, FieldValue, Premise as NotationPremise, Scalar,
+    Syntax,
 };
 
 use super::constraint::{ConstraintInfo, lookup_constraint};
@@ -39,6 +42,94 @@ use crate::analyzer::Working;
 use dialog_artifacts::Entity;
 use dialog_query::rule::inductive::Polarity;
 use tonk_schema::rule::Rule as StoredRule;
+
+struct TransientTriggerShape {
+    name: String,
+    attributes: BTreeSet<String>,
+}
+
+/// Reject differently named transient commands whose required descriptor
+/// shapes are equal or subsets when both are positive inductive-rule triggers
+/// in this document.
+pub(crate) fn check_overlapping_transient_rule_triggers(
+    syntax: &Syntax,
+    scope: &Scope,
+) -> Result<(), AnalyzeError> {
+    let mut triggers: Vec<TransientTriggerShape> = Vec::new();
+    let mut seen = HashSet::new();
+
+    for expression in &syntax.expressions {
+        let Expression::Claim(effectful) = expression else {
+            continue;
+        };
+        let application = &effectful.inner;
+        if !super::is_rule_claim(application) || is_rule_retract_body(application) {
+            continue;
+        }
+        let body = parse_rule_body(application)?;
+        if !matches!(body.head, RuleHead::Inductive(_)) {
+            continue;
+        }
+
+        for premise in body.when {
+            let name = premise.concept.value.as_str();
+            if seen.contains(name) {
+                continue;
+            }
+            let Some(concept) = scope.concept(name) else {
+                continue;
+            };
+            let tonk_core::claim::ConceptDescriptor::Transient(descriptor) = concept.descriptor
+            else {
+                continue;
+            };
+            seen.insert(name.to_owned());
+
+            let attributes: BTreeSet<String> = descriptor
+                .with()
+                .iter()
+                .filter(|(field, attribute)| *field != "this" && !attribute.is_optional())
+                .map(|(_, attribute)| attribute.the().to_string())
+                .collect();
+
+            for prior in &triggers {
+                if !attributes.is_subset(&prior.attributes)
+                    && !prior.attributes.is_subset(&attributes)
+                {
+                    continue;
+                }
+
+                let (event_command, also_matches) = if attributes == prior.attributes
+                    || attributes.is_superset(&prior.attributes)
+                {
+                    (name.to_owned(), prior.name.clone())
+                } else {
+                    (prior.name.clone(), name.to_owned())
+                };
+                let shared_attributes = attributes
+                    .intersection(&prior.attributes)
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                return Err(AnalyzeError::at(
+                    AnalyzeErrorKind::OverlappingTransientCommands {
+                        event_command,
+                        also_matches,
+                        shared_attributes,
+                    },
+                    premise.range,
+                ));
+            }
+
+            triggers.push(TransientTriggerShape {
+                name: name.to_owned(),
+                attributes,
+            });
+        }
+    }
+
+    Ok(())
+}
 
 /// Outcome of inspecting a `rule!:` claim body — install (build a
 /// fresh compiled rule) or retract (resolve an existing rule from
@@ -1218,6 +1309,134 @@ mod tests {
             on_uris.iter().any(|u| u == "on:io.gozala.ping/tag"),
             "expected on:io.gozala.ping/tag in {on_uris:?}"
         );
+    }
+
+    const OVERLAPPING_TRANSIENT_RULES: &str = r#"concept!: &toggle-result
+  with:
+    todo:
+      description: The todo that was toggled
+      the: xyz.tonk.result/todo
+      as: entity
+    checked:
+      description: The resulting checked state
+      the: xyz.tonk.result/checked
+      as: boolean
+
+concept!: &remove-result
+  with:
+    todo:
+      description: The todo that was removed
+      the: xyz.tonk.result/todo
+      as: entity
+
+command!: &toggle-todo
+  with:
+    todo:
+      description: The todo targeted by the event
+      the: dom.event.current-target.dataset/todo
+      as: entity
+    checked:
+      description: The checkbox state
+      the: dom.event.current-target/checked
+      as: boolean
+
+command!: &remove-todo
+  with:
+    todo:
+      description: The todo targeted by the event
+      the: dom.event.current-target.dataset/todo
+      as: entity
+
+rule!:
+  assert!: toggle-result
+  when:
+    - assert: toggle-todo
+      where: { this: ?this, todo: ?todo, checked: ?checked }
+
+rule!:
+  assert!: remove-result
+  when:
+    - assert: remove-todo
+      where: { this: ?this, todo: ?todo }
+"#;
+
+    /// A DOM event that satisfies a narrower transient command also satisfies
+    /// any broader command whose required descriptor set is a subset. Reject
+    /// that document before either rule can be installed.
+    #[test]
+    fn it_rejects_a_strict_subset_of_another_transient_trigger() {
+        let doc = OVERLAPPING_TRANSIENT_RULES;
+        let parsed = parse(doc);
+        assert!(
+            parsed.diagnostics.is_empty(),
+            "unexpected parse diagnostics: {:?}",
+            parsed.diagnostics
+        );
+        let syntax = parsed.syntax.expect("parsed syntax");
+        let error = crate::analyzer::analyze_local(&syntax)
+            .expect_err("overlapping transient triggers must be rejected");
+        let AnalyzeErrorKind::OverlappingTransientCommands {
+            event_command,
+            also_matches,
+            shared_attributes,
+        } = &error.kind
+        else {
+            panic!("expected overlap error, got {error:?}");
+        };
+        assert_eq!(event_command, "toggle-todo");
+        assert_eq!(also_matches, "remove-todo");
+        assert_eq!(shared_attributes, "dom.event.current-target.dataset/todo");
+        assert_eq!(error.code(), "E_OVERLAPPING_TRANSIENT_COMMANDS");
+    }
+
+    #[test]
+    fn it_accepts_verb_specific_transient_trigger_paths() {
+        let doc = OVERLAPPING_TRANSIENT_RULES
+            .replacen(
+                "dom.event.current-target.dataset/todo",
+                "dom.event.current-target.dataset/toggle",
+                1,
+            )
+            .replacen(
+                "dom.event.current-target.dataset/todo",
+                "dom.event.current-target.dataset/remove",
+                1,
+            );
+        let syntax = parse(&doc).syntax.expect("parsed syntax");
+        crate::analyzer::analyze_local(&syntax)
+            .expect("verb-specific transient shapes must not overlap");
+    }
+
+    #[test]
+    fn it_accepts_overlapping_durable_rule_premises() {
+        let doc = OVERLAPPING_TRANSIENT_RULES.replace("command!:", "concept!:");
+        let syntax = parse(&doc).syntax.expect("parsed syntax");
+        crate::analyzer::analyze_local(&syntax)
+            .expect("durable concepts are not event command triggers");
+    }
+
+    #[test]
+    fn it_accepts_two_rules_driven_by_the_same_command() {
+        let doc = OVERLAPPING_TRANSIENT_RULES
+            .replace("command!: &remove-todo", "concept!: &remove-todo")
+            .replace("assert: remove-todo", "assert: toggle-todo")
+            .replace(
+                "where: { this: ?this, todo: ?todo }",
+                "where: { this: ?this, todo: ?todo, checked: ?checked }",
+            );
+        let syntax = parse(&doc).syntax.expect("parsed syntax");
+        crate::analyzer::analyze_local(&syntax)
+            .expect("reusing one command name across rules is safe");
+    }
+
+    #[test]
+    fn it_ignores_transient_commands_used_only_under_unless() {
+        let doc = OVERLAPPING_TRANSIENT_RULES.replace(
+            "  when:\n    - assert: remove-todo\n      where: { this: ?this, todo: ?todo }",
+            "  when:\n    - assert: toggle-todo\n      where: { this: ?this, todo: ?todo, checked: ?checked }\n  unless:\n    - assert: remove-todo\n      where: { this: ?this, todo: ?todo }",
+        );
+        let syntax = parse(&doc).syntax.expect("parsed syntax");
+        crate::analyzer::analyze_local(&syntax).expect("negative premises are not event triggers");
     }
 
     /// A `rule!:` with an `assert:` (no-bang) head lifts to a

--- a/rust/tonk-cli/README.md
+++ b/rust/tonk-cli/README.md
@@ -40,6 +40,7 @@ tonk invite
 # Evaluate a notation document: inline, from a file, or piped.
 tonk eval -c 'person:'
 tonk eval ./doc.notation
+tonk eval interactive.notation --home todo # install the document and replace the home atomically
 cat doc.notation | tonk eval -
 tonk eval -c 'person:' --json --quiet
 
@@ -65,6 +66,7 @@ tonk retract habit <entity>                   # retract the whole instance
 # Authoring — schema, views, and the space home.
 tonk concept add habit --field name:text:one  # anchored concept + typed fields
 tonk view add habit --template '<b>{name}</b>'  # declarative view (auto-surfaces an unset home)
+tonk view add habit --kind directory --template-file habit.html --home
 tonk space home habit                         # put habit's directory on the space home
 
 # CSV transfer over the main branch.
@@ -90,6 +92,11 @@ tonk invite --recipient-root did:key:z6Mk... # seed-free targeted invite
 tonk invite --no-remote        # embed none; the claimer wires an upstream by hand
 tonk join 'https://...#invite' --name garden
 ```
+
+`view add` authors `detail` by default; `--kind` also accepts `directory`,
+`label`, and `title`. A first detail or directory view auto-surfaces only while
+the home is blank. `--home` is explicit replacement authority: it installs the
+view and replaces the prior home with this one concept in the same transaction.
 
 ## Telemetry
 

--- a/rust/tonk-cli/src/authoring.rs
+++ b/rust/tonk-cli/src/authoring.rs
@@ -19,6 +19,46 @@ use std::fmt::Write as _;
 
 use crate::schema::SPACE_HOME_CONCEPT;
 
+/// One of the four view concepts the standard library resolves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ViewKind {
+    /// A single entity's full presentation (`tonk:view`).
+    Detail,
+    /// Every entity of a model (`tonk:view/directory`).
+    Directory,
+    /// A compact reference label (`tonk:view/label`).
+    Label,
+    /// A title presentation (`tonk:view/title`).
+    Title,
+}
+
+impl ViewKind {
+    fn notation_head(self) -> &'static str {
+        match self {
+            Self::Detail => "view!",
+            Self::Directory => "view/directory!",
+            Self::Label => "view/label!",
+            Self::Title => "view/title!",
+        }
+    }
+
+    /// Stable default anchor for this kind and model.
+    pub fn default_anchor(self, model: &str) -> String {
+        match self {
+            Self::Detail => format!("{model}-view"),
+            Self::Directory => format!("{model}-directory"),
+            Self::Label => format!("{model}-label"),
+            Self::Title => format!("{model}-title"),
+        }
+    }
+
+    /// Whether a first view of this kind can sensibly surface a model's
+    /// directory on an otherwise blank home.
+    pub fn can_auto_surface(self) -> bool {
+        matches!(self, Self::Detail | Self::Directory)
+    }
+}
+
 /// One parsed `--field field:type:cardinality` flag, ready to render
 /// into an `attribute!:` block and a `with:` entry.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -275,9 +315,9 @@ fn entity_attr_values(template: &str) -> Vec<String> {
 /// anchor) supersedes rather than duplicates it. `template` is
 /// emitted verbatim, line by line, under a `display: |` block
 /// indented four spaces.
-pub fn build_view_decl(anchor: &str, model: &str, template: &str) -> String {
+pub fn build_view_decl(kind: ViewKind, anchor: &str, model: &str, template: &str) -> String {
     let mut out = String::new();
-    let _ = writeln!(out, "view!: &{anchor}");
+    let _ = writeln!(out, "{}: &{anchor}", kind.notation_head());
     let _ = writeln!(out, "  this: id:{anchor}");
     let _ = writeln!(out, "  model: {model}");
     out.push_str("  display: |\n");
@@ -402,11 +442,39 @@ mod tests {
     }
     #[test]
     fn it_builds_a_view_decl_with_a_stable_this() {
-        let doc = build_view_decl("note-view", "note", "<b>{title}</b>");
+        let doc = build_view_decl(ViewKind::Detail, "note-view", "note", "<b>{title}</b>");
         assert!(doc.contains("view!: &note-view"));
         assert!(doc.contains("this: id:note-view"));
         assert!(doc.contains("model: note"));
         assert!(doc.contains("<b>{title}</b>"));
+    }
+    #[test]
+    fn it_builds_each_view_kind_with_its_stable_default_anchor() {
+        for (kind, head, anchor) in [
+            (ViewKind::Detail, "view!", "note-view"),
+            (ViewKind::Directory, "view/directory!", "note-directory"),
+            (ViewKind::Label, "view/label!", "note-label"),
+            (ViewKind::Title, "view/title!", "note-title"),
+        ] {
+            assert_eq!(kind.default_anchor("note"), anchor);
+            let doc = build_view_decl(kind, anchor, "note", "<b>{title}</b>");
+            assert!(doc.starts_with(&format!("{head}: &{anchor}")), "{doc}");
+            assert!(doc.contains(&format!("this: id:{anchor}")), "{doc}");
+        }
+    }
+
+    #[test]
+    fn it_preserves_a_caller_supplied_view_anchor_for_every_kind() {
+        for kind in [
+            ViewKind::Detail,
+            ViewKind::Directory,
+            ViewKind::Label,
+            ViewKind::Title,
+        ] {
+            let doc = build_view_decl(kind, "custom-card", "note", "<b>{title}</b>");
+            assert!(doc.contains("&custom-card"), "{doc}");
+            assert!(doc.contains("this: id:custom-card"), "{doc}");
+        }
     }
     fn fields(names: &[&str]) -> Vec<String> {
         names.iter().map(|s| s.to_string()).collect()

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -901,10 +901,10 @@ enum ConceptCommand {
 enum ViewCommand {
     /// Assert a declarative view for a concept
     ///
-    /// When no home is set yet, the build is auto-surfaced onto the
-    /// space home so it's immediately visible.
+    /// A first detail or directory view is auto-surfaced when the home is
+    /// blank. --home explicitly replaces an existing home.
     #[command(
-        after_help = "Examples:\n  tonk view add habit --template '<b>{name}</b>'\n  tonk view add habit --template-file card.html --name habit-card"
+        after_help = "Examples:\n  tonk view add habit --template '<b>{name}</b>'\n  tonk view add habit --template-file card.html --name habit-card\n  tonk view add habit --kind directory --template-file habit.html --home"
     )]
     Add {
         /// The concept this view renders.
@@ -921,15 +921,40 @@ enum ViewCommand {
         /// Read the template from a file instead.
         #[arg(long, value_name = "PATH")]
         template_file: Option<PathBuf>,
-        /// Anchor name for the view (default: <concept>-view).
+        /// Anchor name (default depends on --kind).
         #[arg(long, value_name = "NAME")]
         name: Option<String>,
+        /// Which standard view concept to author.
+        #[arg(long, value_enum, default_value_t = ViewKindArg::Detail)]
+        kind: ViewKindArg,
+        /// Atomically replace the current home with this concept's directory.
+        #[arg(long)]
+        home: bool,
         /// Print the notation document without evaluating it.
         #[arg(long)]
         notation: bool,
         #[command(flatten)]
         write: WriteArgs,
     },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+enum ViewKindArg {
+    Detail,
+    Directory,
+    Label,
+    Title,
+}
+
+impl From<ViewKindArg> for tonk_cli::authoring::ViewKind {
+    fn from(kind: ViewKindArg) -> Self {
+        match kind {
+            ViewKindArg::Detail => Self::Detail,
+            ViewKindArg::Directory => Self::Directory,
+            ViewKindArg::Label => Self::Label,
+            ViewKindArg::Title => Self::Title,
+        }
+    }
 }
 
 /// The switches every write verb takes, matching `tonk eval`'s.
@@ -980,7 +1005,7 @@ impl WriteArgs {
 
 #[derive(Args, Debug)]
 #[command(
-    after_help = "Examples:\n  tonk eval -c 'person:'\n  tonk eval ./doc.notation\n  cat doc.notation | tonk eval -\n  tonk eval -c 'person:' --json\n  tonk eval ./doc.notation --no-sync\n  tonk eval ./doc.notation --dry-run"
+    after_help = "Examples:\n  tonk eval -c 'person:'\n  tonk eval ./doc.notation\n  cat doc.notation | tonk eval -\n  tonk eval -c 'person:' --json\n  tonk eval ./doc.notation --home todo\n  tonk eval ./doc.notation --no-sync\n  tonk eval ./doc.notation --dry-run"
 )]
 struct EvalArgs {
     /// Inline document. Mutually exclusive with the positional
@@ -1001,6 +1026,10 @@ struct EvalArgs {
     /// Omit to read from a piped stdin.
     #[arg(value_name = "PATH")]
     path: Option<String>,
+
+    /// Atomically replace the current home with this concept's directory.
+    #[arg(long, value_name = "CONCEPT")]
+    home: Option<String>,
 
     /// Skip the automatic pull-before / push-after that wraps a
     /// committing eval when an upstream is configured. The manual
@@ -2333,6 +2362,7 @@ async fn eval(args: EvalArgs, space: Option<&str>) -> ExitCode {
         },
         quiet: args.quiet,
         dry_run: args.dry_run,
+        home: args.home,
     };
 
     let (_, site) = match open_selected(space).await {
@@ -3655,6 +3685,8 @@ async fn view_op(command: Option<ViewCommand>, json: bool, space: Option<&str>) 
             template,
             template_file,
             name,
+            kind,
+            home,
             notation,
             write,
         }) => {
@@ -3678,8 +3710,10 @@ async fn view_op(command: Option<ViewCommand>, json: bool, space: Option<&str>) 
             match data_ops::view_add(
                 &site,
                 &model,
+                kind.into(),
                 name.as_deref(),
                 &template,
+                home,
                 write.options(notation),
             )
             .await
@@ -4197,6 +4231,81 @@ mod account_spaces_parser_tests {
                 "guide command no longer parses: {args:?}"
             );
         }
+    }
+
+    #[test]
+    fn view_kind_and_home_flags_parse() {
+        for (value, expected) in [
+            ("detail", ViewKindArg::Detail),
+            ("directory", ViewKindArg::Directory),
+            ("label", ViewKindArg::Label),
+            ("title", ViewKindArg::Title),
+        ] {
+            let cli = Cli::try_parse_from([
+                "tonk",
+                "view",
+                "add",
+                "note",
+                "--kind",
+                value,
+                "--template",
+                "<p>{title}</p>",
+                "--home",
+            ])
+            .expect("view kind parses");
+            let Some(Command::View {
+                command: Some(ViewCommand::Add { kind, home, .. }),
+                ..
+            }) = cli.command
+            else {
+                panic!("expected view add command");
+            };
+            assert_eq!(kind, expected);
+            assert!(home);
+        }
+
+        let cli = Cli::try_parse_from([
+            "tonk",
+            "view",
+            "add",
+            "note",
+            "--template",
+            "<p>{title}</p>",
+        ])
+        .expect("default view kind parses");
+        assert!(matches!(
+            cli.command,
+            Some(Command::View {
+                command: Some(ViewCommand::Add {
+                    kind: ViewKindArg::Detail,
+                    home: false,
+                    ..
+                }),
+                ..
+            })
+        ));
+        assert!(
+            Cli::try_parse_from([
+                "tonk",
+                "view",
+                "add",
+                "note",
+                "--kind",
+                "gallery",
+                "--template",
+                "<p>{title}</p>",
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn eval_home_flag_parses() {
+        let cli = Cli::try_parse_from(["tonk", "eval", "app.notation", "--home", "todo"]).unwrap();
+        let Some(Command::Eval(EvalArgs { home, .. })) = cli.command else {
+            panic!("expected eval command");
+        };
+        assert_eq!(home.as_deref(), Some("todo"));
     }
 
     #[test]

--- a/rust/tonk-cli/src/data_ops.rs
+++ b/rust/tonk-cli/src/data_ops.rs
@@ -3,8 +3,8 @@
 //! binary maps errors to exit codes.
 
 use crate::authoring::{
-    AuthoringError, build_concept_decl, build_home_recipe, build_view_decl, lint_view_template,
-    parse_attr_spec,
+    AuthoringError, ViewKind, build_concept_decl, build_home_recipe, build_view_decl,
+    lint_view_template, parse_attr_spec,
 };
 use crate::auto_sync;
 use crate::data::{build_assert, build_retract, build_supersede};
@@ -40,6 +40,7 @@ impl WriteOptions {
             format: Format::Notation,
             quiet: self.quiet,
             dry_run: self.dry_run,
+            home: None,
         }
     }
 
@@ -606,8 +607,10 @@ pub async fn home(
 pub async fn view_add(
     site: &TonkSite,
     model: &str,
+    kind: ViewKind,
     name: Option<&str>,
     template: &str,
+    set_home: bool,
     write: WriteOptions,
 ) -> Result<String, DataOpError> {
     let info = require_concept(site, model).await?;
@@ -623,10 +626,11 @@ pub async fn view_add(
     let lint = lint_view_template(template, &fields);
     let anchor = name
         .map(str::to_string)
-        .unwrap_or_else(|| format!("{model}-view"));
-    let auto_surface = home_is_unset(site).await?;
-    let mut doc = build_view_decl(&anchor, model, template);
-    if auto_surface {
+        .unwrap_or_else(|| kind.default_anchor(model));
+    let auto_surface = !set_home && kind.can_auto_surface() && home_is_unset(site).await?;
+    let surface_home = set_home || auto_surface;
+    let mut doc = build_view_decl(kind, &anchor, model, template);
+    if surface_home {
         doc.push('\n');
         doc.push_str(&build_home_recipe(&[model.to_string()]));
     }
@@ -643,14 +647,14 @@ pub async fn view_add(
         out.push_str(&format!("warning: {warning}\n"));
     }
     out.push_str(&outcome.stdout);
-    if auto_surface {
+    if surface_home {
         let did = site.repository.did();
         out.push_str(&format!(
             "\n{}\nlive at /space/{did}/\n",
             write.summarize(format_args!("set the home to {model}"))
         ));
     } else {
-        out.push_str("home already set; re-point it explicitly with `tonk space home <concept>`\n");
+        out.push_str("home unchanged; use --home or `tonk space home <concept>`\n");
     }
     Ok(out)
 }

--- a/rust/tonk-cli/src/eval.rs
+++ b/rust/tonk-cli/src/eval.rs
@@ -9,6 +9,7 @@ use tonk_evaluator::evaluate::{EvaluateError, SyntaxEvaluateExt};
 use tonk_notation::{Parsed, Syntax, parse};
 
 use crate::ExitCode;
+use crate::authoring::build_home_recipe;
 use crate::output::{self, EvaluateResponse, Format};
 use crate::site::TonkSite;
 
@@ -70,6 +71,8 @@ pub struct Options {
     /// preview: `commits.claims` is zeroed and `revision_after ==
     /// revision_before`, so the branch is left untouched.
     pub dry_run: bool,
+    /// Atomically replace the home with this concept's directory.
+    pub home: Option<String>,
 }
 
 impl Default for Options {
@@ -78,6 +81,7 @@ impl Default for Options {
             format: Format::Notation,
             quiet: false,
             dry_run: false,
+            home: None,
         }
     }
 }
@@ -138,7 +142,17 @@ pub async fn run_against_site(
     options: Options,
 ) -> Result<Outcome, EvalError> {
     let label = source.label();
-    let text = source.read().await?;
+    let mut text = source.read().await?;
+    if let Some(model) = &options.home {
+        text.push('\n');
+        // Keep validation inside this same analyzed document: an empty query
+        // binds no variables and writes nothing, but forces ordinary concept
+        // resolution to accept an in-document declaration or reject an
+        // unknown name before the transaction can commit the home recipe.
+        text.push_str(model);
+        text.push_str(":\n\n");
+        text.push_str(&build_home_recipe(std::slice::from_ref(model)));
+    }
     let syntax = parse_or_diagnose(&label, &text)?;
 
     let session = site

--- a/rust/tonk-cli/src/guide-events.md
+++ b/rust/tonk-cli/src/guide-events.md
@@ -27,8 +27,9 @@ call.
 
 ### Wiring a click
 
-```yaml
+```yaml tonk=eval
 attribute!: &count
+  description: The counter's current value
   the: xyz.tonk.counter/count
   as:  unsigned-integer
 
@@ -41,6 +42,7 @@ concept!: &counter
 command!: &increment
   with:
     subject:
+      description: The counter entity to increment
       the: dom.event.current-target.dataset/subject
       as:  entity
 
@@ -159,28 +161,30 @@ Commands are matched **structurally**: a rule premise `assert:
 <command>` matches ANY transient carrying all of that command's
 attributes — not just transients posted under that command's name. So
 two commands that read the same event attributes are the same shape,
-and one event fires both rules:
+and one event fires both rules. The analyzer rejects different named
+transient commands used as positive rule triggers when their required
+descriptor sets are equal or one is a subset of the other:
 
-```yaml
+```yaml tonk=illustrative-overlap
 # WRONG: same shape — a "navigate" event also fires the delete rule.
 command!: &activate-page
   with:
-    page: { the: dom.event.detail/page, as: entity }
+    page: { description: The page to activate, the: dom.event.detail/page, as: entity }
 command!: &delete-page
   with:
-    page: { the: dom.event.detail/page, as: entity }
+    page: { description: The page to delete, the: dom.event.detail/page, as: entity }
 ```
 
 Give each command verb-specific attributes, and make sure no
 command's attribute set is a subset of what another event carries:
 
-```yaml
+```yaml tonk=eval
 command!: &activate-page
   with:
-    page: { the: dom.event.detail/activate, as: entity }
+    page: { description: The page to activate, the: dom.event.detail/activate, as: entity }
 command!: &delete-page
   with:
-    page: { the: dom.event.detail/delete, as: entity }
+    page: { description: The page to delete, the: dom.event.detail/delete, as: entity }
 ```
 
 (The event *detail* keys follow: `detail: { activate: <uri> }` vs
@@ -194,7 +198,7 @@ A click handler doesn't implicitly know the row it was rendered
 for. Surface what you need on the element with `data-*` and
 read it back through `dom.event.current-target.dataset/<name>`:
 
-```yaml
+```yaml tonk=parse
 view!: &todo-row
   this: id:todo-row
   model: todo
@@ -207,6 +211,7 @@ view!: &todo-row
 command!: &complete
   with:
     todo:
+      description: The todo to complete
       the: dom.event.current-target.dataset/todo
       as:  entity
 ```
@@ -238,17 +243,19 @@ signal — no value, no `as:` (there's nothing to read). The
 runtime sees a `the:` under `dom.event.do` and calls the method
 before the handler returns.
 
-```yaml
+```yaml tonk=eval
 command!: &save
   with:
     body:
+      description: The note body to save
       the: dom.event.current-target.elements.body/value
       as:  text
     prevent-default:
+      description: Prevent the form's native submission
       the: dom.event.do/prevent-default
 ```
 
-```yaml
+```yaml tonk=parse
 view!: &save-form
   this: id:save-form
   model: note
@@ -285,7 +292,7 @@ via `dom.event.current-target.form.elements.<name>/value`.
 
 A rule has a head with one polarity and a body of premises:
 
-```yaml
+```yaml tonk=illustrative-placeholders
 rule!:
   assert!: <head-concept>      # or `retract!: <head-concept>`
   when:
@@ -322,10 +329,11 @@ between bindings.
 
 To remove a fact in response to a transient, use `retract!:`:
 
-```yaml
+```yaml tonk=parse
 command!: &complete
   with:
     todo:
+      description: The todo to complete
       the: dom.event.current-target.dataset/todo
       as:  entity
 
@@ -350,10 +358,10 @@ from a plain `type="button"` (NOT a form submit — see the
 prevent-default trap below) and reach the form controls through
 `current-target.form`:
 
-```yaml
+```yaml tonk=parse
 command!: &publish
   with:
-    body: { the: dom.event.current-target.form.elements.body/value, as: text }
+    body: { description: The post body to publish, the: dom.event.current-target.form.elements.body/value, as: text }
 
 rule!:
   assert!: post
@@ -362,7 +370,7 @@ rule!:
       where: { this: ?this, body: ?body }   # the transient's own entity
 ```
 
-```yaml
+```yaml tonk=parse
 view!: &composer
   this: id:composer
   model: board
@@ -429,6 +437,10 @@ view in the space: `/space/<space>/<model>` for the model's directory,
 named view concept. `tonk render` is no substitute here — it prints the
 HTML with nothing behind it, so a click reaches no command. Use it to
 check the markup, the shell to check the wiring.
+
+For a raw first build, `tonk eval interactive.notation --home todo`
+installs the rules and views and replaces the home with `todo` in one
+transaction. Use `tonk space home todo` when repointing the home later.
 
 To put a collaborator in front of the same view, hand them the repo
 with `tonk invite`.

--- a/rust/tonk-cli/src/guide-tutorial.md
+++ b/rust/tonk-cli/src/guide-tutorial.md
@@ -5,13 +5,27 @@
    <field>:<type>:<cardinality>`. The concept is immediately usable.
 3. Create or update facts with `tonk assert`; read them with `tonk query`; use
    `tonk retract` to invalidate a field or instance.
-4. Add a view with `tonk view add`. The first view automatically becomes the
-   home when none is set; use `tonk space home` to replace or order the visible
-   concept directories. Check the result headlessly with `tonk render`.
+4. Add a view with `tonk view add`. A first detail or directory view
+   automatically becomes the home when none is set. Use `--home` to install a
+   view and replace the home atomically, or `tonk space home` to repoint it
+   later. Check the result headlessly with `tonk render`.
 5. Use `tonk eval` for rules, effects, joins, or multi-statement documents the
-   convenient verbs cannot express.
+   convenient verbs cannot express. On a raw first build,
+   `tonk eval interactive.notation --home todo` installs the document and
+   replaces the home in one transaction.
 6. Share the space with `tonk invite` and let the recipient `tonk join` it.
 
 Every notation-building write accepts `--notation` to print the document it
 would evaluate. A committing write syncs automatically unless `--no-sync` is
 set; `--dry-run` evaluates and plans but drops the transaction.
+
+The shortest schema-to-visible-directory workflow is:
+
+```text
+tonk concept add todo --field title:text:one
+tonk assert todo --title "Write the guide"
+tonk view add todo --kind directory --template-file todo.html --home
+tonk render todo
+```
+
+`--home` replaces the prior home with `todo`; it does not append to it.

--- a/rust/tonk-cli/src/guide-views.md
+++ b/rust/tonk-cli/src/guide-views.md
@@ -11,7 +11,7 @@ concept; use `--notation` to inspect that document.
 `view` is `{model, display}`: the concept it renders and the HTML
 template. Assert one per presentation:
 
-```yaml
+```yaml tonk=parse
 view!: &person-card
   this: id:person-card
   model: person
@@ -28,6 +28,22 @@ name; the explicit `this: id:person-card` pins the view entity so a
 later assertion supersedes its cardinality-one `display` instead of
 leaving the old view entity queryable. `tonk view add --name person-card`
 adds this stable `this:` automatically.
+
+## Authoring detail, directory, label, and title views
+
+`tonk view add` authors a detail view by default. Select any standard view
+concept explicitly with `--kind detail|directory|label|title`; each kind gets a
+stable default anchor (`<model>-view`, `<model>-directory`, `<model>-label`, or
+`<model>-title`). A supplied `--name` is preserved unchanged.
+
+```text
+tonk view add todo --kind directory --template-file todo.html --home
+```
+
+A first detail or directory view automatically surfaces its model while the
+home is blank. Label and title views do not. `--home` explicitly replaces an
+existing home with this one concept's directory and commits the view plus home
+change atomically. Without it, an existing home is always preserved.
 
 ## `<tonk-display>` — one entity through a view
 
@@ -49,7 +65,7 @@ renders a single entity. The resolution that trips people up:
 So you author the instance with a `model` (above) and point callers at
 the concept:
 
-```yaml
+```yaml tonk=illustrative-view-config
 # Correct: the sheet/host references the view CONCEPT.
 view: tonk:view
 # Wrong: referencing a view instance (id:person-card) makes the
@@ -104,7 +120,7 @@ Render the reference through a small **label view** — a `view/label`
 instance. It lives under the built-in `tonk:view/label` concept, so it
 doesn't collide with the model's default `tonk:view`:
 
-```yaml
+```yaml tonk=parse
 # A comment points at its author (a person).
 view!: &comment-card
   this: id:comment-card
@@ -169,7 +185,7 @@ interactions) is packaged as a **web component** instead.
 A component is branch data: a `component` row whose `module` field is
 a JS module that defines your element.
 
-```yaml
+```yaml tonk=eval
 component!: &tally-widget
   module: |
     customElements.get('tally-widget') || customElements.define('tally-widget',
@@ -218,7 +234,7 @@ For an imperative HTML document, assert the always-seeded `portal` concept.
 Its `content` may contain scripts and query through `window.tonk` in the live
 browser:
 
-```yaml
+```yaml tonk=eval
 portal!: &about
   this: id:about
   content: |

--- a/rust/tonk-cli/src/guide-workspace.md
+++ b/rust/tonk-cli/src/guide-workspace.md
@@ -40,7 +40,7 @@ for their authoritative fields.
 A sheet points at the entity to display, that entity's model concept, and the
 view concept used to resolve a model-specific template:
 
-```yaml
+```yaml tonk=parse
 workspace/sheet!: &sheet-alice
   this: id:sheet-alice
   title:    "Alice"
@@ -63,7 +63,7 @@ tonk view add person --name person-card --template '<article><h2>{name}</h2></ar
 The CLI pins the view to `id:person-card`, so re-running it updates the same
 view. In raw notation, include the equivalent stable `this:` yourself:
 
-```yaml
+```yaml tonk=parse
 view!: &person-card
   this: id:person-card
   model: person

--- a/rust/tonk-cli/tests/authoring.rs
+++ b/rust/tonk-cli/tests/authoring.rs
@@ -109,8 +109,10 @@ mod when_setting_the_home {
         tonk_cli::data_ops::view_add(
             &test.site,
             "habit",
+            tonk_cli::authoring::ViewKind::Detail,
             None,
             "<b>{name}</b>",
+            false,
             Default::default(),
         )
         .await?;
@@ -153,6 +155,17 @@ mod when_setting_the_home {
 
 mod when_adding_a_view {
     use super::*;
+    use tonk_cli::authoring::ViewKind;
+
+    async fn render_home(test: &TestSite) -> Result<String> {
+        let replica = tonk_cli::data_ops::query(&test.site, "tonk/replica", false).await?;
+        let entity = replica
+            .lines()
+            .find_map(|line| line.trim().strip_prefix("this: ").map(str::to_owned))
+            .expect("a fresh site has a replica entity");
+        let route = tonk_cli::render::RenderRoute::parse(&format!("{entity}@tonk/space"))?;
+        Ok(tonk_cli::render::render(&test.site, &route).await?)
+    }
 
     #[dialog_common::test]
     async fn it_asserts_the_view_and_auto_surfaces_an_unset_home() -> Result<()> {
@@ -170,8 +183,10 @@ mod when_adding_a_view {
         let out = tonk_cli::data_ops::view_add(
             &test.site,
             "habit",
+            tonk_cli::authoring::ViewKind::Detail,
             None,
             "<b>{name}</b>",
+            false,
             Default::default(),
         )
         .await?;
@@ -204,8 +219,10 @@ mod when_adding_a_view {
         let out = tonk_cli::data_ops::view_add(
             &test.site,
             "habit",
+            tonk_cli::authoring::ViewKind::Detail,
             Some("habit-alt"),
             "<i>{name}</i>",
+            false,
             Default::default(),
         )
         .await?;
@@ -213,6 +230,125 @@ mod when_adding_a_view {
             !out.contains("home set:"),
             "an explicitly set home must not be re-pointed by view add:\n{out}"
         );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_authors_and_renders_a_directory_view_for_every_row() -> Result<()> {
+        let test = TestSite::new().await?;
+        super::seed_habit(&test).await?;
+        tonk_cli::data_ops::assert_op(&test.site, "habit", None, &["--name".into(), "Walk".into()])
+            .await?;
+
+        let out = tonk_cli::data_ops::view_add(
+            &test.site,
+            "habit",
+            ViewKind::Directory,
+            None,
+            "<li>{name}</li>",
+            false,
+            Default::default(),
+        )
+        .await?;
+        assert!(out.contains("set the home to habit"), "{out}");
+
+        let route = tonk_cli::render::RenderRoute::parse("habit")?;
+        let html = tonk_cli::render::render(&test.site, &route).await?;
+        assert!(html.contains("Run"), "{html}");
+        assert!(html.contains("Walk"), "{html}");
+        assert!(!html.contains("<wa-carousel"), "{html}");
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn label_and_title_views_do_not_auto_surface_a_blank_home() -> Result<()> {
+        let test = TestSite::new().await?;
+        super::seed_habit(&test).await?;
+
+        for kind in [ViewKind::Label, ViewKind::Title] {
+            let out = tonk_cli::data_ops::view_add(
+                &test.site,
+                "habit",
+                kind,
+                None,
+                "<b>{name}</b>",
+                false,
+                Default::default(),
+            )
+            .await?;
+            assert!(out.contains("home unchanged"), "{out}");
+            assert!(!out.contains("live at /space/"), "{out}");
+        }
+
+        let html = render_home(&test).await?;
+        assert!(!html.contains("Run"), "blank home was replaced:\n{html}");
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn explicit_home_replaces_the_existing_home_in_one_revision() -> Result<()> {
+        let test = TestSite::new().await?;
+        super::seed_habit(&test).await?;
+        tonk_cli::data_ops::view_add(
+            &test.site,
+            "habit",
+            ViewKind::Detail,
+            None,
+            "<b>{name}</b>",
+            false,
+            Default::default(),
+        )
+        .await?;
+        tonk_cli::data_ops::concept_add(
+            &test.site,
+            "note",
+            &["title:text:one".into()],
+            Some("a note"),
+            Default::default(),
+        )
+        .await?;
+        tonk_cli::data_ops::assert_op(
+            &test.site,
+            "note",
+            None,
+            &["--title".into(), "Write".into()],
+        )
+        .await?;
+        let before = test
+            .site
+            .branch()
+            .await?
+            .handle()
+            .revision()
+            .expect("revision before explicit home")
+            .edition
+            .value();
+
+        let out = tonk_cli::data_ops::view_add(
+            &test.site,
+            "note",
+            ViewKind::Directory,
+            None,
+            "<li>{title}</li>",
+            true,
+            Default::default(),
+        )
+        .await?;
+        assert!(out.contains("set the home to note"), "{out}");
+        let after = test
+            .site
+            .branch()
+            .await?
+            .handle()
+            .revision()
+            .expect("revision after explicit home")
+            .edition
+            .value();
+        assert_eq!(after, before + 1);
+
+        let html = render_home(&test).await?;
+        assert!(html.contains("Write"), "{html}");
+        assert!(!html.contains("Run"), "old home remained active:\n{html}");
         Ok(())
     }
 }

--- a/rust/tonk-cli/tests/data_verbs.rs
+++ b/rust/tonk-cli/tests/data_verbs.rs
@@ -666,9 +666,16 @@ mod when_previewing_a_write {
         .await?;
         let before = revision(&test).await?;
 
-        let out =
-            tonk_cli::data_ops::view_add(&test.site, "habit", None, "<b>{name}</b>", preview())
-                .await?;
+        let out = tonk_cli::data_ops::view_add(
+            &test.site,
+            "habit",
+            tonk_cli::authoring::ViewKind::Detail,
+            None,
+            "<b>{name}</b>",
+            false,
+            preview(),
+        )
+        .await?;
 
         assert!(out.contains("dry run"), "{out}");
         // `view_add` auto-surfaces onto an unset home, so a preview that
@@ -801,9 +808,16 @@ mod when_printing_notation_for_a_write {
         assert!(asserted.contains("name: \"Read\""), "{asserted}");
         assert_eq!(revision(&test).await?, before);
 
-        let view =
-            tonk_cli::data_ops::view_add(&test.site, "habit", None, "<b>{name}</b>", notation())
-                .await?;
+        let view = tonk_cli::data_ops::view_add(
+            &test.site,
+            "habit",
+            tonk_cli::authoring::ViewKind::Detail,
+            None,
+            "<b>{name}</b>",
+            false,
+            notation(),
+        )
+        .await?;
         assert!(view.contains("view!: &habit-view"), "{view}");
         assert_eq!(revision(&test).await?, before);
 

--- a/rust/tonk-cli/tests/notation.rs
+++ b/rust/tonk-cli/tests/notation.rs
@@ -204,6 +204,7 @@ task!:
             format: Format::Notation,
             quiet: false,
             dry_run: true,
+            home: None,
         };
         let outcome = test
             .eval_inline_with(
@@ -270,6 +271,7 @@ blob!:
             format: Format::Notation,
             quiet: false,
             dry_run: true,
+            home: None,
         };
         let outcome = test
             .eval_inline_with("task:\n  this: ?t\n  title: ?title\n", dry_run)
@@ -345,6 +347,7 @@ task!: &ax
                     format: Format::Notation,
                     quiet: false,
                     dry_run: false,
+                    home: None,
                 },
             )
             .await?;
@@ -420,7 +423,103 @@ mod when_introspecting_the_schema {
 }
 
 mod when_serving_the_guide {
+    use crate::common;
+    use tonk_cli::eval::{self, Source};
     use tonk_cli::guide;
+
+    #[derive(Debug)]
+    struct GuideYamlFence {
+        info: String,
+        body: String,
+        opening_line: usize,
+    }
+
+    fn guide_yaml_fences(topic: &str, body: &str) -> Vec<GuideYamlFence> {
+        let lines: Vec<_> = body.lines().collect();
+        let mut fences = Vec::new();
+        let mut index = 0;
+
+        while index < lines.len() {
+            let info = lines[index].trim_start();
+            if !info.starts_with("```yaml") {
+                index += 1;
+                continue;
+            }
+
+            let opening_line = index + 1;
+            let fence_info = info.trim_start_matches("```").to_string();
+            index += 1;
+            let body_start = index;
+            while index < lines.len() && lines[index].trim() != "```" {
+                index += 1;
+            }
+            assert!(
+                index < lines.len(),
+                "{topic}:{opening_line}: unterminated YAML fence"
+            );
+            fences.push(GuideYamlFence {
+                info: fence_info,
+                body: lines[body_start..index].join("\n"),
+                opening_line,
+            });
+            index += 1;
+        }
+
+        fences
+    }
+
+    #[dialog_common::test]
+    async fn guide_notation_examples_are_classified_and_executable() {
+        for (topic, body) in [
+            ("notation", guide::NOTATION),
+            ("views", guide::VIEWS),
+            ("events", guide::EVENTS),
+            ("workspace", guide::WORKSPACE),
+        ] {
+            for fence in guide_yaml_fences(topic, body) {
+                let location = format!("{topic}:{}", fence.opening_line);
+                match fence.info.as_str() {
+                    "yaml tonk=parse" => {
+                        let parsed = tonk_notation::parse(&fence.body);
+                        assert!(
+                            parsed.diagnostics.is_empty(),
+                            "{location}: parse example has diagnostics: {:#?}",
+                            parsed.diagnostics
+                        );
+                    }
+                    "yaml tonk=eval" => {
+                        let test = common::TestSite::new().await.unwrap_or_else(|error| {
+                            panic!("{location}: create test site: {error}")
+                        });
+                        let outcome = eval::run_against_site(
+                            &test.site,
+                            Source::Inline(fence.body),
+                            eval::Options {
+                                dry_run: true,
+                                ..eval::Options::default()
+                            },
+                        )
+                        .await
+                        .unwrap_or_else(|error| panic!("{location}: eval example failed: {error}"));
+                        assert_eq!(
+                            outcome.response.revision_before, outcome.response.revision_after,
+                            "{location}: dry run changed the revision"
+                        );
+                        assert_eq!(
+                            outcome.response.commits.claims, 0,
+                            "{location}: dry run reported committed claims"
+                        );
+                    }
+                    info if info.starts_with("yaml tonk=illustrative-")
+                        && info.len() > "yaml tonk=illustrative-".len() => {}
+                    _ => panic!(
+                        "{location}: YAML fence must use tonk=eval, tonk=parse, or a specific tonk=illustrative-<reason> classification; got `{}`",
+                        fence.info
+                    ),
+                }
+            }
+        }
+    }
 
     #[dialog_common::test]
     fn it_returns_each_topic_body() {
@@ -529,5 +628,226 @@ mod when_serving_the_guide {
                 "workspace guide omits current module surface {name}"
             );
         }
+    }
+}
+
+mod when_rejecting_overlapping_transient_commands {
+    use anyhow::Result;
+    use tonk_cli::eval::{self, EvalError, Source};
+
+    use crate::common;
+
+    #[dialog_common::test]
+    async fn overlapping_transient_commands_fail_without_mutating() -> Result<()> {
+        let test = common::TestSite::new().await?;
+        let before = test.site.branch().await?.handle().revision();
+        let doc = r#"concept!: &toggle-result
+  with:
+    todo: { description: The todo, the: xyz.tonk.result/todo, as: entity }
+    checked: { description: The checked state, the: xyz.tonk.result/checked, as: boolean }
+
+concept!: &remove-result
+  with:
+    todo: { description: The todo, the: xyz.tonk.result/todo, as: entity }
+
+command!: &toggle-todo
+  with:
+    todo: { description: The todo, the: dom.event.current-target.dataset/todo, as: entity }
+    checked: { description: The checked state, the: dom.event.current-target/checked, as: boolean }
+
+command!: &remove-todo
+  with:
+    todo: { description: The todo, the: dom.event.current-target.dataset/todo, as: entity }
+
+rule!:
+  assert!: toggle-result
+  when:
+    - assert: toggle-todo
+      where: { this: ?this, todo: ?todo, checked: ?checked }
+
+rule!:
+  assert!: remove-result
+  when:
+    - assert: remove-todo
+      where: { this: ?this, todo: ?todo }
+"#;
+
+        let error = eval::run_against_site(
+            &test.site,
+            Source::Inline(doc.to_owned()),
+            eval::Options {
+                dry_run: true,
+                ..eval::Options::default()
+            },
+        )
+        .await
+        .expect_err("unsafe command shapes must fail analysis");
+        let EvalError::Analyze(message) = error else {
+            panic!("expected analyzer error, got {error}");
+        };
+        assert!(message.contains("toggle-todo"), "{message}");
+        assert!(message.contains("remove-todo"), "{message}");
+        assert_eq!(test.site.branch().await?.handle().revision(), before);
+        Ok(())
+    }
+}
+
+mod eval_home {
+    use anyhow::Result;
+    use tonk_cli::eval::{self, Source};
+
+    use crate::common;
+
+    const TODO_DIRECTORY_VIEW: &str = r#"view/directory!: &todo-directory
+  this: id:todo-directory
+  model: todo
+  display: |
+    <li>{title}</li>
+"#;
+
+    async fn seed_todo(test: &common::TestSite) -> Result<()> {
+        tonk_cli::data_ops::concept_add(
+            &test.site,
+            "todo",
+            &["title:text:one".into()],
+            Some("a todo"),
+            Default::default(),
+        )
+        .await?;
+        tonk_cli::data_ops::assert_op(
+            &test.site,
+            "todo",
+            None,
+            &["--title".into(), "Write".into()],
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn render_home(test: &common::TestSite) -> Result<String> {
+        let replica = tonk_cli::data_ops::query(&test.site, "tonk/replica", false).await?;
+        let entity = replica
+            .lines()
+            .find_map(|line| line.trim().strip_prefix("this: ").map(str::to_owned))
+            .expect("a fresh site has a replica entity");
+        let route = tonk_cli::render::RenderRoute::parse(&format!("{entity}@tonk/space"))?;
+        Ok(tonk_cli::render::render(&test.site, &route).await?)
+    }
+
+    #[dialog_common::test]
+    async fn it_installs_a_view_and_home_in_one_eval_commit() -> Result<()> {
+        let test = common::TestSite::new().await?;
+        seed_todo(&test).await?;
+        let before = test
+            .site
+            .branch()
+            .await?
+            .handle()
+            .revision()
+            .expect("revision before eval home")
+            .edition
+            .value();
+
+        eval::run_against_site(
+            &test.site,
+            Source::Inline(TODO_DIRECTORY_VIEW.to_owned()),
+            eval::Options {
+                home: Some("todo".to_owned()),
+                ..eval::Options::default()
+            },
+        )
+        .await?;
+
+        let after = test
+            .site
+            .branch()
+            .await?
+            .handle()
+            .revision()
+            .expect("revision after eval home")
+            .edition
+            .value();
+        assert_eq!(after, before + 1, "view and home must share one commit");
+
+        let html = render_home(&test).await?;
+        assert!(
+            html.contains("Write"),
+            "eval home did not render todo:\n{html}"
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_accepts_a_home_concept_declared_in_the_same_document() -> Result<()> {
+        let test = common::TestSite::new().await?;
+        let doc = format!(
+            "concept!: &todo\n  with:\n    title: {{ description: The title, the: xyz.tonk.todo/title, as: text }}\n\ntodo!: &write\n  title: \"Write\"\n\n{TODO_DIRECTORY_VIEW}"
+        );
+        eval::run_against_site(
+            &test.site,
+            Source::Inline(doc),
+            eval::Options {
+                home: Some("todo".to_owned()),
+                ..eval::Options::default()
+            },
+        )
+        .await?;
+
+        let html = render_home(&test).await?;
+        assert!(html.contains("Write"), "same-document home failed:\n{html}");
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_previews_eval_home_without_mutating() -> Result<()> {
+        let test = common::TestSite::new().await?;
+        seed_todo(&test).await?;
+        let before = test.site.branch().await?.handle().revision();
+
+        let outcome = eval::run_against_site(
+            &test.site,
+            Source::Inline(TODO_DIRECTORY_VIEW.to_owned()),
+            eval::Options {
+                dry_run: true,
+                home: Some("todo".to_owned()),
+                ..eval::Options::default()
+            },
+        )
+        .await?;
+
+        assert!(!outcome.committed);
+        assert_eq!(
+            outcome.response.revision_before,
+            outcome.response.revision_after
+        );
+        assert_eq!(test.site.branch().await?.handle().revision(), before);
+        let html = render_home(&test).await?;
+        assert!(
+            !html.contains("Write"),
+            "dry run replaced the home:\n{html}"
+        );
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_eval_home_for_an_unknown_concept_without_mutating() -> Result<()> {
+        let test = common::TestSite::new().await?;
+        seed_todo(&test).await?;
+        let before = test.site.branch().await?.handle().revision();
+
+        let error = eval::run_against_site(
+            &test.site,
+            Source::Inline(TODO_DIRECTORY_VIEW.to_owned()),
+            eval::Options {
+                home: Some("missing".to_owned()),
+                ..eval::Options::default()
+            },
+        )
+        .await
+        .expect_err("an unknown home concept must fail analysis");
+
+        assert!(matches!(error, eval::EvalError::Analyze(_)), "{error}");
+        assert_eq!(test.site.branch().await?.handle().revision(), before);
+        Ok(())
     }
 }

--- a/rust/tonk-cli/tests/site.rs
+++ b/rust/tonk-cli/tests/site.rs
@@ -1094,8 +1094,10 @@ mod when_listing_views {
         tonk_cli::data_ops::view_add(
             &test.site,
             "task",
+            tonk_cli::authoring::ViewKind::Detail,
             None,
             "<b>{title}</b>",
+            false,
             Default::default(),
         )
         .await?;
@@ -1123,8 +1125,10 @@ mod when_listing_views {
         tonk_cli::data_ops::view_add(
             &test.site,
             "task",
+            tonk_cli::authoring::ViewKind::Detail,
             None,
             "<b>{title}</b>",
+            false,
             Default::default(),
         )
         .await?;

--- a/rust/tonk-notation/guide.md
+++ b/rust/tonk-notation/guide.md
@@ -83,7 +83,7 @@ All of these are direct references and require no resolution.
 
 Define attributes, compose a concept, assert an entity, query it:
 
-```yaml
+```yaml tonk=eval
 attribute!: &person-name
   description: The person's name
   the:         xyz.tonk.person/name
@@ -182,7 +182,7 @@ retraction).
 A YAML anchor written between the head's colon and its body
 publishes the resulting entity under that name:
 
-```yaml
+```yaml tonk=illustrative-ellipsis
 attribute!: &person-name
   ...
 ```
@@ -234,7 +234,7 @@ value can take four forms:
 The mapping form lets you control entity derivation
 explicitly:
 
-```yaml
+```yaml tonk=parse
 person!:
   name: Alice
   age: 23
@@ -283,7 +283,7 @@ an object (rename it, query its target, etc.).
    same variable name unify — the same value must satisfy
    every position the variable appears in.
 
-```yaml
+```yaml tonk=parse
 # Find people whose name matches their xyz.tonk role.
 person:
   this: ?p
@@ -329,7 +329,7 @@ with the same name across expressions join. Results are
 filtered to bindings that satisfy every expression
 simultaneously.
 
-```yaml
+```yaml tonk=parse
 person:
   this: ?e
   name: ?name
@@ -341,7 +341,7 @@ xyz.tonk:
 
 A query+mutation document also joins via shared variables:
 
-```yaml
+```yaml tonk=parse
 person:
   this: ?alice
   name: "Alice"
@@ -361,7 +361,7 @@ Joins are limited to a single evaluation scope.
 The `&` anchor on a head's value is sugar for an explicit
 `name!` operation. The desugaring:
 
-```yaml
+```yaml tonk=eval
 attribute!: &person-name
   description: "The person's name"
   the:         xyz.tonk.person/name
@@ -371,7 +371,7 @@ attribute!: &person-name
 
 is equivalent to:
 
-```yaml
+```yaml tonk=eval
 attribute!:
   this: ?person-name
   description: "The person's name"
@@ -391,7 +391,7 @@ as a name pointing to it.
 Use `name!` directly when you need to publish under multiple
 names, rename, or alias:
 
-```yaml
+```yaml tonk=eval
 attribute!: &person-name
   description: "The person's name"
   the:         xyz.tonk.person/name
@@ -401,11 +401,11 @@ attribute!: &person-name
 # Additional names for the same entity:
 name!:
   this:   id:tonk-person-name
-  entity: ?person-name
+  entity: person-name
 
 name!:
   this:   id:p-name
-  entity: ?person-name
+  entity: person-name
 ```
 
 ### Cardinality and what `this:` is for
@@ -429,7 +429,7 @@ at a time. Two consequences:
 
 Renaming is `name!` plus retraction:
 
-```yaml
+```yaml tonk=eval
 # Re-point id:alice to a different entity:
 name!:
   this:   id:alice
@@ -473,7 +473,7 @@ Defines an attribute by domain/name, value type, and
 cardinality. Although `attribute` is a built-in, its is a regular concept and
 can be described in the notation:
 
-```yaml
+```yaml tonk=illustrative-built-in-schema
 # The four attributes that make up the attribute concept.
 
 attribute!:
@@ -529,12 +529,12 @@ of a new one.
 
 Because `attribute` is a regular concept, you can query it:
 
-```yaml
+```yaml tonk=eval
 # Find every attribute whose cardinality is "many".
 attribute:
   this:        ?a
-  the:         ?selector
-  cardinality: many
+  id:          ?selector
+  cardinality: "many"
 ```
 
 Note: the schema definition above is illustrative. In an
@@ -545,7 +545,7 @@ itself are built-in.
 
 Composes attributes into a shape with named fields:
 
-```yaml
+```yaml tonk=parse
 concept!: &person
   description: "A person"
   with:
@@ -571,7 +571,7 @@ express the `concept` concept's own schema.
 
 Establishes a name that can be resolved to an associated entity.
 
-```yaml
+```yaml tonk=parse
 name!:
   this:   id:alice
   entity: did:key:zAlice
@@ -585,7 +585,7 @@ Fields:
 
 The schema, illustratively:
 
-```yaml
+```yaml tonk=illustrative-built-in-schema
 attribute!:
   this: ?entity
   description: "The entity identified by the name"
@@ -604,7 +604,7 @@ queries can find every name pointing at a given entity, or
 every entity with at least one name, using the regular query
 machinery:
 
-```yaml
+```yaml tonk=illustrative-placeholders
 # Find all names for this entity.
 name:
   this:   ?n
@@ -622,7 +622,7 @@ premises under `when:` (all must match) and optionally `unless:`
 (none may match); the head under `assert:`, `assert!:`, or
 `retract!:` says what to conclude.
 
-```yaml
+```yaml tonk=parse
 rule!:
   assert!: alert
   when:
@@ -653,7 +653,7 @@ Predicates filter bindings rather than reading stored facts.
 The range predicates order every comparable type — numbers, strings,
 symbols, entities, bytes — and read `of` as the left side:
 
-```yaml
+```yaml tonk=illustrative-rule-fragment
 # ?count is in the half-open interval (1, 100].
 - assert: ">"
   where: { of: ?count, with: 1 }
@@ -691,7 +691,7 @@ run; a join is what binds it.
 Because they are ordinary premises, they compose — a span's child
 reference feeds the next node lookup:
 
-```yaml
+```yaml tonk=illustrative-rule-fragment
 - assert: tree/span
   where: { of: ?root, node: ?child }
 - assert: tree/node
@@ -703,7 +703,7 @@ formula's outputs; only the required input (`of:`) must be given.
 
 A resolver also heads a query on its own, not just a rule premise:
 
-```yaml
+```yaml tonk=parse
 tree/node:
   of: "8QsR69j39jU7acb4H9VfsSpR2SrHJ6f2PPKHoosnsAPr"
   kind: ?kind
@@ -716,7 +716,7 @@ before concepts. A concept declared under one of those names could
 never be referenced, since every mention would mean the built-in, so
 declaring one is an error rather than a silent shadowing:
 
-```yaml
+```yaml tonk=illustrative-error
 concept!: &tree/node   # error: "tree/node" is a built-in resolver
 ```
 


### PR DESCRIPTION
## Summary

- make guide YAML fences executable or explicitly illustrative and repair drifted examples
- reject ambiguous overlapping transient command triggers during analysis
- add detail, directory, label, and title view authoring with atomic home selection
- add atomic `tonk eval --home` support with analyzer validation

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p tonk-analyzer -p tonk-cli --all-targets -- -D warnings`
- `cargo test -p tonk-analyzer`
- `cargo test -p tonk-cli -- --test-threads=1`
- `git diff --check`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `tonk` CLI by introducing a new `ViewKind` enum to manage different view types and implementing the `--home` option for atomic home replacements. It also improves error handling for overlapping transient commands.

### Detailed summary
- Added `ViewKind` enum with variants: `Detail`, `Directory`, `Label`, `Title`.
- Updated `view_add` function to accept `ViewKind` and a `set_home` flag.
- Implemented `--home` option for atomic home replacement in CLI commands.
- Added tests for view kinds and home functionality.
- Enhanced error handling for overlapping transient commands in the analyzer.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->