### PR TITLE
feat(access): look up a customer by email address

### DIFF
--- a/plan/customer-email-lookup.md
+++ b/plan/customer-email-lookup.md
@@ -1,0 +1,222 @@
+# Customer Lookup by Email Address
+
+Status: implemented
+Scope: the access service worker, its control database, and the email normalization the two services already disagree about
+
+## 1. Problem
+
+Given an email address, there is no way to find the `did:key` it belongs to. Inviting someone by address, or checking whether an address is already known before offering to invite it, both need that direction and neither has it.
+
+The mapping exists. It is `customer.email → customer.did` in the access service's control database, written at `/customer/enroll`. Nothing exposes it, and nothing indexes it.
+
+## 2. Where the mapping lives
+
+Two databases hold an email-to-DID mapping, and the choice between them is not arbitrary.
+
+`tonk-accounts` (account service) holds `accounts.email → accounts.root_did`, the passkey identity registry. `tonk-access-control` (access service) holds `customer.email → customer.did`, the registration and billing state. The two DIDs are the same value: `customer.did` is the account root, as `rust/tonk-worker/src/router/customer.rs:35` states and enrollment enforces by invoking on the account link's issuer.
+
+The lookup reads the access service, for three reasons.
+
+It is already the `did:web` host. `/.well-known/did.json` is served there (`rust/tonk-access-service/src/service.rs:30`, routed at `lib.rs:79`), so a `did:web:tonk.network:...` name resolves to the same worker with no new deployment and no new domain.
+
+It is the only side that knows whether an address is confirmed. `customer.status` is `Registered | Active | Suspended`, and `verified` carries the activation timestamp. The `accounts` table has no equivalent, so a lookup rooted there could not distinguish an address someone claimed from one they proved control of.
+
+It already exposes customer state by DID at `GET /customer/:did` (`handlers/registration.rs:104`), so this is a second view of a registry that is public by design, not a new disclosure.
+
+An account that has a passkey but never enrolled has an `accounts` row and no `customer` row. Such an address resolves as unknown. That is correct: it has not been confirmed, so there is nothing to attest.
+
+## 3. The DID
+
+The address is encoded into the DID rather than hashed, following the split that `did:mailto` uses ([spec](https://github.com/storacha/specs/blob/main/did-mailto.md)) but under our own `did:web` name:
+
+```
+did:web:tonk.network:customer:example.com:jsmith
+```
+
+Domain first, then the local part percent-encoded per the `did:mailto` `idchar` rule: alphanumerics, `.`, `-`, and `_` pass through, everything else becomes `%XX`. So `tag+alice@web.mail` is `did:web:tonk.network:customer:web.mail:tag%2Balice`.
+
+An earlier draft hashed the address with blake3 to keep it out of the URL. That is abandoned. The input space is enumerable, so the hash bought no real secrecy, and it forced a stored hash column, a backfill script D1 could not express in SQL, and a nullable column where a missed row would be silently unfindable rather than loudly broken. Encoding the address instead makes the DID self-describing and the lookup a plain indexed equality match.
+
+The consequence is that the address is plaintext wherever one of these DIDs is written down: a delegation, an invite record, a log line, a browser history entry. This is accepted, and it is what makes the design honest, but it should be understood before these DIDs start appearing in stored UCAN chains.
+
+## 4. Resolution and the path
+
+`did:web` resolution maps the DID to `https://tonk.network/customer/example.com/jsmith/did.json`, percent-decoding each path segment as it builds the URL. The local part's own percent-encoding is decoded by that same step, so `tag%2Balice` arrives at the worker as the path segment `tag+alice`.
+
+A `+` in a path segment is legal and means `+`; it only means space in a query string. The handler must therefore read the raw path segment and must not run it through form decoding. A test pins an address containing `+`, end to end through the service.
+
+The route is `/customer/:domain/:local/did.json`. It does not collide with the existing single-segment `/customer/:did` probe, and `run_worker_first`'s `/customer/*` entry in `wrangler.toml` already covers it.
+
+## 5. One address, one customer
+
+`customer.email` gains a unique index. Registration has always been one
+account per address in practice, and the constraint is what lets the
+lookup answer with a single DID rather than a set.
+
+Normalization can create a duplicate where none was visible before, by
+merging two spellings of one address. The service has no production
+deployment, so the migration drops duplicates rather than reconciling
+them: the highest `rowid`, the most recently inserted, is kept, and the
+self-provided `consumer` rows of the dropped customers go with them,
+deleted first while the customers they name still exist.
+
+## 6. Normalization
+
+The address is the lookup key, so the two sides must agree on its spelling exactly. Today they do not.
+
+The account service normalizes to `trim().to_lowercase()` at `core/accounts.rs:93`, `core/codes.rs:43`, and `core/deletion.rs:32`. The access service only trims (`registration.rs:214`), storing whatever case the client sent. That is the form the codebase has otherwise settled on, so the access service adopts it.
+
+`customer.email` stores the normalized address. Not a raw address with a normalized key beside it: the column itself holds the normalized form, and the invariant is unconditional. `registration.rs:214` becomes `.trim().to_lowercase()`, and that value flows into both `enroll_customer` and `update_registered_email`. Existing rows are normalized by `UPDATE customer SET email = lower(trim(email))`, which is plain SQL and runs as part of the migration.
+
+Normalization is extracted as one shared helper so the writer and the lookup cannot drift.
+
+Two things follow. The comparison at `registration.rs:251` becomes normalized-against-normalized, which fixes a latent bug where re-enrolling as `Alice@x.com` after `alice@x.com` triggers a pointless `update_registered_email` write. And the address as originally typed is lost. This does not affect delivery, since `email.rs` sends to the stored value and no mail server in practice treats the local part as case-sensitive, but it means an outgoing `To:` header reads lowercase.
+
+Incoming path segments are normalized the same way before the query, so `Jsmith` and `jsmith` resolve identically despite being different URLs.
+
+## 7. Responses
+
+| Case | Status | Body |
+| --- | --- | --- |
+| `status = 'Active'` | 200 | DID document |
+| `status = 'Registered'` | 202 | DID document, plus `"status": "Registered"` |
+| `status = 'Suspended'` | 410 | DID document, plus `"deactivated": true` |
+| no row | 404 | error |
+| malformed DID path | 404 | error |
+
+`Registered` answers 202 rather than 200 because the address is claimed but not confirmed: the DID is real and worth returning, but a caller about to act on it should know the confirmation has not happened.
+
+`Suspended` answers 410 Gone rather than 403 or 404. The resource existed and is not currently available, which is what a suspension is, and unlike 403 it does not read as a permission failure on the caller's part. The document still comes back with `"deactivated": true`, matching DID Core deactivation semantics: a suspension is reversible, and discarding the key mapping would force every caller to re-resolve from scratch when it lifts. A suspended customer is therefore distinguishable from an unknown address, which is consistent with the address being in the URL to begin with.
+
+## 8. The document
+
+The key is embedded under the `did:web` name rather than referenced, so
+the document verifies standalone without a resolver having to dereference
+a second DID:
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/multikey/v1"
+  ],
+  "id": "did:web:tonk.network:customer:example.com:jsmith",
+  "alsoKnownAs": ["did:key:z6Mk..."],
+  "verificationMethod": [{
+    "id": "did:web:tonk.network:customer:example.com:jsmith#z6Mk...",
+    "type": "Multikey",
+    "controller": "did:web:tonk.network:customer:example.com:jsmith",
+    "publicKeyMultibase": "z6Mk..."
+  }],
+  "authentication": ["...#z6Mk..."],
+  "assertionMethod": ["...#z6Mk..."],
+  "status": "Active"
+}
+```
+
+`alsoKnownAs` carries the `did:key`, which is the form the rest of the
+system uses, so a caller need not rebuild it from the multibase. A
+`did:mailto` alias would assert an identity in a method we do not
+otherwise use, so there is none.
+
+`status` carries the registration state the status code already encodes,
+so a caller reading the body does not have to infer it. A suspended
+customer's document also carries `"deactivated": true`.
+
+The builder is shared with the service's own `/.well-known/did.json`
+document, so the two cannot drift in `@context` or verification-method
+shape.
+
+## 9. Changes
+
+**Migration** `migrations/0005_customer_email.sql` normalizes existing
+addresses, drops the duplicates that creates, and adds the unique index.
+`store/sqlite.rs` applies it as `user_version` 5, so the native store and
+D1 hold the same schema.
+
+**`email.rs`** gains `normalize_email`, the one definition of the stored
+spelling, which `registration.rs` now applies at enrollment.
+
+**`store.rs`** gains `customer_by_email` on the `Store` trait and
+`SELECT_CUSTOMER_BY_EMAIL`, implemented in both backends.
+
+**`lookup.rs`** holds the DID encoding, the address/segment round trip,
+and the resolution, generic over `Store`.
+
+**`service.rs`** gains `customer_document`, sharing a private `document`
+builder with `did_document`.
+
+**`handlers/lookup.rs`** binds it to D1 and shapes the answer, registered
+in `lib.rs` at `/customer/:domain/:local/did.json`, with a native twin in
+`helpers/server.rs` matched before the single-segment probe.
+
+**CORS** matches every other public route.
+
+Two bugs surfaced while testing, both in test-only code. The native
+server in `helpers/server.rs` built its host from `req.uri().authority()`,
+which is absent for the origin-form request line every real client sends,
+so it minted `did:web::...`; `request_host` now falls back to the `Host`
+header. The deployed worker was never affected: it reads `req.url()`,
+which reassembles the authority from that header, so `/.well-known/did.json`
+has always served the right host in production. The same fix applies to
+the native twin of that route, which had the bug. And the test harness
+matched captured activation emails by verbatim address, which stopped
+finding them once enrollment normalized before sending.
+
+## 10. Cache and rate limiting
+
+The two work together, and the order matters. A cached answer never
+reaches the worker, so it never counts against the limit: the cache
+absorbs repeat lookups of one address, and what reaches the limiter is
+closer to the distinct-address rate, which is the signal enumeration
+actually produces.
+
+**Only a settled answer is cacheable.** A `200` is stored in the
+Cloudflare cache and carries `Cache-Control: public, max-age=60` — long
+enough to absorb a burst, short enough that a suspension is not missed. A
+`202` and a `404` carry `no-store` and are stored nowhere. Both are about
+to change, and the change is what a caller polling an address is waiting
+on: an invite flow must not be told for a minute that the person it just
+invited is still unregistered. Setting the header matters as much as
+declining to store it, because the header is what browsers and
+intermediaries obey.
+
+**The limit is keyed by client IP** (`CF-Connecting-IP`), 60 per minute,
+declared as a `[[ratelimits]]` binding in every environment. Keying by
+address would not constrain walking a list of them, which is the thing
+worth limiting on an endpoint whose URL carries the address. A throttled
+caller gets `429` with `Retry-After: 60`.
+
+A limiter that cannot answer is logged and the request proceeds. The
+endpoint discloses nothing a caller could not already reach through the
+registration probe, so failing closed would cost more than it protects.
+
+## 11. Tests
+
+`lookup.rs` unit tests cover the encoding: the `did:mailto` split, the
+percent-encoding of a local part, normalization before encoding, the
+last-`@` split, the segment round trip (over `+`, a literal `%`, a `/`,
+non-ASCII, and the RFC-legal punctuation set), and the status each
+registration state maps to.
+
+Two encodings are correct but do not resolve, and the tests say so: an
+`@` inside a local part, and a `/`, which `did:web` resolution decodes
+back into a path separator. Both fail closed with a `404` rather than
+reaching the wrong customer, and both are vanishingly rare.
+
+`store/sqlite.rs` tests cover the schema: an address finds its customer,
+an unregistered address finds nothing, a second customer on one address
+is a conflict, the store matches exactly rather than normalizing, and a
+suspended customer is still found so the lookup can answer 410 with the
+key.
+
+`tests/lookup.rs` covers the wired service: the 200 and 202 answers, the
+move from one to the other on confirmation, 404 for an unknown address,
+resolution whatever the casing, a `+` in the local part surviving the
+path, the registration probe staying reachable beside the lookup, CORS,
+a DID built by a caller resolving to the customer it names, and the
+`Cache-Control` walk from `404` through `202` to `200`.
+
+The 410 answer is covered at the store level only. Nothing writes
+`Suspended` yet — no admin path exists — so the integration harness
+cannot produce one.

--- a/rust/tonk-access-service/migrations/0005_customer_email.sql
+++ b/rust/tonk-access-service/migrations/0005_customer_email.sql
@@ -1,0 +1,27 @@
+-- Lookup by email address: `did:web:{host}:customer:{domain}:{local}`
+-- resolves an address to its customer's `did:key`. The address is the
+-- lookup key, so its stored spelling has to be the one a caller can
+-- reconstruct: normalize existing rows to the `trim().to_lowercase()`
+-- form the account service already writes, then make the address unique.
+--
+-- One address holds one customer. Registration has always worked that
+-- way in practice; the constraint is what makes the lookup able to
+-- answer with a single DID rather than a set.
+UPDATE customer SET email = lower(trim(email));
+
+-- Normalization can merge two spellings of one address into a duplicate,
+-- and nothing before now forbade one. This service has no production
+-- deployment, so duplicates are dropped rather than reconciled: the
+-- highest rowid, the most recently inserted, is kept.
+--
+-- The self-provided consumer rows of dropped customers go with them.
+-- They are deleted first, while the customers they name still exist.
+DELETE FROM consumer WHERE provider IN (
+  SELECT did FROM customer
+   WHERE rowid NOT IN (SELECT max(rowid) FROM customer GROUP BY email)
+);
+
+DELETE FROM customer
+ WHERE rowid NOT IN (SELECT max(rowid) FROM customer GROUP BY email);
+
+CREATE UNIQUE INDEX customer_email ON customer(email);

--- a/rust/tonk-access-service/src/email.rs
+++ b/rust/tonk-access-service/src/email.rs
@@ -7,6 +7,25 @@
 
 use async_trait::async_trait;
 
+/// The stored spelling of an email address.
+///
+/// The address is a lookup key -- `did:web:{host}:customer:{domain}:{local}`
+/// resolves one to a customer -- so the form written at enrollment has to
+/// be the one a caller can reconstruct from the address they hold. Every
+/// write and every lookup passes through here, so the two cannot drift.
+///
+/// This is the form the account service already stores (see its
+/// `core::accounts` and `core::deletion`), so both databases agree on
+/// what one address looks like.
+///
+/// Case folding is ASCII-only and the local part is folded along with
+/// the domain. RFC 5321 makes the local part case-sensitive, but no mail
+/// provider in practice treats it that way, and folding it is what makes
+/// an address one key rather than several.
+pub fn normalize_email(address: &str) -> String {
+    address.trim().to_lowercase()
+}
+
 /// Errors surfaced by an [`EmailSender`] implementation.
 #[derive(Debug)]
 pub enum EmailError {

--- a/rust/tonk-access-service/src/handlers.rs
+++ b/rust/tonk-access-service/src/handlers.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod deletion;
 pub mod health;
 pub mod info;
+pub mod lookup;
 pub mod registration;
 pub mod revoke;
 pub mod shortcut;

--- a/rust/tonk-access-service/src/handlers/lookup.rs
+++ b/rust/tonk-access-service/src/handlers/lookup.rs
@@ -1,0 +1,171 @@
+//! Worker-side glue for the email lookup.
+//!
+//! The logic lives in [`crate::lookup`], generic over storage; this
+//! module binds it to D1 and shapes the HTTP answer. See that module for
+//! the DID form and why the address is encoded rather than hashed.
+
+use worker::{Request, Response, RouteContext};
+
+/// The `Cache-Control` a settled answer carries.
+///
+/// A customer's registration state changes, so even a settled answer is
+/// cacheable only briefly: a minute keeps a burst of lookups off D1
+/// without letting a suspension go unnoticed for long.
+#[cfg(target_arch = "wasm32")]
+const CACHE_CONTROL: &str = "public, max-age=60";
+
+/// The `Cache-Control` an unsettled answer carries.
+///
+/// A `202` says the customer has not confirmed their address yet, and a
+/// `404` that nobody has claimed it. Both are about to change, and the
+/// change is what the caller is waiting on: an invite flow polling an
+/// address must not be told for a minute that the person it just invited
+/// is still unregistered. Storing nothing our own side is not enough,
+/// because this header is what browsers and intermediaries obey.
+#[cfg(target_arch = "wasm32")]
+const NO_CACHE: &str = "no-store";
+
+/// The rate limit binding, declared in `wrangler.toml`.
+#[cfg(target_arch = "wasm32")]
+const LIMITER: &str = "LOOKUP_LIMITER";
+
+/// What a throttled caller is told to wait, matching the binding's
+/// period. The limiter is a fixed window, so this is an upper bound.
+#[cfg(target_arch = "wasm32")]
+const RETRY_AFTER: &str = "60";
+
+/// GET `/customer/:domain/:local/did.json` → the DID document for an
+/// email address.
+///
+/// `404` when nothing is registered under the address, or when the path
+/// segments do not form one: an address nobody registered and an address
+/// that cannot exist are the same fact to a caller.
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn handle(_req: Request, _ctx: RouteContext<()>) -> worker::Result<Response> {
+    Response::error("Not Found", 404)
+}
+
+/// GET `/customer/:domain/:local/did.json` (worker body; see the native
+/// twin above, and the helpers server for the native implementation).
+#[cfg(target_arch = "wasm32")]
+pub async fn handle(req: Request, ctx: RouteContext<()>) -> worker::Result<Response> {
+    use crate::lookup::{address_from_segments, customer_did, resolve};
+    use crate::store::d1::D1Store;
+    use worker::Cache;
+
+    // A cached answer skips both the limiter and D1. That is the right
+    // order: repeat lookups of one address are absorbed here, so what
+    // reaches the limiter below is closer to the distinct-address rate,
+    // which is the signal enumeration actually produces.
+    let cache = Cache::default();
+    if let Ok(Some(hit)) = cache.get(&req, false).await {
+        return Ok(hit);
+    }
+
+    // Keyed by caller, not by address: a budget that reset per address
+    // would not constrain walking a list of them, which is the thing
+    // worth limiting on an endpoint whose URL carries the address.
+    if let Ok(limiter) = ctx.env.rate_limiter(LIMITER) {
+        let caller = req
+            .headers()
+            .get("CF-Connecting-IP")
+            .ok()
+            .flatten()
+            .unwrap_or_default();
+        match limiter.limit(caller).await {
+            Ok(outcome) if !outcome.success => return throttled(),
+            Ok(_) => {}
+            // A limiter that cannot answer must not take the endpoint
+            // down with it; the lookup discloses nothing a caller could
+            // not reach through the registration probe anyway.
+            Err(err) => worker::console_error!("lookup rate limit unavailable: {err}"),
+        }
+    }
+
+    // Segments are read raw. `did:web` resolution already percent-decoded
+    // them, and the router hands them over untouched, so a `+` in a local
+    // part stays a `+` rather than becoming a space.
+    let (Some(domain), Some(local)) = (ctx.param("domain"), ctx.param("local")) else {
+        return not_found();
+    };
+    let Some(address) = address_from_segments(domain, local) else {
+        return not_found();
+    };
+
+    let store = match ctx.env.d1("CONTROL") {
+        Ok(database) => D1Store::new(database),
+        Err(err) => {
+            worker::console_error!("email lookup unavailable, no CONTROL binding: {err}");
+            return with_cors(Response::error("Customer registry is not configured", 500));
+        }
+    };
+
+    let host = req
+        .url()?
+        .host_str()
+        .map(ToString::to_string)
+        .unwrap_or_default();
+    let Some(did) = customer_did(&host, &address) else {
+        return not_found();
+    };
+
+    match resolve(&store, &did, &address).await {
+        Ok(Some(found)) => {
+            let response = Response::from_json(&found.document)?.with_status(found.status);
+            let mut response = with_cors(Ok(response))?;
+            // Only a settled answer is cacheable, by us or by anyone
+            // downstream. A `202` is by definition about to change, and
+            // holding it would leave an activated customer reading as
+            // unconfirmed until the entry aged out.
+            let settled = found.status == 200;
+            response.headers_mut().set(
+                "Cache-Control",
+                if settled { CACHE_CONTROL } else { NO_CACHE },
+            )?;
+            if settled {
+                let stored = response.cloned()?;
+                cache.put(&req, stored).await?;
+            }
+            Ok(response)
+        }
+        Ok(None) => not_found(),
+        Err(err) => {
+            worker::console_error!("email lookup failed: {err}");
+            with_cors(Response::error("Customer registry is unavailable", 500))
+        }
+    }
+}
+
+/// The answer for a caller over their budget.
+#[cfg(target_arch = "wasm32")]
+fn throttled() -> worker::Result<Response> {
+    let mut response = with_cors(
+        Response::from_json(&serde_json::json!({ "error": "too many lookups" }))
+            .map(|response| response.with_status(429)),
+    )?;
+    response.headers_mut().set("Retry-After", RETRY_AFTER)?;
+    Ok(response)
+}
+
+/// The answer for an address no customer holds, and for a path that does
+/// not form an address.
+#[cfg(target_arch = "wasm32")]
+fn not_found() -> worker::Result<Response> {
+    let mut response = with_cors(
+        Response::from_json(&serde_json::json!({ "error": "no customer for this address" }))
+            .map(|response| response.with_status(404)),
+    )?;
+    response.headers_mut().set("Cache-Control", NO_CACHE)?;
+    Ok(response)
+}
+
+/// Attach the permissive CORS header every public route on this service
+/// answers with; the invite flow calls this one from the browser.
+#[cfg(target_arch = "wasm32")]
+fn with_cors(response: worker::Result<Response>) -> worker::Result<Response> {
+    let mut response = response?;
+    response
+        .headers_mut()
+        .set("Access-Control-Allow-Origin", "*")?;
+    Ok(response)
+}

--- a/rust/tonk-access-service/src/helpers.rs
+++ b/rust/tonk-access-service/src/helpers.rs
@@ -69,11 +69,35 @@ impl AccessServiceAddress {
         Ok(())
     }
 
+    /// Enroll `customer` under `email`, leaving it `Registered`: the
+    /// address is claimed, and the activation email is waiting in the
+    /// test inbox. [`Self::activate_customer`] is this plus confirming
+    /// it; a test that wants a customer stopped short of confirmation
+    /// wants this one.
+    pub async fn enroll_customer(
+        &self,
+        customer: &dialog_credentials::Ed25519Signer,
+        email: &str,
+    ) -> anyhow::Result<()> {
+        self.enroll_only(customer, email).await
+    }
+
     /// Enroll `customer` and confirm its email, leaving it `Active` and
     /// providing its own account space. Returns once the service has
     /// recorded the activation, so a presign on `customer`'s subject
     /// immediately afterwards is served.
     pub async fn activate_customer(
+        &self,
+        customer: &dialog_credentials::Ed25519Signer,
+        email: &str,
+    ) -> anyhow::Result<()> {
+        self.enroll_only(customer, email).await?;
+        self.confirm_email(email).await
+    }
+
+    /// The enrollment half of the ceremony: mint a device delegation and
+    /// the service deposits, and invoke `/customer/enroll`.
+    async fn enroll_only(
         &self,
         customer: &dialog_credentials::Ed25519Signer,
         email: &str,
@@ -116,9 +140,15 @@ impl AccessServiceAddress {
             response.status(),
             response.text().await.unwrap_or_default()
         );
+        Ok(())
+    }
 
-        // The emailed link carries a complete service-signed invocation;
-        // presenting it is activating.
+    /// The confirmation half: present the invocation the activation email
+    /// carries. It is complete and service-signed, so presenting it is
+    /// activating and no key is needed here.
+    async fn confirm_email(&self, email: &str) -> anyhow::Result<()> {
+        let client = reqwest::Client::new();
+        let endpoint = self.ucan_endpoint();
         let inbox: Vec<(String, String)> = client
             .get(format!(
                 "{}/_test/emails",
@@ -128,10 +158,14 @@ impl AccessServiceAddress {
             .await?
             .json()
             .await?;
+        // Enrollment normalizes the address before storing and sending,
+        // so the inbox is keyed by the normalized form: matching the
+        // caller's spelling verbatim would miss a mixed-case address.
+        let normalized = crate::email::normalize_email(email);
         let (_, link) = inbox
             .into_iter()
             .rev()
-            .find(|(to, _)| to == email)
+            .find(|(to, _)| crate::email::normalize_email(to) == normalized)
             .ok_or_else(|| anyhow::anyhow!("no activation email was captured for {email}"))?;
         let encoded = link
             .split_once("ucan=")

--- a/rust/tonk-access-service/src/helpers/server.rs
+++ b/rust/tonk-access-service/src/helpers/server.rs
@@ -213,6 +213,27 @@ impl AccessServer {
     }
 }
 
+/// The host this request was addressed to.
+///
+/// A client sends an origin-form request line, the path alone, and
+/// carries the host in the `Host` header, so the URI's own authority is
+/// absent for every real request. The worker reads `req.url()`, which
+/// reassembles the two; natively the header is the only source, and
+/// falling back to an empty authority would mint `did:web::...`.
+fn request_host(req: &Request<Incoming>) -> String {
+    req.uri()
+        .authority()
+        .map(ToString::to_string)
+        .or_else(|| {
+            req.headers()
+                .get(hyper::header::HOST)?
+                .to_str()
+                .ok()
+                .map(ToString::to_string)
+        })
+        .unwrap_or_default()
+}
+
 /// Handle an incoming UCAN access service request.
 ///
 /// This implements the same logic as the Cloudflare Worker handler:
@@ -220,6 +241,9 @@ impl AccessServer {
 /// - PUT /@ → Store a shortcut target, respond with its hash
 /// - GET /@/{hash} → Permanent relative redirect to the stored target
 /// - GET /.well-known/tonk → Deployment configuration, when configured
+/// - GET /.well-known/did.json → The service's own DID document
+/// - GET /customer/{domain}/{local}/did.json → The DID document for an
+///   email address
 /// - OPTIONS → CORS preflight
 async fn handle_request(
     req: Request<Incoming>,
@@ -272,12 +296,7 @@ async fn handle_request(
         return Ok(cors_response(response));
     }
     if req.method() == Method::GET && req.uri().path() == "/.well-known/did.json" {
-        let host = req
-            .uri()
-            .authority()
-            .map(ToString::to_string)
-            .unwrap_or_default();
-        let document = did_document(&host, &registration.service);
+        let document = did_document(&request_host(&req), &registration.service);
         return Ok(cors_response(
             Response::builder()
                 .status(StatusCode::OK)
@@ -364,6 +383,59 @@ async fn handle_request(
                 )))
                 .unwrap(),
         ));
+    }
+    // Lookup by email address. Mirrors the Worker handler, and is matched
+    // before the probe below: that one strips `/customer/` and treats the
+    // whole remainder as a DID, so it would otherwise swallow this path.
+    if req.method() == Method::GET
+        && let Some(rest) = req.uri().path().strip_prefix("/customer/")
+        && let Some(segments) = rest.strip_suffix("/did.json")
+        && let Some((domain, local)) = segments.split_once('/')
+        && !local.contains('/')
+    {
+        use crate::lookup::{address_from_segments, customer_did, resolve};
+
+        let host = request_host(&req);
+        let found = match address_from_segments(domain, local) {
+            Some(address) => match customer_did(&host, &address) {
+                Some(did) => resolve(&registration.store, &did, &address).await,
+                None => Ok(None),
+            },
+            None => Ok(None),
+        };
+        let response = match found {
+            // Only a settled answer is cacheable: a 202 and a 404 are
+            // both about to change, and the change is what a caller
+            // polling an address is waiting on.
+            Ok(Some(found)) => Response::builder()
+                .status(StatusCode::from_u16(found.status).expect("lookup status is valid"))
+                .header(CONTENT_TYPE, "application/json")
+                .header(
+                    "Cache-Control",
+                    if found.status == 200 {
+                        "public, max-age=60"
+                    } else {
+                        "no-store"
+                    },
+                )
+                .body(Full::new(Bytes::from(
+                    serde_json::to_vec(&found.document).expect("did document serializes"),
+                )))
+                .unwrap(),
+            Ok(None) => Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .header(CONTENT_TYPE, "application/json")
+                .header("Cache-Control", "no-store")
+                .body(Full::new(Bytes::from(
+                    r#"{"error":"no customer for this address"}"#,
+                )))
+                .unwrap(),
+            Err(_) => Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(Full::new(Bytes::from("Customer registry is unavailable")))
+                .unwrap(),
+        };
+        return Ok(cors_response(response));
     }
     // Registration state probe, polled by enrolling clients. Mirrors the
     // Worker handler.

--- a/rust/tonk-access-service/src/lib.rs
+++ b/rust/tonk-access-service/src/lib.rs
@@ -46,6 +46,7 @@ pub mod deletion;
 pub mod email;
 mod error;
 mod handlers;
+pub mod lookup;
 pub mod metering;
 pub mod provisioning;
 pub mod registration;
@@ -81,6 +82,13 @@ async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
         )
         // Registration state probe, polled by enrolling clients.
         .get_async("/customer/:did", handlers::registration::handle_customer)
+        // Lookup by email address: the `did:web` document naming the
+        // customer registered under one. Two segments, so it does not
+        // collide with the single-segment probe above.
+        .get_async(
+            "/customer/:domain/:local/did.json",
+            handlers::lookup::handle,
+        )
         // Service info endpoint
         .get_async("/", handlers::info::handle)
         // Health check

--- a/rust/tonk-access-service/src/lookup.rs
+++ b/rust/tonk-access-service/src/lookup.rs
@@ -1,0 +1,305 @@
+//! Lookup of customers by email address.
+//!
+//! An address names the customers registered under it through a `did:web`
+//! DID under this service's host:
+//!
+//! ```text
+//! did:web:tonk.network:customer:example.com:jsmith
+//! ```
+//!
+//! The split follows [`did:mailto`][spec] — domain first, then the local
+//! part percent-encoded — but under our own `did:web` name, so it
+//! resolves through ordinary `did:web` resolution to this service:
+//!
+//! ```text
+//! GET https://tonk.network/customer/example.com/jsmith/did.json
+//! ```
+//!
+//! [spec]: https://github.com/storacha/specs/blob/main/did-mailto.md
+//!
+//! The address is encoded rather than hashed. Hashing it would keep the
+//! plaintext out of the URL, but the input space is enumerable, so the
+//! obscurity is thin, and it would force a stored hash column that D1
+//! cannot backfill in SQL and where a missed row is silently unfindable.
+//! The cost of encoding is that the address is plaintext wherever one of
+//! these DIDs is written down — a delegation, a log line, a browser
+//! history entry.
+//!
+//! One address holds one customer: `customer_email` is unique.
+
+use serde_json::Value;
+
+use crate::email::normalize_email;
+use crate::service::customer_document;
+use crate::store::{Store, StoreError};
+use tonk_account::customer::CustomerStatus;
+
+/// The path segment the customer namespace lives under, in both the DID
+/// (`did:web:{host}:customer:...`) and the URL it resolves to
+/// (`/customer/...`).
+pub const CUSTOMER_SEGMENT: &str = "customer";
+
+/// Characters that pass through a `did:mailto` local part unencoded.
+/// Everything else becomes `%XX`. From the spec's `idchar` rule.
+fn is_idchar(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_')
+}
+
+/// Percent-encode a local part per the `did:mailto` `idchar` rule.
+pub fn encode_local(local: &str) -> String {
+    let mut encoded = String::with_capacity(local.len());
+    for byte in local.bytes() {
+        if is_idchar(byte) {
+            encoded.push(byte as char);
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
+}
+
+/// The `did:web` DID naming the customers registered under `address`,
+/// under this service's `host`.
+///
+/// The address is normalized first, so two spellings of one address
+/// produce one DID.
+pub fn customer_did(host: &str, address: &str) -> Option<String> {
+    let address = normalize_email(address);
+    let (local, domain) = split_address(&address)?;
+    Some(format!(
+        "did:web:{host}:{CUSTOMER_SEGMENT}:{domain}:{}",
+        encode_local(local)
+    ))
+}
+
+/// Split a normalized address into its local part and domain at the last
+/// `@`, which is the separator RFC 5322 designates. `None` when either
+/// side is empty or there is no `@` at all.
+fn split_address(address: &str) -> Option<(&str, &str)> {
+    let (local, domain) = address.rsplit_once('@')?;
+    (!local.is_empty() && !domain.is_empty()).then_some((local, domain))
+}
+
+/// Rebuild an address from the `{domain}` and `{local}` path segments of
+/// a resolved `did:web` URL.
+///
+/// `did:web` resolution percent-decodes each path segment as it builds
+/// the URL, and the local part's own encoding is that same encoding, so
+/// the segments arrive here already decoded: `tag%2Balice` reaches the
+/// worker as `tag+alice`. The segments are therefore used as given, and
+/// must be read raw — running them through form decoding would turn that
+/// `+` into a space and the lookup would miss.
+///
+/// The result is normalized, so a DID spelled with different casing than
+/// the stored row still resolves to it.
+pub fn address_from_segments(domain: &str, local: &str) -> Option<String> {
+    (!domain.is_empty() && !local.is_empty() && !domain.contains('@') && !local.contains('@'))
+        .then(|| normalize_email(&format!("{local}@{domain}")))
+}
+
+/// The HTTP status a customer's registration state answers with.
+///
+/// `Registered` answers `202` rather than `200` because the address is
+/// claimed but not confirmed: the DID is real and worth returning, but a
+/// caller about to act on it should know the confirmation has not
+/// happened. `Suspended` answers `410` because the resource existed and
+/// is not currently available, which is what a suspension is, and unlike
+/// `403` it does not read as a permission failure on the caller's part.
+pub fn status_of(status: CustomerStatus) -> u16 {
+    match status {
+        CustomerStatus::Active => 200,
+        CustomerStatus::Registered => 202,
+        CustomerStatus::Suspended => 410,
+    }
+}
+
+/// A resolved lookup: the document to answer with, and its status code.
+#[derive(Debug, Clone)]
+pub struct Found {
+    /// The DID document naming the customer on the address.
+    pub document: Value,
+    /// The status to answer with, fixed by the customer's state.
+    pub status: u16,
+}
+
+/// Resolve `address` against `store`, building the document for `did`.
+///
+/// `Ok(None)` when no customer holds the address, which the caller
+/// answers as `404`: an address nobody registered and an address that
+/// does not exist are the same fact.
+pub async fn resolve<S: Store>(
+    store: &S,
+    did: &str,
+    address: &str,
+) -> Result<Option<Found>, StoreError> {
+    let Some(customer) = store.customer_by_email(address).await? else {
+        return Ok(None);
+    };
+    let suspended = customer.status == CustomerStatus::Suspended;
+    Ok(Some(Found {
+        document: customer_document(did, &customer, suspended),
+        status: status_of(customer.status),
+    }))
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+
+    #[dialog_common::test]
+    fn it_encodes_an_address_as_a_did() {
+        assert_eq!(
+            customer_did("tonk.network", "jsmith@example.com").unwrap(),
+            "did:web:tonk.network:customer:example.com:jsmith"
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_percent_encodes_a_local_part() {
+        assert_eq!(
+            customer_did("tonk.network", "tag+alice@web.mail").unwrap(),
+            "did:web:tonk.network:customer:web.mail:tag%2Balice"
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_normalizes_before_encoding() {
+        assert_eq!(
+            customer_did("tonk.network", "  JSmith@Example.COM ").unwrap(),
+            customer_did("tonk.network", "jsmith@example.com").unwrap()
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_refuses_an_address_without_a_local_part_or_domain() {
+        assert!(customer_did("tonk.network", "jsmith").is_none());
+        assert!(customer_did("tonk.network", "@example.com").is_none());
+        assert!(customer_did("tonk.network", "jsmith@").is_none());
+    }
+
+    #[dialog_common::test]
+    fn it_splits_at_the_last_at_sign() {
+        // RFC 5322 quotes a local part containing `@`; the domain never
+        // holds one, so the last is the separator.
+        assert_eq!(
+            split_address("a@b@example.com").unwrap(),
+            ("a@b", "example.com")
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_rebuilds_an_address_from_decoded_segments() {
+        // `tag%2Balice` reaches the worker already decoded.
+        assert_eq!(
+            address_from_segments("web.mail", "tag+alice").unwrap(),
+            "tag+alice@web.mail"
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_round_trips_an_address_through_a_did() {
+        for address in [
+            "jsmith@example.com",
+            "tag+alice@web.mail",
+            "a.b-c_d@sub.example.org",
+            // A literal `%`, which encodes to `%25`. Decoding it twice
+            // would yield a stray `%` and lose the rest of the segment.
+            "a%b@example.com",
+            // A `/`, which would otherwise open a path segment and take
+            // the route apart.
+            "a/b@example.com",
+            // Byte-wise encoding over UTF-8, so a non-ASCII local part
+            // survives as its encoded bytes.
+            "josé@example.com",
+            "!#$&'*=?^`{|}~@example.com",
+        ] {
+            let did = customer_did("tonk.network", address).unwrap();
+            let encoded = did.rsplit(':').next().unwrap();
+            // Resolution decodes the segment before it reaches us.
+            let decoded = percent_decode(encoded);
+            let domain = did.split(':').nth(4).unwrap();
+            assert_eq!(
+                address_from_segments(domain, &decoded).unwrap(),
+                address,
+                "round trip failed for {address}"
+            );
+        }
+    }
+
+    #[dialog_common::test]
+    fn it_normalizes_rebuilt_segments() {
+        assert_eq!(
+            address_from_segments("Example.COM", "JSmith").unwrap(),
+            "jsmith@example.com"
+        );
+    }
+
+    /// A `/` in a local part encodes to `%2F`, so the DID keeps one
+    /// segment for the local part. Leaving it raw would split the path
+    /// and route the request somewhere else entirely.
+    #[dialog_common::test]
+    fn it_encodes_a_separator_that_would_break_the_path() {
+        let did = customer_did("tonk.network", "a/b@example.com").unwrap();
+        assert_eq!(did, "did:web:tonk.network:customer:example.com:a%2Fb");
+        assert!(
+            !did.trim_start_matches("did:web:tonk.network:")
+                .contains('/'),
+            "no raw separator survives into the DID"
+        );
+    }
+
+    /// A literal `%` encodes to `%25`, so one decoding pass returns the
+    /// `%` itself rather than consuming the two characters after it.
+    #[dialog_common::test]
+    fn it_encodes_a_literal_percent() {
+        assert_eq!(
+            customer_did("tonk.network", "a%b@example.com").unwrap(),
+            "did:web:tonk.network:customer:example.com:a%25b"
+        );
+    }
+
+    /// An address whose local part holds a quoted `@` encodes, but does
+    /// not resolve: the rebuilt segments refuse an `@` because it would
+    /// make the split ambiguous. Encoding and resolution disagree here,
+    /// and the disagreement is deliberate -- such an address is
+    /// vanishingly rare, and refusing it is better than resolving it to
+    /// the wrong customer.
+    #[dialog_common::test]
+    fn it_does_not_resolve_an_at_sign_inside_a_local_part() {
+        assert!(customer_did("tonk.network", "a@b@example.com").is_some());
+        assert!(address_from_segments("example.com", "a@b").is_none());
+    }
+
+    #[dialog_common::test]
+    fn it_refuses_empty_or_malformed_segments() {
+        assert!(address_from_segments("", "jsmith").is_none());
+        assert!(address_from_segments("example.com", "").is_none());
+        assert!(address_from_segments("exa@mple.com", "jsmith").is_none());
+    }
+
+    /// Stands in for the percent-decoding `did:web` resolution performs
+    /// on each path segment before the request reaches this service.
+    fn percent_decode(segment: &str) -> String {
+        let bytes = segment.as_bytes();
+        let mut decoded = Vec::with_capacity(bytes.len());
+        let mut index = 0;
+        while index < bytes.len() {
+            if bytes[index] == b'%' && index + 2 < bytes.len() {
+                let hex = std::str::from_utf8(&bytes[index + 1..index + 3]).unwrap();
+                decoded.push(u8::from_str_radix(hex, 16).unwrap());
+                index += 3;
+            } else {
+                decoded.push(bytes[index]);
+                index += 1;
+            }
+        }
+        String::from_utf8(decoded).unwrap()
+    }
+
+    #[dialog_common::test]
+    fn it_maps_each_registration_state_to_its_status() {
+        assert_eq!(status_of(CustomerStatus::Active), 200);
+        assert_eq!(status_of(CustomerStatus::Registered), 202);
+        assert_eq!(status_of(CustomerStatus::Suspended), 410);
+    }
+}

--- a/rust/tonk-access-service/src/registration.rs
+++ b/rust/tonk-access-service/src/registration.rs
@@ -38,7 +38,7 @@ use tonk_account::customer::{
     Receipt, RegistrationError, deposit_scopes,
 };
 
-use crate::email::EmailSender;
+use crate::email::{EmailSender, normalize_email};
 use crate::store::{SIGNUP_PLAN, Store, StoreError};
 use dialog_ucan_core::revocation::RevocationChecker;
 use dialog_ucan_core::{Environment, VerificationContext};
@@ -211,7 +211,7 @@ impl<S: Store, E: EmailSender, R: RevocationChecker + ConditionalSync> Registrat
     ) -> Result<Receipt, RegistrationError> {
         let customer = capability.subject().clone();
         let effect = capability.into_effect();
-        let address = effect.email.trim().to_string();
+        let address = normalize_email(&effect.email);
         if !address.contains('@') || address.len() > 254 {
             return Err(RegistrationError::Invalid {
                 message: "email must be a plausible address".to_string(),

--- a/rust/tonk-access-service/src/service.rs
+++ b/rust/tonk-access-service/src/service.rs
@@ -13,6 +13,8 @@ use dialog_varsig::Principal;
 use ed25519_dalek::SigningKey;
 use serde_json::{Value, json};
 
+use crate::store::Customer;
+
 /// Build the service signer from its hex-encoded 32-byte seed.
 pub fn signer_from_hex(seed_hex: &str) -> Result<Ed25519Signer, String> {
     let bytes = hex::decode(seed_hex.trim())
@@ -23,33 +25,76 @@ pub fn signer_from_hex(seed_hex: &str) -> Result<Ed25519Signer, String> {
     Ok(Ed25519Signer::from(SigningKey::from_bytes(&seed)))
 }
 
-/// The DID document for `did:web:{host}`, carrying the service's ed25519
-/// key as a `Multikey` verification method. The multibase key is the
-/// `did:key` identifier's method-specific part, so the two names verify
-/// against the same key.
-pub fn did_document(host: &str, signer: &Ed25519Signer) -> Value {
-    let id = format!("did:web:{host}");
-    let did_key = signer.did().to_string();
-    let multibase = did_key
-        .strip_prefix("did:key:")
-        .unwrap_or(&did_key)
-        .to_string();
-    let method = format!("{id}#{multibase}");
+/// The multibase key of a `did:key`, which is its method-specific part.
+/// A DID that is not a `did:key` has none.
+fn multibase_of(did_key: &str) -> Option<&str> {
+    did_key.strip_prefix("did:key:")
+}
+
+/// A DID document for `id`, carrying every `did:key` in `keys` as a
+/// `Multikey` verification method under that name.
+///
+/// Keys are embedded rather than referenced: each method is identified by
+/// `{id}#{multibase}` and controlled by `id`, so the document verifies
+/// standalone without a resolver having to dereference a second DID. The
+/// multibase is the `did:key` identifier's method-specific part, so a
+/// name here and the `did:key` it came from verify against one key.
+///
+/// A key that is not a `did:key` is skipped: there is no multibase to
+/// publish, and emitting a method without key material would produce a
+/// document that resolves but cannot verify anything.
+fn document(id: &str, keys: impl IntoIterator<Item = String>) -> Value {
+    let methods: Vec<Value> = keys
+        .into_iter()
+        .filter_map(|did_key| {
+            let multibase = multibase_of(&did_key)?;
+            Some(json!({
+                "id": format!("{id}#{multibase}"),
+                "type": "Multikey",
+                "controller": id,
+                "publicKeyMultibase": multibase
+            }))
+        })
+        .collect();
+    let references: Vec<Value> = methods.iter().map(|method| method["id"].clone()).collect();
     json!({
         "@context": [
             "https://www.w3.org/ns/did/v1",
             "https://w3id.org/security/multikey/v1"
         ],
         "id": id,
-        "verificationMethod": [{
-            "id": method,
-            "type": "Multikey",
-            "controller": id,
-            "publicKeyMultibase": multibase
-        }],
-        "authentication": [method],
-        "assertionMethod": [method]
+        "verificationMethod": methods,
+        "authentication": references,
+        "assertionMethod": references
     })
+}
+
+/// The DID document for `did:web:{host}`, carrying the service's ed25519
+/// key.
+pub fn did_document(host: &str, signer: &Ed25519Signer) -> Value {
+    let id = format!("did:web:{host}");
+    document(&id, [signer.did().to_string()])
+}
+
+/// The DID document for an email address, carrying the `did:key` of the
+/// customer registered under it.
+///
+/// The key is embedded under the `did:web` name rather than referenced,
+/// so the document verifies standalone. `alsoKnownAs` names the same key
+/// as a `did:key`, which is the form the rest of the system uses, so a
+/// caller need not rebuild it from the multibase.
+///
+/// `deactivated` marks a suspended customer. The key stays in the
+/// document: a suspension is reversible, and dropping the mapping would
+/// make a resumed customer unresolvable to anyone holding the old answer.
+pub fn customer_document(id: &str, customer: &Customer, deactivated: bool) -> Value {
+    let mut document = document(id, [customer.did.clone()]);
+    document["alsoKnownAs"] = json!([customer.did]);
+    document["status"] = json!(customer.status.as_str());
+    if deactivated {
+        document["deactivated"] = Value::Bool(true);
+    }
+    document
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]

--- a/rust/tonk-access-service/src/store.rs
+++ b/rust/tonk-access-service/src/store.rs
@@ -149,6 +149,15 @@ pub trait Store {
     /// Look up a customer by DID.
     async fn customer(&self, did: &str) -> Result<Option<Customer>, StoreError>;
 
+    /// Look up the customer registered under a normalized email address.
+    /// The address must already be in
+    /// [`normalize_email`](crate::email::normalize_email) form; this does
+    /// not normalize it, because a caller that skipped normalization has
+    /// a bug the lookup should not paper over.
+    ///
+    /// At most one customer holds an address: `customer_email` is unique.
+    async fn customer_by_email(&self, email: &str) -> Result<Option<Customer>, StoreError>;
+
     /// Look up a consumer by DID.
     async fn consumer(&self, did: &str) -> Result<Option<Consumer>, StoreError>;
 
@@ -214,6 +223,12 @@ pub trait Store {
 pub const SELECT_CUSTOMER: &str = r#"
 SELECT did, email, status, plan, verified, terms_version
   FROM customer WHERE did = ?1
+"#;
+
+/// Lookup by address, which `customer_email` makes unique.
+pub const SELECT_CUSTOMER_BY_EMAIL: &str = r#"
+SELECT did, email, status, plan, verified, terms_version
+  FROM customer WHERE email = ?1
 "#;
 
 pub const SELECT_CONSUMER: &str = r#"

--- a/rust/tonk-access-service/src/store/d1.rs
+++ b/rust/tonk-access-service/src/store/d1.rs
@@ -16,8 +16,8 @@ use crate::store::{
     ACTIVATE_CUSTOMER, ADD_CONSUMER, ANONYMIZE_DELETED_CONSUMERS, Consumer, ConsumerDeletionState,
     ConsumerKind, Customer, DELETE_CUSTOMER, DELETE_SELF_CONSUMER, FINISH_CONSUMER_DELETION,
     INSERT_CUSTOMER, INSERT_SELF_CONSUMER, MARK_CONSUMER_DELETING, MARK_SELF_CONSUMER_DELETING,
-    SELECT_CONSUMER, SELECT_CONSUMERS_BY_OWNER, SELECT_CUSTOMER, Store, StoreError,
-    UPDATE_REGISTERED_EMAIL, parse_status,
+    SELECT_CONSUMER, SELECT_CONSUMERS_BY_OWNER, SELECT_CUSTOMER, SELECT_CUSTOMER_BY_EMAIL, Store,
+    StoreError, UPDATE_REGISTERED_EMAIL, parse_status,
 };
 
 /// Cloudflare D1-backed [`Store`], for production use.
@@ -104,6 +104,18 @@ impl Store for D1Store {
             .0
             .prepare(SELECT_CUSTOMER)
             .bind(&[JsValue::from(did)])
+            .map_err(map_err)?
+            .first(None)
+            .await
+            .map_err(map_err)?;
+        row.map(Customer::try_from).transpose()
+    }
+
+    async fn customer_by_email(&self, email: &str) -> Result<Option<Customer>, StoreError> {
+        let row: Option<CustomerRowD1> = self
+            .0
+            .prepare(SELECT_CUSTOMER_BY_EMAIL)
+            .bind(&[JsValue::from(email)])
             .map_err(map_err)?
             .first(None)
             .await

--- a/rust/tonk-access-service/src/store/sqlite.rs
+++ b/rust/tonk-access-service/src/store/sqlite.rs
@@ -11,8 +11,8 @@ use super::{
     ACTIVATE_CUSTOMER, ADD_CONSUMER, ANONYMIZE_DELETED_CONSUMERS, Consumer, ConsumerDeletionState,
     ConsumerKind, Customer, DELETE_CUSTOMER, DELETE_SELF_CONSUMER, FINISH_CONSUMER_DELETION,
     INSERT_CUSTOMER, INSERT_SELF_CONSUMER, MARK_CONSUMER_DELETING, MARK_SELF_CONSUMER_DELETING,
-    SELECT_CONSUMER, SELECT_CONSUMERS_BY_OWNER, SELECT_CUSTOMER, Store, StoreError,
-    UPDATE_REGISTERED_EMAIL, parse_status,
+    SELECT_CONSUMER, SELECT_CONSUMERS_BY_OWNER, SELECT_CUSTOMER, SELECT_CUSTOMER_BY_EMAIL, Store,
+    StoreError, UPDATE_REGISTERED_EMAIL, parse_status,
 };
 
 /// Native `rusqlite`-backed [`Store`], for tests and local development.
@@ -67,6 +67,13 @@ impl SqliteStore {
                 .map_err(map_err)?;
             conn.pragma_update(None, "user_version", 4)
                 .map_err(map_err)?;
+            version = 4;
+        }
+        if version < 5 {
+            conn.execute_batch(include_str!("../../migrations/0005_customer_email.sql"))
+                .map_err(map_err)?;
+            conn.pragma_update(None, "user_version", 5)
+                .map_err(map_err)?;
         }
         Ok(Self(Mutex::new(conn)))
     }
@@ -94,6 +101,34 @@ impl Store for SqliteStore {
         let conn = self.0.lock().expect("store mutex poisoned");
         let row = conn
             .query_row(SELECT_CUSTOMER, params![did], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, i64>(4)?,
+                    row.get::<_, Option<String>>(5)?,
+                ))
+            })
+            .optional()
+            .map_err(map_err)?;
+        row.map(|(did, email, status, plan, verified, terms_version)| {
+            Ok(Customer {
+                did,
+                email,
+                status: parse_status(&status)?,
+                plan,
+                verified: verified as u64,
+                terms_version,
+            })
+        })
+        .transpose()
+    }
+
+    async fn customer_by_email(&self, email: &str) -> Result<Option<Customer>, StoreError> {
+        let conn = self.0.lock().expect("store mutex poisoned");
+        let row = conn
+            .query_row(SELECT_CUSTOMER_BY_EMAIL, params![email], |row| {
                 Ok((
                     row.get::<_, String>(0)?,
                     row.get::<_, String>(1)?,
@@ -274,5 +309,114 @@ impl Store for SqliteStore {
             .execute(ACTIVATE_CUSTOMER, params![did, now as i64, terms_version])
             .map_err(map_err)?;
         Ok(changed > 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::SIGNUP_PLAN;
+    use tonk_account::customer::CustomerStatus;
+
+    async fn enrolled(store: &SqliteStore, did: &str, email: &str) {
+        store
+            .enroll_customer(did, email, &[], SIGNUP_PLAN, 1_700_000_000)
+            .await
+            .expect("enrollment writes a customer");
+    }
+
+    #[dialog_common::test]
+    async fn it_finds_an_enrolled_customer_by_their_address() {
+        let store = SqliteStore::in_memory().expect("store");
+        enrolled(&store, "did:key:zA", "jsmith@example.com").await;
+
+        let found = store
+            .customer_by_email("jsmith@example.com")
+            .await
+            .expect("lookup succeeds")
+            .expect("the enrolled customer is found");
+        assert_eq!(found.did, "did:key:zA");
+        assert_eq!(found.status, CustomerStatus::Registered);
+    }
+
+    #[dialog_common::test]
+    async fn it_finds_nothing_for_an_unregistered_address() {
+        let store = SqliteStore::in_memory().expect("store");
+        enrolled(&store, "did:key:zA", "jsmith@example.com").await;
+
+        assert!(
+            store
+                .customer_by_email("nobody@example.com")
+                .await
+                .expect("lookup succeeds")
+                .is_none()
+        );
+    }
+
+    /// The lookup answers with one customer because the schema permits
+    /// only one. Without the unique index this is where a second account
+    /// on an address would slip in and make the answer arbitrary.
+    #[dialog_common::test]
+    async fn it_refuses_a_second_customer_on_one_address() {
+        let store = SqliteStore::in_memory().expect("store");
+        enrolled(&store, "did:key:zA", "jsmith@example.com").await;
+
+        let conflict = store
+            .enroll_customer(
+                "did:key:zB",
+                "jsmith@example.com",
+                &[],
+                SIGNUP_PLAN,
+                1_700_000_001,
+            )
+            .await;
+        assert!(
+            matches!(conflict, Err(StoreError::Conflict(_))),
+            "a second customer on one address is a conflict, got {conflict:?}"
+        );
+    }
+
+    /// The address a lookup is keyed by is the normalized one, so a
+    /// caller holding the address finds the row whatever the enrolling
+    /// client sent. Enrollment normalizes before it reaches the store, so
+    /// this pins the store's half: what goes in is what comes back out.
+    #[dialog_common::test]
+    async fn it_keys_a_customer_by_the_address_it_was_given() {
+        let store = SqliteStore::in_memory().expect("store");
+        enrolled(&store, "did:key:zA", "jsmith@example.com").await;
+
+        assert!(
+            store
+                .customer_by_email("JSmith@Example.COM")
+                .await
+                .expect("lookup succeeds")
+                .is_none(),
+            "the store matches exactly; normalizing is the caller's job"
+        );
+    }
+
+    /// A suspended customer is still found, so the lookup can answer 410
+    /// with the key rather than pretending the address is unknown.
+    /// Nothing writes `Suspended` yet, so the status is set directly.
+    #[dialog_common::test]
+    async fn it_finds_a_suspended_customer() {
+        let store = SqliteStore::in_memory().expect("store");
+        enrolled(&store, "did:key:zA", "jsmith@example.com").await;
+        store
+            .0
+            .lock()
+            .expect("store mutex poisoned")
+            .execute(
+                "UPDATE customer SET status = 'Suspended' WHERE did = ?1",
+                params!["did:key:zA"],
+            )
+            .expect("the status is written");
+
+        let found = store
+            .customer_by_email("jsmith@example.com")
+            .await
+            .expect("lookup succeeds")
+            .expect("a suspended customer is still found");
+        assert_eq!(found.status, CustomerStatus::Suspended);
     }
 }

--- a/rust/tonk-access-service/tests/lookup.rs
+++ b/rust/tonk-access-service/tests/lookup.rs
@@ -1,0 +1,330 @@
+//! Lookup of a customer by email address, end to end against the running
+//! service.
+//!
+//! The unit tests in `tonk_access_service::lookup` cover the DID encoding
+//! in isolation. These cover what only the wired service can answer: that
+//! the address a caller holds finds the row enrollment wrote, that the
+//! registration state picks the status code, and that the path survives
+//! the segments `did:web` resolution hands over.
+//!
+//! Run with:
+//! ```bash
+//! cargo test -p tonk-access-service --features integration-tests --test lookup
+//! ```
+
+#![cfg(feature = "integration-tests")]
+
+use dialog_credentials::Ed25519Signer;
+use dialog_varsig::{Did, Principal};
+use tonk_access_service::helpers::AccessServiceAddress;
+use tonk_access_service::lookup::customer_did;
+
+/// The host the service answers as, which is the host its `did:web` names
+/// are minted under.
+fn host(env: &AccessServiceAddress) -> String {
+    url::Url::parse(&env.access_service_url)
+        .expect("the service url parses")
+        .authority()
+        .to_string()
+}
+
+/// The base URL, without a trailing slash.
+fn base(env: &AccessServiceAddress) -> String {
+    env.access_service_url.trim_end_matches('/').to_string()
+}
+
+/// Resolve an address through the service, answering the status and body.
+async fn lookup(
+    env: &AccessServiceAddress,
+    address: &str,
+) -> anyhow::Result<(u16, serde_json::Value)> {
+    let (local, domain) = address.rsplit_once('@').expect("an address with a domain");
+    let response = reqwest::Client::new()
+        .get(format!("{}/customer/{domain}/{local}/did.json", base(env)))
+        .send()
+        .await?;
+    let status = response.status().as_u16();
+    Ok((status, response.json().await?))
+}
+
+/// An activated customer resolves with `200` and a document naming the
+/// key it enrolled with. This is the whole point of the endpoint: an
+/// address in, that address's `did:key` out.
+#[dialog_common::test]
+async fn it_answers_an_activated_customer_with_their_key(
+    env: AccessServiceAddress,
+) -> anyhow::Result<()> {
+    let customer = Ed25519Signer::generate().await?;
+    env.activate_customer(&customer, "jsmith@example.com")
+        .await?;
+
+    let (status, document) = lookup(&env, "jsmith@example.com").await?;
+    assert_eq!(status, 200, "an activated customer resolves");
+    assert_eq!(
+        document["id"],
+        format!("did:web:{}:customer:example.com:jsmith", host(&env)),
+        "the document names the DID that was resolved"
+    );
+    assert_eq!(
+        document["alsoKnownAs"][0],
+        customer.did().to_string(),
+        "and carries the customer's did:key"
+    );
+
+    // The embedded key verifies against the same did:key, so a caller
+    // that reads only the verification method reaches the same identity.
+    let multibase = document["verificationMethod"][0]["publicKeyMultibase"]
+        .as_str()
+        .expect("a multikey verification method");
+    assert_eq!(format!("did:key:{multibase}"), customer.did().to_string());
+    Ok(())
+}
+
+/// An enrolled customer who has not clicked the activation link resolves
+/// with `202`: the DID is real, but the address is claimed rather than
+/// confirmed, and a caller about to act on it should be able to tell.
+#[dialog_common::test]
+async fn it_answers_an_unconfirmed_customer_with_accepted(
+    env: AccessServiceAddress,
+) -> anyhow::Result<()> {
+    let customer = Ed25519Signer::generate().await?;
+    env.enroll_customer(&customer, "pending@example.com")
+        .await?;
+
+    let (status, document) = lookup(&env, "pending@example.com").await?;
+    assert_eq!(status, 202, "an unactivated customer is accepted, not ok");
+    assert_eq!(document["status"], "Registered");
+    assert_eq!(document["alsoKnownAs"][0], customer.did().to_string());
+    Ok(())
+}
+
+/// Confirming the email moves the same address from `202` to `200`
+/// without changing anything else about the answer. The status is the
+/// only thing activation is allowed to move here.
+#[dialog_common::test]
+async fn it_moves_from_accepted_to_ok_on_confirmation(
+    env: AccessServiceAddress,
+) -> anyhow::Result<()> {
+    let customer = Ed25519Signer::generate().await?;
+    env.enroll_customer(&customer, "confirming@example.com")
+        .await?;
+    let (before, first) = lookup(&env, "confirming@example.com").await?;
+    assert_eq!(before, 202);
+
+    env.activate_customer(&customer, "confirming@example.com")
+        .await?;
+    let (after, second) = lookup(&env, "confirming@example.com").await?;
+    assert_eq!(after, 200, "confirmation lifts the answer to ok");
+    assert_eq!(second["status"], "Active");
+    assert_eq!(
+        first["alsoKnownAs"], second["alsoKnownAs"],
+        "the key does not move when the status does"
+    );
+    Ok(())
+}
+
+/// An address nobody enrolled is a `404`. A caller learns the same thing
+/// from an unregistered address as from one that never existed.
+#[dialog_common::test]
+async fn it_answers_an_unknown_address_with_not_found(
+    env: AccessServiceAddress,
+) -> anyhow::Result<()> {
+    let (status, _) = lookup(&env, "nobody@example.com").await?;
+    assert_eq!(status, 404);
+    Ok(())
+}
+
+/// The address is normalized on both sides, so the casing a caller holds
+/// does not have to match the casing the customer typed at enrollment.
+#[dialog_common::test]
+async fn it_resolves_an_address_whatever_its_casing(
+    env: AccessServiceAddress,
+) -> anyhow::Result<()> {
+    let customer = Ed25519Signer::generate().await?;
+    // Enrolled in mixed case, stored normalized.
+    env.activate_customer(&customer, "JSmith@Example.COM")
+        .await?;
+
+    for spelling in [
+        "jsmith@example.com",
+        "JSmith@Example.COM",
+        "JSMITH@EXAMPLE.COM",
+    ] {
+        let (status, document) = lookup(&env, spelling).await?;
+        assert_eq!(status, 200, "{spelling} resolves");
+        assert_eq!(
+            document["alsoKnownAs"][0],
+            customer.did().to_string(),
+            "{spelling} reaches the same customer"
+        );
+    }
+    Ok(())
+}
+
+/// A local part containing `+` survives the round trip. `did:web`
+/// resolution percent-decodes each path segment, so `tag%2Balice` arrives
+/// as `tag+alice`, and reading it as anything but a raw segment would
+/// turn that `+` into a space and miss the row.
+#[dialog_common::test]
+async fn it_resolves_a_local_part_that_needs_encoding(
+    env: AccessServiceAddress,
+) -> anyhow::Result<()> {
+    let customer = Ed25519Signer::generate().await?;
+    env.activate_customer(&customer, "tag+alice@web.mail")
+        .await?;
+
+    let (status, document) = lookup(&env, "tag+alice@web.mail").await?;
+    assert_eq!(status, 200, "a + in the local part resolves");
+    assert_eq!(document["alsoKnownAs"][0], customer.did().to_string());
+    assert_eq!(
+        document["id"],
+        format!("did:web:{}:customer:web.mail:tag%2Balice", host(&env)),
+        "and the DID it names carries the encoded form"
+    );
+    Ok(())
+}
+
+/// The two-segment lookup does not shadow the single-segment registration
+/// probe. Both live under `/customer/`, and the probe reads its whole
+/// remainder as a DID, so matching it first would swallow every lookup.
+#[dialog_common::test]
+async fn it_leaves_the_registration_probe_reachable(
+    env: AccessServiceAddress,
+) -> anyhow::Result<()> {
+    let customer = Ed25519Signer::generate().await?;
+    env.activate_customer(&customer, "probe@example.com")
+        .await?;
+
+    let receipt: serde_json::Value = reqwest::Client::new()
+        .get(format!("{}/customer/{}", base(&env), customer.did()))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(receipt["status"], "Active", "the probe still answers");
+
+    let (status, _) = lookup(&env, "probe@example.com").await?;
+    assert_eq!(status, 200, "and the lookup answers too");
+    Ok(())
+}
+
+/// The lookup is called from the browser by the invite flow, so it
+/// answers with the same permissive CORS header every other public route
+/// on this service does.
+#[dialog_common::test]
+async fn it_answers_with_cors_for_the_browser(env: AccessServiceAddress) -> anyhow::Result<()> {
+    let customer = Ed25519Signer::generate().await?;
+    env.activate_customer(&customer, "cors@example.com").await?;
+
+    let response = reqwest::Client::new()
+        .get(format!("{}/customer/example.com/cors/did.json", base(&env)))
+        .send()
+        .await?;
+    assert_eq!(
+        response
+            .headers()
+            .get("access-control-allow-origin")
+            .and_then(|value| value.to_str().ok()),
+        Some("*")
+    );
+    Ok(())
+}
+
+/// A DID a caller built from an address finds the customer that address
+/// belongs to. This closes the loop the endpoint exists for: the half
+/// that mints the DID and the half that resolves it agree on the form.
+#[dialog_common::test]
+async fn it_resolves_a_did_built_by_a_caller(env: AccessServiceAddress) -> anyhow::Result<()> {
+    let customer = Ed25519Signer::generate().await?;
+    env.activate_customer(&customer, "round.trip@example.com")
+        .await?;
+
+    let did = customer_did(&host(&env), "round.trip@example.com").expect("a resolvable address");
+    // Resolution turns the method-specific id into a path and appends
+    // did.json, which is the request this service answers.
+    let path = did
+        .strip_prefix(&format!("did:web:{}:", host(&env)))
+        .expect("the DID sits under this host")
+        .replace(':', "/");
+    let document: serde_json::Value = reqwest::Client::new()
+        .get(format!("{}/{path}/did.json", base(&env)))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(document["alsoKnownAs"][0], customer.did().to_string());
+    let _: Did = document["alsoKnownAs"][0]
+        .as_str()
+        .expect("a did:key string")
+        .parse()
+        .map_err(|error| anyhow::anyhow!("the answered key does not parse: {error:?}"))?;
+    Ok(())
+}
+
+/// Only a settled answer is cacheable. A `202` says the customer has not
+/// confirmed yet and a `404` that nobody has claimed the address; both
+/// are about to change, and an invite flow polling an address must not be
+/// told for a minute that the person it just invited is still unknown.
+#[dialog_common::test]
+async fn it_lets_only_a_settled_answer_be_cached(env: AccessServiceAddress) -> anyhow::Result<()> {
+    let client = reqwest::Client::new();
+    let cache_control = |response: &reqwest::Response| {
+        response
+            .headers()
+            .get("cache-control")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_string()
+    };
+
+    // Nobody has claimed this address yet.
+    let missing = client
+        .get(format!(
+            "{}/customer/example.com/uncached/did.json",
+            base(&env)
+        ))
+        .send()
+        .await?;
+    assert_eq!(missing.status().as_u16(), 404);
+    assert_eq!(
+        cache_control(&missing),
+        "no-store",
+        "a 404 is not cacheable"
+    );
+
+    // Enrolled but unconfirmed.
+    let customer = Ed25519Signer::generate().await?;
+    env.enroll_customer(&customer, "uncached@example.com")
+        .await?;
+    let pending = client
+        .get(format!(
+            "{}/customer/example.com/uncached/did.json",
+            base(&env)
+        ))
+        .send()
+        .await?;
+    assert_eq!(pending.status().as_u16(), 202);
+    assert_eq!(
+        cache_control(&pending),
+        "no-store",
+        "a 202 is not cacheable"
+    );
+
+    // Confirmed, and now settled enough to cache.
+    env.activate_customer(&customer, "uncached@example.com")
+        .await?;
+    let settled = client
+        .get(format!(
+            "{}/customer/example.com/uncached/did.json",
+            base(&env)
+        ))
+        .send()
+        .await?;
+    assert_eq!(settled.status().as_u16(), 200);
+    assert_eq!(
+        cache_control(&settled),
+        "public, max-age=60",
+        "a settled answer is cacheable, briefly"
+    );
+    Ok(())
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -63,6 +63,23 @@ migrations_dir = "rust/tonk-access-service/migrations-ingest"
 binding = "REVOCATIONS_KV"
 id = "04f72780ec4541318e768ec26d9cc5e4"
 
+# Lookup rate limit: the email lookup answers an unauthenticated GET, and
+# the address it resolves is in the URL, so the endpoint is a registration
+# oracle to anyone willing to walk a list of addresses. Keyed by client
+# IP, so a caller's budget follows them across addresses rather than
+# resetting per address. Cached answers never reach the worker, so this
+# sees roughly the distinct-address rate, which is the enumeration signal.
+#
+# `namespace_id` is local to this worker and need not be provisioned; the
+# period must be 10 or 60.
+[[ratelimits]]
+name = "LOOKUP_LIMITER"
+namespace_id = "1001"
+
+  [ratelimits.simple]
+  limit = 60
+  period = 60
+
 [vars]
 R2_ACCOUNT_ID = "5f20ca8a0de0a5ac52a14fa8bf9c90db"
 R2_BUCKET_NAME = "tonk-spaces"
@@ -93,6 +110,14 @@ migrations_dir = "rust/tonk-access-service/migrations-ingest"
 [[env.staging.kv_namespaces]]
 binding = "REVOCATIONS_KV"
 id = "02b830113c7f47879b3a839a52f643df"
+
+[[env.staging.ratelimits]]
+name = "LOOKUP_LIMITER"
+namespace_id = "1001"
+
+  [env.staging.ratelimits.simple]
+  limit = 60
+  period = 60
 
 [env.staging.vars]
 R2_ACCOUNT_ID = "5f20ca8a0de0a5ac52a14fa8bf9c90db"
@@ -140,6 +165,14 @@ migrations_dir = "rust/tonk-access-service/migrations-ingest"
 [[env.preview.kv_namespaces]]
 binding = "REVOCATIONS_KV"
 id = "REPLACED-PER-PULL-REQUEST"
+
+[[env.preview.ratelimits]]
+name = "LOOKUP_LIMITER"
+namespace_id = "1001"
+
+  [env.preview.ratelimits.simple]
+  limit = 60
+  period = 60
 
 [env.preview.vars]
 R2_ACCOUNT_ID = "5f20ca8a0de0a5ac52a14fa8bf9c90db"


### PR DESCRIPTION
Inviting someone by email address needs to find the `did:key` behind it, and nothing exposed that direction. The mapping already existed as `customer.email → customer.did`, unindexed and unreachable.

## The DID

The address is encoded into the DID rather than hashed, following the [`did:mailto`](https://github.com/storacha/specs/blob/main/did-mailto.md) split but under our own `did:web` name:

```
did:web:tonk.network:customer:example.com:jsmith
  → GET /customer/example.com/jsmith/did.json
```

An earlier draft hashed the address with blake3 to keep it out of the URL. That was abandoned: the input space is enumerable, so the hash bought no real secrecy, and it forced a stored hash column that D1 cannot backfill in SQL and where a missed row would be silently unfindable. The tradeoff accepted in exchange is that the address is plaintext wherever one of these DIDs is written down.

## Why the access service

It is already the `did:web` host, so the name resolves to the same worker with no new deployment. And it is the only side that knows whether an address was *confirmed*: `customer.status` distinguishes an address someone claimed from one they proved control of, which the account service's `accounts` table cannot. That distinction is the endpoint's most useful answer, so 202 exists alongside 200.

`410` for a suspended customer rather than 403 or 404: the resource existed and is not currently available. The document still comes back with `deactivated: true`, since a suspension is reversible and discarding the key mapping would force every caller to re-resolve when it lifts.

## Normalization

The address is the lookup key, so both sides must agree on its spelling. The account service already normalized to `trim().to_lowercase()`; the access service only trimmed. It now matches, and a unique index makes one address hold one customer. The migration normalizes existing rows and drops the duplicates that can create, which is safe because this service has no production deployment yet.

This loses the casing customers originally typed. No delivery impact, but outgoing `To:` headers read lowercase from here on.

## Cache and rate limiting

A cached answer never reaches the worker, so it never counts against the limit: the cache absorbs repeat lookups of one address, leaving the limiter to see roughly the distinct-address rate, which is what enumeration produces. The limit is keyed by client IP rather than by address, since a per-address budget would not constrain walking a list of them.

Only a settled answer is cacheable. A `202` and a `404` carry `no-store`, because both are about to change and the change is what a caller polling an address is waiting on.

## Notes for review

- **`410` has no integration test.** Nothing in the codebase writes `Suspended` yet, so the harness cannot produce one. Covered at the store level, where the status can be written directly.
- **Two encodings are correct but do not resolve**: an `@` inside a local part, and a `/`, which `did:web` resolution decodes back into a path separator. Both fail closed with a 404 rather than reaching the wrong customer, and both are vanishingly rare. Tests pin the behavior.
- Two test-only bugs surfaced and are fixed here: the native test server built its host from `req.uri().authority()`, absent for the origin-form request line every real client sends, and the test harness matched activation emails by verbatim address. Neither affected the deployed worker, which reads `req.url()`.

Design notes in `plan/customer-email-lookup.md`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a customer lookup feature by email address in the `tonk-access-service`. It normalizes email addresses, ensures uniqueness in the database, and provides a new endpoint to retrieve customer information based on email.

### Detailed summary
- Added `lookup` module for customer email lookup.
- Introduced endpoint `GET /customer/:domain/:local/did.json` for email resolution.
- Implemented email normalization to ensure consistent storage.
- Added `customer_by_email` method to `Store` trait.
- Created SQL migration to normalize existing email addresses and enforce uniqueness.
- Updated handlers to integrate new lookup functionality.
- Added CORS support for the new endpoint.
- Implemented tests for lookup functionality and email normalization.

> The following files were skipped due to too many changes: `plan/customer-email-lookup.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->