### PR TITLE
Spaces are created with a public key; the seed lives under custody

### DIFF
--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -592,24 +592,57 @@ pub mod tests {
     /// creates a root without an account around it.
     pub async fn test_state_without_account() -> TonkState {
         let state = test_state_without_root().await;
+        persist_test_root(&state).await;
+        state
+    }
+
+    /// Persist the test root on `state`, the way a creation or unlock
+    /// ceremony does: the `root -> device` grant, the recipient custodied
+    /// seeds are sealed to, and that recipient published on profile main.
+    /// Returns the root DID.
+    pub(crate) async fn persist_test_root(state: &TonkState) -> dialog_varsig::Did {
         let root = Ed25519Signer::import(&test_root_seed(&state.profile_name))
             .await
             .unwrap();
+        let root_did = root.did();
         let grant = tonk_identity::delegation::mint_device_delegation(root, &state.profile.did())
             .await
             .unwrap();
+        // What a creation or unlock ceremony hands back with the root, and
+        // what the account sweep then publishes: the recipient custodied
+        // seeds are sealed to. Published here directly, since the fixture
+        // has no account branch to sweep.
+        let recipient = tonk_identity::envelope::AccountSecret::from_bytes(
+            zeroize::Zeroizing::new(test_root_seed(&state.profile_name)),
+        )
+        .encryption_key()
+        .recipient()
+        .did();
         super::identity::persist_root(
-            &state,
+            state,
             tonk_worker_api::SaveRootRequest {
                 credential_id: "test-credential".to_string(),
                 delegation_hex: hex::encode(grant.to_bytes().unwrap()),
                 passkey: None,
-                encryption_key: None,
+                encryption_key: Some(recipient.to_string()),
             },
         )
         .await
         .unwrap();
         state
+            .reactor
+            .profile_repository()
+            .branch(tonk_account::MAIN_BRANCH)
+            .transaction()
+            .assert(tonk_schema::AccountEncryptionKey::new(
+                root_did.this(),
+                recipient.this(),
+            ))
+            .commit()
+            .perform(&state.operator)
+            .await
+            .expect("the fixture publishes the account's encryption key");
+        root_did
     }
 
     /// Create an isolated test state with a stable local root grant and an

--- a/rust/tonk-worker/src/router/account_state.rs
+++ b/rust/tonk-worker/src/router/account_state.rs
@@ -1129,16 +1129,35 @@ async fn custody_recipient(
 ) -> Result<(dialog_varsig::Did, Option<ReadyAccountBranch>), TonkWorkerError> {
     match super::identity::local_root(tonk).await {
         Ok(root) => {
-            let recipient = published_encryption_key(tonk, &root.root_did)
-                .await?
-                .ok_or_else(|| {
-                    TonkWorkerError::Conflict(
-                        "the account has not published its encryption key on this device; \
-                         signing in with the passkey once publishes it"
-                            .to_string(),
-                    )
+            let ready = require_ready_account_state(tonk).await.ok();
+            if let Some(recipient) = published_encryption_key(tonk, &root.root_did).await? {
+                return Ok((recipient, ready));
+            }
+            // A ceremony recorded the key with the root but the sweep has
+            // not published it yet (the account branch may not be ready).
+            // Publish it here: profile main is where it lives either way.
+            let Some(recipient) = root.encryption_key else {
+                return Err(TonkWorkerError::Conflict(
+                    "the account has not published its encryption key on this device; a \
+                     passkey assertion derives it"
+                        .to_string(),
+                ));
+            };
+            tonk.reactor
+                .profile_repository()
+                .branch(tonk_account::MAIN_BRANCH)
+                .transaction()
+                .assert(AccountEncryptionKey::new(
+                    root.root_did.this(),
+                    recipient.this(),
+                ))
+                .commit()
+                .perform(&tonk.operator)
+                .await
+                .map_err(|error| {
+                    TonkWorkerError::Internal(format!("publish account encryption key: {error}"))
                 })?;
-            Ok((recipient, require_ready_account_state(tonk).await.ok()))
+            Ok((recipient, ready))
         }
         Err(TonkWorkerError::RootRequired) => {
             let secret = crate::onboarding::account(tonk).await?;

--- a/rust/tonk-worker/src/router/account_state.rs
+++ b/rust/tonk-worker/src/router/account_state.rs
@@ -969,18 +969,29 @@ pub(crate) async fn read_encryption_key(
     tonk: &TonkState,
     ready: &ReadyAccountBranch,
 ) -> Result<Option<dialog_varsig::Did>, TonkWorkerError> {
+    published_encryption_key(tonk, &ready.subject).await
+}
+
+/// The encryption key published for `account` on profile `main`, if any.
+/// Reads the branch as it is, ready or not: the fact arrives with the
+/// account pull or is written locally, and neither needs the descriptor
+/// gate to be read back.
+async fn published_encryption_key(
+    tonk: &TonkState,
+    account: &dialog_varsig::Did,
+) -> Result<Option<dialog_varsig::Did>, TonkWorkerError> {
     let branch = tonk
         .reactor
         .profile_repository()
         .branch(tonk_account::MAIN_BRANCH)
         .acquire(&tonk.operator)
         .await
-        .map_err(|error| TonkWorkerError::Internal(format!("open ready account state: {error}")))?;
+        .map_err(|error| TonkWorkerError::Internal(format!("open profile main: {error}")))?;
     let rows: Vec<AccountEncryptionKey> = branch
         .handle()
         .query()
         .select(Query::<AccountEncryptionKey> {
-            this: Term::from(ready.subject.this()),
+            this: Term::from(account.this()),
             key: Term::var("key"),
         })
         .perform(&tonk.operator)
@@ -1117,14 +1128,17 @@ async fn custody_recipient(
     tonk: &TonkState,
 ) -> Result<(dialog_varsig::Did, Option<ReadyAccountBranch>), TonkWorkerError> {
     match super::identity::local_root(tonk).await {
-        Ok(_) => {
-            let ready = require_ready_account_state(tonk).await?;
-            let recipient = read_encryption_key(tonk, &ready).await?.ok_or_else(|| {
-                TonkWorkerError::Conflict(
-                    "the account has published no encryption key yet".to_string(),
-                )
-            })?;
-            Ok((recipient, Some(ready)))
+        Ok(root) => {
+            let recipient = published_encryption_key(tonk, &root.root_did)
+                .await?
+                .ok_or_else(|| {
+                    TonkWorkerError::Conflict(
+                        "the account has not published its encryption key on this device; \
+                         signing in with the passkey once publishes it"
+                            .to_string(),
+                    )
+                })?;
+            Ok((recipient, require_ready_account_state(tonk).await.ok()))
         }
         Err(TonkWorkerError::RootRequired) => {
             let secret = crate::onboarding::account(tonk).await?;
@@ -1134,31 +1148,10 @@ async fn custody_recipient(
                 .await
                 .map_err(|error| TonkWorkerError::Internal(format!("{error}")))?
                 .did();
-            let branch = tonk
-                .reactor
-                .profile_repository()
-                .branch(tonk_account::MAIN_BRANCH)
-                .acquire(&tonk.operator)
-                .await
-                .map_err(|error| {
-                    TonkWorkerError::Internal(format!("open profile main: {error}"))
-                })?;
-            let published: Vec<AccountEncryptionKey> = branch
-                .handle()
-                .query()
-                .select(Query::<AccountEncryptionKey> {
-                    this: Term::from(account.this()),
-                    key: Term::var("key"),
-                })
-                .perform(&tonk.operator)
-                .try_vec()
-                .await
-                .map_err(|error| {
-                    TonkWorkerError::Internal(format!("read onboarding encryption key: {error:?}"))
-                })?;
-            if published.is_empty() {
-                branch
-                    .handle()
+            if published_encryption_key(tonk, &account).await?.is_none() {
+                tonk.reactor
+                    .profile_repository()
+                    .branch(tonk_account::MAIN_BRANCH)
                     .transaction()
                     .assert(AccountEncryptionKey::new(account.this(), recipient.this()))
                     .commit()
@@ -1174,6 +1167,54 @@ async fn custody_recipient(
         }
         Err(error) => Err(error),
     }
+}
+
+/// Open the seed custodied for `subject` under this device's onboarding
+/// account, when there is one. `None` when no row is sealed to the
+/// onboarding recipient: the subject predates seed custody, or was joined
+/// rather than created here.
+///
+/// Only the onboarding account's rows are openable without a ceremony,
+/// because only its secret is local; a passkey account's rows are opened
+/// by rotation, inside one.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) async fn open_onboarding_seed(
+    tonk: &TonkState,
+    subject: &dialog_varsig::Did,
+) -> Result<Option<Zeroizing<[u8; 32]>>, TonkWorkerError> {
+    let secret = crate::onboarding::account(tonk).await?;
+    let key = secret.encryption_key();
+    let recipient = key.recipient().did();
+    let branch = tonk
+        .reactor
+        .profile_repository()
+        .branch(tonk_account::MAIN_BRANCH)
+        .acquire(&tonk.operator)
+        .await
+        .map_err(|error| TonkWorkerError::Internal(format!("open profile main: {error}")))?;
+    let rows: Vec<CustodiedSeed> = branch
+        .handle()
+        .query()
+        .select(Query::<CustodiedSeed> {
+            this: Term::var("this"),
+            subject: Term::from(tonk_schema::domain::custody::Subject(subject.this())),
+            kind: Term::var("kind"),
+            recipient: Term::from(tonk_schema::domain::custody::Recipient(recipient.this())),
+            sealed: Term::var("sealed"),
+        })
+        .perform(&tonk.operator)
+        .try_vec()
+        .await
+        .map_err(|error| TonkWorkerError::Internal(format!("read custodied seed: {error:?}")))?;
+    let Some(row) = rows.into_iter().next() else {
+        return Ok(None);
+    };
+    let sealed = tonk_identity::sealed::Sealed::decode(&row.sealed.0).map_err(|error| {
+        TonkWorkerError::Internal(format!("custodied seed unreadable: {error}"))
+    })?;
+    key.open(&sealed, subject)
+        .map(Some)
+        .map_err(|error| TonkWorkerError::Internal(format!("custodied seed did not open: {error}")))
 }
 
 /// Project the authoritative account display name into the local profile

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -7,7 +7,6 @@
 //! share a label. The response carries the new repository's routing key
 //! (the DID suffix), which the UI routes by.
 
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use dialog_capability::Subject;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use dialog_effects::Use;
@@ -20,7 +19,8 @@ use ::axum::{
     http::{HeaderMap, StatusCode},
 };
 use axum_wasm_macros::wasm_compat;
-use dialog_credentials::{Ed25519Signer, SignerCredential};
+use dialog_credentials::{Credential, Ed25519Signer, Ed25519Verifier};
+use dialog_effects::space::{Space, SpaceExt as _};
 use dialog_query::{Output as _, Query, Term};
 use dialog_repository::{
     RemoteRepository, Repository, RepositoryExt as _, Revision, SiteAddress, Upstream,
@@ -2595,7 +2595,7 @@ pub async fn create_repository(
     tonk: &TonkState,
     display_name: &str,
     configuration: &RepositoryConfiguration,
-) -> Result<Repository<SignerCredential>, RepositoryError> {
+) -> Result<Repository, RepositoryError> {
     // A space always delegates to an ACCOUNT: the passkey-derived root
     // once one is persisted, else this device's onboarding account,
     // which is a real account custodied locally rather than by WebAuthn
@@ -2658,22 +2658,38 @@ pub async fn create_repository(
     let did = signer.did();
     let key = did.repo_key();
 
-    let repository = tonk
-        .profile
-        .repository(key)
-        .create()
-        .with_credential(signer)
+    // The seed sealed to the account is the ONLY copy of the space secret
+    // that outlives this function: the repository stores the verifier, and
+    // every later act on the space proves through `space -> account ->
+    // device`, the way a joined replica does. So the custody row lands
+    // before anything else does, and a seed that cannot be custodied is a
+    // space that is not created.
+    if !super::account_state::custody_seed(tonk, &did, SeedKind::Space, seed).await {
+        return Err(RepositoryError::Internal(
+            "the space seed could not be custodied under the account".to_string(),
+        ));
+    }
+
+    let verifier: Ed25519Verifier = did.to_string().parse().map_err(|e| {
+        RepositoryError::Internal(format!("space DID is not a valid Ed25519 did:key: {e:?}"))
+    })?;
+    let space_credential = Subject::from(tonk.profile.did())
+        .attenuate(Space::new(key))
+        .create(Credential::from(verifier))
         .perform(&tonk.operator)
         .await
         .map_err(|e| {
             RepositoryError::Internal(format!("Failed to create repository '{}': {}", key, e))
         })?;
+    let repository = Repository::from(space_credential);
     log!("Repository created. DID: {}", repository.did());
 
-    // 2. Delegate subject-specific authority to the owner key.
-    let delegation = repository
+    // 2. Delegate subject-specific authority to the owner key, from the
+    //    signer this function still holds.
+    let minter = Repository::from(signer);
+    let delegation = minter
         .access()
-        .claim(&repository)
+        .claim(&minter)
         .delegate(owner.clone())
         .perform(&tonk.operator)
         .await
@@ -2719,10 +2735,6 @@ pub async fn create_repository(
         .map_err(|error| {
             RepositoryError::Internal(format!("Failed to persist space root delegation: {error}"))
         })?;
-    // The recovery copy: the seed sealed to the account, so any device
-    // on the account can re-issue this space after a ceremony. Best
-    // effort like the retain above; the space is usable without it.
-    super::account_state::custody_seed(tonk, &repository.did(), SeedKind::Space, seed).await;
 
     // 3-7. Wire up the meta branch and register the replica. The
     // replica is a name-less membership index; its identity (`subject`)
@@ -2771,18 +2783,22 @@ pub(crate) async fn space_root_prefix(
 
 /// Bring pre-account spaces under the account after linking.
 ///
-/// A space created before any account existed delegates to the profile's
-/// device key, the only durable key the client had. Once a root is
-/// persisted, each such space re-delegates from its own signer to the
-/// account root: the stored prefix is replaced, the new authority lands
-/// in the profile's access branch, is retained into the account space,
-/// and the space is provisioned as a consumer under the account's
-/// customer. Spaces already rooted at the account — created while signed
-/// out, or adopted by an earlier pass — skip the redelegation but still
-/// get the retain and the provisioning, both idempotent. Joined replicas
-/// (whose prefix reaches this profile through someone else's chain) are
-/// left alone. Best effort per space: adoption failing must never fail
-/// the link that triggered it.
+/// A space created before accreditation delegates to the onboarding
+/// account. Once a root is persisted, each such space is re-issued to the
+/// account root from its custodied seed (the repository holds only the
+/// verifier): the stored prefix is replaced, the new authority lands in
+/// the profile's access branch, is retained into the account space, and
+/// the space is provisioned as a consumer under the account's customer.
+/// Spaces already rooted at the account — created while signed out, or
+/// adopted by an earlier pass — skip the re-issue but still get the
+/// retain and the provisioning, both idempotent. Joined replicas (whose
+/// prefix reaches this profile through someone else's chain) and spaces
+/// with no custodied seed are left alone. Best effort per space: adoption
+/// failing must never fail the link that triggered it.
+///
+/// Re-sealing the seed to the new account, retracting the old row, and
+/// retiring the onboarding account are the rest of accreditation
+/// (`plan/join-under-custody.md`, Stage 3).
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) async fn adopt_profile_spaces(tonk: &TonkState) {
     let Ok(root) = super::identity::local_root(tonk).await else {
@@ -2813,13 +2829,29 @@ pub(crate) async fn adopt_profile_spaces(tonk: &TonkState) {
             continue;
         };
         let chain = if reissuable(prefix.audience()) {
-            // Joined replicas carry a verifier-only credential: nothing
-            // to redelegate from, their authority is the inviter's.
-            let Some(access) = repository.try_access() else {
-                continue;
+            // The space's own signer is re-issued from its custodied seed:
+            // the repository stores only the verifier, and the seed sealed
+            // to the onboarding account is the copy that survives. A space
+            // with no custodied seed (created before seeds were custodied,
+            // or joined rather than created) is left alone.
+            let seed = match super::account_state::open_onboarding_seed(tonk, &subject).await {
+                Ok(Some(seed)) => seed,
+                Ok(None) => continue,
+                Err(error) => {
+                    log!("space '{subject}' was not adopted by the account: {error}");
+                    continue;
+                }
             };
-            let delegation = match access
-                .claim(&repository)
+            let minter = match Ed25519Signer::import(&*seed).await {
+                Ok(signer) => Repository::from(signer),
+                Err(error) => {
+                    log!("space '{subject}' was not adopted by the account: {error}");
+                    continue;
+                }
+            };
+            let delegation = match minter
+                .access()
+                .claim(&minter)
                 .delegate(root.root_did.clone())
                 .perform(&tonk.operator)
                 .await
@@ -4862,6 +4894,115 @@ mod tests {
     use crate::router::evaluate::evaluate_body;
     use crate::router::tests::{content_invitations, put_repo, put_repo_info};
     use crate::router::{AppState, CreateInviteResponse, api_router_with_state, tests::test_state};
+
+    /// The seed sealed to the account is the only copy of a created
+    /// space's secret: the repository stores the verifier, the space still
+    /// proves for the operator through `space -> account -> device`, and
+    /// opening the custodied seed with the account key re-derives exactly
+    /// the space's signer.
+    #[dialog_common::test]
+    async fn it_creates_a_space_with_a_public_key_and_custodies_its_seed() {
+        use dialog_capability::Subject;
+        use dialog_effects::Use;
+        use dialog_query::{Output as _, Query, Term};
+        use dialog_repository::RepositoryExt as _;
+        use dialog_varsig::Principal as _;
+        use tonk_schema::prelude::DidExt as _;
+
+        let (app, state, _lsp) = api_router_with_state(test_state().await);
+        let key = put_repo(&app, "public-key-space").await;
+        let tonk = state.read().await;
+        let repository: dialog_repository::Repository = tonk
+            .profile
+            .repository(&key)
+            .load()
+            .perform(&tonk.operator)
+            .await
+            .unwrap();
+        assert!(
+            repository.try_access().is_none(),
+            "the repository stores only the verifier",
+        );
+        let subject = repository.did();
+
+        tonk.profile
+            .access()
+            .prove(Subject::from(subject.clone()).attenuate(Use))
+            .audience(&tonk.operator)
+            .perform(&tonk.operator)
+            .await
+            .expect("the space proves through the account without its own key");
+
+        let branch = tonk
+            .reactor
+            .profile_repository()
+            .branch(tonk_account::MAIN_BRANCH)
+            .acquire(&tonk.operator)
+            .await
+            .unwrap();
+        let rows: Vec<tonk_schema::CustodiedSeed> = branch
+            .handle()
+            .query()
+            .select(Query::<tonk_schema::CustodiedSeed> {
+                this: Term::var("this"),
+                subject: Term::from(tonk_schema::domain::custody::Subject(subject.this())),
+                kind: Term::var("kind"),
+                recipient: Term::var("recipient"),
+                sealed: Term::var("sealed"),
+            })
+            .perform(&tonk.operator)
+            .try_vec()
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1, "one custodied space seed");
+        assert_eq!(rows[0].kind.0.to_string(), tonk_schema::SeedKind::SPACE);
+        let sealed = tonk_identity::sealed::Sealed::decode(&rows[0].sealed.0).unwrap();
+        let account = tonk_identity::envelope::AccountSecret::from_bytes(zeroize::Zeroizing::new(
+            crate::router::tests::test_root_seed(&tonk.profile_name),
+        ));
+        let opened = account
+            .encryption_key()
+            .open(&sealed, &subject)
+            .expect("the account key opens the custodied seed");
+        let reissued = dialog_credentials::Ed25519Signer::import(&*opened)
+            .await
+            .unwrap();
+        assert_eq!(reissued.did(), subject, "the seed derives the space's key");
+    }
+
+    /// A space created under the onboarding account is re-rooted at the
+    /// passkey root by opening its custodied seed, not by reaching for a
+    /// local signer the repository no longer holds.
+    #[dialog_common::test]
+    async fn it_adopts_an_onboarding_space_from_its_custodied_seed() {
+        use crate::router::tests::{persist_test_root, test_state_without_root};
+        use dialog_varsig::Principal as _;
+
+        let (app, state, _lsp) = api_router_with_state(test_state_without_root().await);
+        let key = put_repo(&app, "onboarding-space").await;
+        let subject: dialog_varsig::Did = key.parse().unwrap();
+        let tonk = state.read().await;
+        let onboarding = crate::onboarding::did(&tonk).await.unwrap().unwrap();
+        assert_eq!(
+            super::space_root_prefix(&tonk, &subject)
+                .await
+                .unwrap()
+                .audience(),
+            &onboarding,
+            "created under the onboarding account",
+        );
+
+        let root_did = persist_test_root(&tonk).await;
+        super::adopt_profile_spaces(&tonk).await;
+
+        let prefix = super::space_root_prefix(&tonk, &subject).await.unwrap();
+        assert_eq!(
+            prefix.audience(),
+            &root_did,
+            "re-issued to the passkey root"
+        );
+        assert_eq!(prefix.issuer(), &subject, "minted by the space itself");
+    }
 
     /// The scaffold notation, embedded at compile time.
     const CORE: &str = include_str!("../../../tonk-core/assets/library/core.yaml");


### PR DESCRIPTION
Stacked on #763. Stage 2 of `plan/join-under-custody.md`.

A space's private key used to be stored in the creating device's credential store, a copy the account could never revoke and the reason accreditation needed that device. Now the signer exists only long enough to mint `space → account`; the repository stores the verifier, and every later act on the space proves through `space → account → device`, the way a joined replica already does. The only copy of the space secret is the `CustodiedSeed` sealed to the account (#759), written before anything durable; a seed that cannot be custodied is a space that is not created.

`adopt_profile_spaces` re-issues an onboarding-rooted space to the passkey root by opening its custodied seed with the onboarding secret rather than reaching for a local signer. Re-sealing to the new account, retracting the old row, and retiring the onboarding account are Stage 3.

Two consequences worth knowing:
- The encryption-key read no longer needs a ready account branch: the fact lives on profile `main` and is read as-is.
- Creating a space on a linked device requires the account's published encryption key. New accounts publish it at creation; existing accounts publish it the first time they unlock on any browser (#759). Until then a linked device refuses to create a space with a clear message rather than minting a key it cannot custody.

Verified in Chrome: tonk-worker 288/288 plus the two new tests (verifier-only credential, seed opens to the space's DID and the space still proves; onboarding space re-issued to the root from its seed). Native clippy `-D warnings` clean.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of account encryption keys and the management of spaces within the Tonk system, particularly regarding the persistence of keys and the adoption of onboarding spaces.

### Detailed summary
- Added `persist_test_root` function to persist the test root state.
- Updated `test_state_without_account` to call `persist_test_root`.
- Introduced `published_encryption_key` to read the encryption key for accounts.
- Modified `custody_recipient` to publish encryption keys when necessary.
- Created `open_onboarding_seed` to access seeds custodied for onboarding accounts.
- Updated `create_repository` to ensure space seeds are custodied under accounts.
- Enhanced `adopt_profile_spaces` to re-issue spaces from custodied seeds.
- Added tests for space creation and onboarding space adoption scenarios.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->