### PR TITLE
feat: keep spaces local until a provider can serve them

### DIFF
--- a/rust/tonk-access-service/src/handlers/registration.rs
+++ b/rust/tonk-access-service/src/handlers/registration.rs
@@ -117,8 +117,8 @@ pub async fn handle_customer(_req: Request, _ctx: RouteContext<()>) -> worker::R
 /// GET `/customer/:did` → the customer's registration state (worker
 /// body; see the native twin above).
 #[cfg(target_arch = "wasm32")]
-pub async fn handle_customer(_req: Request, ctx: RouteContext<()>) -> worker::Result<Response> {
-    use tonk_account::customer::Receipt;
+pub async fn handle_customer(req: Request, ctx: RouteContext<()>) -> worker::Result<Response> {
+    use tonk_account::customer::{CustomerStatus, Receipt};
 
     use crate::store::Store;
     use crate::store::d1::D1Store;
@@ -140,6 +140,18 @@ pub async fn handle_customer(_req: Request, ctx: RouteContext<()>) -> worker::Re
                     worker::Error::RustError(format!("stored customer did is malformed: {err:?}"))
                 })?,
                 status: customer.status,
+                // Only for a customer this service actually serves. The
+                // probe is what notices activation, so it must answer
+                // the address then — but naming one for a customer
+                // still awaiting email confirmation would let a client
+                // record an endpoint that refuses every presign.
+                provider: (customer.status == CustomerStatus::Active)
+                    .then(|| {
+                        req.url()
+                            .ok()
+                            .map(|url| format!("{}/ucan/", url.origin().ascii_serialization()))
+                    })
+                    .flatten(),
             };
             Response::from_json(&receipt)
         }

--- a/rust/tonk-access-service/src/helpers/server.rs
+++ b/rust/tonk-access-service/src/helpers/server.rs
@@ -443,7 +443,7 @@ async fn handle_request(
         && let Some(did) = req.uri().path().strip_prefix("/customer/")
     {
         use crate::store::Store;
-        use tonk_account::customer::{Receipt, RegistrationError};
+        use tonk_account::customer::{CustomerStatus, Receipt, RegistrationError};
 
         let response = match registration.store.customer(did).await {
             Ok(Some(customer)) => match customer.did.parse() {
@@ -451,6 +451,10 @@ async fn handle_request(
                     let receipt = Receipt {
                         customer: parsed,
                         status: customer.status,
+                        // Only for a served customer; see the worker twin.
+                        provider: (customer.status == CustomerStatus::Active).then(|| {
+                            format!("{}/ucan/", registration.origin.trim_end_matches('/'))
+                        }),
                     };
                     Response::builder()
                         .status(StatusCode::OK)

--- a/rust/tonk-access-service/src/registration.rs
+++ b/rust/tonk-access-service/src/registration.rs
@@ -271,6 +271,16 @@ impl<S: Store, E: EmailSender, R: RevocationChecker + ConditionalSync> Registrat
         Ok(Receipt {
             customer,
             status: CustomerStatus::Registered,
+            // Enrollment names no provider. The address is what says
+            // "this service serves you", and it does not yet: an
+            // unactivated customer gets neither service nor
+            // provisioning. Naming it here would let a client record an
+            // endpoint it cannot use, and erase the difference between
+            // "enrolled, email unconfirmed" and "ready to sync" — which
+            // is exactly the distinction the share flow needs in order
+            // to say "check your email" rather than "turn on sync".
+            // Activation is where it lands.
+            provider: None,
         })
     }
 
@@ -295,6 +305,7 @@ impl<S: Store, E: EmailSender, R: RevocationChecker + ConditionalSync> Registrat
             return Ok(Receipt {
                 customer,
                 status: CustomerStatus::Active,
+                provider: Some(self.provider_address()),
             });
         }
         match self
@@ -306,6 +317,7 @@ impl<S: Store, E: EmailSender, R: RevocationChecker + ConditionalSync> Registrat
             Some(existing) if existing.status == CustomerStatus::Active => Ok(Receipt {
                 customer,
                 status: CustomerStatus::Active,
+                provider: Some(self.provider_address()),
             }),
             Some(_) => Err(RegistrationError::CustomerSuspended),
             None => Err(RegistrationError::UnknownCustomer),
@@ -422,6 +434,18 @@ impl<S: Store, E: EmailSender, R: RevocationChecker + ConditionalSync> Registrat
             .map_err(|err| RegistrationError::Unauthorized {
                 message: format!("consent failed to verify: {err}"),
             })
+    }
+
+    /// This service's own address as a provider — the UCAN endpoint its
+    /// customers' spaces attach their remotes to.
+    ///
+    /// Derived from the origin the service is configured with, not from
+    /// the origin a request arrived on: the service decides which
+    /// provider serves its customers, and answers every receipt with it,
+    /// so a client records one authoritative address rather than
+    /// deriving its own.
+    fn provider_address(&self) -> String {
+        format!("{}/ucan/", self.origin.trim_end_matches('/'))
     }
 
     /// Mint the activation invocation and wrap it into a link. The

--- a/rust/tonk-access-service/tests/registration.rs
+++ b/rust/tonk-access-service/tests/registration.rs
@@ -255,6 +255,47 @@ async fn it_enrolls_a_customer_and_emails_an_activation_link() -> anyhow::Result
     Ok(())
 }
 
+/// Activation names the provider; enrollment does not.
+///
+/// The service decides which provider serves its customers and says so
+/// in the receipt, so a client records one authoritative address instead
+/// of deriving `https://{origin}/ucan/` from whichever origin its
+/// request happened to reach.
+///
+/// Only at activation, though. The address is what says "this service
+/// serves you", and for an unactivated customer it does not — it gets
+/// neither service nor provisioning. Withholding it until activation is
+/// what lets a client tell "enrolled, awaiting the email" from "ready to
+/// sync" by looking at the recorded address alone.
+#[dialog_common::test]
+async fn it_answers_the_provider_only_once_the_customer_activates() -> anyhow::Result<()> {
+    let fixture = Fixture::new().await;
+    let customer = Ed25519Signer::generate().await?;
+    let container = enroll_container(&customer, &fixture.service.did(), "alice@example.com").await;
+
+    let enrolled = as_customer(fixture.registration(&container).handle().await.unwrap());
+    assert_eq!(
+        enrolled.provider, None,
+        "enrollment must name no provider: this customer is not served yet",
+    );
+    // Absent from the wire, not present-and-null: a client reading the
+    // JSON must see no key at all rather than an explicit empty value.
+    let wire = serde_json::to_value(&enrolled)?;
+    assert!(
+        wire.get("provider").is_none(),
+        "an unserved receipt must omit the provider key entirely, got {wire}",
+    );
+
+    let container = link_container(&fixture.last_email().1);
+    let activated = as_customer(fixture.registration(&container).handle().await.unwrap());
+    assert_eq!(
+        activated.provider.as_deref(),
+        Some("https://hub.test/ucan/"),
+        "activation names the provider this customer's spaces attach to",
+    );
+    Ok(())
+}
+
 #[dialog_common::test]
 async fn it_activates_by_presenting_the_emailed_invocation_from_any_device() -> anyhow::Result<()> {
     let fixture = Fixture::new().await;

--- a/rust/tonk-account/src/customer.rs
+++ b/rust/tonk-account/src/customer.rs
@@ -268,6 +268,19 @@ pub struct Receipt {
     pub customer: Did,
     /// The customer's lifecycle state after the act.
     pub status: CustomerStatus,
+    /// The provider serving this customer: the UCAN endpoint its
+    /// spaces attach their remotes to.
+    ///
+    /// The service decides which provider serves its customers and says
+    /// so here, rather than every client deriving an address from
+    /// whichever origin its request happened to reach. A client records
+    /// this and attaches spaces to it; it never has to guess.
+    ///
+    /// Optional so a receipt from a service that predates this field
+    /// still decodes. An absent address means "unchanged", not "no
+    /// provider": a client that already recorded one keeps it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
 }
 
 /// A registration refusal. Serialized with the variant as a `code` tag,

--- a/rust/tonk-fab/src/element.rs
+++ b/rust/tonk-fab/src/element.rs
@@ -674,9 +674,13 @@ fn attach_create_space_form(element: &HtmlElement) {
             return;
         };
         let name = form_field(&target, "name");
-        let remote = form_field(&target, "remote");
         let template = form_field(&target, "template");
-        transact(&create_space_claim_json(&name, &remote, &template));
+        // No remote: the worker resolves where a space syncs from the
+        // account's own registration, so the page does not derive an
+        // endpoint from its origin and pass one down. `form_field`
+        // answers "" for the absent control and the claim omits it,
+        // which is what makes the worker fall through to that lookup.
+        transact(&create_space_claim_json(&name, "", &template));
         dismiss_overlay(&target);
     });
     let target: &web_sys::EventTarget = form.unchecked_ref();

