### PR TITLE
chore: release 0.6.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "dialog-reactor"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4630,7 +4630,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-access-service"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-account"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "blake3",
@@ -4711,7 +4711,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-account-service"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "blake3",
@@ -4745,7 +4745,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-analytics"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "dialog-common",
  "hex",
@@ -4761,7 +4761,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-analyzer"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4786,7 +4786,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-board"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "custom-elements",
  "js-sys",
@@ -4801,7 +4801,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-cli"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4867,7 +4867,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-code"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4876,7 +4876,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-common"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "dialog-common",
  "futures-util",
@@ -4889,7 +4889,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-core"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "base58",
  "dialog-artifacts",
@@ -4908,7 +4908,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-display"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4933,7 +4933,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-email"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -4942,7 +4942,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-evaluator"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "dialog-artifacts",
@@ -4965,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-fab"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4985,7 +4985,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-guest"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "console_error_panic_hook",
  "custom-elements",
@@ -5008,7 +5008,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-host"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "bytes",
  "custom-elements",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-identity"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -5063,7 +5063,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-inspector"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "bs58",
  "custom-elements",
@@ -5082,7 +5082,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-invite"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "bs58",
@@ -5099,7 +5099,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-language-server"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -5119,7 +5119,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-macros"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-notation"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "dialog-common",
  "lsp-types",
@@ -5147,7 +5147,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-portal"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -5169,7 +5169,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-prose"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-render"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "async-trait",
  "dialog-common",
@@ -5195,7 +5195,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-router"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "dialog-common",
  "tokio",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-schema"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-sigil"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "blake3",
  "bs58",
@@ -5252,7 +5252,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-table"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-template"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "dialog-common",
  "indexmap",
@@ -5275,7 +5275,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-tree"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "custom-elements",
  "js-sys",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-ui"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-worker"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5410,7 +5410,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-worker-api"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "dialog-artifacts",
  "dialog-capability",
@@ -5428,7 +5428,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-workspace"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "custom-elements",
  "dialog-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.7"
+version = "0.6.8"
 authors = ["Tonk Labs"]
 edition = "2024"
 license = "MIT"
@@ -226,6 +226,5 @@ inherits = "release"
 opt-level = "s"
 debug = 0
 strip = "debuginfo"
-
 
 


### PR DESCRIPTION
Bumps the shared Cargo workspace version from 0.6.7 to 0.6.8, including the inherited workspace package versions in Cargo.lock.

Merging this into staging lets release-tag.yml create v0.6.8 and dispatch the CLI npm publish workflow.

Verification:
- cargo pkgid -p tonk-cli
- cargo test -p tonk-cli
- cargo fmt --all -- --check
- git diff --check HEAD^ HEAD

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version numbers for multiple packages in the `Cargo.toml` and `Cargo.lock` files from `0.6.7` to `0.6.8`, indicating a new release version for the project.

### Detailed summary
- Updated `version` from `0.6.7` to `0.6.8` for:
  - `workspace.package`
  - `dialog-reactor`
  - `tonk-access-service`
  - `tonk-account`
  - `tonk-account-service`
  - `tonk-analytics`
  - `tonk-analyzer`
  - `tonk-board`
  - `tonk-cli`
  - `tonk-code`
  - `tonk-common`
  - `tonk-core`
  - `tonk-display`
  - `tonk-email`
  - `tonk-evaluator`
  - `tonk-fab`
  - `tonk-guest`
  - `tonk-host`
  - `tonk-identity`
  - `tonk-inspector`
  - `tonk-invite`
  - `tonk-language-server`
  - `tonk-macros`
  - `tonk-notation`
  - `tonk-portal`
  - `tonk-prose`
  - `tonk-render`
  - `tonk-router`
  - `tonk-schema`
  - `tonk-sigil`
  - `tonk-table`
  - `tonk-template`
  - `tonk-tree`
  - `tonk-ui`
  - `tonk-worker`
  - `tonk-worker-api`
  - `tonk-workspace`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->