### PR TITLE
feat(fab): add edge-state ceremonies

### DIFF
--- a/plan/edges.md
+++ b/plan/edges.md
@@ -1,0 +1,333 @@
+# Edge states implementation plan
+
+**Goal:** Implement the six captured edge states for “the moments a space
+will not open” so every refusal in the product speaks the FABB grammar:
+walls get a cluster, conditions get a banner, one solid ink block per screen,
+rejection flashes ink instead of taking a hue.
+
+**Approach:** Build the two missing materials first — the cluster grammar
+(statement / entry row / narrator / fused run / ghost) as `tonk-fab` shadow
+components for ceremonies over a space, and the same grammar as CSS-plus-markup
+inside `profile.yaml` for the walls, exactly as the wireframes restate tokens
+per file. Then convert each existing refusal surface: the Web-Awesome join
+failure and paste form become walls, the share-driven "turn on sync?" dialog
+becomes the offline banner's connect ceremony, and the activation nag becomes
+the not-activated banner and ceremony.
+
+Reference: the historical `~/tonk/gooey/fabb/edges.html` behavior already
+captured in this plan (the source file is no longer present as of 2026-08-25),
+`~/tonk/gooey/fabb/README.md` (laws), and the current `hub.html` stone tokens.
+This plan is normative for edge anatomy and interaction; implementation must
+not depend on recovering the removed prototype.
+
+**Depends on:** `plan/hub-color.md` — Task 1's stone FABB skin, Task 2's Hub
+tokens (`--dim`, `--cur`, `--panel`), and Task 5's truthful provider-free local
+state. Land that plan first.
+
+**Constraints:**
+
+- One solid ink block per screen; the coloring is the CTA. Soft grey may sit
+  on a reading, never on an actionable word.
+- Rejection = flash the ink wash twice (`.45s × 2`) and re-arm; no hue, ever.
+- A ceremony bails on Escape or its ghost word only — **a click on the dim
+  does nothing**. Native `<dialog>` in `rust/tonk-fab/src/dialog.rs` must be
+  configured so no backdrop or light-dismiss path closes a cluster.
+- Revoked and deleted are one screen. The UI must not reveal which — that
+  leaks whether a space exists. Detail stays in the console.
+- Email activation stays the access-service **link** flow
+  (`rust/tonk-account/src/customer.rs` — `Enrolled, activation email not yet
+  acted on`). The wireframe's typed six-digit code row for screen 6 is **not
+  built** in this slice: the code ceremony that exists
+  (`tonk-account-service` `/codes`) proves address control at account
+  *creation* and is consumed by `plan/onboarding.md`. Adding code-based
+  *activation* is an access-service change; do it with that service, not
+  here. The ceremony structure, banner, resend verb, and success payoff are
+  all built now, so the code row later replaces one narrator sentence.
+- The sealed guest has no `localStorage`; walls and banners live in guest
+  chrome and views. `tonk-fab` components stay shadow-DOM;
+  `profile.yaml`/`core.yaml` walls are light-DOM markup+CSS.
+- Link validation reuses `rust/tonk-workspace/src/invite_link.rs` parsing —
+  not the wireframe's `tonk.xyz` regex, which encodes a deployment origin
+  this repo doesn't use.
+
+## File map
+
+- `rust/tonk-fab/src/field.rs`: `<tonk-field>` — the entry/record row.
+- `rust/tonk-fab/src/cluster.rs`: `<tonk-cluster>` — statement, narrator,
+  slotted rows/run/ghost, dim, bail semantics, focus loop.
+- `rust/tonk-fab/src/banner.rs`: `<tonk-banner>` — the condition banner.
+- `rust/tonk-fab/src/skin.rs`: edge-grammar tokens shared by the above.
+- `rust/tonk-fab/src/share.rs`: enable-sync rerouted through the connect
+  ceremony.
+- `rust/tonk-fab/src/markup.rs`: refusal dialogs re-authored; law tests.
+- `rust/tonk-core/assets/library/profile.yaml`: the walls (no access,
+  invitation closed), provider-free Hub treatment, and empty-Hub column.
+- `rust/tonk-core/assets/library/core.yaml`: local-spot notice restyled to
+  the grammar.
+- `rust/tonk-workspace/src/sync.rs`: revoked/deleted collapse at the copy
+  boundary.
+- `rust/tonk-worker/tests/standard_library.rs`: wall/copy contracts.
+
+### Task 1: `<tonk-field>` — the entry and record row
+
+**Files:**
+
+- Create: `rust/tonk-fab/src/field.rs`
+- Modify: `rust/tonk-fab/src/skin.rs` (row tokens: 36px block, noun
+  bottom-left soft, value bottom-right ink, the existing 7×13 `.cur` block
+  cursor on the tail)
+- Modify: `rust/tonk-fab/src/lib.rs` (registration)
+- Test: `rust/tonk-fab/src/field.rs:tests` (native markup) and
+  `rust/tonk-fab/tests/edge_primitives.rs` (wasm interaction)
+
+**Interfaces:**
+
+- Attributes: `noun`, `value`, `settled` (record row, no cursor),
+  `filter="digits"` (strip non-matching input), `autolen="6"` (auto-commit at
+  length, `.14em` tracking), `changeable` (the noun swaps to an underlined
+  `change` verb + cursor glyph on hover/focus; on `(pointer:coarse)` the
+  glyph is always shown and hover does nothing — captured screen 6 behavior).
+- Events: composed `fabb-commit {value}` on Enter or autolen;
+  `fabb-change-noun` when the changeable noun is picked.
+- Method surface for the owner: `reject()` — flash the ink wash twice and
+  re-arm with contents selected. No hue.
+- This is the `tonk-field` that `plan/fabb-conformance.md` deferred "with the
+  surface that needs it"; `plan/onboarding.md` consumes the same element.
+
+- [ ] Add native markup tests: noun/value seating, settled has no cursor,
+      digits filter declared, no color literal outside the skin tokens; run
+      `cargo test -p tonk-fab field` and record the failures.
+- [ ] Add wasm tests: typing commits on Enter; `autolen` commits at exactly
+      six digits and strips letters; `reject()` re-arms with the value
+      selected; changeable-noun event fires; run
+      `nix develop path:. -c cargo test --target wasm32-unknown-unknown -p tonk-fab field`
+      and record the failures.
+- [ ] Implement in the `shadow.rs` idiom: `shadow::Bound` for every listener,
+      reduced-motion kills the flash and blink.
+- [ ] Run both focused suites; expect green.
+
+### Task 2: `<tonk-cluster>` — the ceremony shell
+
+**Files:**
+
+- Create: `rust/tonk-fab/src/cluster.rs`
+- Modify: `rust/tonk-fab/src/skin.rs`, `rust/tonk-fab/src/lib.rs`
+- Test: `rust/tonk-fab/src/cluster.rs:tests` (native markup) and
+  `rust/tonk-fab/tests/edge_primitives.rs` (wasm interaction)
+
+**Interfaces:**
+
+- A 432px column of 36px blocks with 7px gaps over an ink dim, seated at
+  modal density: `statement` slot (IBM Plex Sans 600 ink 13.5/1.55), default
+  slot for `<tonk-field>` rows, `narrator` slot (sans 400 soft, at most one
+  underlined verb bottom-right), `run` slot (fused `<tonk-button>` pair at
+  gap 0, the fill boundary is the divider; a lone door fills the rung),
+  `ghost` slot (bare underlined word, `◂` prefix, no box).
+- Bail: Escape and the ghost emit composed `fabb-bail`; pointer events on the
+  dim are swallowed. A minimal Tab loop cycles the open cluster.
+- Phone: fused runs unstack, preserving the captured phone behavior.
+- Reuses `tonk-button`; does not reuse `tonk-dialog` (heading/×/actions
+  chrome is the wrong grammar).
+
+- [ ] Native tests: one dim, slots present, ghost is not a button, run
+      buttons have zero gap; run `cargo test -p tonk-fab cluster`, record
+      failures.
+- [ ] Wasm tests: Escape bails; ghost bails; a click on the dim does nothing
+      and the cluster stays; Tab from the last focusable lands on the first;
+      record failures, implement, re-run to green.
+- [ ] Run the full `cargo test -p tonk-fab`; expect no regressions in the
+      existing 96 native tests.
+
+### Task 3: `<tonk-banner>` — conditions get a banner
+
+**Files:**
+
+- Create: `rust/tonk-fab/src/banner.rs`
+- Modify: `rust/tonk-fab/src/lib.rs`
+- Test: `rust/tonk-fab/src/banner.rs:tests` (native markup) and
+  `rust/tonk-fab/tests/edge_primitives.rs` (wasm interaction)
+
+**Interfaces:**
+
+- Fixed, bottom-centered: `bottom:40px`, `width:min(680px, 100vw - 48px)`,
+  frost glass with backdrop-blur, a soft message cell plus **one** solid ink
+  door cell; slides up 70px after a 450ms beat; composed `fabb-open` when the
+  door is picked; `retire()` slides it away.
+- Phone: seats at `bottom:max(76px, env(safe-area-inset-bottom) + 68px)` so
+  it clears the bar's bottom-right seat, and wraps rather than clips.
+- The door is the screen's one solid — a mounted banner and a mounted
+  cluster never show together (opening the ceremony hides the banner's
+  door under the dim; captured screen 6's live email repaint reaches the
+  banner behind the dim).
+
+- [ ] Native tests: one door cell, message cell soft, no hue; wasm tests:
+      the beat delay exists (class flips after mount), `fabb-open` fires,
+      `retire()` removes it; record failures, implement, green.
+
+### Task 4: The walls — no access, invitation closed
+
+**Files:**
+
+- Modify: `rust/tonk-core/assets/library/profile.yaml:772-807` (join failure
+  card), `:958-985` (join paste form), plus the wall CSS block
+- Modify: `rust/tonk-workspace/src/sync.rs:99-102` (revoked copy collapse)
+- Modify: `rust/tonk-workspace/src/invite_link.rs` (expose the parse verdict
+  the wall's row needs)
+- Test: `rust/tonk-worker/tests/standard_library.rs`,
+  `rust/tonk-workspace/src/invite_link.rs:tests`
+
+**Interfaces:**
+
+- Walls are light-DOM markup+CSS in the profile library (they render in
+  views, where `tonk-fab` is chrome, not content): the 432 column keeps its
+  seat under a phantom rung (`margin-left:216`, `margin-top:43px`, preserving
+  the captured wall geometry), masthead logo fixed at 48/48.
+- **No access** (historical screen 2): statement "you do not have access to
+  this space", an `invitation link` entry row, narrator, fused run —
+  `start a new space` quiet / `join this space` solid. A paste that
+  `invite_link.rs` cannot parse flashes the row, rewrites the narrator to
+  point at the link shape, and stays armed. This replaces both the
+  `<wa-callout variant="danger">` failure card and the `<wa-input>` paste
+  form.
+- **Invitation closed** (screen 3): one screen for revoked *and* deleted;
+  the dead link stays on as a settled row; the run offers the same two
+  doors. `sync.rs`'s distinct revoked sentence collapses into the shared
+  copy; the variant distinction survives only in console diagnostics.
+  `<tonk-join-retry>` stays wired to the solid door where a retry is the
+  honest action.
+
+- [ ] Add standard-library contract tests: no `wa-callout`/`variant="danger"`
+      in the join surfaces, no `{reason}` interpolation in wall copy, the
+      exact statement strings above, exactly one solid (`.ebtn.solid`-class
+      count) per wall; run
+      `cargo test -p tonk-worker --test standard_library`, record failures.
+- [ ] Add an `invite_link.rs` unit test for the parse-verdict function the
+      wall consumes (good link → target, bad paste → structured refusal, no
+      panic on garbage).
+- [ ] Rewrite the two surfaces; wire the flash/narrator-rewrite through the
+      library's existing scripting hooks; delete the orphaned Web Awesome
+      wall styling.
+- [ ] Run the standard-library suite and
+      `nix develop path:. -c cargo test --target wasm32-unknown-unknown -p tonk-workspace`;
+      expect green.
+
+### Task 5: No sync server — the offline condition
+
+**Files:**
+
+- Modify: `rust/tonk-fab/src/bar.rs` (mount the banner when the bar's sync
+  state is offline-with-no-remote), `rust/tonk-fab/src/share.rs:541-648`
+  (enable-sync machinery extracted and reused), `rust/tonk-fab/src/markup.rs`
+  (retire `#fab-enable-sync`)
+- Modify: `rust/tonk-core/assets/library/core.yaml:435-459` (local-spot
+  notice restyled to the grammar)
+- Test: `rust/tonk-fab/tests/` wasm + native markup tests
+
+**Interfaces:**
+
+- The banner reads `connect this space` and mounts beside the offline bar
+  (real `state="offline"` disc). Its door opens a `<tonk-cluster>` ceremony:
+  header `connect this space`, a `sync server` `<tonk-field>` prefilled from
+  `default_remote_url(&origin)` (`share.rs:614`), narrator, one full-width
+  solid `connect`, ghost `◂ keep it on this device`.
+- Commit runs the existing enable-sync path (set upstream, sync); success
+  sets the disc to `synced` and retires the banner. The wireframe's
+  editable server row is the delta from today's yes/no dialog — the user can
+  point the space at their own remote.
+- Share on a local-only space routes through this same ceremony instead of
+  the `turn on sync?` dialog, which is deleted with its markup test rows.
+  The ghost returns to the share stack with sync still off.
+
+- [ ] Wasm test: a bar driven to offline-no-remote mounts one banner; the
+      door opens the ceremony with the prefilled server value; ghost retires
+      to banner; record failure against current behavior.
+- [ ] Update the native markup law tests that pin `REFUSAL_DIALOGS_HTML` to
+      expect the ceremony grammar instead of the dialog.
+- [ ] Extract the enable-sync commit from `share.rs` into a function taking
+      the remote URL; wire both entries (banner, share) through it.
+- [ ] Restyle the core-library local-spot notice with the wall/condition
+      grammar and copy pointing at the banner's verb, dropping the
+      `--wa-*` tokens.
+- [ ] Run `cargo test -p tonk-fab`,
+      `nix develop path:. -c cargo test --target wasm32-unknown-unknown -p tonk-fab`,
+      and `cargo test -p tonk-worker --test standard_library`; expect green,
+      with `rust/tonk-worker/tests/fab_drift.rs` and the browser fixtures in
+      `rust/tonk-ui` updated for the removed dialog.
+
+### Task 6: Email not activated — banner and ceremony
+
+**Files:**
+
+- Modify: `rust/tonk-fab/src/bar.rs` (condition detection),
+  `rust/tonk-fab/src/share.rs` (the apologising share row swap)
+- Test: `rust/tonk-fab/tests/activation_banner.rs` (wasm)
+
+**Interfaces:**
+
+- Condition source: `GET /api/customer`, whose
+  `rust/tonk-worker/src/router/customer.rs::CustomerState` response carries
+  `status` and `email`. Mount only when `status == "Registered"`; retire when
+  it becomes `"Active"`. `rust/tonk-ui/src/api.rs::customer_state` is the
+  trusted top-document precedent for the same read.
+- Banner: `{email} is not activated yet — nothing syncs until it is` /
+  solid `activate`. Ceremony: settled email `<tonk-field changeable>` (the
+  change verb routes to `/account`, where email is owned), a narrator
+  carrying the link-flow sentence and a `resend activation email` verb. It
+  sends `POST /api/customer/enroll` with the same `{email:null,deposits:[]}`
+  shape as `rust/tonk-ui/src/api.rs::enroll_customer(None, &[])`; the guest
+  reaches both requests through the existing fetch bridge. Ghost copy is
+  `◂ back to your space`.
+- Success: on the activation state flipping (re-poll on ceremony open and on
+  an interval while mounted), dim lifts, disc fills, banner retires, and the
+  share menu's `sharing needs an activated email` row becomes `copy link`.
+- A live email repaints every mention, including the banner behind the dim.
+
+- [ ] Wasm test with a stubbed `/api/customer` response: `Registered` mounts
+      the banner with the response email; resend POSTs once to
+      `/api/customer/enroll` and reports in the
+      narrator; a flipped activation state retires banner and dim; record
+      failures, implement, green.
+- [ ] Verify the share-row swap with the existing share wasm fixtures.
+
+### Task 7: Truthful provider-free and empty-Hub states
+
+**Files:**
+
+- Modify: `rust/tonk-core/assets/library/profile.yaml` (provider-free and empty
+  states)
+- Test: `rust/tonk-worker/tests/standard_library.rs`
+
+**Interfaces:**
+
+- Consumes `plan/hub-color.md` Task 5's provider-free local state.
+- **Provider-free local profile** (historical screen 5): the available roster
+  data does not distinguish “never attached” from “signed out”, and removing a
+  provider does not remove local repositories. Do not render a blocking edge
+  wall. The account cell retains the active local profile label and roster
+  trigger; settings offers the local-account `/account` handoff; and the spaces
+  view, existing local rows, open actions, and solid local create row stay
+  available. The create row remains the screen's one solid. This is a
+  deliberate truthfulness delta from the historical “this device was signed
+  out” wireframe.
+- **Empty Hub** (historical screen 1): the provider-free profile/roster header
+  sits above the normal empty spaces stack. Render one neutral `no spaces yet`
+  fact and the normal solid `create a new space` row; do not claim that account
+  state made spaces unavailable.
+
+- [ ] Standard-library contract tests: provider-free markup contains no
+      “signed out” or “no spaces available” claim; existing space links and
+      the create form remain present; the roster trigger and settings handoff
+      remain reachable; the empty state says `no spaces yet` exactly once. Add
+      a structural one-solid assertion for each edge surface; run, record
+      failures, implement, green.
+- [ ] Full-slice verify: `cargo fmt --all -- --check`,
+      `cargo test -p tonk-fab`,
+      `cargo test -p tonk-worker --test standard_library`,
+      `nix develop path:. -c cargo test --target wasm32-unknown-unknown -p tonk-fab -p tonk-workspace`,
+      `nix develop path:. -c build:web`.
+- [ ] Walk all six captured states in isolated Chrome (fresh provider-free
+      profile for the local/empty Hub;
+      a local-only space for the offline banner; a revoked invite for the
+      closed wall), light and dark, 1440px and 390px: one solid per screen,
+      flashes not hues, banner clears the bar on the phone seat, Escape/ghost
+      bail everywhere, dim clicks dead, no console errors.

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -437,25 +437,45 @@ view!:
         .local-invite-notice {
           display: flex;
           flex-direction: column;
-          gap: var(--wa-space-2xs);
-          color: var(--wa-color-text-quiet);
+          gap: 7px;
+          width: min(432px, 100%);
+          --edge-ink: #131313;
+          --edge-soft: #55544f;
+          --edge-panel: #fafafa;
+          --edge-ring: rgba(19,19,19,.28);
+          color: var(--edge-soft);
+          font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+        }
+        :root.wa-dark .local-invite-notice {
+          --edge-ink: #e9e6d6;
+          --edge-soft: #cdcaba;
+          --edge-panel: #1e1e19;
+          --edge-ring: rgba(233,230,214,.28);
         }
         .local-invite-notice__label {
-          font-family: var(--wa-font-family-code);
-          font-size: var(--wa-font-size-xs);
-          letter-spacing: 0.06em;
-          text-transform: uppercase;
+          min-height: 36px;
+          padding: 9px 12px;
+          display: flex;
+          align-items: flex-end;
+          background: var(--edge-panel);
+          box-shadow: 0 0 0 1px var(--edge-ring);
+          font-size: 12px;
+          font-weight: 600;
+          text-transform: lowercase;
         }
         .local-invite-notice p {
           margin: 0;
-          font-family: var(--wa-font-family-body);
-          font-size: var(--wa-font-size-s);
-          line-height: var(--wa-line-height-normal);
+          min-height: 36px;
+          padding: 12px 14px;
+          background: var(--edge-panel);
+          box-shadow: 0 0 0 1px var(--edge-ring);
+          font-size: 13px;
+          line-height: 1.55;
           text-wrap: pretty;
         }
       </style>
       <span class="local-invite-notice__label">local spot &middot; no sync remote</span>
-      <p>{detail} Use Share to turn on sync and create an agent link.</p>
+      <p>{detail} Use connect in the condition banner, then create the agent link again.</p>
     </div>
 
 # Derive `tonk:agent-invite` by joining the repo's `tonk:repository` name

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -396,6 +396,10 @@ view/directory!:
         .stack { width:100%; margin-top:7px; padding-bottom:120px; display:flex;
           flex-direction:column; gap:7px; }
         .stack[hidden] { display:none; }
+        .sempty { height:36px; padding:0 10px 9px 16px; display:flex;
+          align-items:flex-end; justify-content:flex-end; color:var(--soft);
+          background:var(--frost-solid); box-shadow:0 0 0 1px var(--sep); }
+        .stack:has(.srow-wrap) .sempty { display:none; }
         /* the wrapper, not the link, is the positioning context: the verbs
            and the confirm cluster sit OUTSIDE the anchor (a control inside
            one is invalid markup, and a label inside one navigates instead of
@@ -525,6 +529,7 @@ view/directory!:
         <ui-hub-account></ui-hub-account>
 
       <div class="stack chrome" data-spaces-view aria-label="spaces">
+        <div class="sempty">no spaces yet</div>
         <!-- `data-id={this}` designates the repeat row — the WRAPPER, not the
              link, so the verbs and the confirm cluster travel with the row
              while staying outside it: reaching for remove never navigates.
@@ -775,24 +780,21 @@ view/directory!:
   model: tonk:join/status
   display: |
     <div class="join-card-wrap">
-      <style>
-        .join-card { display: block; margin: 40px auto; width: min(540px, 100%); }
-      </style>
       <!-- Only the in-flight and failed states live here. The resting
            (paste) state is the ROUTE view's, because this directory is
            empty until a join starts and an empty nested directory renders
-           nothing. `data-id={this}` marks the repeat row; the card is
+           nothing. `data-id={this}` marks the repeat row; the wall is
            inside it, so the whole surface is per-status. -->
       <div class="join-status" data-id={this}>
-        <wa-card class="join-card">
-          <div slot="header"><h1>Joining…</h1></div>
+        <div class="join-opening" aria-live="polite">
+          <span>opening this space</span>
           <wa-spinner></wa-spinner>
-          <tonk-display entity={this} model=tonk:join/failure>
-            <span slot="no-entity"></span>
-            <span slot="no-model"></span>
-            <span slot="loading"></span>
-          </tonk-display>
-        </wa-card>
+        </div>
+        <tonk-display entity={this} model=tonk:join/failure>
+          <span slot="no-entity"></span>
+          <span slot="no-model"></span>
+          <span slot="loading"></span>
+        </tonk-display>
       </div>
     </div>
 
@@ -803,12 +805,21 @@ view!: &join/failure-view
   this: id:tonk:join/failure/view
   model: tonk:join/failure
   display: |
-    <wa-callout variant="danger" class="join-error">
-      <wa-icon slot="icon" name="circle-exclamation"></wa-icon>
-      <strong>Couldn’t join</strong>
-      <p>{reason}</p>
-      <tonk-join-retry kind={kind}></tonk-join-retry>
-    </wa-callout>
+    <!-- Revoked and deleted intentionally share this one screen. The
+         diagnostic reason remains in the console/worker status; rendering it
+         here would reveal whether the space still exists. -->
+    <section class="edge-wall edge-wall--closed" aria-labelledby="edge-closed-title">
+      <div class="edge-statement" id="edge-closed-title">this invitation is closed</div>
+      <div class="edge-field edge-field--settled">
+        <span class="edge-noun">invitation link</span>
+        <span class="edge-value">closed</span>
+      </div>
+      <div class="edge-narrator">this link no longer opens a space; ask its sender for a current invitation</div>
+      <div class="edge-run">
+        <a class="ebtn quiet" href="/">start a new space</a>
+        <tonk-join-retry class="ebtn solid" kind={kind}>join this space</tonk-join-retry>
+      </div>
+    </section>
 
 # ============================================================
 # ROUTING (profile branch) — mirrors core.yaml, scoped to the profile
@@ -949,26 +960,89 @@ view!: &join/route-view
       <tonk-title text="Tonk"></tonk-title>
       <main class="join-view">
         <style>
-          /* The paste form is this route's RESTING state and renders from
-             the route view itself — an entity view on the site, the same
-             shape the Hub uses. It deliberately does NOT live behind the
-             nested `tonk:join/status` directory: that directory is empty
-             until a join is actually in flight, and an empty nested
-             directory renders nothing at all, which left `/join` on a
-             spinner forever. The status directory below now carries ONLY
-             the in-flight and failed states, and hides the form once it
-             has a row to show. */
-          .join-paste { display: flex; flex-direction: column; gap: 14px;
-            width: min(540px, 100%); margin: 40px auto; }
-          .join-paste wa-input { width: 100%; }
-          .join-paste wa-button { align-self: center; min-width: 220px; }
-          .join-paste-error { display: none; color: var(--wa-color-danger-on-quiet); }
-          tonk-invite-link[data-state="invalid"] ~ .join-paste-error { display: block; }
+          .join-view {
+            --edge-page:#ececec; --edge-ink:#131313; --edge-on:#fbfaef;
+            --edge-soft:#55544f; --edge-card:#fafafa;
+            --edge-ring:rgba(19,19,19,.85); --edge-wash:rgba(19,19,19,.12);
+            min-height:100vh; padding:1px; color:var(--edge-ink);
+            background:var(--edge-page); font-family:'IBM Plex Sans Condensed',
+              'Bahnschrift','Arial Narrow',system-ui,sans-serif;
+            font-weight:600; letter-spacing:.02em; -webkit-font-smoothing:antialiased;
+          }
+          :root.wa-dark .join-view {
+            --edge-page:#161613; --edge-ink:#e9e6d6; --edge-on:#22221c;
+            --edge-soft:#cdcaba; --edge-card:#1e1e19;
+            --edge-ring:rgba(233,230,214,.55); --edge-wash:rgba(251,250,239,.15);
+          }
+          .edge-mast { position:fixed; left:48px; top:48px; width:132px;
+            color:var(--edge-ink); z-index:2; }
+          .edge-mast img { display:block; width:100%; height:auto; }
+          :root.wa-dark .edge-mast img { filter:invert(1); }
+          .edge-wall { width:min(432px, calc(100vw - 32px)); margin-left:216px;
+            margin-top:43px; display:flex; flex-direction:column; gap:7px; }
+          .edge-statement, .edge-field, .edge-narrator { min-height:36px;
+            background:var(--edge-card); box-shadow:0 0 0 1px var(--edge-ring); }
+          .edge-statement { padding:10px 14px; display:flex; align-items:flex-end;
+            font-family:'IBM Plex Sans',system-ui,sans-serif; font-size:13.5px;
+            line-height:1.55; text-wrap:balance; }
+          .edge-field { height:36px; min-width:0; padding:0 10px 8px 12px;
+            display:flex; align-items:flex-end; gap:12px; overflow:hidden; }
+          .edge-noun { flex:none; color:var(--edge-soft); font-size:12px;
+            line-height:1; text-transform:lowercase; }
+          .edge-value { flex:1; min-width:0; color:var(--edge-ink); font:inherit;
+            font-size:13px; line-height:1; text-align:right; }
+          .edge-input { border:0; outline:0; padding:0; background:transparent;
+            caret-color:transparent; }
+          .edge-cur { width:7px; height:13px; margin-left:-7px;
+            background:var(--edge-ink); mix-blend-mode:difference;
+            animation:edge-cursor 1.05s steps(1,end) infinite; }
+          .edge-narrator { padding:10px 14px; color:var(--edge-soft);
+            font-family:'IBM Plex Sans',system-ui,sans-serif; font-size:13px;
+            font-weight:400; line-height:1.55; text-wrap:pretty; }
+          .edge-narrator__invalid { display:none; }
+          .edge-run { display:flex; gap:0; }
+          .ebtn { min-height:40px; flex:1 1 0; padding:8px 10px; display:flex;
+            align-items:flex-end; justify-content:flex-end; color:var(--edge-ink);
+            text-decoration:none; text-transform:lowercase; cursor:pointer; }
+          .ebtn.quiet { background:var(--edge-card);
+            box-shadow:0 0 0 1px var(--edge-ring); }
+          .ebtn.solid { color:var(--edge-on); background:var(--edge-ink); }
+          .ebtn.solid button { width:100%; min-height:40px; padding:8px 10px;
+            display:flex; align-items:flex-end; justify-content:flex-end;
+            border:0; color:inherit; background:transparent; font:inherit;
+            text-transform:lowercase; cursor:pointer; }
+          .ebtn:active, .ebtn.solid button:active { scale:.96; }
+          tonk-invite-link { display:none; }
+          .edge-wall:has(tonk-invite-link[data-state="invalid"]) .edge-field {
+            animation:edge-reject .45s ease 2; }
+          .edge-wall:has(tonk-invite-link[data-state="invalid"])
+            .edge-narrator__default { display:none; }
+          .edge-wall:has(tonk-invite-link[data-state="invalid"])
+            .edge-narrator__invalid { display:inline; }
+          @keyframes edge-reject { 0%,100% { background:var(--edge-card); }
+            50% { background:var(--edge-wash); } }
+          @keyframes edge-cursor { 0%,49% { opacity:1; } 50%,100% { opacity:0; } }
           /* A join in flight or failed gives the status display a row;
              `data-state=ready` is `<tonk-display>`'s own signal for that,
              so the form steps aside without depending on the row's markup. */
           .join-view:has(.join-status-slot[data-state="ready"]) .join-paste { display: none; }
+          .join-opening { width:min(432px, calc(100vw - 32px)); min-height:36px;
+            margin-left:216px; margin-top:43px; padding:10px 14px;
+            display:flex; align-items:center; justify-content:space-between;
+            background:var(--edge-card); box-shadow:0 0 0 1px var(--edge-ring); }
+          .join-status:has(tonk-display[data-state="ready"]) .join-opening { display:none; }
+          @media (max-width:680px) {
+            .edge-mast { left:16px; top:24px; width:98px; }
+            .edge-wall, .join-opening { margin-left:16px; margin-top:132px; }
+            .edge-run { flex-direction:column; }
+            .ebtn { min-height:44px; }
+          }
+          @media (prefers-reduced-motion:reduce) {
+            .edge-cur, .edge-wall:has(tonk-invite-link[data-state="invalid"])
+              .edge-field { animation:none; }
+          }
         </style>
+        <a class="edge-mast" href="/" aria-label="Tonk home"><img src="/images/tonk-logo.svg" alt=""></a>
         <tonk-page onmount=tonk:join></tonk-page>
         <!-- `onmount`, not `onsubmit`: `<tonk-invite-link>` cancels the
              submit, resolves the pasted text (expanding a short link on
@@ -976,13 +1050,22 @@ view!: &join/route-view
              carrying `detail.href` — the one read path `tonk:join`
              declares. Same command, same handler, whether the invite
              arrived in the address bar or in this box. -->
-        <form class="join-paste" onmount=tonk:join>
-          <h1>Join a spot</h1>
-          <p>Paste the invite link someone shared with you.</p>
-          <wa-input name="url" placeholder="https://&hellip;" autocomplete="off" required></wa-input>
+        <form class="join-paste edge-wall edge-wall--no-access" onmount=tonk:join>
+          <div class="edge-statement">you do not have access to this space</div>
+          <label class="edge-field">
+            <span class="edge-noun">invitation link</span>
+            <input class="edge-value edge-input" name="url" type="url" autocomplete="off" required aria-label="invitation link">
+            <i class="edge-cur" aria-hidden="true"></i>
+          </label>
           <tonk-invite-link field="url"></tonk-invite-link>
-          <p class="join-paste-error">That doesn't look like an invite link.</p>
-          <wa-button type="submit" variant="brand">Join spot</wa-button>
+          <div class="edge-narrator">
+            <span class="edge-narrator__default">paste the complete invitation link you were sent</span>
+            <span class="edge-narrator__invalid">an invitation link is a complete web address carrying its access information</span>
+          </div>
+          <div class="edge-run">
+            <a class="ebtn quiet" href="/">start a new space</a>
+            <button class="ebtn solid" type="submit">join this space</button>
+          </div>
         </form>
         <!-- The `tonk:join` trigger lives INSIDE the status display, not
              beside the form. `<tonk-page>` waits for its enclosing

--- a/rust/tonk-fab/src/activation.rs
+++ b/rust/tonk-fab/src/activation.rs
@@ -1,0 +1,288 @@
+//! The pending-email condition shared by the bar and its share stack.
+
+use wasm_bindgen::JsCast;
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen_futures::spawn_local;
+use web_sys::{Element, HtmlElement, window};
+
+const BANNER_ID: &str = "fabb-activation-banner";
+const CLUSTER_ID: &str = "fabb-activation-cluster";
+const POLL_MS: i32 = 10_000;
+
+pub(crate) struct ActivationWatch {
+    interval: i32,
+    _tick: Closure<dyn FnMut()>,
+}
+
+impl Drop for ActivationWatch {
+    fn drop(&mut self) {
+        if let Some(window) = window() {
+            window.clear_interval_with_handle(self.interval);
+        }
+    }
+}
+
+pub(crate) fn watch(this: &HtmlElement) -> Option<ActivationWatch> {
+    poll(this);
+    let host = this.clone();
+    let tick = Closure::<dyn FnMut()>::new(move || poll(&host));
+    let interval = window()?
+        .set_interval_with_callback_and_timeout_and_arguments_0(
+            tick.as_ref().unchecked_ref(),
+            POLL_MS,
+        )
+        .ok()?;
+    Some(ActivationWatch {
+        interval,
+        _tick: tick,
+    })
+}
+
+pub(crate) fn poll(this: &HtmlElement) {
+    let host = this.clone();
+    spawn_local(async move {
+        let Ok(body) = tonk_host::get_json("/api/customer").await else {
+            return;
+        };
+        let Ok(state) = serde_json::from_str::<serde_json::Value>(&body) else {
+            return;
+        };
+        render(&host, state["status"].as_str(), state["email"].as_str());
+    });
+}
+
+fn render(this: &HtmlElement, status: Option<&str>, email: Option<&str>) {
+    if !this.is_connected() {
+        return;
+    }
+    let status = status.unwrap_or_default();
+    let _ = this.set_attribute("data-customer-status", status);
+    if let Some(email) = email {
+        let _ = this.set_attribute("data-customer-email", email);
+    } else {
+        let _ = this.remove_attribute("data-customer-email");
+    }
+    if let Ok(Some(row)) = this.query_selector("[data-share-link]") {
+        if status == "Registered" {
+            let _ = row.set_attribute("data-activation-blocked", "");
+        } else {
+            let _ = row.remove_attribute("data-activation-blocked");
+        }
+    }
+
+    if status != "Registered" {
+        retire_condition();
+        crate::bar::refresh_sync_condition(this);
+        return;
+    }
+
+    if let Some(document) = window().and_then(|window| window.document()) {
+        if let Some(connect) = document.get_element_by_id(crate::bar::CONNECT_BANNER_ID) {
+            connect.remove();
+        }
+    }
+    ensure_banner(this, email.unwrap_or("your email address"));
+    repaint_cluster(email.unwrap_or("your email address"));
+}
+
+fn ensure_banner(this: &HtmlElement, email: &str) {
+    let Some(document) = window().and_then(|window| window.document()) else {
+        return;
+    };
+    if let Some(banner) = document.get_element_by_id(BANNER_ID) {
+        set_banner_copy(&banner, email);
+        if let Some(mode) = this.get_attribute("mode") {
+            let _ = banner.set_attribute("mode", &mode);
+        } else {
+            let _ = banner.remove_attribute("mode");
+        }
+        return;
+    }
+    let Ok(banner) = document.create_element("tonk-banner") else {
+        return;
+    };
+    banner.set_id(BANNER_ID);
+    if let Some(mode) = this.get_attribute("mode") {
+        let _ = banner.set_attribute("mode", &mode);
+    }
+    let Ok(message) = document.create_element("span") else {
+        return;
+    };
+    let _ = message.set_attribute("data-activation-message", "");
+    let Ok(door) = document.create_element("span") else {
+        return;
+    };
+    let _ = door.set_attribute("slot", "door");
+    door.set_text_content(Some("activate"));
+    let _ = banner.append_child(&message);
+    let _ = banner.append_child(&door);
+    set_banner_copy(&banner, email);
+
+    let host = this.clone();
+    let on_open = Closure::<dyn FnMut(web_sys::Event)>::new(move |_| {
+        open_cluster(&host);
+        poll(&host);
+    });
+    let _ = banner.add_event_listener_with_callback("fabb-open", on_open.as_ref().unchecked_ref());
+    on_open.forget();
+    if let Some(body) = document.body() {
+        let _ = body.append_child(&banner);
+    }
+}
+
+fn set_banner_copy(banner: &Element, email: &str) {
+    if let Ok(Some(message)) = banner.query_selector("[data-activation-message]") {
+        message.set_text_content(Some(&format!(
+            "{email} is not activated yet — nothing syncs until it is"
+        )));
+    }
+}
+
+fn open_cluster(this: &HtmlElement) {
+    let Some(document) = window().and_then(|window| window.document()) else {
+        return;
+    };
+    if let Some(banner) = document.get_element_by_id(BANNER_ID) {
+        let _ = banner.set_attribute("hidden", "");
+    }
+    if let Some(cluster) = document.get_element_by_id(CLUSTER_ID) {
+        let _ = cluster.remove_attribute("hidden");
+        return;
+    }
+    let email = activation_email(this);
+    let Ok(cluster) = document.create_element("tonk-cluster") else {
+        return;
+    };
+    cluster.set_id(CLUSTER_ID);
+    if let Some(mode) = this.get_attribute("mode") {
+        let _ = cluster.set_attribute("mode", &mode);
+    }
+    cluster.set_inner_html(
+        r#"<p slot="statement">activate sync for this account</p>
+<tonk-field noun="email" settled changeable data-activation-email></tonk-field>
+<p slot="narrator" data-activation-narrator>Open the link in your activation email. <button data-resend-activation>resend activation email</button></p>
+<tonk-button slot="run" variant="primary" solid data-check-activation>check activation</tonk-button>
+<span slot="ghost">back to your space</span>"#,
+    );
+    style_narrator_verb(&cluster);
+    if let Ok(Some(field)) = cluster.query_selector("[data-activation-email]") {
+        let _ = field.set_attribute("value", &email);
+    }
+
+    let ceremony = cluster.clone();
+    let on_bail = Closure::<dyn FnMut(web_sys::Event)>::new(move |_| {
+        ceremony.remove();
+        if let Some(banner) = window()
+            .and_then(|window| window.document())
+            .and_then(|document| document.get_element_by_id(BANNER_ID))
+        {
+            let _ = banner.remove_attribute("hidden");
+        }
+    });
+    let _ = cluster.add_event_listener_with_callback("fabb-bail", on_bail.as_ref().unchecked_ref());
+    on_bail.forget();
+
+    let on_change = Closure::<dyn FnMut(web_sys::Event)>::new(move |_| {
+        tonk_host::navigate_to("/account");
+    });
+    let _ = cluster
+        .add_event_listener_with_callback("fabb-change-noun", on_change.as_ref().unchecked_ref());
+    on_change.forget();
+
+    if let Ok(Some(resend)) = cluster.query_selector("[data-resend-activation]") {
+        let ceremony = cluster.clone();
+        let on_resend = Closure::<dyn FnMut(web_sys::Event)>::new(move |event: web_sys::Event| {
+            event.prevent_default();
+            let ceremony = ceremony.clone();
+            spawn_local(async move {
+                let result =
+                    tonk_host::post_json("/api/customer/enroll", r#"{"email":null,"deposits":[]}"#)
+                        .await;
+                if let Ok(Some(narrator)) = ceremony.query_selector("[data-activation-narrator]") {
+                    narrator.set_text_content(Some(if result.is_ok() {
+                        "Sent — open the link in your activation email."
+                    } else {
+                        "The activation email could not be sent. Try again from account settings."
+                    }));
+                }
+            });
+        });
+        let _ =
+            resend.add_event_listener_with_callback("click", on_resend.as_ref().unchecked_ref());
+        on_resend.forget();
+    }
+
+    if let Ok(Some(check)) = cluster.query_selector("[data-check-activation]") {
+        let host = this.clone();
+        let on_check = Closure::<dyn FnMut(web_sys::Event)>::new(move |_| poll(&host));
+        let _ =
+            check.add_event_listener_with_callback("fabb-press", on_check.as_ref().unchecked_ref());
+        on_check.forget();
+    }
+
+    if let Some(body) = document.body() {
+        let _ = body.append_child(&cluster);
+    }
+}
+
+fn activation_email(this: &HtmlElement) -> String {
+    this.get_attribute("data-customer-email")
+        .unwrap_or_else(|| "your email address".to_owned())
+}
+
+fn repaint_cluster(email: &str) {
+    let Some(cluster) = window()
+        .and_then(|window| window.document())
+        .and_then(|document| document.get_element_by_id(CLUSTER_ID))
+    else {
+        return;
+    };
+    if let Ok(Some(field)) = cluster.query_selector("[data-activation-email]") {
+        let _ = field.set_attribute("value", email);
+    }
+}
+
+fn style_narrator_verb(cluster: &Element) {
+    if let Ok(Some(button)) = cluster.query_selector("[data-resend-activation]") {
+        let Some(button) = button.dyn_ref::<HtmlElement>() else {
+            return;
+        };
+        let style = button.style();
+        let _ = style.set_property("all", "unset");
+        let _ = style.set_property("cursor", "pointer");
+        let _ = style.set_property("color", "var(--fabb-ink, currentColor)");
+        let _ = style.set_property("text-decoration", "underline");
+        let _ = style.set_property("text-underline-offset", "2px");
+    }
+}
+
+fn retire_condition() {
+    let Some(document) = window().and_then(|window| window.document()) else {
+        return;
+    };
+    if let Some(cluster) = document.get_element_by_id(CLUSTER_ID) {
+        cluster.remove();
+    }
+    if let Some(banner) = document.get_element_by_id(BANNER_ID) {
+        let retire = js_sys::Reflect::get(&banner, &"retire".into())
+            .ok()
+            .and_then(|value| value.dyn_into::<js_sys::Function>().ok());
+        if let Some(retire) = retire {
+            let _ = retire.call0(&banner);
+        } else {
+            banner.remove();
+        }
+    }
+}
+
+pub(crate) fn remove() {
+    retire_condition();
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn registration_poll_is_deliberately_slow_and_non_spinning() {
+        assert_eq!(super::POLL_MS, 10_000);
+    }
+}

--- a/rust/tonk-fab/src/banner.rs
+++ b/rust/tonk-fab/src/banner.rs
@@ -1,0 +1,170 @@
+//! `<tonk-banner>` — a transient condition banner.
+
+#[cfg_attr(not(any(test, target_arch = "wasm32")), allow(dead_code))]
+const CSS: &str = r#"
+:host{ position:fixed; left:50%; bottom:40px; width:min(680px, calc(100vw - 48px));
+  z-index:2147483645; transform:translateX(-50%); display:block; }
+:host([hidden]){ display:none; }
+.w{ min-height:44px; display:grid; grid-template-columns:minmax(0,1fr) auto;
+  opacity:0; transform:translateY(70px); transition-property:transform,opacity;
+  transition-duration:300ms; transition-timing-function:var(--_ease);
+  -webkit-backdrop-filter:var(--_filter); backdrop-filter:var(--_filter); }
+.w.live{ opacity:1; transform:translateY(0); }
+.w.retiring{ opacity:0; transform:translateY(-12px); transition-duration:150ms; }
+.message{ min-width:0; padding:11px 16px; display:flex; align-items:center;
+  color:var(--_soft); background:var(--_bg); box-shadow:var(--_ring);
+  font-size:13px; line-height:1.45; text-wrap:pretty; }
+.door{ min-width:144px; min-height:44px; padding:10px 14px; display:flex;
+  align-items:flex-end; justify-content:flex-end; color:var(--_on);
+  background:var(--_ink); font-size:13px; line-height:1; text-transform:lowercase;
+  transition-property:scale,filter; transition-duration:150ms; }
+.door:hover{ filter:brightness(.92); }
+.door:active{ filter:brightness(.86); scale:.96; }
+@media (max-width:519px){
+  :host{ bottom:max(76px, env(safe-area-inset-bottom) + 68px);
+    width:min(680px, calc(100vw - 32px)); }
+  .w{ grid-template-columns:minmax(0,1fr); }
+  .door{ min-width:0; justify-content:flex-end; }
+}
+@media (prefers-reduced-motion:reduce){ .w{ transition-duration:0ms; } }
+"#;
+
+#[cfg_attr(not(any(test, target_arch = "wasm32")), allow(dead_code))]
+const HTML: &str = r#"<div class="w" role="status">
+  <div class="message"><slot></slot></div>
+  <button class="door"><slot name="door"></slot></button>
+</div>"#;
+
+#[cfg(target_arch = "wasm32")]
+mod element {
+    use custom_elements::CustomElement;
+    use js_sys::Reflect;
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen::prelude::*;
+    use web_sys::{HtmlElement, window};
+
+    use crate::shadow::{self, Bound};
+
+    use super::{CSS, HTML};
+
+    const BEAT_MS: i32 = 450;
+    const RETIRE_MS: i32 = 150;
+
+    #[derive(Default)]
+    pub(super) struct TonkBanner {
+        listeners: Vec<Bound>,
+    }
+
+    impl CustomElement for TonkBanner {
+        fn shadow() -> bool {
+            false
+        }
+
+        fn observed_attributes() -> &'static [&'static str] {
+            &["mode"]
+        }
+
+        fn inject_children(&mut self, _this: &HtmlElement) {}
+
+        fn connected_callback(&mut self, this: &HtmlElement) {
+            let root = shadow::build(this, CSS, HTML);
+            install_retire_api(this);
+            if let Ok(Some(door)) = root.query_selector(".door") {
+                let host = this.clone();
+                self.listeners.push(shadow::on_click(&door, move || {
+                    shadow::emit(&host, "fabb-open", &JsValue::NULL)
+                }));
+            }
+            self.listeners.push(shadow::install_visibility_pause(this));
+            if let Some(listener) = shadow::install_system_mode(this) {
+                self.listeners.push(listener);
+            }
+
+            let host = this.clone();
+            let reveal = Closure::once_into_js(move || {
+                if let Some(root) = host.shadow_root()
+                    && let Ok(Some(wrapper)) = root.query_selector(".w")
+                {
+                    let _ = wrapper.class_list().add_1("live");
+                }
+            });
+            if let Some(win) = window() {
+                let _ = win.set_timeout_with_callback_and_timeout_and_arguments_0(
+                    reveal.unchecked_ref(),
+                    BEAT_MS,
+                );
+            }
+        }
+
+        fn disconnected_callback(&mut self, _this: &HtmlElement) {
+            self.listeners.clear();
+        }
+
+        fn attribute_changed_callback(
+            &mut self,
+            this: &HtmlElement,
+            name: String,
+            old: Option<String>,
+            new: Option<String>,
+        ) {
+            if name == "mode" && old != new {
+                shadow::apply_mode(this);
+            }
+        }
+    }
+
+    fn install_retire_api(this: &HtmlElement) {
+        let host = this.clone();
+        let retire = Closure::<dyn FnMut()>::new(move || retire(&host));
+        let _ = Reflect::set(this, &"retire".into(), retire.as_ref());
+        retire.forget();
+    }
+
+    fn retire(this: &HtmlElement) {
+        if let Some(root) = this.shadow_root()
+            && let Ok(Some(wrapper)) = root.query_selector(".w")
+        {
+            let _ = wrapper.class_list().add_1("retiring");
+        }
+        let host = this.clone();
+        let remove = Closure::once_into_js(move || host.remove());
+        if let Some(win) = window() {
+            let _ = win.set_timeout_with_callback_and_timeout_and_arguments_0(
+                remove.unchecked_ref(),
+                RETIRE_MS,
+            );
+        }
+    }
+
+    pub(crate) fn register() {
+        let Some(win) = window() else { return };
+        if win.custom_elements().get("tonk-banner").is_undefined() {
+            TonkBanner::define("tonk-banner");
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) use element::register;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn markup_has_one_soft_message_and_one_solid_door() {
+        assert_eq!(HTML.matches("class=\"message\"").count(), 1);
+        assert_eq!(HTML.matches("class=\"door\"").count(), 1);
+        assert!(CSS.contains("color:var(--_soft)"));
+        assert!(CSS.contains("background:var(--_ink)"));
+        assert!(!CSS.contains('#'));
+        assert!(!CSS.contains("rgb("));
+    }
+
+    #[test]
+    fn banner_pins_the_desktop_and_phone_seats() {
+        assert!(CSS.contains("bottom:40px"));
+        assert!(CSS.contains("width:min(680px, calc(100vw - 48px))"));
+        assert!(CSS.contains("bottom:max(76px, env(safe-area-inset-bottom) + 68px)"));
+    }
+}

--- a/rust/tonk-fab/src/bar.rs
+++ b/rust/tonk-fab/src/bar.rs
@@ -56,6 +56,8 @@ use crate::shadow::{self, Bound, Edit};
 /// out sideways: sideways flight needs the room a hover pointer implies.
 const INPLACE_MAX_WIDTH_PX: f64 = 640.0;
 
+pub(crate) const CONNECT_BANNER_ID: &str = "fabb-connect-banner";
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum Cell {
     Sync,
@@ -774,6 +776,81 @@ pub(crate) fn update(this: &HtmlElement) {
         let _ = mode.set_attribute("aria-checked", &shadow::is_dark(this).to_string());
     }
     update_more_glyph(this);
+    update_sync_condition(this);
+}
+
+fn update_sync_condition(this: &HtmlElement) {
+    let Some(document) = window().and_then(|window| window.document()) else {
+        return;
+    };
+    let local_only = this.get_attribute("data-sync-status").as_deref() == Some("sync:local")
+        && this.get_attribute("data-customer-status").as_deref() != Some("Registered");
+    if !local_only {
+        if let Some(cluster) = document.get_element_by_id("fabb-connect-cluster") {
+            let _ = cluster.set_attribute("hidden", "");
+        }
+        if let Some(banner) = document.get_element_by_id(CONNECT_BANNER_ID) {
+            retire_banner(&banner);
+        }
+        return;
+    }
+    if document.get_element_by_id(CONNECT_BANNER_ID).is_some() {
+        sync_condition_mode(this, &document);
+        return;
+    }
+    let Ok(banner) = document.create_element("tonk-banner") else {
+        return;
+    };
+    banner.set_id(CONNECT_BANNER_ID);
+    banner.set_inner_html("connect this space<span slot=\"door\">connect</span>");
+    if let Some(mode) = this.get_attribute("mode") {
+        let _ = banner.set_attribute("mode", &mode);
+    }
+    let on_open = wasm_bindgen::closure::Closure::<dyn FnMut(web_sys::Event)>::new(move |_| {
+        crate::share::open_enable_sync_from_banner();
+    });
+    let _ = banner.add_event_listener_with_callback("fabb-open", on_open.as_ref().unchecked_ref());
+    on_open.forget();
+    if let Some(body) = document.body() {
+        let _ = body.append_child(&banner);
+    }
+}
+
+fn sync_condition_mode(this: &HtmlElement, document: &web_sys::Document) {
+    for id in [CONNECT_BANNER_ID, "fabb-connect-cluster"] {
+        let Some(element) = document.get_element_by_id(id) else {
+            continue;
+        };
+        if let Some(mode) = this.get_attribute("mode") {
+            let _ = element.set_attribute("mode", &mode);
+        } else {
+            let _ = element.remove_attribute("mode");
+        }
+    }
+}
+
+pub(crate) fn refresh_sync_condition(this: &HtmlElement) {
+    update_sync_condition(this);
+}
+
+fn retire_banner(banner: &Element) {
+    let retire = Reflect::get(banner, &"retire".into())
+        .ok()
+        .and_then(|value| value.dyn_into::<js_sys::Function>().ok());
+    if let Some(retire) = retire {
+        let _ = retire.call0(banner);
+    } else {
+        banner.remove();
+    }
+}
+
+pub(crate) fn remove_conditions() {
+    let Some(document) = window().and_then(|window| window.document()) else {
+        return;
+    };
+    if let Some(banner) = document.get_element_by_id(CONNECT_BANNER_ID) {
+        banner.remove();
+    }
 }
 
 fn update_more_glyph(this: &HtmlElement) {

--- a/rust/tonk-fab/src/cluster.rs
+++ b/rust/tonk-fab/src/cluster.rs
@@ -1,0 +1,259 @@
+//! `<tonk-cluster>` — the ceremony shell for a wall or condition.
+
+#[cfg_attr(not(any(test, target_arch = "wasm32")), allow(dead_code))]
+const CSS: &str = r#"
+:host{ position:fixed; inset:0; z-index:2147483647; display:block; }
+:host([hidden]){ display:none; }
+.w{ position:absolute; inset:0; }
+.dim{ position:absolute; inset:0; display:grid; place-items:center; padding:24px;
+  background:color-mix(in srgb, var(--_ink) 32%, transparent); }
+.cluster{ width:min(432px, calc(100vw - 48px)); display:flex; flex-direction:column;
+  gap:7px; color:var(--_ink); }
+.statement,.narrator{ min-height:36px; padding:12px 14px; display:flex;
+  align-items:flex-end; background:var(--_panel); box-shadow:var(--_ring); }
+.statement{ font-family:'IBM Plex Sans',system-ui,sans-serif; font-size:13.5px;
+  font-weight:600; line-height:1.55; text-wrap:balance; }
+.narrator{ color:var(--_soft); font-family:'IBM Plex Sans',system-ui,sans-serif;
+  font-size:13px; font-weight:400; line-height:1.55; text-wrap:pretty; }
+.fields{ display:flex; flex-direction:column; gap:7px; }
+.run{ display:flex; gap:0; align-items:stretch; }
+.run ::slotted(*){ flex:1 1 0; min-width:0; }
+.ghost{ align-self:flex-start; min-height:40px; padding:10px 0; color:var(--_on);
+  font-size:13px; line-height:20px; text-decoration:underline;
+  text-underline-offset:2px; cursor:pointer; }
+@media (max-width:519px){
+  .dim{ padding:16px; }
+  .cluster{ width:min(432px, calc(100vw - 32px)); }
+  .run{ display:grid; grid-template-columns:1fr; gap:0; }
+}
+"#;
+
+#[cfg_attr(not(any(test, target_arch = "wasm32")), allow(dead_code))]
+const HTML: &str = r#"<div class="w"><div class="dim" part="dim">
+  <section class="cluster" role="dialog" aria-modal="true">
+    <div class="statement"><slot name="statement"></slot></div>
+    <div class="fields"><slot></slot></div>
+    <div class="narrator"><slot name="narrator"></slot></div>
+    <div class="run"><slot name="run"></slot></div>
+    <span class="ghost" role="button" tabindex="0"><span aria-hidden="true">&#9666; </span><slot name="ghost"></slot></span>
+  </section>
+</div></div>"#;
+
+#[cfg(target_arch = "wasm32")]
+mod element {
+    use custom_elements::CustomElement;
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen::prelude::*;
+    use web_sys::{Element, HtmlElement, KeyboardEvent, window};
+
+    use crate::shadow::{self, Bound};
+
+    use super::{CSS, HTML};
+
+    #[derive(Default)]
+    pub(super) struct TonkCluster {
+        listeners: Vec<Bound>,
+    }
+
+    impl CustomElement for TonkCluster {
+        fn shadow() -> bool {
+            false
+        }
+
+        fn observed_attributes() -> &'static [&'static str] {
+            &["mode"]
+        }
+
+        fn inject_children(&mut self, _this: &HtmlElement) {}
+
+        fn connected_callback(&mut self, this: &HtmlElement) {
+            let root = shadow::build(this, CSS, HTML);
+
+            if let Ok(Some(dim)) = root.query_selector(".dim") {
+                let dim_target = dim.clone();
+                self.listeners
+                    .push(shadow::bind(&dim, "click", move |event| {
+                        if event
+                            .target()
+                            .and_then(|target| target.dyn_into::<Element>().ok())
+                            .is_some_and(|target| target == dim_target)
+                        {
+                            event.prevent_default();
+                            event.stop_propagation();
+                        }
+                    }));
+            }
+
+            if let Ok(Some(ghost)) = root.query_selector(".ghost") {
+                let host = this.clone();
+                self.listeners.push(shadow::on_click(&ghost, move || {
+                    shadow::emit(&host, "fabb-bail", &JsValue::NULL)
+                }));
+
+                let host = this.clone();
+                self.listeners
+                    .push(shadow::bind(&ghost, "keydown", move |event| {
+                        let Some(event) = event.dyn_ref::<KeyboardEvent>() else {
+                            return;
+                        };
+                        if matches!(event.key().as_str(), "Enter" | " ") {
+                            event.prevent_default();
+                            shadow::emit(&host, "fabb-bail", &JsValue::NULL);
+                        }
+                    }));
+            }
+
+            let host = this.clone();
+            self.listeners
+                .push(shadow::bind(this, "keydown", move |event| {
+                    let Some(key) = event.dyn_ref::<KeyboardEvent>() else {
+                        return;
+                    };
+                    match key.key().as_str() {
+                        "Escape" => {
+                            key.prevent_default();
+                            shadow::emit(&host, "fabb-bail", &JsValue::NULL);
+                        }
+                        "Tab" => loop_focus(&host, key),
+                        _ => {}
+                    }
+                }));
+
+            if let Ok(slots) = root.query_selector_all("slot") {
+                for index in 0..slots.length() {
+                    if let Some(slot) = slots.item(index)
+                        && let Ok(slot) = slot.dyn_into::<Element>()
+                    {
+                        let host = this.clone();
+                        self.listeners
+                            .push(shadow::bind(&slot, "slotchange", move |_| propagate(&host)));
+                    }
+                }
+            }
+
+            self.listeners.push(shadow::install_visibility_pause(this));
+            if let Some(listener) = shadow::install_system_mode(this) {
+                self.listeners.push(listener);
+            }
+            propagate(this);
+        }
+
+        fn disconnected_callback(&mut self, _this: &HtmlElement) {
+            self.listeners.clear();
+        }
+
+        fn attribute_changed_callback(
+            &mut self,
+            this: &HtmlElement,
+            name: String,
+            old: Option<String>,
+            new: Option<String>,
+        ) {
+            if name == "mode" && old != new {
+                shadow::apply_mode(this);
+                propagate(this);
+            }
+        }
+    }
+
+    fn light_focusables(this: &HtmlElement) -> Vec<Element> {
+        let Ok(nodes) = this.query_selector_all(
+            "button:not([disabled]),a[href],input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex='-1']),tonk-button:not([disabled]),tonk-field:not([settled])",
+        ) else {
+            return Vec::new();
+        };
+        (0..nodes.length())
+            .filter_map(|index| nodes.item(index))
+            .filter_map(|node| node.dyn_into::<Element>().ok())
+            .collect()
+    }
+
+    fn event_hit(event: &KeyboardEvent, wanted: &Element) -> bool {
+        let path = event.composed_path();
+        (0..path.length()).any(|index| {
+            path.get(index)
+                .dyn_into::<Element>()
+                .ok()
+                .is_some_and(|element| element == *wanted)
+        })
+    }
+
+    fn focus(element: &Element) {
+        let target = element
+            .shadow_root()
+            .and_then(|root| {
+                root.query_selector("button,input,[tabindex]:not([tabindex='-1'])")
+                    .ok()
+                    .flatten()
+            })
+            .unwrap_or_else(|| element.clone());
+        if let Ok(target) = target.dyn_into::<HtmlElement>() {
+            let _ = target.focus();
+        }
+    }
+
+    fn loop_focus(this: &HtmlElement, event: &KeyboardEvent) {
+        let focusables = light_focusables(this);
+        let Some(first) = focusables.first() else {
+            return;
+        };
+        let Some(ghost) = this
+            .shadow_root()
+            .and_then(|root| root.query_selector(".ghost").ok().flatten())
+        else {
+            return;
+        };
+        if !event.shift_key() && event_hit(event, &ghost) {
+            event.prevent_default();
+            focus(first);
+        } else if event.shift_key() && event_hit(event, first) {
+            event.prevent_default();
+            focus(&ghost);
+        }
+    }
+
+    fn propagate(this: &HtmlElement) {
+        let Ok(children) = this.query_selector_all("tonk-button,tonk-field") else {
+            return;
+        };
+        for index in 0..children.length() {
+            if let Some(child) = children.item(index)
+                && let Ok(child) = child.dyn_into::<Element>()
+            {
+                shadow::pass_mode(this, &child);
+            }
+        }
+    }
+
+    pub(crate) fn register() {
+        let Some(win) = window() else { return };
+        if win.custom_elements().get("tonk-cluster").is_undefined() {
+            TonkCluster::define("tonk-cluster");
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) use element::register;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn markup_has_one_dim_and_all_ceremony_slots() {
+        assert_eq!(HTML.matches("class=\"dim\"").count(), 1);
+        for slot in ["statement", "narrator", "run", "ghost"] {
+            assert!(HTML.contains(&format!("name=\"{slot}\"")));
+        }
+        assert!(!HTML.contains("<button class=\"ghost\""));
+    }
+
+    #[test]
+    fn run_is_fused_and_the_column_uses_the_shared_rhythm() {
+        assert!(CSS.contains("width:min(432px"));
+        assert!(CSS.contains("gap:7px"));
+        assert!(CSS.contains(".run{"));
+        assert!(CSS.contains("gap:0"));
+    }
+}

--- a/rust/tonk-fab/src/element.rs
+++ b/rust/tonk-fab/src/element.rs
@@ -97,6 +97,7 @@ pub(crate) struct TonkFab {
     listeners: Rc<RefCell<Vec<Bound>>>,
     responsive_observer: Option<ResizeObserver>,
     responsive_callback: Option<Closure<dyn FnMut(JsValue, JsValue)>>,
+    activation_watch: Option<crate::activation::ActivationWatch>,
 }
 
 impl CustomElement for TonkFab {
@@ -149,6 +150,7 @@ impl CustomElement for TonkFab {
         restore_position(this);
         self.listeners.borrow_mut().extend(attach_presence(this));
         self.listeners.borrow_mut().extend(attach_account(this));
+        self.activation_watch = crate::activation::watch(this);
     }
 
     fn disconnected_callback(&mut self, _this: &HtmlElement) {
@@ -156,7 +158,10 @@ impl CustomElement for TonkFab {
             observer.disconnect();
         }
         self.responsive_callback = None;
+        self.activation_watch = None;
         self.listeners.borrow_mut().clear();
+        bar::remove_conditions();
+        crate::activation::remove();
     }
 
     fn attribute_changed_callback(
@@ -253,7 +258,7 @@ pub(crate) fn mount_refusal_dialogs() {
     let Some(document) = window().and_then(|w| w.document()) else {
         return;
     };
-    if document.get_element_by_id("fab-enable-sync").is_some() {
+    if document.get_element_by_id("fabb-connect-cluster").is_some() {
         return;
     }
     let Some(body) = document.body() else { return };

--- a/rust/tonk-fab/src/field.rs
+++ b/rust/tonk-fab/src/field.rs
@@ -1,0 +1,319 @@
+//! `<tonk-field>` — an entry or settled record row.
+//!
+//! The row keeps the edge grammar's two readings on one 36px block: the
+//! noun sits bottom-left in soft ink and the value sits bottom-right in ink.
+//! Entry rows carry the shared terminal cursor; settled records do not.
+
+#[cfg_attr(not(any(test, target_arch = "wasm32")), allow(dead_code))]
+const CSS: &str = r#"
+:host{ display:block; min-width:0; }
+.w{ display:block; }
+.row{ height:36px; min-width:0; padding:0 10px 8px 12px; display:flex;
+  align-items:flex-end; gap:12px; background:var(--_bg);
+  -webkit-backdrop-filter:var(--_filter); backdrop-filter:var(--_filter);
+  box-shadow:var(--_ring); overflow:hidden; }
+.noun{ position:relative; flex:none; min-width:0; color:var(--_soft);
+  font-size:12px; font-weight:600; line-height:1; text-transform:lowercase;
+  white-space:nowrap; }
+.noun-change{ display:none; color:var(--_ink); text-decoration:underline;
+  text-underline-offset:2px; }
+.noun .cur{ vertical-align:-2px; margin-left:3px; mix-blend-mode:normal; }
+.value{ flex:1 1 auto; min-width:0; padding:0; border:0; outline:0;
+  color:var(--_ink); background:transparent; font:inherit; font-size:13px;
+  font-weight:600; line-height:1; text-align:right; caret-color:transparent; }
+.value-cur{ margin-bottom:0; }
+:host([filter=digits]) .value{ font-variant-numeric:tabular-nums; }
+:host([autolen="6"]) .value{ letter-spacing:.14em; }
+:host([settled]) .value{ pointer-events:none; }
+:host([settled]) .value-cur{ display:none; }
+:host([changeable]) .noun{ cursor:pointer; min-height:20px; display:inline-flex;
+  align-items:flex-end; }
+:host([changeable]) .noun:hover .noun-current,
+:host([changeable]) .noun:focus-visible .noun-current{ display:none; }
+:host([changeable]) .noun:hover .noun-change,
+:host([changeable]) .noun:focus-visible .noun-change{ display:inline-flex; align-items:flex-end; }
+.row.rejecting{ animation:fabb-wash .45s var(--_ease) 2; }
+@media (pointer:coarse){
+  :host([changeable]) .noun-current{ display:none; }
+  :host([changeable]) .noun-change{ display:inline-flex; align-items:flex-end; }
+}
+@media (prefers-reduced-motion:reduce){
+  .row.rejecting{ animation:none; }
+  .cur{ animation:none; }
+}
+"#;
+
+#[cfg_attr(not(any(test, target_arch = "wasm32")), allow(dead_code))]
+const HTML: &str = r#"<div class="w"><label class="row">
+  <span class="noun"><span class="noun-current"></span><span class="noun-change">change<i class="cur" aria-hidden="true"></i></span></span>
+  <input class="value" type="text" autocomplete="off" spellcheck="false">
+  <i class="cur value-cur" aria-hidden="true"></i>
+</label></div>"#;
+
+#[cfg(target_arch = "wasm32")]
+mod element {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    use custom_elements::CustomElement;
+    use js_sys::{Object, Reflect};
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen::prelude::*;
+    use web_sys::{HtmlElement, HtmlInputElement, KeyboardEvent, window};
+
+    use crate::shadow::{self, Bound};
+
+    use super::{CSS, HTML};
+
+    #[derive(Default)]
+    pub(super) struct TonkField {
+        listeners: Vec<Bound>,
+        last_auto_commit: Rc<RefCell<Option<String>>>,
+    }
+
+    impl CustomElement for TonkField {
+        fn shadow() -> bool {
+            false
+        }
+
+        fn observed_attributes() -> &'static [&'static str] {
+            &[
+                "mode",
+                "noun",
+                "value",
+                "settled",
+                "filter",
+                "autolen",
+                "changeable",
+            ]
+        }
+
+        fn inject_children(&mut self, _this: &HtmlElement) {}
+
+        fn connected_callback(&mut self, this: &HtmlElement) {
+            let root = shadow::build(this, CSS, HTML);
+            install_reject_api(this);
+
+            if let Ok(Some(value)) = root.query_selector(".value") {
+                let host = this.clone();
+                let last = self.last_auto_commit.clone();
+                self.listeners.push(shadow::bind(&value, "input", move |_| {
+                    normalize_and_maybe_commit(&host, &last);
+                }));
+
+                let host = this.clone();
+                self.listeners
+                    .push(shadow::bind(&value, "keydown", move |event| {
+                        let Some(event) = event.dyn_ref::<KeyboardEvent>() else {
+                            return;
+                        };
+                        if event.key() == "Enter" {
+                            event.prevent_default();
+                            emit_commit(&host);
+                        }
+                    }));
+            }
+
+            if let Ok(Some(noun)) = root.query_selector(".noun") {
+                let host = this.clone();
+                self.listeners
+                    .push(shadow::bind(&noun, "click", move |event| {
+                        if host.has_attribute("changeable") {
+                            event.prevent_default();
+                            shadow::emit(&host, "fabb-change-noun", &JsValue::NULL);
+                        }
+                    }));
+
+                let host = this.clone();
+                self.listeners
+                    .push(shadow::bind(&noun, "keydown", move |event| {
+                        let Some(event) = event.dyn_ref::<KeyboardEvent>() else {
+                            return;
+                        };
+                        if host.has_attribute("changeable")
+                            && matches!(event.key().as_str(), "Enter" | " ")
+                        {
+                            event.prevent_default();
+                            shadow::emit(&host, "fabb-change-noun", &JsValue::NULL);
+                        }
+                    }));
+            }
+
+            if let Ok(Some(row)) = root.query_selector(".row") {
+                let row_for_end = row.clone();
+                self.listeners
+                    .push(shadow::bind(&row, "animationend", move |_| {
+                        let _ = row_for_end.class_list().remove_1("rejecting");
+                    }));
+            }
+
+            self.listeners.push(shadow::install_visibility_pause(this));
+            if let Some(listener) = shadow::install_system_mode(this) {
+                self.listeners.push(listener);
+            }
+            sync(this);
+        }
+
+        fn disconnected_callback(&mut self, _this: &HtmlElement) {
+            self.listeners.clear();
+            *self.last_auto_commit.borrow_mut() = None;
+        }
+
+        fn attribute_changed_callback(
+            &mut self,
+            this: &HtmlElement,
+            _name: String,
+            old: Option<String>,
+            new: Option<String>,
+        ) {
+            if old != new {
+                sync(this);
+            }
+        }
+    }
+
+    fn input(this: &HtmlElement) -> Option<HtmlInputElement> {
+        this.shadow_root()?
+            .query_selector(".value")
+            .ok()
+            .flatten()?
+            .dyn_into::<HtmlInputElement>()
+            .ok()
+    }
+
+    fn sync(this: &HtmlElement) {
+        shadow::apply_mode(this);
+        let Some(root) = this.shadow_root() else {
+            return;
+        };
+        if let Ok(Some(noun)) = root.query_selector(".noun-current") {
+            noun.set_text_content(Some(&this.get_attribute("noun").unwrap_or_default()));
+        }
+        if let Some(input) = input(this) {
+            let next = this.get_attribute("value").unwrap_or_default();
+            if input.value() != next {
+                input.set_value(&next);
+            }
+            input.set_read_only(this.has_attribute("settled"));
+            input.set_tab_index(if this.has_attribute("settled") { -1 } else { 0 });
+            if this.get_attribute("filter").as_deref() == Some("digits") {
+                let _ = input.set_attribute("inputmode", "numeric");
+            } else {
+                let _ = input.remove_attribute("inputmode");
+            }
+            if let Some(length) = this.get_attribute("autolen") {
+                let _ = input.set_attribute("maxlength", &length);
+            } else {
+                let _ = input.remove_attribute("maxlength");
+            }
+        }
+        if let Ok(Some(noun)) = root.query_selector(".noun") {
+            if this.has_attribute("changeable") {
+                let _ = noun.set_attribute("role", "button");
+                let _ = noun.set_attribute("tabindex", "0");
+                let _ = noun.set_attribute("aria-label", "change");
+            } else {
+                let _ = noun.remove_attribute("role");
+                let _ = noun.remove_attribute("tabindex");
+                let _ = noun.remove_attribute("aria-label");
+            }
+        }
+    }
+
+    fn normalize_and_maybe_commit(
+        this: &HtmlElement,
+        last_auto_commit: &Rc<RefCell<Option<String>>>,
+    ) {
+        let Some(input) = input(this) else {
+            return;
+        };
+        let mut value = input.value();
+        if this.get_attribute("filter").as_deref() == Some("digits") {
+            value.retain(|character| character.is_ascii_digit());
+        }
+        let limit = this
+            .get_attribute("autolen")
+            .and_then(|length| length.parse::<usize>().ok())
+            .filter(|length| *length > 0);
+        if let Some(limit) = limit
+            && value.chars().count() > limit
+        {
+            value = value.chars().take(limit).collect();
+        }
+        if input.value() != value {
+            input.set_value(&value);
+        }
+        let _ = this.set_attribute("value", &value);
+
+        if limit.is_some_and(|limit| value.chars().count() == limit) {
+            if last_auto_commit.borrow().as_deref() != Some(value.as_str()) {
+                *last_auto_commit.borrow_mut() = Some(value);
+                emit_commit(this);
+            }
+        } else {
+            *last_auto_commit.borrow_mut() = None;
+        }
+    }
+
+    fn emit_commit(this: &HtmlElement) {
+        let value = input(this).map(|input| input.value()).unwrap_or_default();
+        let detail = Object::new();
+        let _ = Reflect::set(&detail, &"value".into(), &value.into());
+        shadow::emit(this, "fabb-commit", &detail.into());
+    }
+
+    fn install_reject_api(this: &HtmlElement) {
+        let host = this.clone();
+        let reject = Closure::<dyn FnMut()>::new(move || reject(&host));
+        let _ = Reflect::set(this, &"reject".into(), reject.as_ref());
+        reject.forget();
+    }
+
+    fn reject(this: &HtmlElement) {
+        if let Some(root) = this.shadow_root()
+            && let Ok(Some(row)) = root.query_selector(".row")
+        {
+            let _ = row.class_list().remove_1("rejecting");
+            let _ = row.get_bounding_client_rect();
+            let _ = row.class_list().add_1("rejecting");
+        }
+        if let Some(input) = input(this) {
+            let _ = input.focus();
+            input.select();
+        }
+    }
+
+    pub(crate) fn register() {
+        let Some(win) = window() else { return };
+        if win.custom_elements().get("tonk-field").is_undefined() {
+            TonkField::define("tonk-field");
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) use element::register;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn markup_has_the_edge_row_anatomy() {
+        assert!(HTML.contains("class=\"noun\""));
+        assert!(HTML.contains("class=\"value\""));
+        assert!(HTML.contains("class=\"cur\""));
+        assert!(CSS.contains("height:36px"));
+        assert!(CSS.contains(":host([settled])"));
+        assert!(CSS.contains(":host([filter=digits])"));
+    }
+
+    #[test]
+    fn component_css_uses_only_skin_tokens_for_colour() {
+        assert!(!CSS.contains('#'));
+        assert!(!CSS.contains("rgb("));
+        assert!(!CSS.contains("rgba("));
+        assert!(CSS.contains("var(--_ink)"));
+        assert!(CSS.contains("var(--_soft)"));
+    }
+}

--- a/rust/tonk-fab/src/lib.rs
+++ b/rust/tonk-fab/src/lib.rs
@@ -11,6 +11,13 @@ pub mod markup;
 pub mod retry;
 pub mod skin;
 
+mod banner;
+mod cluster;
+mod field;
+
+#[cfg(target_arch = "wasm32")]
+mod activation;
+
 /// `<tonk-button>` — a block button.
 #[cfg(target_arch = "wasm32")]
 mod button;
@@ -69,6 +76,9 @@ pub fn register() {
     mi::register();
     dialog::register();
     button::register();
+    field::register();
+    cluster::register();
+    banner::register();
     share::register();
     space_name::register();
     profile_name::register();

--- a/rust/tonk-fab/src/markup.rs
+++ b/rust/tonk-fab/src/markup.rs
@@ -155,6 +155,7 @@ pub const STACKS_HTML: &str = r#"<ui-sync-status headless with="main@{space}"></
     <span class="say say--copying">copying&hellip;</span>
     <span class="say say--copied">copied</span>
     <span class="say say--failed">couldn&rsquo;t copy</span>
+    <span class="say say--activation">sharing needs an activated email</span>
   </tonk-mi>
   <ui-member-roster space="{space}"></ui-member-roster>
 </tonk-menu>
@@ -193,6 +194,8 @@ tonk-fab [data-share-link][data-share-state="blocked"] .say--idle{ display:inlin
 tonk-fab [data-share-link][data-share-state="copying"] .say--copying{ display:inline; }
 tonk-fab [data-share-link][data-share-state="copied"] .say--copied{ display:inline; }
 tonk-fab [data-share-link][data-share-state="failed"] .say--failed{ display:inline; }
+tonk-fab [data-share-link][data-activation-blocked] .say{ display:none; }
+tonk-fab [data-share-link][data-activation-blocked] .say--activation{ display:inline; }
 "#;
 
 /// The share flow's repairable sync refusal.
@@ -208,13 +211,13 @@ tonk-fab [data-share-link][data-share-state="failed"] .say--failed{ display:inli
 /// The action run reads left-to-right as dismiss-then-commit, and the two
 /// fuse flush — the fill boundary between quiet and primary IS the divider
 /// (law 3), which is why there is no gap and no separator between them.
-pub const REFUSAL_DIALOGS_HTML: &str = r#"<tonk-dialog id="fab-enable-sync" heading="turn on sync?">
-  <p data-enable-sync-detail>This spot only exists on this device.</p>
-  <p data-enable-sync-action>Turn on sync so the people you share with can open it.</p>
-  <tonk-button slot="actions" variant="quiet" data-dialog="close">not now</tonk-button>
-  <tonk-button slot="actions" variant="primary" data-enable-sync-confirm>turn on sync &amp; copy link</tonk-button>
-</tonk-dialog>
-"#;
+pub const REFUSAL_DIALOGS_HTML: &str = r#"<tonk-cluster id="fabb-connect-cluster" hidden>
+  <p slot="statement" data-enable-sync-statement>connect this space</p>
+  <tonk-field noun="sync server" value="" data-enable-sync-remote></tonk-field>
+  <p slot="narrator"><span data-enable-sync-detail>This space only exists on this device.</span> <span data-enable-sync-action>Connect it so other people can open it.</span></p>
+  <tonk-button slot="run" variant="primary" solid data-enable-sync-confirm>connect</tonk-button>
+  <span slot="ghost">keep it on this device</span>
+</tonk-cluster>"#;
 
 /// Stamp the space DID into [`STACKS_HTML`].
 ///
@@ -484,8 +487,12 @@ mod tests {
     }
 
     #[test]
-    fn it_gives_the_sync_refusal_its_prompt() {
-        assert!(REFUSAL_DIALOGS_HTML.contains(r#"id="fab-enable-sync""#));
+    fn it_gives_sync_a_connect_ceremony() {
+        assert!(!REFUSAL_DIALOGS_HTML.contains(r#"id="fab-enable-sync""#));
+        assert!(REFUSAL_DIALOGS_HTML.contains(r#"id="fabb-connect-cluster""#));
+        assert!(REFUSAL_DIALOGS_HTML.contains("<tonk-cluster"));
+        assert!(REFUSAL_DIALOGS_HTML.contains(r#"noun="sync server""#));
+        assert!(REFUSAL_DIALOGS_HTML.contains("keep it on this device"));
         assert!(REFUSAL_DIALOGS_HTML.contains("data-enable-sync-confirm"));
         // The line share.rs rewrites per refusal class. Without the hook the
         // prompt is silently stuck on the `not-synced` wording.
@@ -496,22 +503,21 @@ mod tests {
 
     #[test]
     fn it_offers_a_way_out_of_every_prompt() {
-        // Each cluster needs a dismiss; `data-dialog=close` is what the
-        // dialog's own handler acts on.
+        // The ceremony bails only through the cluster's ghost or Escape.
         assert_eq!(
             REFUSAL_DIALOGS_HTML
                 .matches(r#"data-dialog="close""#)
                 .count(),
-            1
+            0
         );
+        assert!(REFUSAL_DIALOGS_HTML.contains(r#"slot="ghost""#));
     }
 
     #[test]
     fn it_keeps_prompt_chrome_lowercase() {
         // Law 4. The prompt BODIES carry sentences and stay as written; the
         // headings and the action labels are chrome.
-        assert!(REFUSAL_DIALOGS_HTML.contains(r#"heading="turn on sync?""#));
-        for label in ["not now", "turn on sync &amp; copy link"] {
+        for label in ["connect"] {
             assert!(REFUSAL_DIALOGS_HTML.contains(&format!(">{label}</tonk-button>")));
         }
     }

--- a/rust/tonk-fab/src/markup.rs
+++ b/rust/tonk-fab/src/markup.rs
@@ -517,9 +517,7 @@ mod tests {
     fn it_keeps_prompt_chrome_lowercase() {
         // Law 4. The prompt BODIES carry sentences and stay as written; the
         // headings and the action labels are chrome.
-        for label in ["connect"] {
-            assert!(REFUSAL_DIALOGS_HTML.contains(&format!(">{label}</tonk-button>")));
-        }
+        assert!(REFUSAL_DIALOGS_HTML.contains(">connect</tonk-button>"));
     }
 
     #[test]

--- a/rust/tonk-fab/src/share.rs
+++ b/rust/tonk-fab/src/share.rs
@@ -173,17 +173,19 @@ const BLOCKED_TAG: &str = "tonk-share-blocked";
 /// every refusal so `detail` always lands somewhere visible, disabling the
 /// confirm button (see `open_enable_sync_dialog`) on the one class it cannot
 /// repair.
-const DIALOG_ID: &str = "fab-enable-sync";
+const DIALOG_ID: &str = "fabb-connect-cluster";
 const DIALOG_CONFIRM: &str = "[data-enable-sync-confirm]";
 const DIALOG_DETAIL: &str = "[data-enable-sync-detail]";
 const DIALOG_ACTION: &str = "[data-enable-sync-action]";
+const DIALOG_STATEMENT: &str = "[data-enable-sync-statement]";
+const DIALOG_REMOTE: &str = "[data-enable-sync-remote]";
 
 /// Heading and confirm label for a refusal with no repair. The button stays
 /// visible but disabled, so it needs wording that doesn't promise an action —
 /// "Turn on sync & copy link" greyed out reads as a broken control rather than
 /// an answer.
-const TERMINAL_LABEL: &str = "Can't share this spot";
-const TERMINAL_CONFIRM: &str = "Copy link";
+const TERMINAL_LABEL: &str = "this space cannot be shared";
+const TERMINAL_CONFIRM: &str = "copy link";
 
 /// What confirming the prompt is offering to do, for one refusal class.
 ///
@@ -210,9 +212,9 @@ impl Repair {
     fn for_code(code: &str) -> Option<Self> {
         match code {
             BLOCKED_NOT_SYNCED => Some(Self {
-                label: "Turn on sync?",
-                action: "Turn on sync so the people you share with can open it.",
-                confirm: "Turn on sync & copy link",
+                label: "connect this space",
+                action: "Connect it so the people you share with can open it.",
+                confirm: "connect",
             }),
             _ => None,
         }
@@ -581,28 +583,89 @@ impl TonkShare {
             // `location.origin` is the opaque `"null"` and the remote URL
             // built from it would be unusable. `context_origin` prefers the
             // true origin the portal bridge injects.
-            let Some(origin) = tonk_host::bridge::context_origin() else {
-                warn("share: cannot resolve this page's origin");
+            let remote = enable_sync_dialog()
+                .and_then(|dialog| dialog.query_selector(DIALOG_REMOTE).ok().flatten())
+                .and_then(|field| field.get_attribute("value"))
+                .filter(|value| !value.trim().is_empty())
+                .or_else(|| {
+                    tonk_host::bridge::context_origin().map(|origin| default_remote_url(&origin))
+                });
+            let Some(remote) = remote else {
+                warn("share: cannot resolve this page's sync server");
                 return;
             };
-            let remote = default_remote_url(&origin);
+            let wants_share = enable_sync_dialog().is_some_and(|dialog| {
+                dialog.get_attribute("data-share").as_deref() == Some("true")
+            });
 
             let time = js_sys::Date::now();
             state.borrow_mut().pending_time = Some(time);
-            let stale = current_link.borrow().clone();
-            if let Err(e) = open_clipboard_write(Rc::clone(&state), stale) {
-                warn(&format!("share: clipboard unavailable: {e:?}"));
+            if wants_share {
+                let stale = current_link.borrow().clone();
+                if let Err(e) = open_clipboard_write(Rc::clone(&state), stale) {
+                    warn(&format!("share: clipboard unavailable: {e:?}"));
+                }
+                set_state(&host, ShareState::Copying);
+                arm_timeout(&host, &state);
             }
-            set_state(&host, ShareState::Copying);
-            arm_timeout(&host, &state);
-            close_enable_sync_dialog();
-            dispatch_enable_sync(&space, &remote, time);
+            if let Some(narrator) = enable_sync_dialog()
+                .and_then(|dialog| dialog.query_selector(DIALOG_DETAIL).ok().flatten())
+            {
+                narrator.set_text_content(Some("connecting…"));
+            }
+            let _ = confirm.set_attribute("disabled", "");
+            dispatch_enable_sync(&space, &remote, wants_share, time);
         });
         let target: &web_sys::EventTarget = document.unchecked_ref();
         let _ =
             target.add_event_listener_with_callback("click", on_confirm.as_ref().unchecked_ref());
         self.document_listeners
             .push(("click".to_owned(), on_confirm));
+
+        let host = this.clone();
+        let on_bail = Closure::<dyn FnMut(web_sys::Event)>::new(move |event: web_sys::Event| {
+            let Some(target) = event
+                .target()
+                .and_then(|target| target.dyn_into::<Element>().ok())
+            else {
+                return;
+            };
+            if target.id() != DIALOG_ID {
+                return;
+            }
+            close_enable_sync_dialog();
+            if read_state(&host) == ShareState::Blocked {
+                set_state(&host, ShareState::Idle);
+            }
+        });
+        let target: &web_sys::EventTarget = document.unchecked_ref();
+        let _ =
+            target.add_event_listener_with_callback("fabb-bail", on_bail.as_ref().unchecked_ref());
+        self.document_listeners
+            .push(("fabb-bail".to_owned(), on_bail));
+
+        let on_commit = Closure::<dyn FnMut(web_sys::Event)>::new(move |event: web_sys::Event| {
+            let Some(field) = event
+                .target()
+                .and_then(|target| target.dyn_into::<Element>().ok())
+            else {
+                return;
+            };
+            if !field.matches(DIALOG_REMOTE).unwrap_or(false) {
+                return;
+            }
+            let Some(confirm) = enable_sync_dialog()
+                .and_then(|dialog| dialog.query_selector(DIALOG_CONFIRM).ok().flatten())
+            else {
+                return;
+            };
+            confirm.unchecked_ref::<HtmlElement>().click();
+        });
+        let target: &web_sys::EventTarget = document.unchecked_ref();
+        let _ = target
+            .add_event_listener_with_callback("fabb-commit", on_commit.as_ref().unchecked_ref());
+        self.document_listeners
+            .push(("fabb-commit".to_owned(), on_commit));
     }
 }
 
@@ -618,8 +681,8 @@ fn dispatch_invite(space: &str, time: f64) {
 /// Dispatch the `tonk:enable-sync` claim, asking the worker to attach `remote`
 /// to this spot and — because `share` is set — mint the invite the refused
 /// click was after, as soon as the attach lands.
-fn dispatch_enable_sync(space: &str, remote: &str, time: f64) {
-    dispatch_claim(&enable_sync_claim_json(space, remote, true, time));
+fn dispatch_enable_sync(space: &str, remote: &str, share: bool, time: f64) {
+    dispatch_claim(&enable_sync_claim_json(space, remote, share, time));
 }
 
 /// Hand a claim to `window.tonk.transact`. A no-op wherever the bridge is not
@@ -919,6 +982,10 @@ fn abandon(state: &Rc<RefCell<ShareStateCell>>, reason: &str) {
 /// signature exists to make hard — a repairable refusal must also restore
 /// what a terminal one disabled.
 fn open_enable_sync_dialog(detail: &str, repair: Option<Repair>) {
+    open_enable_sync_ceremony(detail, repair, true);
+}
+
+fn open_enable_sync_ceremony(detail: &str, repair: Option<Repair>, wants_share: bool) {
     let Some(dialog) = enable_sync_dialog() else {
         return;
     };
@@ -937,7 +1004,18 @@ fn open_enable_sync_dialog(detail: &str, repair: Option<Repair>) {
     if let Ok(Some(slot)) = dialog.query_selector(DIALOG_ACTION) {
         slot.set_text_content(Some(action));
     }
-    let _ = dialog.set_attribute("label", label);
+    if let Ok(Some(slot)) = dialog.query_selector(DIALOG_STATEMENT) {
+        slot.set_text_content(Some(label));
+    }
+    let _ = dialog.set_attribute("data-share", if wants_share { "true" } else { "false" });
+    if let Some(origin) = tonk_host::bridge::context_origin()
+        && let Ok(Some(field)) = dialog.query_selector(DIALOG_REMOTE)
+        && field
+            .get_attribute("value")
+            .is_none_or(|value| value.is_empty())
+    {
+        let _ = field.set_attribute("value", &default_remote_url(&origin));
+    }
     if let Ok(Some(confirm)) = dialog.query_selector(DIALOG_CONFIRM) {
         confirm.set_text_content(Some(confirm_label));
         // Visible either way — an unrepairable refusal greys the button rather
@@ -951,14 +1029,36 @@ fn open_enable_sync_dialog(detail: &str, repair: Option<Repair>) {
             let _ = confirm.set_attribute("disabled", "");
         }
     }
-    let _ = Reflect::set(&dialog, &JsValue::from_str("open"), &JsValue::TRUE);
+    let _ = dialog.remove_attribute("hidden");
+    if let Some(banner) = window()
+        .and_then(|window| window.document())
+        .and_then(|document| document.get_element_by_id(crate::bar::CONNECT_BANNER_ID))
+    {
+        let _ = banner.set_attribute("hidden", "");
+    }
+}
+
+/// Open the same editable connect ceremony from the local-only condition
+/// banner. Unlike the share refusal, this attaches without minting a link.
+pub(crate) fn open_enable_sync_from_banner() {
+    open_enable_sync_ceremony(
+        "This space only exists on this device.",
+        Repair::for_code(BLOCKED_NOT_SYNCED),
+        false,
+    );
 }
 
 fn close_enable_sync_dialog() {
     let Some(dialog) = enable_sync_dialog() else {
         return;
     };
-    let _ = Reflect::set(&dialog, &JsValue::from_str("open"), &JsValue::FALSE);
+    let _ = dialog.set_attribute("hidden", "");
+    if let Some(banner) = window()
+        .and_then(|window| window.document())
+        .and_then(|document| document.get_element_by_id(crate::bar::CONNECT_BANNER_ID))
+    {
+        let _ = banner.remove_attribute("hidden");
+    }
 }
 
 fn enable_sync_dialog() -> Option<Element> {
@@ -1931,15 +2031,18 @@ mod tests {
         let document = window().expect("window").document().expect("document");
         let host = fresh_host();
         host.set_attribute("space", "did:key:z6Mk").expect("space");
-        let button = document.create_element("button").expect("create button");
-        button
-            .set_attribute("data-enable-sync-confirm", "")
-            .expect("mark button");
-        document
-            .body()
-            .expect("body")
-            .append_child(&button)
-            .expect("attach button");
+        let (dialog, _detail, button) = dialog_stub();
+        dialog
+            .set_attribute("data-share", "true")
+            .expect("share ceremony");
+        let remote = document.create_element("tonk-field").expect("remote field");
+        remote
+            .set_attribute("data-enable-sync-remote", "")
+            .expect("mark remote");
+        remote
+            .set_attribute("value", "https://example.test/ucan/")
+            .expect("remote value");
+        dialog.append_child(&remote).expect("attach remote");
 
         let mut element = TonkShare::default();
         let state = Rc::clone(&element.state);
@@ -1969,7 +2072,7 @@ mod tests {
             state.borrow().pending_time.is_none(),
             "a click after disconnect must reach nothing",
         );
-        button.remove();
+        dialog.remove();
     }
 
     #[wasm_bindgen_test]

--- a/rust/tonk-fab/tests/activation_banner.rs
+++ b/rust/tonk-fab/tests/activation_banner.rs
@@ -1,0 +1,185 @@
+//! Pending customer activation in a real browser DOM.
+
+#![cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use js_sys::{Function, Object, Promise, Reflect};
+use wasm_bindgen::JsCast;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_test::wasm_bindgen_test_configure;
+use web_sys::{Element, HtmlElement, window};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+async fn yield_for(ms: i32) {
+    let promise = Promise::new(&mut |resolve, _| {
+        window()
+            .expect("window")
+            .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, ms)
+            .expect("timeout");
+    });
+    wasm_bindgen_futures::JsFuture::from(promise)
+        .await
+        .expect("timeout resolves");
+}
+
+async fn wait_for(selector: &str) -> Element {
+    for _ in 0..100 {
+        if let Ok(Some(element)) = window()
+            .expect("window")
+            .document()
+            .expect("document")
+            .query_selector(selector)
+        {
+            return element;
+        }
+        yield_for(10).await;
+    }
+    panic!("{selector} did not mount");
+}
+
+fn response(body: &str) -> JsValue {
+    let constructor = Reflect::get(&window().expect("window"), &"Response".into())
+        .expect("Response")
+        .dyn_into::<Function>()
+        .expect("Response constructor");
+    let init = Object::new();
+    Reflect::set(&init, &"status".into(), &JsValue::from_f64(200.0)).expect("status");
+    let args = js_sys::Array::new();
+    args.push(&body.into());
+    args.push(&init);
+    Reflect::construct(&constructor, &args).expect("response")
+}
+
+#[dialog_common::test]
+async fn registered_customer_can_resend_and_retires_when_active() {
+    let win = window().expect("window");
+    let document = win.document().expect("document");
+    let original_fetch = Reflect::get(&win, &"fetch".into()).expect("original fetch");
+    let status = Rc::new(RefCell::new("Registered".to_owned()));
+    let posts = Rc::new(Cell::new(0_u32));
+    let status_for_fetch = status.clone();
+    let posts_for_fetch = posts.clone();
+    let fetch = Closure::<dyn FnMut(JsValue, JsValue) -> Promise>::new(
+        move |url: JsValue, init: JsValue| {
+            let url = url.as_string().unwrap_or_default();
+            let method = Reflect::get(&init, &"method".into())
+                .ok()
+                .and_then(|value| value.as_string())
+                .unwrap_or_else(|| "GET".to_owned());
+            let body = if url == "/api/customer/enroll" && method == "POST" {
+                posts_for_fetch.set(posts_for_fetch.get() + 1);
+                r#"{"status":"Registered"}"#.to_owned()
+            } else {
+                format!(
+                    r#"{{"customer":"did:key:zAccount","status":"{}","email":"jack@example.test"}}"#,
+                    status_for_fetch.borrow()
+                )
+            };
+            Promise::resolve(&response(&body))
+        },
+    );
+    Reflect::set(&win, &"fetch".into(), fetch.as_ref()).expect("stub fetch");
+
+    tonk_fab::register();
+    let bar = document
+        .create_element("tonk-fab")
+        .expect("bar")
+        .dyn_into::<HtmlElement>()
+        .expect("html bar");
+    bar.set_attribute("space", "did:key:zSpace").expect("space");
+    document
+        .body()
+        .expect("body")
+        .append_child(&bar)
+        .expect("mount");
+
+    let banner = wait_for("#fabb-activation-banner").await;
+    assert!(
+        banner
+            .text_content()
+            .unwrap_or_default()
+            .contains("jack@example.test is not activated yet — nothing syncs until it is")
+    );
+    banner
+        .shadow_root()
+        .expect("banner shadow")
+        .query_selector(".door")
+        .expect("door selector")
+        .expect("door")
+        .dyn_into::<HtmlElement>()
+        .expect("door html")
+        .click();
+
+    let cluster = wait_for("#fabb-activation-cluster").await;
+    let field = cluster
+        .query_selector("[data-activation-email]")
+        .expect("field selector")
+        .expect("email field");
+    assert_eq!(
+        field.get_attribute("value").as_deref(),
+        Some("jack@example.test")
+    );
+    cluster
+        .query_selector("[data-resend-activation]")
+        .expect("resend selector")
+        .expect("resend")
+        .dyn_into::<HtmlElement>()
+        .expect("resend html")
+        .click();
+    yield_for(20).await;
+    assert_eq!(posts.get(), 1);
+    assert!(
+        cluster
+            .query_selector("[data-activation-narrator]")
+            .expect("narrator selector")
+            .expect("narrator")
+            .text_content()
+            .unwrap_or_default()
+            .starts_with("Sent")
+    );
+
+    *status.borrow_mut() = "Active".to_owned();
+    let check = cluster
+        .query_selector("[data-check-activation]")
+        .expect("check selector")
+        .expect("check");
+    check
+        .shadow_root()
+        .expect("check shadow")
+        .query_selector(".b")
+        .expect("button selector")
+        .expect("button")
+        .dyn_into::<HtmlElement>()
+        .expect("button html")
+        .click();
+    yield_for(20).await;
+    assert!(
+        document
+            .get_element_by_id("fabb-activation-cluster")
+            .is_none()
+    );
+    yield_for(180).await;
+    assert!(
+        document
+            .get_element_by_id("fabb-activation-banner")
+            .is_none()
+    );
+    let share = bar
+        .query_selector("[data-share-link]")
+        .expect("share selector")
+        .expect("share row");
+    assert!(!share.has_attribute("data-activation-blocked"));
+
+    bar.remove();
+    if let Some(cluster) = document.get_element_by_id("fabb-connect-cluster") {
+        cluster.remove();
+    }
+    if let Some(join) = document.get_element_by_id("fab-join-first") {
+        join.remove();
+    }
+    Reflect::set(&win, &"fetch".into(), &original_fetch).expect("restore fetch");
+    drop(fetch);
+}

--- a/rust/tonk-fab/tests/edge_primitives.rs
+++ b/rust/tonk-fab/tests/edge_primitives.rs
@@ -1,0 +1,303 @@
+//! Edge-grammar components in a real browser DOM.
+
+#![cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use wasm_bindgen::JsCast;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_test::wasm_bindgen_test_configure;
+use web_sys::{CustomEvent, Element, HtmlElement, HtmlInputElement, window};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn document() -> web_sys::Document {
+    window().expect("window").document().expect("document")
+}
+
+async fn yield_for(ms: i32) {
+    let promise = js_sys::Promise::new(&mut |resolve, _reject| {
+        window()
+            .expect("window")
+            .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, ms)
+            .expect("set timeout");
+    });
+    wasm_bindgen_futures::JsFuture::from(promise)
+        .await
+        .expect("timeout resolves");
+}
+
+fn keyboard_event(key: &str, shift: bool) -> web_sys::Event {
+    let init = js_sys::Object::new();
+    js_sys::Reflect::set(&init, &"bubbles".into(), &JsValue::TRUE).expect("bubbles");
+    js_sys::Reflect::set(&init, &"composed".into(), &JsValue::TRUE).expect("composed");
+    js_sys::Reflect::set(&init, &"key".into(), &key.into()).expect("key");
+    js_sys::Reflect::set(&init, &"shiftKey".into(), &JsValue::from_bool(shift)).expect("shift key");
+    let constructor = js_sys::Reflect::get(&window().expect("window"), &"KeyboardEvent".into())
+        .expect("KeyboardEvent constructor")
+        .dyn_into::<js_sys::Function>()
+        .expect("KeyboardEvent function");
+    let args = js_sys::Array::new();
+    args.push(&"keydown".into());
+    args.push(&init);
+    js_sys::Reflect::construct(&constructor, &args)
+        .expect("construct keyboard event")
+        .dyn_into::<web_sys::Event>()
+        .expect("keyboard event")
+}
+
+fn input_event() -> web_sys::Event {
+    let init = web_sys::EventInit::new();
+    init.set_bubbles(true);
+    init.set_composed(true);
+    web_sys::Event::new_with_event_init_dict("input", &init).expect("input event")
+}
+
+fn shadow(host: &HtmlElement, selector: &str) -> Element {
+    host.shadow_root()
+        .expect("shadow root")
+        .query_selector(selector)
+        .expect("selector")
+        .unwrap_or_else(|| panic!("missing {selector}"))
+}
+
+fn mount(tag: &str) -> HtmlElement {
+    tonk_fab::register();
+    let host = document()
+        .create_element(tag)
+        .expect("create host")
+        .dyn_into::<HtmlElement>()
+        .expect("html host");
+    document()
+        .body()
+        .expect("body")
+        .append_child(&host)
+        .expect("mount host");
+    host
+}
+
+fn set_context_origin(value: &str) {
+    let win = window().expect("window");
+    let tonk = js_sys::Reflect::get(&win, &"tonk".into())
+        .ok()
+        .filter(|value| value.is_object())
+        .unwrap_or_else(|| js_sys::Object::new().into());
+    let context = js_sys::Object::new();
+    js_sys::Reflect::set(&context, &"origin".into(), &value.into()).expect("context origin");
+    js_sys::Reflect::set(&tonk, &"context".into(), &context).expect("context");
+    js_sys::Reflect::set(&win, &"tonk".into(), &tonk).expect("tonk");
+}
+
+#[dialog_common::test]
+async fn field_filters_commits_rejects_and_changes_its_noun() {
+    let host = mount("tonk-field");
+    host.set_attribute("noun", "activation code").expect("noun");
+    host.set_attribute("value", "").expect("value");
+    host.set_attribute("filter", "digits").expect("filter");
+    host.set_attribute("autolen", "6").expect("autolen");
+    host.set_attribute("changeable", "").expect("changeable");
+
+    let commits = Rc::new(RefCell::new(Vec::<String>::new()));
+    let sink = commits.clone();
+    let on_commit = Closure::<dyn FnMut(CustomEvent)>::new(move |event: CustomEvent| {
+        let value = js_sys::Reflect::get(&event.detail(), &"value".into())
+            .expect("detail value")
+            .as_string()
+            .expect("string value");
+        sink.borrow_mut().push(value);
+    });
+    host.add_event_listener_with_callback("fabb-commit", on_commit.as_ref().unchecked_ref())
+        .expect("commit listener");
+
+    let changes = Rc::new(Cell::new(0));
+    let sink = changes.clone();
+    let on_change = Closure::<dyn FnMut(CustomEvent)>::new(move |_| sink.set(sink.get() + 1));
+    host.add_event_listener_with_callback("fabb-change-noun", on_change.as_ref().unchecked_ref())
+        .expect("change listener");
+
+    let input = shadow(&host, ".value")
+        .dyn_into::<HtmlInputElement>()
+        .expect("value input");
+    input.set_value("1a2b3");
+    input
+        .dispatch_event(&input_event())
+        .expect("dispatch input");
+    assert_eq!(input.value(), "123");
+    assert!(commits.borrow().is_empty(), "short value does not commit");
+
+    input.set_value("12x3456");
+    input
+        .dispatch_event(&input_event())
+        .expect("dispatch input");
+    assert_eq!(commits.borrow().as_slice(), &["123456"]);
+
+    input.set_value("765432");
+    input
+        .dispatch_event(&keyboard_event("Enter", false))
+        .expect("dispatch Enter");
+    assert_eq!(commits.borrow().last().map(String::as_str), Some("765432"));
+
+    let reject = js_sys::Reflect::get(&host, &"reject".into())
+        .expect("reject member")
+        .dyn_into::<js_sys::Function>()
+        .expect("reject function");
+    reject.call0(&host).expect("reject call");
+    assert_eq!(input.selection_start().expect("selection start"), Some(0));
+    assert_eq!(input.selection_end().expect("selection end"), Some(6));
+    assert!(shadow(&host, ".row").class_list().contains("rejecting"));
+
+    shadow(&host, ".noun")
+        .dyn_into::<HtmlElement>()
+        .expect("noun control")
+        .click();
+    assert_eq!(changes.get(), 1);
+
+    host.remove();
+    drop(on_commit);
+    drop(on_change);
+}
+
+#[dialog_common::test]
+async fn cluster_bails_only_from_escape_or_ghost_and_loops_focus() {
+    let host = mount("tonk-cluster");
+    host.set_inner_html(
+        r#"<p slot="statement">connect this space</p>
+           <button id="first" slot="run">quiet</button>
+           <button id="last" slot="run">solid</button>
+           <span slot="ghost">keep it here</span>"#,
+    );
+    yield_for(0).await;
+
+    let bails = Rc::new(Cell::new(0));
+    let sink = bails.clone();
+    let on_bail = Closure::<dyn FnMut(CustomEvent)>::new(move |_| sink.set(sink.get() + 1));
+    host.add_event_listener_with_callback("fabb-bail", on_bail.as_ref().unchecked_ref())
+        .expect("bail listener");
+
+    shadow(&host, ".dim")
+        .dyn_into::<HtmlElement>()
+        .expect("dim")
+        .click();
+    assert_eq!(bails.get(), 0, "the dim is inert");
+
+    host.dispatch_event(&keyboard_event("Escape", false))
+        .expect("dispatch Escape");
+    assert_eq!(bails.get(), 1);
+
+    shadow(&host, ".ghost")
+        .dyn_into::<HtmlElement>()
+        .expect("ghost")
+        .click();
+    assert_eq!(bails.get(), 2);
+
+    let first = host
+        .query_selector("#first")
+        .expect("first selector")
+        .expect("first")
+        .dyn_into::<HtmlElement>()
+        .expect("first html");
+    let ghost = shadow(&host, ".ghost")
+        .dyn_into::<HtmlElement>()
+        .expect("ghost html");
+    ghost.focus().expect("focus ghost");
+    ghost
+        .dispatch_event(&keyboard_event("Tab", false))
+        .expect("dispatch Tab");
+    assert!(
+        document()
+            .active_element()
+            .is_some_and(|active| active.is_same_node(Some(&first))),
+        "Tab from the last focusable loops to the first"
+    );
+
+    host.remove();
+    drop(on_bail);
+}
+
+#[dialog_common::test]
+async fn banner_beats_opens_and_retires() {
+    let host = mount("tonk-banner");
+    host.set_inner_html("connect this space<span slot=door>connect</span>");
+
+    assert!(!shadow(&host, ".w").class_list().contains("live"));
+    yield_for(500).await;
+    assert!(shadow(&host, ".w").class_list().contains("live"));
+
+    let opens = Rc::new(Cell::new(0));
+    let sink = opens.clone();
+    let on_open = Closure::<dyn FnMut(CustomEvent)>::new(move |_| sink.set(sink.get() + 1));
+    host.add_event_listener_with_callback("fabb-open", on_open.as_ref().unchecked_ref())
+        .expect("open listener");
+    shadow(&host, ".door")
+        .dyn_into::<HtmlElement>()
+        .expect("door")
+        .click();
+    assert_eq!(opens.get(), 1);
+
+    let retire = js_sys::Reflect::get(&host, &"retire".into())
+        .expect("retire member")
+        .dyn_into::<js_sys::Function>()
+        .expect("retire function");
+    retire.call0(&host).expect("retire call");
+    yield_for(200).await;
+    assert!(!host.is_connected());
+
+    drop(on_open);
+}
+
+#[dialog_common::test]
+async fn local_only_bar_opens_the_shared_connect_ceremony() {
+    set_context_origin("https://local.tonk.test");
+    let bar = mount("tonk-fab");
+    bar.set_attribute("space", "did:key:zLocal").expect("space");
+    bar.set_attribute("state", "offline")
+        .expect("offline state");
+    bar.set_attribute("data-sync-status", "sync:local")
+        .expect("precise status");
+    yield_for(0).await;
+
+    let banner = document()
+        .get_element_by_id("fabb-connect-banner")
+        .expect("local-only banner")
+        .dyn_into::<HtmlElement>()
+        .expect("banner html");
+    assert_eq!(
+        banner.text_content().as_deref(),
+        Some("connect this spaceconnect")
+    );
+
+    shadow(&banner, ".door")
+        .dyn_into::<HtmlElement>()
+        .expect("banner door")
+        .click();
+    let cluster = document()
+        .get_element_by_id("fabb-connect-cluster")
+        .expect("connect ceremony");
+    assert!(!cluster.has_attribute("hidden"));
+    assert!(banner.has_attribute("hidden"));
+    let field = cluster
+        .query_selector("[data-enable-sync-remote]")
+        .expect("remote selector")
+        .expect("remote field");
+    assert_eq!(
+        field.get_attribute("value").as_deref(),
+        Some("https://local.tonk.test/ucan/")
+    );
+
+    shadow(
+        &cluster
+            .clone()
+            .dyn_into::<HtmlElement>()
+            .expect("cluster html"),
+        ".ghost",
+    )
+    .dyn_into::<HtmlElement>()
+    .expect("ghost")
+    .click();
+    assert!(cluster.has_attribute("hidden"));
+    assert!(!banner.has_attribute("hidden"));
+
+    bar.remove();
+    cluster.remove();
+}

--- a/rust/tonk-ui/styles.css
+++ b/rust/tonk-ui/styles.css
@@ -550,11 +550,11 @@ tonk-display > .site-pending:not([hidden]) {
     cursor: default;
 }
 .workspace__sync.is-revoked {
-    color: var(--wa-color-danger-on-quiet);
-    background: var(--wa-color-danger-fill-quiet);
+    color: var(--wa-color-text-quiet);
+    background: var(--wa-color-neutral-fill-quiet);
 }
 .workspace__sync.is-revoked::before {
-    background: var(--wa-color-danger-fill-loud);
+    background: currentColor;
 }
 .workspace__sync.is-conflict {
     color: var(--wa-color-warning-on-quiet);
@@ -2456,10 +2456,4 @@ tonk-code:focus-within {
     display: block;
     block-size: 100%;
     min-block-size: 0;
-}
-
-.join-error__retry {
-    min-height: 40px;
-    margin-top: var(--wa-space-s);
-    padding-inline: var(--wa-space-m);
 }

--- a/rust/tonk-worker/tests/standard_library.rs
+++ b/rust/tonk-worker/tests/standard_library.rs
@@ -250,10 +250,26 @@ fn it_builds_one_centered_hub_launcher_with_an_attached_settings_view() {
         !PROFILE_LIBRARY.contains(rejected),
         "the centered Hub launcher must reject `{rejected}`",
     );
-    for rejected in ["class=\"sempty", "no spaces yet"] {
+    assert_eq!(
+        PROFILE_LIBRARY.matches("no spaces yet").count(),
+        1,
+        "the empty Hub must state the neutral roster fact exactly once",
+    );
+    for rejected in ["signed out", "no spaces available"] {
         assert!(
-            !PROFILE_LIBRARY.contains(rejected),
-            "an empty Hub roster must show only the creation action, not `{rejected}`",
+            !PROFILE_LIBRARY.to_lowercase().contains(rejected),
+            "a provider-free local profile must not claim `{rejected}`",
+        );
+    }
+    for contract in [
+        "<ui-hub-account>",
+        "data-account-handoff",
+        "href=\"/space/{subject}\"",
+        "class=\"snew-form\"",
+    ] {
+        assert!(
+            PROFILE_LIBRARY.contains(contract),
+            "provider-free Hub access must preserve `{contract}`",
         );
     }
 }
@@ -364,5 +380,38 @@ fn it_adapts_the_gooey_settings_hierarchy_to_the_wider_launcher() {
             HUB_ACCOUNT_MARKUP.contains(contract),
             "the adapted settings hierarchy must contain `{contract}`",
         );
+    }
+}
+
+#[test]
+fn it_renders_join_refusals_as_neutral_edge_walls() {
+    let failure = PROFILE_LIBRARY
+        .split("view!: &join/failure-view")
+        .nth(1)
+        .and_then(|tail| tail.split("# ROUTING (profile branch)").next())
+        .expect("join failure view");
+    let route = PROFILE_LIBRARY
+        .split("view!: &join/route-view")
+        .nth(1)
+        .and_then(|tail| tail.split("# The /inspector and /diagnose routes").next())
+        .expect("join route view");
+
+    for rejected in ["<wa-callout", "variant=\"danger\"", "{reason}"] {
+        assert!(
+            !failure.contains(rejected),
+            "the closed-invitation wall must not expose `{rejected}`",
+        );
+    }
+    assert!(failure.contains("this invitation is closed"));
+    assert!(route.contains("you do not have access to this space"));
+    for wall in [("closed", failure), ("no-access", route)] {
+        assert_eq!(
+            wall.1.matches("class=\"ebtn solid\"").count(),
+            1,
+            "the {} wall must carry exactly one solid ink door",
+            wall.0,
+        );
+        assert!(wall.1.contains("start a new space"));
+        assert!(wall.1.contains("join this space"));
     }
 }

--- a/rust/tonk-workspace/src/invite_link.rs
+++ b/rust/tonk-workspace/src/invite_link.rs
@@ -47,6 +47,26 @@ const ACCESS_PARAM: &str = "access";
 /// can style an error state without any script of its own.
 const STATE_ATTR: &str = "data-state";
 
+/// Why pasted text could not become a local join target. Kept on the
+/// element as `data-refusal` so the light-DOM wall can explain and animate
+/// the exact refusal without parsing URLs a second way.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum InviteLinkRefusal {
+    Empty,
+    Malformed,
+    Unresolvable,
+}
+
+impl InviteLinkRefusal {
+    fn as_attr(self) -> &'static str {
+        match self {
+            Self::Empty => "empty",
+            Self::Malformed => "malformed",
+            Self::Unresolvable => "unresolvable",
+        }
+    }
+}
+
 #[derive(Default)]
 pub(crate) struct TonkInviteLink {
     submit: SubmitClosure,
@@ -111,12 +131,14 @@ async fn submit(this: &HtmlElement) {
     let pasted = read_field(this, &field).unwrap_or_default();
     let _ = this.set_attribute(STATE_ATTR, "resolving");
     match local_join_href(pasted.trim()).await {
-        Some(href) => {
+        Ok(href) => {
             let _ = this.remove_attribute(STATE_ATTR);
+            let _ = this.remove_attribute("data-refusal");
             dispatch_mount(this, &href);
         }
-        None => {
+        Err(refusal) => {
             let _ = this.set_attribute(STATE_ATTR, "invalid");
+            let _ = this.set_attribute("data-refusal", refusal.as_attr());
         }
     }
 }
@@ -188,20 +210,22 @@ fn read_field(this: &HtmlElement, field: &str) -> Option<String> {
 /// are deliberately discarded — they only say where the link was minted —
 /// EXCEPT for the one thing only that origin can do: expand `/@/{hash}`
 /// into the query it stands for.
-async fn local_join_href(pasted: &str) -> Option<String> {
+async fn local_join_href(pasted: &str) -> Result<String, InviteLinkRefusal> {
     if pasted.is_empty() {
-        return None;
+        return Err(InviteLinkRefusal::Empty);
     }
-    let url = web_sys::Url::new(pasted).ok()?;
+    let url = web_sys::Url::new(pasted).map_err(|_| InviteLinkRefusal::Malformed)?;
     // The seed rides the fragment and is never sent to any server; carry
     // it across from the pasted link whichever form the link took.
     let fragment = url.hash();
     let query = if carries_access(&url) {
         url.search()
     } else {
-        resolve_invite(&url).await?
+        resolve_invite(&url)
+            .await
+            .ok_or(InviteLinkRefusal::Unresolvable)?
     };
-    Some(format!("/join{query}{fragment}"))
+    Ok(format!("/join{query}{fragment}"))
 }
 
 /// Whether the link already carries its delegation chain, and so needs
@@ -256,15 +280,37 @@ mod tests {
         assert_eq!(
             local_join_href("https://staging.tonk.xyz/join?access=abc&remote=https%3A%2F%2Fs#seed")
                 .await,
-            Some("/join?access=abc&remote=https%3A%2F%2Fs#seed".to_string()),
+            Ok("/join?access=abc&remote=https%3A%2F%2Fs#seed".to_string()),
         );
-        assert_eq!(local_join_href("").await, None, "empty paste is refused");
+        assert_eq!(
+            local_join_href("").await,
+            Err(InviteLinkRefusal::Empty),
+            "empty paste is refused"
+        );
         assert_eq!(
             local_join_href("https://staging.tonk.xyz/").await,
-            None,
+            Err(InviteLinkRefusal::Unresolvable),
             "a bare origin carries no invite"
         );
-        assert_eq!(local_join_href("not a url").await, None);
+        assert_eq!(
+            local_join_href("not a url").await,
+            Err(InviteLinkRefusal::Malformed)
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_returns_a_target_or_a_structured_parse_refusal() {
+        let target = format!(
+            "{:?}",
+            local_join_href("https://staging.tonk.xyz/join?access=abc#seed").await
+        );
+        assert!(target.contains("/join?access=abc#seed"));
+
+        let refusal = format!("{:?}", local_join_href("definitely not a url").await);
+        assert_eq!(
+            refusal, "Err(Malformed)",
+            "garbage must produce a named refusal instead of a bare absence or panic",
+        );
     }
 
     /// What decides whether a link needs resolving is the chain it

--- a/rust/tonk-workspace/src/join_retry.rs
+++ b/rust/tonk-workspace/src/join_retry.rs
@@ -30,10 +30,14 @@ impl CustomElement for TonkJoinRetry {
         let host = this.clone();
         let listener = Closure::wrap(Box::new(move |event: Event| {
             event.prevent_default();
-            let init = CustomEventInit::new();
-            init.set_bubbles(true);
-            if let Ok(retry) = CustomEvent::new_with_event_init_dict("tonk:join-retry", &init) {
-                let _ = host.dispatch_event(&retry);
+            if host.get_attribute("kind").as_deref() == Some(RETRYABLE_KIND) {
+                let init = CustomEventInit::new();
+                init.set_bubbles(true);
+                if let Ok(retry) = CustomEvent::new_with_event_init_dict("tonk:join-retry", &init) {
+                    let _ = host.dispatch_event(&retry);
+                }
+            } else if let Some(win) = window() {
+                let _ = win.location().assign("/join");
             }
         }) as Box<dyn FnMut(Event)>);
         let _ = this.add_event_listener_with_callback("click", listener.as_ref().unchecked_ref());
@@ -59,13 +63,9 @@ impl CustomElement for TonkJoinRetry {
 }
 
 fn render(this: &HtmlElement) {
-    if this.get_attribute("kind").as_deref() == Some(RETRYABLE_KIND) {
-        this.set_inner_html(
-            r#"<button type="button" class="join-error__retry">Try again</button>"#,
-        );
-    } else {
-        this.set_inner_html("");
-    }
+    this.set_inner_html(
+        r#"<button type="button" class="join-error__retry">join this space</button>"#,
+    );
 }
 
 pub(crate) fn register() {

--- a/rust/tonk-workspace/src/sync.rs
+++ b/rust/tonk-workspace/src/sync.rs
@@ -96,11 +96,7 @@ mod logic {
     /// Label, modifier class, and accessible explanation for a failure pill.
     pub(crate) fn failure_chip(failure: SyncFailure) -> (&'static str, &'static str, &'static str) {
         match failure {
-            SyncFailure::Revoked => (
-                "revoked",
-                "is-revoked",
-                "Sync revoked — reconnect with valid authority",
-            ),
+            SyncFailure::Revoked => ("closed", "is-revoked", "This space is no longer available"),
             SyncFailure::Conflict => (
                 "conflict",
                 "is-conflict",
@@ -1133,6 +1129,14 @@ mod tests {
             let (label, class, _) = failure_chip(failure);
             assert_ne!((label, class), OFFLINE_CHIP);
         }
+    }
+
+    #[dialog_common::test]
+    fn it_does_not_reveal_whether_closed_authority_was_revoked_or_deleted() {
+        let (label, _class, title) = failure_chip(SyncFailure::Revoked);
+        assert_eq!(label, "closed");
+        assert!(!title.to_lowercase().contains("revok"));
+        assert!(!title.to_lowercase().contains("delet"));
     }
 
     #[dialog_common::test]


### PR DESCRIPTION
## Summary

- add reusable field, cluster, and banner primitives for neutral edge-state UI
- route local-only sync and email activation through condition banners and ceremonies
- rework access walls, invitation refusals, revoked copy, and provider-free empty Hub states

## Verification

- cargo fmt --all -- --check
- cargo test -p tonk-fab (100 passed)
- cargo test -p tonk-workspace (16 passed)
- full Wasm workspace suite (67 passed)
- tonk-worker standard_library and fab_drift suites (17 passed)
- nix build path:.#tonk-ui
- isolated Chrome checks for empty/provider-free Hub and join/refusal walls at desktop and 390 px

## Remaining manual check

The static artifact has no configured account/access deployment, so the complete light/dark Chrome sweep of live local-only, activation, and revoked states remains unverified. Their real-Wasm integration coverage passes.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces new modules for handling UI elements related to activation and connection banners, enhances error handling for sync operations, and updates styles and attributes for improved user experience in the `tonk` application.

### Detailed summary
- Added modules: `banner`, `cluster`, `field`, and `activation` for UI components.
- Updated `register` function to include new modules.
- Changed styles in `styles.css` for better visual feedback.
- Modified `failure_chip` to provide clearer error messages.
- Implemented tests for activation and connection behavior.
- Enhanced `TonkShare` to handle sync conditions more effectively.
- Updated `TonkInviteLink` for better error reporting.
- Improved `TonkBanner` and `TonkCluster` with new attributes and functionality.

> The following files were skipped due to too many changes: `rust/tonk-fab/src/field.rs`, `rust/tonk-core/assets/library/profile.yaml`, `plan/edges.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->