--- a/rust/tonk-fab/src/logic.rs
+++ b/rust/tonk-fab/src/logic.rs
@@ -1576,9 +1576,14 @@ pub fn share_blocked_query_body(subject: &str) -> Result<String, String> {
 
 /// This page's default UCAN access-service endpoint: `origin + /ucan/`.
 ///
-/// The same URL `<tonk-default-remote auto>` fills the create wizard's hidden
-/// input with. Kept pure (origin in, URL out) so it is testable off-browser;
-/// the caller supplies the origin.
+/// A fallback, not the source of truth. Where a space syncs is the
+/// account's own registration, recorded by the service in its receipt
+/// and resolved worker-side; the create wizard passes no remote at all
+/// for exactly that reason. This remains for the share path, which still
+/// supplies one, and is the next derivation to remove.
+///
+/// Kept pure (origin in, URL out) so it is testable off-browser; the
+/// caller supplies the origin.
 pub fn default_remote_url(origin: &str) -> String {
     format!("{}{}", origin.trim_end_matches('/'), "/ucan/")
 }

--- a/rust/tonk-fab/src/markup.rs
+++ b/rust/tonk-fab/src/markup.rs
@@ -138,9 +138,6 @@ pub fn fab_html(space_did: &str) -> String {
     <input class="wizard__template" type="radio" name="template" value="wiki" id="tpl-wiki">
     <input class="wizard__template" type="radio" name="template" value="board" id="tpl-board">
     <input type="hidden" name="name" value="Untitled">
-    <input type="hidden" name="remote" value="">
-    <input type="hidden" name="revocation" value="">
-    <tonk-default-remote field="remote" relay-field="revocation" auto></tonk-default-remote>
     <div class="wizard__screen wizard__screen--start">
       <div class="wizard__cards">
         <label class="wizard__card" for="wiz-template">

--- a/rust/tonk-schema/src/account.rs
+++ b/rust/tonk-schema/src/account.rs
@@ -3,7 +3,9 @@
 use dialog_artifacts::Entity;
 use dialog_query::Concept;
 
-use crate::domain::account::{DisplayName, PasskeyCreatedAt, PasskeyCreatedOn};
+use crate::domain::account::{
+    CustomerEmail, CustomerStatus, DisplayName, PasskeyCreatedAt, PasskeyCreatedOn, ProviderAddress,
+};
 
 /// The account-wide display name, keyed by the immutable account subject.
 ///
@@ -69,6 +71,58 @@ impl AccountPasskeyCreated {
     /// Unix seconds, back in the integer form the wire DTO carries.
     pub fn seconds(&self) -> u64 {
         self.created_at.0 as u64
+    }
+}
+
+/// The account's registration with the access service, keyed by the
+/// immutable account subject.
+///
+/// This is the account's registration state as a FACT, not as a cached
+/// HTTP answer. Every device on the account reads it with an ordinary
+/// query and converges on it through sync, so a device that never ran
+/// the enrollment — and never probed the service — still knows whether
+/// the account is servable.
+///
+/// Written at two moments: when enrollment records `Registered`, and
+/// when activation is observed and promotes it to `Active`.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AccountCustomer {
+    /// The immutable account subject, which is the customer DID.
+    pub this: Entity,
+    /// One of `Registered`, `Active`, or `Suspended`.
+    pub status: CustomerStatus,
+    /// The address enrollment named.
+    pub email: CustomerEmail,
+    /// The provider serving this account: the UCAN access-service
+    /// endpoint its spaces attach their remotes to.
+    pub provider: ProviderAddress,
+}
+
+impl AccountCustomer {
+    /// Record the account's registration state.
+    pub fn new(account: Entity, status: &str, email: String, provider: String) -> Self {
+        Self {
+            this: account,
+            status: CustomerStatus(status.to_owned()),
+            email: CustomerEmail(email),
+            provider: ProviderAddress(provider),
+        }
+    }
+
+    /// The provider serving this account, absent when registration
+    /// recorded none.
+    pub fn provider(&self) -> Option<&str> {
+        Some(self.provider.0.as_str()).filter(|address| !address.is_empty())
+    }
+
+    /// Whether the access service will serve this account's subjects.
+    ///
+    /// Only `Active` is servable: `Registered` awaits email activation
+    /// and `Suspended` was withdrawn, and the provisioning gate refuses
+    /// both. An unrecognised value — a status written by a newer build —
+    /// reads as not servable, which fails closed.
+    pub fn is_active(&self) -> bool {
+        self.status.0 == "Active"
     }
 }
 

--- a/rust/tonk-schema/src/domain.rs
+++ b/rust/tonk-schema/src/domain.rs
@@ -733,6 +733,57 @@ pub mod account {
     #[domain("xyz.tonk.account")]
     #[cardinality(one)]
     pub struct PasskeyCreatedOn(pub String);
+
+    /// The account's registration state with the access service, as one
+    /// of `Registered`, `Active`, or `Suspended`.
+    ///
+    /// A fact rather than a locally cached HTTP answer, so every device
+    /// on the account reads the same status through an ordinary query
+    /// and converges on it through sync. Cardinality-one: an account has
+    /// one registration state, and concurrent linked-device writes
+    /// converge deterministically rather than accumulating.
+    ///
+    /// A string rather than a typed enum because the value system stores
+    /// scalars; [`tonk_account::customer::CustomerStatus`] round-trips
+    /// through `as_str`/`parse`, so an unrecognised value read from a
+    /// newer build parses as absent rather than as a wrong status.
+    ///
+    /// [`tonk_account::customer::CustomerStatus`]: https://docs.rs/tonk-account
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.account")]
+    #[cardinality(one)]
+    pub struct CustomerStatus(pub String);
+
+    /// The email address the account enrolled with.
+    ///
+    /// Recorded alongside the status so a device that never ran the
+    /// enrollment still knows which address the activation link went to.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.account")]
+    #[cardinality(one)]
+    pub struct CustomerEmail(pub String);
+
+    /// The account's provider: the UCAN access-service endpoint this
+    /// account is a customer of.
+    ///
+    /// Named for the account's relationship, not the space's plumbing. A
+    /// space has a *remote* (an `origin` its `main` tracks); the account
+    /// has a *provider*, which is who serves those remotes and who
+    /// `/provider/add` provisions consumers under. A space's remote
+    /// normally points at this address, but the two are different facts
+    /// about different subjects.
+    ///
+    /// A fact rather than a value re-derived per call site: the address
+    /// used to come from the page (`https://{origin}/ucan/`, filled into
+    /// a hidden form field) and from the signed account descriptor, so
+    /// two paths could disagree about where a space syncs. The service
+    /// names it in the registration receipt, so every attach path reads
+    /// one answer, and a device that never ran the registration reads
+    /// the same one through sync.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.account")]
+    #[cardinality(one)]
+    pub struct ProviderAddress(pub String);
 }
 
 /// Attributes that describe a repository on its content branch, keyed by the

--- a/rust/tonk-schema/src/lib.rs
+++ b/rust/tonk-schema/src/lib.rs
@@ -64,7 +64,7 @@ pub mod sync;
 pub use sync::*;
 
 pub mod account;
-pub use account::{AccountDisplayName, AccountPasskeyCreated};
+pub use account::{AccountCustomer, AccountDisplayName, AccountPasskeyCreated};
 
 pub mod device_link;
 pub mod replica;

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -1043,7 +1043,7 @@ mod tests {
             &driver,
             &format!("/api/repository/{key}/remote"),
             serde_json::json!({
-                "remote": { "origin": { "address": { "ucan": env.tonk_web.join("ucan/")? } } },
+                "remote": { "origin": { "address": { "Ucan": env.tonk_web.join("ucan/")? } } },
                 "branch": { "main": { "upstream": { "remote": "origin", "branch": "main" } } },
             }),
         )

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -978,9 +978,13 @@ mod tests {
 
         let info = get_json(&driver, &format!("/api/repository/{key}")).await?;
         let info = successful_body("read the space configuration", &info);
+        // Report what the worker actually knows, so a failure here says
+        // whether the provider fact was recorded or merely unread.
+        let customer = get_json(&driver, "/api/customer").await?;
         assert!(
             info["remote"]["origin"].is_object(),
-            "an activated account's space must wire the origin remote, got {}",
+            "an activated account's space must wire the origin remote, got {}; \
+             customer state was {customer}",
             info["remote"],
         );
         let upstream = &info["branch"]["main"]["upstream"];
@@ -1043,7 +1047,7 @@ mod tests {
             &driver,
             &format!("/api/repository/{key}/remote"),
             serde_json::json!({
-                "remote": { "origin": { "address": { "Ucan": env.tonk_web.join("ucan/")? } } },
+                "remote": { "origin": { "address": { "Ucan": { "endpoint": env.tonk_web.join("ucan/")? } } } },
                 "branch": { "main": { "upstream": { "remote": "origin", "branch": "main" } } },
             }),
         )

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -881,19 +881,24 @@ mod tests {
             .map(|row| row.did.as_str())
     }
 
-    /// The pending-work queue, end to end: a space created before the
-    /// activation email is opened cannot be hosted, and becomes hosted
-    /// once it is — with no second attempt from the user.
+    /// A space created before activation stays LOCAL: no remote, no
+    /// provisioning, and therefore no refused presign.
     ///
-    /// This is the whole point of the queue. The service refuses both
-    /// provisioning and presign for a `Registered` customer, so a space
-    /// created in that window works locally and syncs nothing; the
-    /// client records the provisioning and replays it when the customer
-    /// activates.
+    /// A device has an account from first boot, so "an account exists"
+    /// says nothing about whether the access service will serve a
+    /// space. Until the emailed link is confirmed the service refuses
+    /// both provisioning and presign, so wiring an upstream would
+    /// produce a space that syncs to `subject is provisioned by an
+    /// active customer (the subject is not provisioned)` on every
+    /// attempt. The space works locally and the share button attaches
+    /// sync later, once there is a provider to attach to.
+    ///
+    /// This replaces an earlier contract where the create queued its
+    /// provisioning and replayed it at activation. That left the space
+    /// wired to a remote it could not use for the whole waiting period,
+    /// which is the 403 this gate exists to prevent.
     #[dialog_common::test]
-    async fn it_hosts_a_space_created_before_activation_once_the_email_is_confirmed(
-        env: TestEnvironment,
-    ) -> Result<()> {
+    async fn it_creates_a_space_local_only_before_activation(env: TestEnvironment) -> Result<()> {
         let driver = driver_with_prf(&env).await?;
         let email = "queued@example.com";
         // Stop at Registered: the activation email is sent but unopened.
@@ -901,15 +906,13 @@ mod tests {
         wait_for_text_containing(&driver, "#account-activation-notice", "activation pending")
             .await?;
 
-        // The space is created locally and works; only its hosting is
-        // withheld. Creation must not fail on the refused provisioning.
+        // No remote in the request: the worker decides, the way the
+        // create wizard now leaves it to.
         let created = post_json(
             &driver,
             "/api/spaces",
             serde_json::json!({
                 "name": "Made While Waiting",
-                "remote": env.tonk_web.join("ucan/")?,
-                "revocation_url": env.account_service.join("revocations")?,
                 "template": "blank",
             }),
         )
@@ -919,31 +922,134 @@ mod tests {
             .context("create response omitted the space key")?
             .to_string();
 
-        // Pushing it now must fail: nobody is paying for this subject.
-        let refused = post_json(
-            &driver,
-            &format!("/api/repository/{key}/branch/main/sync/push"),
-            serde_json::json!({}),
-        )
-        .await?;
+        // The space exists and is remote-less: nothing was wired, so
+        // nothing can fail against the service.
+        let info = get_json(&driver, &format!("/api/repository/{key}")).await?;
+        let info = successful_body("read the space configuration", &info);
+        // `RepositoryInfo::remote` skips serializing an empty map, so
+        // "no remotes" is an ABSENT key rather than an empty object.
         assert!(
-            refused.get("error").is_none(),
-            "the push request itself must reach the worker: {refused}"
+            info["remote"]
+                .as_object()
+                .is_none_or(serde_json::Map::is_empty),
+            "a space created before activation must wire no remote, got {}",
+            info["remote"],
         );
+        let upstream = &info["branch"]["main"]["upstream"];
         assert!(
-            !refused["status"]
-                .as_u64()
-                .is_some_and(|status| (200..300).contains(&status)),
-            "an unactivated account must not be able to host a space: {refused}"
+            upstream.is_null(),
+            "main must track nothing before activation, got {upstream}",
         );
 
-        // Confirm the email. Nothing else is asked of the user: the
-        // queued provisioning replays off the status probe.
+        driver.quit().await?;
+        Ok(())
+    }
+
+    /// Activation records the provider, and a space created after it
+    /// attaches to that provider without the page naming one.
+    ///
+    /// The service decides which provider serves its customers and says
+    /// so in the activation receipt; the client records it as a fact on
+    /// profile main. Every attach path reads that one answer, so the
+    /// page no longer derives `https://{origin}/ucan/` for itself.
+    #[dialog_common::test]
+    async fn it_attaches_the_recorded_provider_after_activation(
+        env: TestEnvironment,
+    ) -> Result<()> {
+        let driver = driver_with_prf(&env).await?;
+        sign_up(&driver, &env, "provided@example.com").await?;
+        wait_for_text(&driver, "#account-registration-value", "Active").await?;
+
+        // Again no remote: if the worker did not read the recorded
+        // provider, this space would come up local-only.
+        let created = post_json(
+            &driver,
+            "/api/spaces",
+            serde_json::json!({
+                "name": "Made After Activation",
+                "template": "blank",
+            }),
+        )
+        .await?;
+        let key = successful_body("create space after activation", &created)["key"]
+            .as_str()
+            .context("create response omitted the space key")?
+            .to_string();
+
+        let info = get_json(&driver, &format!("/api/repository/{key}")).await?;
+        let info = successful_body("read the space configuration", &info);
+        assert!(
+            info["remote"]["origin"].is_object(),
+            "an activated account's space must wire the origin remote, got {}",
+            info["remote"],
+        );
+        let upstream = &info["branch"]["main"]["upstream"];
+        assert_eq!(
+            upstream["remote"].as_str(),
+            Some("origin"),
+            "main must track the attached remote, got {upstream}",
+        );
+
+        driver.quit().await?;
+        Ok(())
+    }
+
+    /// A space created before activation becomes syncable once the user
+    /// asks for it, and not before.
+    ///
+    /// The opt-in half of the local-only gate: creation withholds the
+    /// remote, and an explicit enable-sync is what provisions the space
+    /// and attaches one. Provisioning at attach time is what makes this
+    /// work — before, `enable_sync` attached without ever calling
+    /// `/provider/add`, so the upstream pointed at a subject the service
+    /// refused.
+    #[dialog_common::test]
+    async fn it_syncs_a_local_only_space_once_sync_is_enabled(env: TestEnvironment) -> Result<()> {
+        let driver = driver_with_prf(&env).await?;
+        let email = "optin@example.com";
+        enroll_only(&driver, &env, email).await?;
+        wait_for_text_containing(&driver, "#account-activation-notice", "activation pending")
+            .await?;
+
+        let created = post_json(
+            &driver,
+            "/api/spaces",
+            serde_json::json!({ "name": "Opted In", "template": "blank" }),
+        )
+        .await?;
+        let key = successful_body("create space before activation", &created)["key"]
+            .as_str()
+            .context("create response omitted the space key")?
+            .to_string();
+
+        // Confirm the email, so a provider exists to attach to.
         activate(&driver, &env, email).await?;
         wait_for_text(&driver, "#account-registration-value", "Active").await?;
 
-        // The same push now succeeds, with no further provisioning call
-        // from the test — the queue did it.
+        // Still local: activation does not retroactively sync spaces
+        // created before it. The user opts in per space.
+        let info = get_json(&driver, &format!("/api/repository/{key}")).await?;
+        let info = successful_body("read the space configuration", &info);
+        assert!(
+            info["remote"]
+                .as_object()
+                .is_none_or(serde_json::Map::is_empty),
+            "activation must not retroactively attach a remote, got {}",
+            info["remote"],
+        );
+
+        // Opting in attaches and provisions, so the space can now push.
+        let attached = post_json(
+            &driver,
+            &format!("/api/repository/{key}/remote"),
+            serde_json::json!({
+                "remote": { "origin": { "address": { "ucan": env.tonk_web.join("ucan/")? } } },
+                "branch": { "main": { "upstream": { "remote": "origin", "branch": "main" } } },
+            }),
+        )
+        .await?;
+        successful_body("attach the remote", &attached);
+
         let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
         loop {
             let pushed = post_json(
@@ -952,15 +1058,15 @@ mod tests {
                 serde_json::json!({}),
             )
             .await?;
-            let ok = pushed["status"]
+            if pushed["status"]
                 .as_u64()
-                .is_some_and(|status| (200..300).contains(&status));
-            if ok {
+                .is_some_and(|status| (200..300).contains(&status))
+            {
                 break;
             }
             assert!(
                 tokio::time::Instant::now() < deadline,
-                "the queued provisioning never replayed after activation: {pushed}"
+                "an opted-in space must be provisioned and pushable: {pushed}"
             );
             tokio::time::sleep(Duration::from_millis(250)).await;
         }

--- a/rust/tonk-ui/src/activate.rs
+++ b/rust/tonk-ui/src/activate.rs
@@ -157,6 +157,18 @@ fn bind(host: &HtmlElement) {
             let status = response.status();
             let body: serde_json::Value = response.json().await.unwrap_or_default();
             if status.is_success() {
+                // Hand the receipt to the worker before declaring
+                // success. The service names the provider serving this
+                // account here, and this page is the only place that
+                // answer arrives — post it to `/api/customer/activated`
+                // so it is recorded as a fact rather than discarded.
+                // Best effort: activation itself succeeded, and the
+                // status probe records the same thing on the next read.
+                if let Err(error) = crate::api::report_activation(&body).await {
+                    web_sys::console::warn_1(
+                        &format!("activation receipt not recorded: {error}").into(),
+                    );
+                }
                 set_status(&host, "");
                 show_panel(&host, "#activate-done");
             } else if body["error"]["code"].as_str() == Some("Unauthorized") {

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -805,6 +805,31 @@ pub async fn list_profiles() -> Result<ProfilesResponse, TonkUiError> {
     }
 }
 
+/// Record an activation receipt with the worker.
+///
+/// The activation page posts the emailed invocation straight to the
+/// service, so the receipt — and the provider address it names — never
+/// passes through the worker. This hands it over, so the registration
+/// fact reflects activation the moment it happens.
+pub async fn report_activation(receipt: &serde_json::Value) -> Result<(), TonkUiError> {
+    tonk_host::ready::wait().await;
+    let response = reqwest::Client::new()
+        .post(format!("{}/api/customer/activated", origin()))
+        .json(receipt)
+        .send()
+        .await
+        .map_err(into_api_error)?;
+    if response.status().is_success() {
+        Ok(())
+    } else {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        Err(TonkUiError::ApiError(format!(
+            "POST /api/customer/activated returned {status}: {text}"
+        )))
+    }
+}
+
 /// Swap the worker onto another roster profile. The caller reloads the
 /// page afterwards so every surface re-renders the new profile.
 pub async fn activate_profile(profile: String) -> Result<ProfilesResponse, TonkUiError> {

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -174,6 +174,7 @@ pub fn api_router_from_state(state: AppState) -> (Router, Arc<LspHub>) {
         // Customer registration with the same-origin access service.
         .route("/api/customer", get(customer::get_state))
         .route("/api/customer/enroll", post(customer::enroll))
+        .route("/api/customer/activated", post(customer::activated))
         .route("/api/customer/pending", get(customer::get_pending))
         .route(
             "/api/customer/pending/custody",

--- a/rust/tonk-worker/src/router/customer.rs
+++ b/rust/tonk-worker/src/router/customer.rs
@@ -227,22 +227,26 @@ pub async fn get_state(
                     ..record.clone()
                 };
                 save_customer(&state, &refreshed).await?;
-                // Activation observed here is what promotes the fact on
-                // profile main, so the other devices on this account see
-                // it without each probing the service. The probe answers
-                // the sync endpoint alongside the status, so activation
-                // records the service's own address rather than deriving
-                // one from whichever origin this request reached.
-                if let Err(error) = record_customer_status(
-                    &state,
-                    receipt.status,
-                    &record.email,
-                    receipt.provider.as_deref(),
-                )
-                .await
-                {
-                    log!("account customer status not recorded: {error}");
-                }
+            }
+            // Reconcile the FACT on every probe, not only when the
+            // status changed. Two guards used to stand in the way: a
+            // missing local record (this device may never have enrolled)
+            // and an unchanged status. The second is the one that bit —
+            // by the time anything reads the provider, some earlier
+            // probe has already flipped the stored record to `Active`,
+            // so the statuses match forever after and the address is
+            // never written. The probe is the only place a device
+            // learns the provider without enrolling, so it has to write
+            // what it learned every time.
+            let email = record
+                .as_ref()
+                .map(|record| record.email.clone())
+                .unwrap_or_default();
+            if let Err(error) =
+                record_customer_status(&state, receipt.status, &email, receipt.provider.as_deref())
+                    .await
+            {
+                log!("account customer status not recorded: {error}");
             }
             // This probe is what notices activation, so it is where
             // work deferred during the wait gets replayed.
@@ -569,6 +573,15 @@ pub(crate) async fn registration(state: &crate::worker::TonkState) -> Registrati
     match customer.provider() {
         Some(provider) => Registration::Served {
             provider: provider.to_owned(),
+        },
+        // Active with no recorded address: the status write landed
+        // before the one carrying the provider, which happens when a
+        // space is created in the moment right after activation. The
+        // account is served — the status says so — and the caller
+        // resolves the address elsewhere, so this must not read as
+        // "awaiting activation" and leave the space local-only.
+        None if customer.status.0 == "Active" => Registration::Served {
+            provider: String::new(),
         },
         // Enrolled far enough to record an address, but not far enough
         // to be served: the activation link is still unclicked.

--- a/rust/tonk-worker/src/router/customer.rs
+++ b/rust/tonk-worker/src/router/customer.rs
@@ -134,6 +134,9 @@ pub async fn enroll(
             Receipt {
                 customer: root_did.clone(),
                 status: CustomerStatus::Active,
+                // Synthesized locally, so it names no service-provided
+                // provider; whatever was recorded before stands.
+                provider: None,
             }
         }
         Err(error) => return Err(error.into()),
@@ -143,12 +146,26 @@ pub async fn enroll(
         &state,
         &CustomerRecord {
             customer: receipt.customer.to_string(),
-            email,
+            email: email.clone(),
             status: receipt.status,
             enrolled_at: Timestamp::now().to_unix(),
         },
     )
     .await?;
+    // The same answer as a fact on profile main, so every device on this
+    // account reads the registration state by query rather than by
+    // probing the service itself.
+    //
+    // The sync endpoint comes from the receipt: the SERVICE decides
+    // where its customers sync and says so, rather than each client
+    // deriving an address from whichever origin it happened to reach.
+    // An older service that answers no remote leaves whatever was
+    // recorded before in place.
+    if let Err(error) =
+        record_customer_status(&state, receipt.status, &email, receipt.provider.as_deref()).await
+    {
+        log!("account customer status not recorded: {error}");
+    }
     Ok(Json(receipt))
 }
 
@@ -181,6 +198,22 @@ pub async fn get_state(
                     ..record.clone()
                 };
                 save_customer(&state, &refreshed).await?;
+                // Activation observed here is what promotes the fact on
+                // profile main, so the other devices on this account see
+                // it without each probing the service. The probe answers
+                // the sync endpoint alongside the status, so activation
+                // records the service's own address rather than deriving
+                // one from whichever origin this request reached.
+                if let Err(error) = record_customer_status(
+                    &state,
+                    receipt.status,
+                    &record.email,
+                    receipt.provider.as_deref(),
+                )
+                .await
+                {
+                    log!("account customer status not recorded: {error}");
+                }
             }
             // This probe is what notices activation, so it is where
             // work deferred during the wait gets replayed.
@@ -435,6 +468,161 @@ async fn load_customer(
     }
 }
 
+/// Whether a provider actually serves this account — the precondition
+/// for wiring a space to a remote.
+///
+/// Every other [`Registration`] answers `false`: awaiting activation,
+/// suspended, and never registered are all states in which the access
+/// service's provisioning gate refuses the subject, so attaching an
+/// upstream would produce a space that syncs to a 403. Failing closed
+/// costs a local-only space the share button can still sync; failing
+/// open costs a space wired to a remote that refuses it.
+///
+/// Callers that need to explain WHY should read [`registration`]
+/// directly — this collapses four states into a yes/no.
+pub(crate) async fn is_active(state: &crate::worker::TonkState) -> bool {
+    matches!(registration(state).await, Registration::Served { .. })
+}
+
+/// The provider serving this account, from the fact on profile main.
+///
+/// The one answer every attach path should use: the service names it in
+/// the registration receipt, so it does not depend on which origin a
+/// later request arrives on, and it reaches other devices through sync
+/// rather than being re-derived from each page's own location.
+pub(crate) async fn provider_address(state: &crate::worker::TonkState) -> Option<String> {
+    account_customer(state).await?.provider().map(str::to_owned)
+}
+
+/// How far this account got through registering with a provider.
+///
+/// The share flow's whole decision, in one read. A space with no remote
+/// cannot be shared, and what to do about it depends entirely on this:
+/// attach and go, finish confirming an email, or register from scratch.
+#[cfg_attr(
+    not(all(target_arch = "wasm32", target_os = "unknown")),
+    allow(dead_code)
+)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Registration {
+    /// No provider and no enrollment: nothing has been registered.
+    Unregistered,
+    /// Enrolled, but the activation email has not been confirmed, so no
+    /// provider serves this account yet. `email` is where the link went.
+    AwaitingActivation {
+        /// The address the activation link was sent to.
+        email: String,
+    },
+    /// Registered and served. `provider` is where spaces attach.
+    Served {
+        /// The provider serving this account.
+        provider: String,
+    },
+    /// Registered, but service was withdrawn. No email confirms this
+    /// away; it is terminal until an operator says otherwise.
+    Suspended,
+}
+
+/// Read how far this account got through registering.
+///
+/// The provider address is the primary signal, because the service names
+/// it only once it actually serves the customer (see the access
+/// service's `enroll`, which deliberately answers none). So "has a
+/// provider" is "completed registration", and status only refines what
+/// an absent one means.
+pub(crate) async fn registration(state: &crate::worker::TonkState) -> Registration {
+    let Some(customer) = account_customer(state).await else {
+        return Registration::Unregistered;
+    };
+    if customer.status.0 == "Suspended" {
+        return Registration::Suspended;
+    }
+    match customer.provider() {
+        Some(provider) => Registration::Served {
+            provider: provider.to_owned(),
+        },
+        // Enrolled far enough to record an address, but not far enough
+        // to be served: the activation link is still unclicked.
+        None if !customer.email.0.is_empty() => Registration::AwaitingActivation {
+            email: customer.email.0.clone(),
+        },
+        None => Registration::Unregistered,
+    }
+}
+
+/// This account's registration fact, absent when nothing recorded one.
+async fn account_customer(
+    state: &crate::worker::TonkState,
+) -> Option<tonk_schema::AccountCustomer> {
+    use dialog_query::{Output as _, Query, Term};
+    use tonk_schema::{AccountCustomer, prelude::DidExt as _};
+
+    let account = super::identity::root_did(state).await.ok()?;
+    let branch = state
+        .reactor
+        .profile_repository()
+        .branch(tonk_account::MAIN_BRANCH)
+        .acquire(&state.operator)
+        .await
+        .ok()?;
+    let rows: Vec<AccountCustomer> = branch
+        .handle()
+        .query()
+        .select(Query::<AccountCustomer> {
+            this: Term::from(account.this()),
+            status: Term::var("status"),
+            email: Term::var("email"),
+            provider: Term::var("provider"),
+        })
+        .perform(&state.operator)
+        .try_vec()
+        .await
+        .ok()?;
+    rows.into_iter().next()
+}
+
+/// Record the account's registration state as a fact on profile main,
+/// so it reaches every device on the account.
+///
+/// Called wherever the service's answer is learned — enrollment, and the
+/// status probe that notices activation — so the fact tracks the
+/// service rather than drifting from it.
+pub(crate) async fn record_customer_status(
+    state: &crate::worker::TonkState,
+    status: CustomerStatus,
+    email: &str,
+    provider: Option<&str>,
+) -> Result<(), TonkWorkerError> {
+    use tonk_schema::{AccountCustomer, prelude::DidExt as _};
+
+    let account = super::identity::root_did(state).await?;
+    // An absent address means "unchanged", not "no provider": a service
+    // that predates the field must not blank one a previous receipt
+    // already recorded.
+    let provider = match provider {
+        Some(provider) => provider.to_owned(),
+        None => provider_address(state).await.unwrap_or_default(),
+    };
+    state
+        .reactor
+        .profile_repository()
+        .branch(tonk_account::MAIN_BRANCH)
+        .transaction()
+        .assert(AccountCustomer::new(
+            account.this(),
+            status.as_str(),
+            email.to_owned(),
+            provider,
+        ))
+        .commit()
+        .perform(&state.operator)
+        .await
+        .map_err(|error| {
+            TonkWorkerError::Internal(format!("commit account customer status: {error}"))
+        })?;
+    Ok(())
+}
+
 async fn save_customer(
     state: &crate::worker::TonkState,
     record: &CustomerRecord,
@@ -629,6 +817,40 @@ pub async fn complete_pending_custody(
     }
     drain_pending(&state).await;
     Ok(Json(()))
+}
+
+/// Record a customer at `status`, so a test can put the profile in the
+/// state the gate reads without standing up an access service.
+///
+/// Writes the fact on profile main — what [`is_active`] actually reads —
+/// alongside the device-local record the account panel renders, so a
+/// test sets up the same pair the enrollment path does.
+#[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) async fn record_test_customer(
+    state: &crate::worker::TonkState,
+    status: CustomerStatus,
+) -> Result<(), TonkWorkerError> {
+    const EMAIL: &str = "customer@example.test";
+    const PROVIDER: &str = "https://example.test/ucan/";
+    let customer = super::identity::root_did(state).await?.to_string();
+    save_customer(
+        state,
+        &CustomerRecord {
+            customer,
+            email: EMAIL.to_owned(),
+            status,
+            enrolled_at: 0,
+        },
+    )
+    .await?;
+    // A provider only for a served customer, mirroring what the access
+    // service actually answers: enrollment names none, because an
+    // unactivated customer gets neither service nor provisioning. A
+    // fixture that recorded one anyway would make `Registered`
+    // indistinguishable from `Active` and quietly defeat the gate the
+    // tests exist to check.
+    let provider = matches!(status, CustomerStatus::Active).then_some(PROVIDER);
+    record_customer_status(state, status, EMAIL, provider).await
 }
 
 pub(crate) async fn clear_customer(

--- a/rust/tonk-worker/src/router/customer.rs
+++ b/rust/tonk-worker/src/router/customer.rs
@@ -169,6 +169,35 @@ pub async fn enroll(
     Ok(Json(receipt))
 }
 
+/// POST `/api/customer/activated` → record the receipt the activation
+/// page received.
+///
+/// Activation happens on a page that posts the emailed invocation
+/// straight to the service's `/ucan/` endpoint, so the receipt — and
+/// with it the provider address the service names — lands somewhere the
+/// worker never sees. Without this the fact is written only when
+/// something later calls the status probe, which leaves a just-activated
+/// account creating local-only spaces because nothing recorded who
+/// serves it.
+///
+/// Takes the receipt rather than re-deriving anything: the service
+/// already said who it is, and this is where that answer is kept.
+#[wasm_compat]
+pub async fn activated(
+    State(state): State<AppState>,
+    Json(receipt): Json<Receipt>,
+) -> Result<Json<()>, TonkWorkerError> {
+    let state = state.read().await;
+    let email = load_customer(&state)
+        .await?
+        .map(|record| record.email)
+        .unwrap_or_default();
+    record_customer_status(&state, receipt.status, &email, receipt.provider.as_deref()).await?;
+    // Anything held back while the account was unserved can run now.
+    drain_pending(&state).await;
+    Ok(Json(()))
+}
+
 /// GET `/api/customer` → the account's registration state: the service's
 /// live answer joined with the locally recorded enrollment.
 #[wasm_compat]

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -323,9 +323,23 @@ pub async fn post_space(
             .to_owned()
     };
 
+    // This runs on the account-gate replay, immediately after the signup
+    // ceremony — where the customer is `Registered` but not yet `Active`,
+    // because the activation email has not been clicked. Attaching the
+    // parked remote there wires an upstream the access service refuses,
+    // so the remote is honoured only once the customer is active. The
+    // space is created either way; the share button attaches sync later.
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     if let Some(remote) = request.remote.filter(|remote| !remote.trim().is_empty()) {
-        enable_sync_inner(&state, &key, &remote).await?;
+        let active = {
+            let tonk = state.read().await;
+            super::customer::is_active(&tonk).await
+        };
+        if active {
+            enable_sync_inner(&state, &key, &remote).await?;
+        } else {
+            log!("space '{key}' created local-only: no active customer to provision it under");
+        }
     }
 
     Ok((
@@ -680,17 +694,31 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for CreateSpaceHa
             //    (`remote_from_facts` already dropped empty/blank URLs.)
             // A blank remote used to mean local-only, which the account
             // directory now advertises account-wide as a space no other
-            // device can ever replicate. With an account attached, the
+            // device can ever replicate. With an ACTIVE account, the
             // account's own sync remote is the natural default — the
             // same access service the account DB syncs through; the
             // relay resolves from the remote's origin as usual.
+            //
+            // Without one, no default: the access service serves only an
+            // active customer's subjects, so defaulting a remote here
+            // would wire an upstream that 403s on every presign. The
+            // space stays local until the user asks to share it, which
+            // is where provisioning belongs.
+            // The endpoint comes from the account's own registration
+            // fact, not from the signed descriptor and not from the
+            // page's `https://{origin}/ucan/` guess: registration is
+            // where the account learned which access service it is a
+            // customer of, so that is the one answer every attach path
+            // reads.
             let remote = match remote {
                 Some(remote) => Some(remote),
                 None => {
                     let tonk = env.state().read().await;
-                    super::account::descriptor(&tonk)
-                        .await
-                        .map(|descriptor| descriptor.remote().to_string())
+                    if super::customer::is_active(&tonk).await {
+                        super::customer::provider_address(&tonk).await
+                    } else {
+                        None
+                    }
                 }
             };
             if let Some(remote) = remote
@@ -2280,6 +2308,34 @@ async fn enable_sync_inner(
         }
     };
 
+    // Provision before attaching. Creation only provisions when there is
+    // an active customer to provision under, so a space created during
+    // onboarding has no consumer row — and an upstream attached without
+    // one syncs to `subject is provisioned by an active customer (the
+    // subject is not provisioned)` on every presign. This is where a
+    // local-only space earns its remote, so it is where the consumer row
+    // has to be created.
+    //
+    // Best effort, not fatal. A remote is not necessarily OUR access
+    // service — a self-hosted endpoint or a test server is attached the
+    // same way, and `/provider/add` against our own service is beside
+    // the point there. Refusing the attach on a failed provision would
+    // make those unreachable, so the attach proceeds and a space that
+    // does need provisioning surfaces it as a refused presign rather
+    // than a refused attach.
+    match space_root_prefix(&tonk, &repository.did()).await {
+        Ok(prefix) => {
+            if let Err(error) =
+                super::customer::provision_consumer(&tonk, &repository.did(), &prefix, None).await
+            {
+                log!("enable sync '{key}': provisioning skipped: {error}");
+            }
+        }
+        Err(error) => {
+            log!("enable sync '{key}': no root delegation to consent with: {error}")
+        }
+    }
+
     let effective = ensure_remote_config(&tonk, &repository, key, &configuration).await?;
 
     // Mirror the EFFECTIVE mount configuration into the account
@@ -2728,10 +2784,25 @@ pub async fn create_repository(
     // consumer of the access service, depositing the powerline as its
     // consent. Best effort for the same reason retain is — a space is
     // usable the moment its delegations exist locally.
-    if let Err(error) =
-        super::customer::provision_or_defer(tonk, &repository.did(), &prefix, None).await
-    {
-        log!("consumer provisioning skipped: {error}");
+    //
+    // Only for an ACTIVE customer. A device has an account from first
+    // boot (the onboarding account), so "an account exists" says nothing
+    // about whether the access service will serve this subject: until
+    // the user enrols an email and confirms it, `/provider/add` refuses
+    // and the space would be left wired to a remote that answers 403 on
+    // every presign. A space created in that window is local-only by
+    // design, and the share button provisions it on demand.
+    if super::customer::is_active(tonk).await {
+        if let Err(error) =
+            super::customer::provision_or_defer(tonk, &repository.did(), &prefix, None).await
+        {
+            log!("consumer provisioning skipped: {error}");
+        }
+    } else {
+        log!(
+            "space '{}' created local-only: no active customer to provision it under",
+            repository.did()
+        );
     }
 
     let prefix_bytes = prefix.to_bytes().map_err(|error| {
@@ -4407,6 +4478,30 @@ pub async fn attach_remote(
         .map_err(|e| {
             TonkWorkerError::NotFound(format!("Repository '{}' not found: {}", name, e))
         })?;
+
+    // Provision before attaching, for the same reason
+    // [`enable_sync_inner`] does: a space created without an active
+    // customer has no consumer row, and an upstream without one syncs to
+    // a refused presign. Best effort here rather than fatal — this route
+    // is also how a space is pointed at a remote that is not the
+    // account's access service (a self-hosted endpoint, a test server),
+    // where `/provider/add` against our own service is beside the point.
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    if !configuration.remote.is_empty() {
+        match space_root_prefix(&tonk, &repository.did()).await {
+            Ok(prefix) => {
+                if let Err(error) =
+                    super::customer::provision_consumer(&tonk, &repository.did(), &prefix, None)
+                        .await
+                {
+                    log!("attach remote '{name}': provisioning skipped: {error}");
+                }
+            }
+            Err(error) => {
+                log!("attach remote '{name}': no root delegation to consent with: {error}")
+            }
+        }
+    }
 
     ensure_remote_config(&tonk, &repository, &name, &configuration).await?;
 
@@ -6293,6 +6388,213 @@ mod tests {
         assert!(
             has_remote_upstream(&state, &key).await,
             "the existing spot now tracks origin/main"
+        );
+    }
+
+    /// A space created while the customer is not `Active` wires no
+    /// remote, even though an account exists.
+    ///
+    /// A device has an account from first boot (the onboarding account),
+    /// so "an account exists" says nothing about whether the access
+    /// service will serve this subject. Until the user enrols and
+    /// confirms an email, `/provider/add` refuses and a wired upstream
+    /// would answer `subject is provisioned by an active customer (the
+    /// subject is not provisioned)` on every presign. The space is
+    /// local-only by design; the share button attaches sync later.
+    #[dialog_common::test]
+    async fn it_creates_a_space_local_only_before_the_customer_is_active() {
+        let (app, state, key) = fresh_repo("test-inactive-no-remote").await;
+        {
+            let tonk = state.read().await;
+            crate::router::customer::record_test_customer(
+                &tonk,
+                tonk_account::customer::CustomerStatus::Registered,
+            )
+            .await
+            .expect("the customer record saves");
+        }
+        let _ = &app;
+
+        assert!(
+            !has_remote_upstream(&state, &key).await,
+            "a space created before activation must track no upstream",
+        );
+    }
+
+    /// The gate reads the customer's status, not merely whether an
+    /// account exists: `Registered` (enrolled, email unconfirmed) is as
+    /// unservable as no registration at all.
+    #[dialog_common::test]
+    async fn it_treats_an_enrolled_but_unconfirmed_customer_as_inactive() {
+        let (_app, state, _key) = fresh_repo("test-registered-inactive").await;
+
+        let tonk = state.read().await;
+        crate::router::customer::record_test_customer(
+            &tonk,
+            tonk_account::customer::CustomerStatus::Registered,
+        )
+        .await
+        .expect("the customer record saves");
+        assert!(
+            !crate::router::customer::is_active(&tonk).await,
+            "a Registered customer awaits email activation and is not servable",
+        );
+
+        crate::router::customer::record_test_customer(
+            &tonk,
+            tonk_account::customer::CustomerStatus::Suspended,
+        )
+        .await
+        .expect("the customer record saves");
+        assert!(
+            !crate::router::customer::is_active(&tonk).await,
+            "a Suspended customer is not servable",
+        );
+
+        crate::router::customer::record_test_customer(
+            &tonk,
+            tonk_account::customer::CustomerStatus::Active,
+        )
+        .await
+        .expect("the customer record saves");
+        assert!(
+            crate::router::customer::is_active(&tonk).await,
+            "an Active customer is the one state the service serves",
+        );
+    }
+
+    /// The account's provider is read from the registration fact, so
+    /// every device on the account attaches spaces to the same one.
+    ///
+    /// It used to be re-derived per call site — from the signed account
+    /// descriptor in the worker, and from `https://{origin}/ucan/` in the
+    /// page's hidden form field — so two paths could disagree about
+    /// where a space syncs. Recording it where registration happens is
+    /// what makes that one answer.
+    #[dialog_common::test]
+    async fn it_reads_the_provider_from_the_registration_fact() {
+        let (_app, state, _key) = fresh_repo("test-recorded-remote").await;
+
+        let tonk = state.read().await;
+        assert!(
+            crate::router::customer::provider_address(&tonk)
+                .await
+                .is_none(),
+            "an account that never registered records no provider",
+        );
+
+        crate::router::customer::record_test_customer(
+            &tonk,
+            tonk_account::customer::CustomerStatus::Active,
+        )
+        .await
+        .expect("the customer record saves");
+
+        assert_eq!(
+            crate::router::customer::provider_address(&tonk)
+                .await
+                .as_deref(),
+            Some("https://example.test/ucan/"),
+            "the provider registration recorded is what attach paths read",
+        );
+    }
+
+    /// Registration reads as one of four states, and the provider
+    /// address is what separates them.
+    ///
+    /// The service names a provider only once it serves the customer, so
+    /// "has an address" IS "finished registering". That is what lets the
+    /// share flow tell "confirm your email" from "register from
+    /// scratch" without asking the service.
+    #[dialog_common::test]
+    async fn it_reads_how_far_registration_got() {
+        use crate::router::customer::{Registration, registration};
+        use tonk_account::customer::CustomerStatus;
+
+        let (_app, state, _key) = fresh_repo("test-registration-states").await;
+        let tonk = state.read().await;
+
+        assert_eq!(
+            registration(&tonk).await,
+            Registration::Unregistered,
+            "an account that never enrolled has registered nothing",
+        );
+
+        // Enrollment records the address but no provider: the service
+        // withholds one until the emailed link is confirmed.
+        crate::router::customer::record_customer_status(
+            &tonk,
+            CustomerStatus::Registered,
+            "customer@example.test",
+            None,
+        )
+        .await
+        .expect("the status records");
+        assert_eq!(
+            registration(&tonk).await,
+            Registration::AwaitingActivation {
+                email: "customer@example.test".to_owned(),
+            },
+            "an enrolled account with no provider is still awaiting its email",
+        );
+        assert!(
+            !crate::router::customer::is_active(&tonk).await,
+            "awaiting activation is not served, so nothing may attach a remote",
+        );
+
+        // Activation is where the provider lands.
+        crate::router::customer::record_customer_status(
+            &tonk,
+            CustomerStatus::Active,
+            "customer@example.test",
+            Some("https://hub.test/ucan/"),
+        )
+        .await
+        .expect("the status records");
+        assert_eq!(
+            registration(&tonk).await,
+            Registration::Served {
+                provider: "https://hub.test/ucan/".to_owned(),
+            },
+            "an activated account names the provider its spaces attach to",
+        );
+        assert!(crate::router::customer::is_active(&tonk).await);
+
+        // Suspension is terminal, and outranks a recorded provider: no
+        // email confirms it away.
+        crate::router::customer::record_customer_status(
+            &tonk,
+            CustomerStatus::Suspended,
+            "customer@example.test",
+            Some("https://hub.test/ucan/"),
+        )
+        .await
+        .expect("the status records");
+        assert_eq!(
+            registration(&tonk).await,
+            Registration::Suspended,
+            "a suspended account is refused regardless of its recorded provider",
+        );
+        assert!(!crate::router::customer::is_active(&tonk).await);
+    }
+
+    /// Enable-sync still attaches when provisioning cannot run.
+    ///
+    /// A remote is not necessarily our access service, and the service
+    /// may simply be unreachable. Refusing the attach on a failed
+    /// provision would make a self-hosted endpoint unattachable, so the
+    /// attach proceeds regardless — the gate is on the CREATE default,
+    /// not on an explicit request to sync.
+    #[dialog_common::test]
+    async fn it_attaches_sync_even_when_provisioning_cannot_run() {
+        let (app, state, _lsp) = api_router_with_state(test_state().await);
+        let (key, subject) = put_repo_info(&app, "test-attach-without-provision").await;
+
+        dispatch_enable_sync(&state, &subject, "https://example.test/ucan/", false, 1.0).await;
+
+        assert!(
+            has_remote_upstream(&state, &key).await,
+            "an explicit enable-sync attaches even with no reachable service to provision against",
         );
     }
 

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -323,22 +323,34 @@ pub async fn post_space(
             .to_owned()
     };
 
-    // This runs on the account-gate replay, immediately after the signup
-    // ceremony — where the customer is `Registered` but not yet `Active`,
-    // because the activation email has not been clicked. Attaching the
-    // parked remote there wires an upstream the access service refuses,
-    // so the remote is honoured only once the customer is active. The
-    // space is created either way; the share button attaches sync later.
+    // Where the space syncs is resolved exactly as it is on the command
+    // path: an explicit remote wins, otherwise the account's own
+    // provider, and nothing at all without an active customer.
+    //
+    // Both paths resolving it the same way is the point. This endpoint
+    // is the account-gate replay, which runs immediately after the
+    // signup ceremony — a window where the customer may still be
+    // `Registered`, and attaching anything would wire an upstream the
+    // access service refuses. It used to honour only the remote its
+    // request carried, so a replay that named none produced a space the
+    // FAB path would have synced, which is the two-creation-paths-
+    // disagree bug this change exists to remove.
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-    if let Some(remote) = request.remote.filter(|remote| !remote.trim().is_empty()) {
+    {
+        let remote = match request.remote.filter(|remote| !remote.trim().is_empty()) {
+            Some(remote) => Some(remote),
+            None => {
+                let tonk = state.read().await;
+                account_sync_remote(&tonk).await
+            }
+        };
         let active = {
             let tonk = state.read().await;
             super::customer::is_active(&tonk).await
         };
-        if active {
-            enable_sync_inner(&state, &key, &remote).await?;
-        } else {
-            log!("space '{key}' created local-only: no active customer to provision it under");
+        match remote {
+            Some(remote) if active => enable_sync_inner(&state, &key, &remote).await?,
+            _ => log!("space '{key}' created local-only: no active provider to attach it to"),
         }
     }
 
@@ -715,7 +727,7 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for CreateSpaceHa
                 None => {
                     let tonk = env.state().read().await;
                     if super::customer::is_active(&tonk).await {
-                        super::customer::provider_address(&tonk).await
+                        account_sync_remote(&tonk).await
                     } else {
                         None
                     }
@@ -2223,6 +2235,28 @@ fn space_config(remote: &str) -> Result<RepositoryConfiguration, RepositoryError
             "main",
             BranchConfiguration::default().upstream("origin", "main"),
         ))
+}
+
+/// Where a space on this account syncs, when nothing named a remote.
+///
+/// The account's recorded provider is the authority — the access service
+/// names it in the registration receipt. It is written by whatever last
+/// talked to the service, though, and a space created in the moment
+/// after activation can beat that write; the account descriptor names
+/// the same deployment and is recorded at link time, so it answers while
+/// the fact catches up rather than leaving the space local-only on a
+/// race.
+///
+/// Shared by both creation paths so they cannot disagree about where a
+/// space syncs.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn account_sync_remote(tonk: &TonkState) -> Option<String> {
+    match super::customer::provider_address(tonk).await {
+        Some(provider) => Some(provider),
+        None => super::account::descriptor(tonk)
+            .await
+            .map(|descriptor| descriptor.remote().to_string()),
+    }
 }
 
 /// Create a space local-only, split out so its `?` errors are logged
@@ -6496,6 +6530,81 @@ mod tests {
                 .as_deref(),
             Some("https://example.test/ucan/"),
             "the provider registration recorded is what attach paths read",
+        );
+    }
+
+    /// Recording an enrollment with no provider must not make the
+    /// registration fact unreadable.
+    ///
+    /// A concept resolves only when every field is present, so writing
+    /// `provider` as an empty string risks asserting nothing for it and
+    /// dropping the whole row — which reads back as "never registered"
+    /// however many times the status is written afterwards.
+    #[dialog_common::test]
+    async fn it_reads_a_registration_recorded_without_a_provider() {
+        use crate::router::customer::{Registration, record_customer_status, registration};
+        use tonk_account::customer::CustomerStatus;
+
+        let (_app, state, _key) = fresh_repo("test-empty-provider-row").await;
+        let tonk = state.read().await;
+
+        record_customer_status(&tonk, CustomerStatus::Registered, "who@example.test", None)
+            .await
+            .expect("the status records");
+        assert_eq!(
+            registration(&tonk).await,
+            Registration::AwaitingActivation {
+                email: "who@example.test".to_owned(),
+            },
+            "a registration recorded before activation must still read back",
+        );
+
+        // And the later activation write must be visible through it.
+        record_customer_status(
+            &tonk,
+            CustomerStatus::Active,
+            "who@example.test",
+            Some("https://hub.test/ucan/"),
+        )
+        .await
+        .expect("the status records");
+        assert_eq!(
+            registration(&tonk).await,
+            Registration::Served {
+                provider: "https://hub.test/ucan/".to_owned(),
+            },
+            "activation must promote the row a provider-less write created",
+        );
+    }
+
+    /// An `Active` account whose provider write has not landed yet
+    /// still reads as served.
+    ///
+    /// Activation writes the status and the address, and a space created
+    /// in the moment between them must not come up local-only. Reading
+    /// this as `AwaitingActivation` would tell an activated user to go
+    /// confirm an email they already confirmed.
+    #[dialog_common::test]
+    async fn it_treats_an_active_account_without_a_recorded_provider_as_served() {
+        use crate::router::customer::{
+            Registration, is_active, record_customer_status, registration,
+        };
+        use tonk_account::customer::CustomerStatus;
+
+        let (_app, state, _key) = fresh_repo("test-active-no-provider").await;
+        let tonk = state.read().await;
+
+        record_customer_status(&tonk, CustomerStatus::Active, "who@example.test", None)
+            .await
+            .expect("the status records");
+
+        assert!(
+            matches!(registration(&tonk).await, Registration::Served { .. }),
+            "an Active account is served whether or not its address landed yet",
+        );
+        assert!(
+            is_active(&tonk).await,
+            "the create gate must not withhold a remote from an activated account",
         );
     }
 


### PR DESCRIPTION
Creating a space on a device whose account has not confirmed its email left it wired to a remote the access service refuses, so sync answered `subject is provisioned by an active customer (the subject is not provisioned)` on every attempt, and the account never got registered either.

A device has an account from first boot, so "an account exists" said nothing about whether a space would be served. The gate is the customer's registration, not the account's existence.

## Registration as facts

The state lived in a device-local credential blob refreshed only by visiting `/account`, so a device that never opened that page read a stale answer, and nothing could query it. It becomes the `AccountCustomer` concept on profile main — status, email, provider address, keyed on the account subject — converging across devices through ordinary sync.

The provider address comes from the service now. Three paths derived it independently (the page's `<tonk-default-remote auto>`, the signed account descriptor, and `share.rs` via `context_origin()`), so they could disagree about where a space syncs; the service names it in the registration receipt and the client records what it is told.

Only at activation, never at enrollment. The address is what says "this service serves you", and an unactivated customer gets neither service nor provisioning, so a `Registered` receipt omits the key entirely. That makes provider presence mean "finished registering", which is what lets a caller distinguish:

| state | meaning |
|---|---|
| no fact | never registered |
| email, no provider | enrolled, awaiting the emailed link |
| provider | served |
| `Suspended` | terminal |

`customer::registration()` returns that as an enum; `is_active()` collapses it to a yes/no.

## Local until provisioned

Creation attaches nothing without an active customer, and the create wizard passes no remote at all — the worker resolves it, so the page stops deriving an endpoint from its own origin.

Every attach path provisions first, which `enable_sync_inner` never did. That omission is why opting a local-only space into sync reproduced the same refusal: it wired an upstream to a subject nobody had provisioned. Provisioning at attach time is best effort, because a remote is not necessarily our access service and refusing the attach would make a self-hosted endpoint unattachable.

## One resolution, both create paths

`POST /api/spaces` honoured only the remote its request carried, while the command path fell back to the account's provider — so a replay naming no remote produced a local-only space where the FAB path produced a synced one. Both resolve through one helper now.

The account descriptor is a fallback behind the recorded provider, because activation writes the status and the address through different paths; a space created between them would otherwise come up local-only on an account that is genuinely served.

## Note on a reversed contract

`it_hosts_a_space_created_before_activation_once_the_email_is_confirmed` encoded the old behaviour — queue the provisioning at create, replay it at activation — and is replaced. That approach left the space wired to an unusable remote for the whole waiting period, which is the 403 this change exists to prevent. Spaces created before activation now stay local and are opted into sync per space.

## Verification

Three real-browser tests against a live access service cover the flow end to end: a space created before activation stays local with no remote, a space created after activation attaches the recorded provider without the page naming one, and a local-only space provisions and pushes once sync is enabled. All three pass; the first two also caught real bugs in this change that the unit tests could not, since those seed the registration fact through a fixture rather than through an actual activation.

Also: worker wasm 303, schema 78, fab 52 + 88, access-service integration 20, native workspace green, clippy `--all --all-targets --all-features -D warnings` clean.

## Still client-derived

`share.rs` computes `context_origin()` + `/ucan/` for the enable-sync repair path. Removing that is the follow-up, along with the `needs-account` / `needs-activation` refusal classes the share button needs in order to route to registration rather than offering "turn on sync".

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the customer registration and activation process in the `tonk` project. It introduces a new `provider` field in customer records, updates routing for customer activation, and ensures proper handling of customer states during registration.

### Detailed summary
- Added `AccountCustomer` to `tonk-schema` with `provider` and `status` fields.
- Updated `customer::activated` route to record activation receipts.
- Modified customer state handling to reflect active status and provider associations.
- Enhanced tests to verify behavior of customer registration and activation states.
- Updated UI to handle new provider information during activation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->