### PR TITLE
The account dashboard follows activation without a reload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5036,6 +5036,7 @@ version = "0.6.8"
 dependencies = [
  "aes-gcm",
  "anyhow",
+ "base64",
  "blake3",
  "bs58",
  "dialog-common",

--- a/rust/tonk-access-service/src/helpers/server.rs
+++ b/rust/tonk-access-service/src/helpers/server.rs
@@ -656,6 +656,20 @@ async fn handle_request(
     // Authorize the UCAN container using UcanAuthorizer
     let authorizer = authorizer.read().await;
     let outcome = authorizer.authorize(&body_bytes).await;
+    // Test visibility: one line per permit request, so a CI job log
+    // shows whether a publish or resolve ever arrived and how it fared
+    // — the service worker's own console never reaches those logs.
+    {
+        let command = dialog_ucan_core::InvocationChain::try_from(body_bytes.as_ref())
+            .map(|chain| chain.command().0.join("/"))
+            .unwrap_or_else(|_| "?".into());
+        let subject =
+            crate::provisioning::container_subject(&body_bytes).unwrap_or_else(|| "?".into());
+        println!(
+            "ACCESS_UCAN command=/{command} subject={subject} authorized={}",
+            outcome.is_ok()
+        );
+    }
     if outcome.is_ok()
         && let Some(subject) = crate::deletion::subject(&body_bytes)
     {
@@ -694,6 +708,7 @@ async fn handle_request(
             {
                 Ok(Ok(())) => {}
                 Ok(Err(reason)) => {
+                    println!("ACCESS_UCAN_REFUSED subject={subject} reason={reason:?}");
                     return Ok(cors_response(authorize_error_response(
                         StatusCode::FORBIDDEN,
                         &reason,

--- a/rust/tonk-access-service/tests/registration.rs
+++ b/rust/tonk-access-service/tests/registration.rs
@@ -971,7 +971,13 @@ async fn it_publishes_and_resolves_the_custody_cell(
     // Seal the secret and publish the cell: permit, then presigned PUT.
     let secret = AccountSecret::generate()?;
     let sealed = kek.seal(&secret, KekMethod::Passkey)?.encode();
-    let publish = custody::build_publish_invocation(custody_key.clone(), &sealed, None).await?;
+    let publish = custody::build_publish_invocation(
+        custody_key.clone(),
+        &sealed,
+        None,
+        dialog_ucan_core::time::Timestamp::five_minutes_from_now(),
+    )
+    .await?;
     let response = client
         .post(&ucan)
         .header("Content-Type", "application/cbor")

--- a/rust/tonk-access-service/tests/registration.rs
+++ b/rust/tonk-access-service/tests/registration.rs
@@ -1028,9 +1028,7 @@ async fn it_publishes_and_resolves_the_custody_cell(
 /// registration ceremonies, not the memory permit an owner signs for
 /// its own cell.
 #[dialog_common::test]
-async fn it_redeems_a_deferred_publish_invocation(
-    env: AccessServiceAddress,
-) -> anyhow::Result<()> {
+async fn it_redeems_a_deferred_publish_invocation(env: AccessServiceAddress) -> anyhow::Result<()> {
     use dialog_remote_s3::Permit;
     use tonk_identity::envelope::{
         AccountSecret, Envelope, KekMethod, custody_kek, custody_signer,

--- a/rust/tonk-access-service/tests/registration.rs
+++ b/rust/tonk-access-service/tests/registration.rs
@@ -1021,3 +1021,114 @@ async fn it_publishes_and_resolves_the_custody_cell(
     );
     Ok(())
 }
+
+/// The deferred variant of the custody publish: the invocation is
+/// pre-signed with the month-long expiration a queued-at-creation
+/// publish carries, and must still redeem — the service bounds
+/// registration ceremonies, not the memory permit an owner signs for
+/// its own cell.
+#[dialog_common::test]
+async fn it_redeems_a_deferred_publish_invocation(
+    env: AccessServiceAddress,
+) -> anyhow::Result<()> {
+    use dialog_remote_s3::Permit;
+    use tonk_identity::envelope::{
+        AccountSecret, Envelope, KekMethod, custody_kek, custody_signer,
+    };
+    use tonk_identity::{custody, delegation};
+
+    let client = reqwest::Client::new();
+    let base = env.access_service_url.trim_end_matches('/').to_string();
+    let ucan = format!("{base}/ucan/");
+    let service_did: Did = env.service_did.parse()?;
+
+    // The account enrolls as a customer.
+    let account = Ed25519Signer::generate().await?;
+    let container = enroll_container(&account, &service_did, "custody@example.com").await;
+    let response = client
+        .post(&ucan)
+        .header("Content-Type", "application/cbor")
+        .body(container)
+        .send()
+        .await?;
+    assert_eq!(response.status(), 200, "enrollment refused");
+
+    // Confirming the email is what unlocks everything below: an
+    // unactivated customer provisions nothing and is served nothing.
+    activate_over_http(&client, &base).await?;
+
+    // The entry function's two outputs; a PRF would produce these
+    // inside one assertion, at the two custody salts.
+    let custody_key = custody_signer(&[21u8; 32]).await?;
+    let kek = custody_kek(&[22u8; 32]);
+
+    // The account provisions the custody DID, depositing the consent
+    // the custody key minted — the ordinary provisioning contract.
+    let device = Ed25519Signer::generate().await?;
+    let link = delegation::mint_device_delegation(account.clone(), &device.did()).await?;
+    let consent = custody::mint_custody_consent(custody_key.clone(), &account.did()).await?;
+    let add = tonk_identity::request::build_provider_add_invocation(
+        device,
+        &link,
+        &custody_key.did(),
+        &consent,
+        Some("custody"),
+    )
+    .await?;
+    let response = client
+        .post(&ucan)
+        .header("Content-Type", "application/cbor")
+        .body(add)
+        .send()
+        .await?;
+    assert_eq!(response.status(), 200, "provisioning refused");
+
+    // Seal the secret and publish the cell: permit, then presigned PUT.
+    let secret = AccountSecret::generate()?;
+    let sealed = kek.seal(&secret, KekMethod::Passkey)?.encode();
+    // The ceremony's pre-signed shape: bounded to a month, redeemed
+    // long after signing — what the worker drains once activation lands.
+    let publish = custody::build_deferred_publish_invocation(custody_key.clone(), &sealed).await?;
+    let response = client
+        .post(&ucan)
+        .header("Content-Type", "application/cbor")
+        .body(publish)
+        .send()
+        .await?;
+    assert_eq!(response.status(), 200, "publish permit refused");
+    let permit: Permit = serde_ipld_dagcbor::from_slice(&response.bytes().await?)?;
+    let stored = permit.upload(sealed.clone()).await?;
+    assert!(
+        stored.status().is_success(),
+        "storage PUT failed: {}",
+        stored.status(),
+    );
+
+    // A fresh device resolves with nothing but the custody key.
+    let resolve = custody::build_resolve_invocation(custody_key.clone()).await?;
+    let response = client
+        .post(&ucan)
+        .header("Content-Type", "application/cbor")
+        .body(resolve)
+        .send()
+        .await?;
+    assert_eq!(response.status(), 200, "resolve permit refused");
+    let permit: Permit = serde_ipld_dagcbor::from_slice(&response.bytes().await?)?;
+    let fetched = permit.send().await?;
+    assert!(
+        fetched.status().is_success(),
+        "storage GET failed: {}",
+        fetched.status(),
+    );
+    let bytes = fetched.bytes().await?.to_vec();
+    assert_eq!(bytes, sealed, "the resolved cell is the sealed envelope");
+
+    // The envelope opens back to the same account.
+    let opened = custody_kek(&[22u8; 32]).open(&Envelope::decode(&bytes)?)?;
+    assert_eq!(
+        opened.signing_seed().as_ref(),
+        secret.signing_seed().as_ref(),
+        "the unwrapped secret derives the same account",
+    );
+    Ok(())
+}

--- a/rust/tonk-account/src/pending.rs
+++ b/rust/tonk-account/src/pending.rs
@@ -34,13 +34,13 @@ pub enum PendingWork {
     },
     /// Publish a sealed account secret into a custody space's cell.
     ///
-    /// Only the sealed bytes are queued, never a signed invocation: the
-    /// custody key is PRF-derived inside a passkey assertion and never
-    /// stored, and an invocation signed during the ceremony carries a
-    /// five-minute expiration that cannot outlive a wait for an email
-    /// click. Replaying therefore needs a fresh assertion, which only a
-    /// page can raise — so this entry drains from the account panel
-    /// rather than from the worker's own status probe.
+    /// The ceremony that sealed the envelope also pre-signed the
+    /// publish invocation — the one moment the PRF-derived custody key
+    /// is in hand — with a bounded long expiration, so the worker can
+    /// drain this with no page, no assertion, and no button the moment
+    /// activation and provisioning land. The signature covers exactly
+    /// this cell and this content's checksum: least authority, held as
+    /// queued work.
     ///
     /// The envelope is already sealed under the passkey's KEK when it
     /// arrives here, so what waits is ciphertext rather than key
@@ -53,6 +53,12 @@ pub enum PendingWork {
         custody: String,
         /// Hex-encoded sealed envelope, the content to publish.
         sealed_hex: String,
+        /// Hex-encoded pre-signed `/memory/publish` invocation. An
+        /// entry from before invocations were queued decodes with an
+        /// empty string and is void: dropped with a log rather than
+        /// blocking the queue forever.
+        #[serde(default)]
+        invocation_hex: String,
     },
 }
 
@@ -123,6 +129,7 @@ mod tests {
         queue.push(PendingWork::PublishCustody {
             custody: "did:key:zCustody".to_string(),
             sealed_hex: "bb".to_string(),
+            invocation_hex: "c0de".to_string(),
         });
         queue.push(provision("did:key:zCustody"));
 
@@ -159,6 +166,7 @@ mod tests {
         queue.push(PendingWork::PublishCustody {
             custody: "did:key:zCustody".to_string(),
             sealed_hex: "bb".to_string(),
+            invocation_hex: "c0de".to_string(),
         });
 
         let bytes = serde_json::to_vec(&queue).expect("queue serializes");

--- a/rust/tonk-identity/Cargo.toml
+++ b/rust/tonk-identity/Cargo.toml
@@ -11,6 +11,7 @@ aes-gcm = { workspace = true }
 anyhow = { workspace = true }
 blake3 = { workspace = true }
 bs58 = { workspace = true }
+base64 = { workspace = true }
 dialog-credentials = { workspace = true }
 dialog-ucan-core = { workspace = true }
 dialog-varsig = { workspace = true }

--- a/rust/tonk-identity/src/ceremony.rs
+++ b/rust/tonk-identity/src/ceremony.rs
@@ -69,11 +69,15 @@ pub struct CustodyAccountCeremony {
     pub custody_did: String,
     /// Hex-encoded consent chain for `/provider/add`.
     pub consent_hex: String,
-    /// Hex-encoded sealed account secret, when the custody cell could
-    /// not be published during the ceremony because the account has not
-    /// confirmed its email yet. The caller queues it and publishes once
-    /// activation lands; `None` means the cell is already published.
-    pub sealed_hex: Option<String>,
+    /// Hex-encoded sealed account secret. Ciphertext under the
+    /// passkey's KEK: queued for the vault publish, and recorded on
+    /// profile main so the account's own sync carries the recovery
+    /// envelope.
+    pub sealed_hex: String,
+    /// Hex-encoded pre-signed publish invocation: the ceremony's
+    /// authorization for the worker to upload the cell once activation
+    /// lands, with no further assertion, page, or button.
+    pub publish_invocation_hex: String,
 }
 
 /// Informational metadata captured by the browser that created a passkey.
@@ -303,13 +307,20 @@ pub async fn create_custody_account(
         passkey,
     )
     .await?;
+    // The one moment the custody key is in hand is now, so it signs the
+    // deferred publish here: once activation and provisioning land, the
+    // worker redeems this invocation and uploads the sealed bytes — no
+    // further assertion, no page, no button.
+    let publish_invocation =
+        crate::custody::build_deferred_publish_invocation(custody.clone(), &sealed).await?;
     Ok(CustodyAccountCeremony {
         root: root_ceremony,
         account,
         deposits_hex,
         custody_did: custody.did().to_string(),
         consent_hex,
-        sealed_hex: Some(hex::encode(&sealed)),
+        sealed_hex: hex::encode(&sealed),
+        publish_invocation_hex: hex::encode(&publish_invocation),
     })
 }
 
@@ -375,10 +386,14 @@ pub struct CustodyEnrollment {
     /// Hex-encoded consent chain for `/provider/add`: the custody
     /// key's agreement to being provided by the account.
     pub consent_hex: String,
-    /// Hex-encoded sealed account secret, when the cell could not be
-    /// published yet — the new custody DID is not provisioned until the
-    /// caller deposits the consent above. `None` once it is published.
-    pub sealed_hex: Option<String>,
+    /// Hex-encoded sealed account secret — ciphertext under the new
+    /// passkey's KEK, recorded on profile main either way.
+    pub sealed_hex: String,
+    /// Hex-encoded pre-signed publish invocation, present when the cell
+    /// could not be published during the ceremony (the new custody DID
+    /// awaits provisioning): the worker redeems it once the deposit
+    /// lands. `None` once the cell is already published.
+    pub publish_invocation_hex: Option<String>,
 }
 
 /// Enroll an additional custody passkey: unlock the account through an
@@ -421,7 +436,11 @@ pub async fn enroll_custody(
     // unprovisioned subject — so a refusal here is the expected first
     // outcome, not a failure. Hand the sealed bytes back to be queued
     // and published once provisioning lands.
-    let mut sealed_hex = Some(hex::encode(&sealed));
+    let mut queued = Some(
+        crate::custody::build_deferred_publish_invocation(custody.clone(), &sealed)
+            .await
+            .map(|invocation| hex::encode(&invocation))?,
+    );
     if let Err(publish_error) =
         crate::custody::publish_secret(custody.clone(), &sealed, endpoint, None).await
     {
@@ -435,7 +454,7 @@ pub async fn enroll_custody(
                     .and_then(|envelope| kek.open(&envelope).ok());
                 match published {
                     Some(open) if open.signing_seed() == secret.signing_seed() => {
-                        sealed_hex = None;
+                        queued = None;
                     }
                     _ => anyhow::bail!("the custody space already holds a different account"),
                 }
@@ -449,7 +468,7 @@ pub async fn enroll_custody(
             }
         }
     } else {
-        sealed_hex = None;
+        queued = None;
     }
 
     let consent = crate::custody::mint_custody_consent(custody.clone(), &root.did()).await?;
@@ -462,50 +481,9 @@ pub async fn enroll_custody(
         custody_did: custody.did().to_string(),
         credential_id,
         consent_hex,
-        sealed_hex,
+        sealed_hex: hex::encode(&sealed),
+        publish_invocation_hex: queued,
     })
-}
-
-/// Publish a queued custody cell, with a fresh assertion.
-///
-/// The queued bytes were sealed under this passkey's KEK during the
-/// ceremony that created it; the assertion here re-derives the custody
-/// key that signs the publish, and proves the same credential is
-/// present. A cell that already holds this account's envelope is
-/// success — another device got there first.
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-pub async fn publish_queued_custody(
-    custody_did: &str,
-    sealed: &[u8],
-    endpoint: &str,
-    credential_id: Option<&[u8]>,
-) -> Result<()> {
-    use crate::envelope::{custody_kek, custody_signer};
-
-    let evaluated = crate::passkey::evaluate_custody_passkey(credential_id).await?;
-    let evaluation = evaluated
-        .evaluation
-        .context("the authenticator returned no PRF outputs")?;
-    let custody = custody_signer(&evaluation.key).await?;
-    if custody.did().to_string() != custody_did {
-        anyhow::bail!("the asserted passkey derives a different custody space");
-    }
-    // Prove the queued bytes open under this passkey before publishing:
-    // a cell that cannot be unsealed by the credential that owns it is
-    // worse than no cell at all.
-    let kek = custody_kek(&evaluation.kek);
-    let envelope = crate::envelope::Envelope::decode(sealed)
-        .map_err(|error| anyhow::anyhow!("the queued envelope is unreadable: {error}"))?;
-    kek.open(&envelope)
-        .map_err(|error| anyhow::anyhow!("the queued envelope did not open: {error}"))?;
-
-    match crate::custody::publish_secret(custody.clone(), sealed, endpoint, None).await {
-        Ok(()) => Ok(()),
-        Err(publish_error) => match crate::custody::resolve_secret(custody, endpoint).await {
-            Ok(Some(_)) => Ok(()),
-            _ => Err(publish_error),
-        },
-    }
 }
 
 /// A passkey unlock's outcome: the device-link ceremony minted from

--- a/rust/tonk-identity/src/ceremony.rs
+++ b/rust/tonk-identity/src/ceremony.rs
@@ -257,14 +257,14 @@ pub async fn create_custody_account(
     let account_did = root.did().to_string();
 
     let created = crate::passkey::create_custody_passkey(Some(&email), &account_did).await?;
-    let credential_id = hex::encode(created.id);
+    let credential_id = hex::encode(&created.id);
     let passkey = created_on.map(|created_on| PasskeyCreationMetadata {
         created_at: (js_sys::Date::now() / 1000.0) as u64,
         created_on: created_on.to_string(),
     });
     let evaluation = match created.evaluation {
         Some(evaluation) => evaluation,
-        None => crate::passkey::evaluate_custody_passkey()
+        None => crate::passkey::evaluate_custody_passkey(Some(&created.id))
             .await?
             .evaluation
             .context("the authenticator returned no PRF outputs")?,
@@ -319,10 +319,13 @@ pub async fn create_custody_account(
 /// derives its keys inside a fresh user-verified assertion, and no key
 /// material is ever stored.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-async fn assert_unlock(endpoint: &str) -> Result<(crate::envelope::AccountSecret, String)> {
+async fn assert_unlock(
+    endpoint: &str,
+    credential_id: Option<&[u8]>,
+) -> Result<(crate::envelope::AccountSecret, String)> {
     use crate::envelope::{Envelope, custody_kek, custody_signer};
 
-    let evaluated = crate::passkey::evaluate_custody_passkey().await?;
+    let evaluated = crate::passkey::evaluate_custody_passkey(credential_id).await?;
     let credential_id = hex::encode(evaluated.id);
     let evaluation = evaluated
         .evaluation
@@ -344,7 +347,7 @@ async fn assert_unlock(endpoint: &str) -> Result<(crate::envelope::AccountSecret
 /// root-signed operations: CLI approval, link completion, revocation.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub async fn unlock_root(endpoint: &str) -> Result<Ed25519Signer> {
-    let (secret, _) = assert_unlock(endpoint).await?;
+    let (secret, _) = assert_unlock(endpoint, None).await?;
     secret.signer().await
 }
 
@@ -352,8 +355,11 @@ pub async fn unlock_root(endpoint: &str) -> Result<Ed25519Signer> {
 /// for a device whose root record predates the key: the worker asks the
 /// page for this when it needs custody set up and nothing recorded it.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-pub async fn publish_encryption_key(endpoint: &str) -> Result<String> {
-    let (secret, _) = assert_unlock(endpoint).await?;
+pub async fn publish_encryption_key(
+    endpoint: &str,
+    credential_id: Option<&[u8]>,
+) -> Result<String> {
+    let (secret, _) = assert_unlock(endpoint, credential_id).await?;
     Ok(secret.encryption_key().recipient().did().to_string())
 }
 
@@ -391,17 +397,17 @@ pub async fn enroll_custody(
     // Unlock through an existing passkey: one assertion recovers the
     // secret, and the new credential seals that same secret. Nothing is
     // read from, or written to, any local store.
-    let (secret, _) = assert_unlock(endpoint).await?;
+    let (secret, _) = assert_unlock(endpoint, None).await?;
     let root = secret.signer().await?;
     if root.did().to_string() != account_did {
         anyhow::bail!("the asserted passkey unlocks a different account");
     }
 
     let created = crate::passkey::create_custody_passkey(label, account_did).await?;
-    let credential_id = hex::encode(created.id);
+    let credential_id = hex::encode(&created.id);
     let evaluation = match created.evaluation {
         Some(evaluation) => evaluation,
-        None => crate::passkey::evaluate_custody_passkey()
+        None => crate::passkey::evaluate_custody_passkey(Some(&created.id))
             .await?
             .evaluation
             .context("the authenticator returned no PRF outputs")?,
@@ -472,10 +478,11 @@ pub async fn publish_queued_custody(
     custody_did: &str,
     sealed: &[u8],
     endpoint: &str,
+    credential_id: Option<&[u8]>,
 ) -> Result<()> {
     use crate::envelope::{custody_kek, custody_signer};
 
-    let evaluated = crate::passkey::evaluate_custody_passkey().await?;
+    let evaluated = crate::passkey::evaluate_custody_passkey(credential_id).await?;
     let evaluation = evaluated
         .evaluation
         .context("the authenticator returned no PRF outputs")?;
@@ -529,7 +536,7 @@ pub async fn unlock_account(
     endpoint: &str,
     service: Option<&dialog_varsig::Did>,
 ) -> Result<CustodyUnlock> {
-    let (secret, credential_id) = assert_unlock(endpoint).await?;
+    let (secret, credential_id) = assert_unlock(endpoint, None).await?;
     let root = secret.signer().await?;
     let encryption_key = secret.encryption_key().recipient().did().to_string();
     let deposits_hex = match service {

--- a/rust/tonk-identity/src/custody.rs
+++ b/rust/tonk-identity/src/custody.rs
@@ -36,6 +36,7 @@ async fn build_self_invocation(
     custody: Ed25519Signer,
     command: Vec<String>,
     arguments: BTreeMap<String, Promised>,
+    expiration: Timestamp,
 ) -> Result<Vec<u8>> {
     let did = custody.did();
     let invocation = InvocationBuilder::new()
@@ -45,7 +46,7 @@ async fn build_self_invocation(
         .command(command)
         .arguments(arguments)
         .proofs(vec![])
-        .expiration(Timestamp::five_minutes_from_now())
+        .expiration(expiration)
         .try_build()
         .await
         .context("failed to sign the custody invocation")?;
@@ -53,6 +54,11 @@ async fn build_self_invocation(
         .to_bytes()
         .context("failed to serialize the custody invocation")
 }
+
+/// How long a deferred publish invocation stays redeemable: the
+/// ceremony pre-signs it, and it waits for an email activation that can
+/// take days. Bounded so a leaked queue entry is not authority forever.
+pub const DEFERRED_PUBLISH_TTL_SECONDS: u64 = 60 * 60 * 24 * 30;
 
 fn cell_arguments() -> BTreeMap<String, Promised> {
     BTreeMap::from([
@@ -78,6 +84,7 @@ pub async fn build_publish_invocation(
     custody: Ed25519Signer,
     content: &[u8],
     when: Option<&[u8]>,
+    expiration: Timestamp,
 ) -> Result<Vec<u8>> {
     let mut arguments = cell_arguments();
     arguments.insert(
@@ -91,8 +98,25 @@ pub async fn build_publish_invocation(
         custody,
         vec!["memory".to_string(), "publish".to_string()],
         arguments,
+        expiration,
     )
     .await
+}
+
+/// Pre-sign the first-write publish for `content`, redeemable for
+/// [`DEFERRED_PUBLISH_TTL_SECONDS`]: what a creation ceremony queues so
+/// the worker can publish the custody cell once activation lands,
+/// with no further passkey assertion. Least authority: the signature
+/// covers exactly this cell and this content's checksum.
+pub async fn build_deferred_publish_invocation(
+    custody: Ed25519Signer,
+    content: &[u8],
+) -> Result<Vec<u8>> {
+    use dialog_ucan_core::time::timestamp::{Duration, SystemTime};
+    let expiration =
+        Timestamp::new(SystemTime::now() + Duration::from_secs(DEFERRED_PUBLISH_TTL_SECONDS))
+            .context("the deferred publish expiration is out of range")?;
+    build_publish_invocation(custody, content, None, expiration).await
 }
 
 /// Build a `/memory/resolve` container for the wrapped-secret cell.
@@ -101,6 +125,7 @@ pub async fn build_resolve_invocation(custody: Ed25519Signer) -> Result<Vec<u8>>
         custody,
         vec!["memory".to_string(), "resolve".to_string()],
         cell_arguments(),
+        Timestamp::five_minutes_from_now(),
     )
     .await
 }
@@ -147,8 +172,19 @@ mod web {
     }
 
     async fn fetch_bytes(request: Request) -> Result<(u16, Vec<u8>)> {
-        let window = web_sys::window().context("no window: custody ceremonies are page-only")?;
-        let response: Response = JsFuture::from(window.fetch_with_request(&request))
+        // `fetch` off the global, so the same exchange runs from a page
+        // (ceremonies) and from the service worker (the queued-publish
+        // drain after activation).
+        let fetch = js_sys::Reflect::get(&js_sys::global(), &"fetch".into())
+            .map_err(|e| web_error("no fetch in this scope", e))?
+            .dyn_into::<js_sys::Function>()
+            .map_err(|_| anyhow!("fetch is not callable in this scope"))?;
+        let promise: js_sys::Promise = fetch
+            .call1(&js_sys::global(), &request)
+            .map_err(|e| web_error("the custody request failed to start", e))?
+            .dyn_into()
+            .map_err(|_| anyhow!("fetch did not answer a promise"))?;
+        let response: Response = JsFuture::from(promise)
             .await
             .map_err(|e| web_error("the custody request failed", e))?
             .dyn_into()
@@ -208,8 +244,22 @@ mod web {
         endpoint: &str,
         when: Option<&[u8]>,
     ) -> Result<()> {
-        let container = super::build_publish_invocation(custody, sealed, when).await?;
-        let permit = redeem(endpoint, container).await?;
+        let container = super::build_publish_invocation(
+            custody,
+            sealed,
+            when,
+            dialog_ucan_core::time::timestamp::Timestamp::five_minutes_from_now(),
+        )
+        .await?;
+        submit_publish(&container, sealed, endpoint).await
+    }
+
+    /// Publish `sealed` with an already-signed invocation: redeem the
+    /// permit and execute the presigned PUT. No signer involved — this
+    /// is what drains a ceremony's pre-signed publish after activation,
+    /// from the worker, with no page and no assertion.
+    pub async fn submit_publish(invocation: &[u8], sealed: &[u8], endpoint: &str) -> Result<()> {
+        let permit = redeem(endpoint, invocation.to_vec()).await?;
         let (status, body) = execute(permit, Some(sealed)).await?;
         if !(200..300).contains(&status) {
             let detail = String::from_utf8_lossy(&body);
@@ -236,7 +286,7 @@ mod web {
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-pub use web::{publish_secret, resolve_secret};
+pub use web::{publish_secret, resolve_secret, submit_publish};
 
 #[cfg(test)]
 mod tests {
@@ -258,9 +308,10 @@ mod tests {
     async fn it_builds_a_self_issued_publish_the_service_verifies() {
         let custody = custody().await;
         let did = custody.did();
-        let bytes = build_publish_invocation(custody, b"sealed", None)
-            .await
-            .unwrap();
+        let bytes =
+            build_publish_invocation(custody, b"sealed", None, Timestamp::five_minutes_from_now())
+                .await
+                .unwrap();
 
         let chain = InvocationChain::try_from(bytes.as_slice()).unwrap();
         chain
@@ -297,9 +348,14 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_builds_a_versioned_overwrite() {
-        let bytes = build_publish_invocation(custody().await, b"resealed", Some(b"etag-1"))
-            .await
-            .unwrap();
+        let bytes = build_publish_invocation(
+            custody().await,
+            b"resealed",
+            Some(b"etag-1"),
+            Timestamp::five_minutes_from_now(),
+        )
+        .await
+        .unwrap();
         let chain = InvocationChain::try_from(bytes.as_slice()).unwrap();
         assert_eq!(
             chain.invocation.arguments().get("when"),

--- a/rust/tonk-identity/src/install.rs
+++ b/rust/tonk-identity/src/install.rs
@@ -218,9 +218,12 @@ async fn create_account(input: JsValue) -> Result<JsValue, JsValue> {
     set_deposits(&result, &ceremony.deposits_hex)?;
     Reflect::set(&result, &"custodyDid".into(), &ceremony.custody_did.into())?;
     Reflect::set(&result, &"consentHex".into(), &ceremony.consent_hex.into())?;
-    if let Some(sealed_hex) = ceremony.sealed_hex {
-        Reflect::set(&result, &"sealedHex".into(), &sealed_hex.into())?;
-    }
+    Reflect::set(&result, &"sealedHex".into(), &ceremony.sealed_hex.into())?;
+    Reflect::set(
+        &result,
+        &"publishInvocationHex".into(),
+        &ceremony.publish_invocation_hex.into(),
+    )?;
     Ok(result)
 }
 
@@ -254,33 +257,11 @@ async fn enroll_custody_passkey(input: JsValue) -> Result<JsValue, JsValue> {
         &"consentHex".into(),
         &enrollment.consent_hex.into(),
     )?;
-    if let Some(sealed_hex) = enrollment.sealed_hex {
-        Reflect::set(&result, &"sealedHex".into(), &sealed_hex.into())?;
+    Reflect::set(&result, &"sealedHex".into(), &enrollment.sealed_hex.into())?;
+    if let Some(invocation) = enrollment.publish_invocation_hex {
+        Reflect::set(&result, &"publishInvocationHex".into(), &invocation.into())?;
     }
     Ok(result.into())
-}
-
-/// `publishQueuedCustody({ custodyDid, sealedHex, endpoint, credentialId? })`
-/// → `{}`. Publishes a custody cell that could not be written when its
-/// ceremony ran, using a fresh assertion of the same passkey —
-/// pinned to `credentialId` (hex) when the caller recorded one, so a
-/// browser holding several passkeys cannot assert the wrong one.
-async fn publish_queued_custody(input: JsValue) -> Result<JsValue, JsValue> {
-    let custody_did = string_property(&input, "custodyDid")?;
-    let sealed_hex = string_property(&input, "sealedHex")?;
-    let endpoint = string_property(&input, "endpoint")?;
-    let credential_id = credential_id_property(&input)?;
-    let sealed = hex::decode(&sealed_hex)
-        .map_err(|error| JsValue::from_str(&format!("sealedHex is not hex: {error}")))?;
-    crate::ceremony::publish_queued_custody(
-        &custody_did,
-        &sealed,
-        &endpoint,
-        credential_id.as_deref(),
-    )
-    .await
-    .map_err(js_error)?;
-    Ok(Object::new().into())
 }
 
 /// `publishEncryptionKey({ endpoint, credentialId? })` → `{ encryptionKey }`:
@@ -396,16 +377,6 @@ pub fn install() {
         enroll_custody_passkey.as_ref().unchecked_ref(),
     );
     enroll_custody_passkey.forget();
-
-    let publish_queued = Closure::<dyn FnMut(JsValue) -> Promise>::new(|input: JsValue| {
-        future_to_promise(publish_queued_custody(input))
-    });
-    let _ = Reflect::set(
-        &identity,
-        &"publishQueuedCustody".into(),
-        publish_queued.as_ref().unchecked_ref(),
-    );
-    publish_queued.forget();
 
     let publish_encryption_key = Closure::<dyn FnMut(JsValue) -> Promise>::new(|input: JsValue| {
         future_to_promise(publish_encryption_key(input))

--- a/rust/tonk-identity/src/install.rs
+++ b/rust/tonk-identity/src/install.rs
@@ -260,32 +260,52 @@ async fn enroll_custody_passkey(input: JsValue) -> Result<JsValue, JsValue> {
     Ok(result.into())
 }
 
-/// `publishQueuedCustody({ custodyDid, sealedHex, endpoint })` → `{}`.
-/// Publishes a custody cell that could not be written when its
-/// ceremony ran, using a fresh assertion of the same passkey.
+/// `publishQueuedCustody({ custodyDid, sealedHex, endpoint, credentialId? })`
+/// → `{}`. Publishes a custody cell that could not be written when its
+/// ceremony ran, using a fresh assertion of the same passkey —
+/// pinned to `credentialId` (hex) when the caller recorded one, so a
+/// browser holding several passkeys cannot assert the wrong one.
 async fn publish_queued_custody(input: JsValue) -> Result<JsValue, JsValue> {
     let custody_did = string_property(&input, "custodyDid")?;
     let sealed_hex = string_property(&input, "sealedHex")?;
     let endpoint = string_property(&input, "endpoint")?;
+    let credential_id = credential_id_property(&input)?;
     let sealed = hex::decode(&sealed_hex)
         .map_err(|error| JsValue::from_str(&format!("sealedHex is not hex: {error}")))?;
-    crate::ceremony::publish_queued_custody(&custody_did, &sealed, &endpoint)
-        .await
-        .map_err(js_error)?;
+    crate::ceremony::publish_queued_custody(
+        &custody_did,
+        &sealed,
+        &endpoint,
+        credential_id.as_deref(),
+    )
+    .await
+    .map_err(js_error)?;
     Ok(Object::new().into())
 }
 
-/// `publishEncryptionKey({ endpoint })` → `{ encryptionKey }`: one
-/// assertion, the account's X25519 recipient. The page saves it with the
-/// root so the worker can set up custody for what it creates.
+/// `publishEncryptionKey({ endpoint, credentialId? })` → `{ encryptionKey }`:
+/// one assertion — pinned to `credentialId` (hex) when the root record
+/// carries one — and the account's X25519 recipient. The page saves it
+/// with the root so the worker can set up custody for what it creates.
 async fn publish_encryption_key(input: JsValue) -> Result<JsValue, JsValue> {
     let endpoint = string_property(&input, "endpoint")?;
-    let key = crate::ceremony::publish_encryption_key(&endpoint)
+    let credential_id = credential_id_property(&input)?;
+    let key = crate::ceremony::publish_encryption_key(&endpoint, credential_id.as_deref())
         .await
         .map_err(js_error)?;
     let result = Object::new();
     Reflect::set(&result, &"encryptionKey".into(), &key.into())?;
     Ok(result.into())
+}
+
+/// The optional `credentialId` property, hex-decoded.
+fn credential_id_property(input: &JsValue) -> Result<Option<Vec<u8>>, JsValue> {
+    optional_string_property(input, "credentialId")
+        .map(|hex| {
+            hex::decode(&hex)
+                .map_err(|error| JsValue::from_str(&format!("credentialId is not hex: {error}")))
+        })
+        .transpose()
 }
 
 /// `unlockWithPasskey({ deviceDid, deviceName, endpoint, serviceDid? })`

--- a/rust/tonk-identity/src/passkey.rs
+++ b/rust/tonk-identity/src/passkey.rs
@@ -243,15 +243,32 @@ pub async fn verify_custody_passkey(credential_id: &[u8]) -> Result<()> {
     Ok(())
 }
 
-/// Evaluate both custody salts via a discoverable-credential assertion.
-/// One biometric prompt; must be called during a user gesture.
-pub async fn evaluate_custody_passkey() -> Result<CustodyCredential> {
+/// Evaluate both custody salts via an assertion. One biometric prompt;
+/// must be called during a user gesture.
+///
+/// Pass the stored credential id whenever the caller knows which passkey
+/// owns the custody being opened: `allowCredentials` then pins the
+/// assertion to it, so a browser holding several passkeys for this RP
+/// cannot offer one that derives a different custody space. Discoverable
+/// (`None`) is only for flows where choosing the passkey IS choosing the
+/// account — login, and a creation chase where the id isn't recorded yet.
+pub async fn evaluate_custody_passkey(credential_id: Option<&[u8]>) -> Result<CustodyCredential> {
     let mut challenge = rand::random::<[u8; 32]>();
     let options = PublicKeyCredentialRequestOptions::new_with_u8_slice(&mut challenge);
     options.set_user_verification(UserVerificationRequirement::Required);
     options.set_extensions(&custody_extensions());
     if let Some(id) = current_rp_id() {
         options.set_rp_id(id);
+    }
+    if let Some(credential_id) = credential_id {
+        let mut credential_id = credential_id.to_vec();
+        let descriptor = PublicKeyCredentialDescriptor::new_with_u8_slice(
+            &mut credential_id,
+            PublicKeyCredentialType::PublicKey,
+        );
+        let allowed = js_sys::Array::new();
+        allowed.push(&descriptor);
+        options.set_allow_credentials(&allowed);
     }
     let request = CredentialRequestOptions::new();
     request.set_public_key(&options);

--- a/rust/tonk-schema/src/custody.rs
+++ b/rust/tonk-schema/src/custody.rs
@@ -5,7 +5,7 @@ use dialog_query::Concept;
 use dialog_varsig::Did;
 use serde::Serialize;
 
-use crate::domain::custody::{Kind, Recipient, Sealed, Subject};
+use crate::domain::custody::{Account, Cell, Kind, Recipient, Sealed, Subject};
 use crate::prelude::*;
 
 /// A seed sealed to one recipient for one subject, in the account space.
@@ -218,5 +218,35 @@ mod tests {
             .await?;
         assert_eq!(for_space_a.len(), 2, "one row per recipient");
         Ok(())
+    }
+}
+
+/// A passkey's custody cell, recorded in the account space beside the
+/// vault copy.
+///
+/// The cell is the account secret sealed under one passkey's KEK
+/// (`tonk_identity::envelope::Envelope`) — ciphertext only a fresh
+/// assertion of that passkey can open. The vault copy bootstraps a
+/// brand-new browser, which has no profile branch yet; this row rides
+/// the account's own sync, so every device already holding the profile
+/// carries the recovery envelope too.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CustodyCell {
+    /// The custody space's DID — the passkey-derived principal.
+    pub this: Entity,
+    /// The account this cell recovers.
+    pub account: Account,
+    /// The sealed envelope bytes.
+    pub cell: Cell,
+}
+
+impl CustodyCell {
+    /// Record `cell` as `custody`'s envelope for `account`.
+    pub fn new(custody: Did, account: Did, cell: Vec<u8>) -> Self {
+        Self {
+            this: custody.this(),
+            account: Account(account.this()),
+            cell: Cell(cell),
+        }
     }
 }

--- a/rust/tonk-schema/src/domain.rs
+++ b/rust/tonk-schema/src/domain.rs
@@ -833,6 +833,20 @@ pub mod custody {
     #[domain("xyz.tonk.custody")]
     #[cardinality(one)]
     pub struct Sealed(pub Vec<u8>);
+
+    /// The account a custody cell recovers.
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.custody")]
+    #[cardinality(one)]
+    pub struct Account(pub Entity);
+
+    /// A custody cell's envelope bytes
+    /// (`tonk_identity::envelope::Envelope`, sealed under a passkey's
+    /// KEK).
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.custody")]
+    #[cardinality(one)]
+    pub struct Cell(pub Vec<u8>);
 }
 
 /// Attributes that describe a repository on its content branch, keyed by the

--- a/rust/tonk-schema/src/lib.rs
+++ b/rust/tonk-schema/src/lib.rs
@@ -69,7 +69,7 @@ pub use account::{
 };
 
 pub mod custody;
-pub use custody::{CustodiedSeed, SeedKind};
+pub use custody::{CustodiedSeed, CustodyCell, SeedKind};
 
 pub mod device_link;
 pub mod replica;

--- a/rust/tonk-ui/src/account.html
+++ b/rust/tonk-ui/src/account.html
@@ -66,7 +66,6 @@
     <p id="account-activation-notice" class="account__hint" role="status" hidden></p>
     <button id="account-resend-activation" class="account__button account__button--quiet" type="button" hidden>Resend activation email</button>
     <p id="account-backup-notice" class="account__hint" role="status" hidden></p>
-    <button id="account-backup-publish" class="account__button account__button--quiet" type="button" hidden>Finish backup with your passkey</button>
 
     <section class="account__section account__passkey" aria-labelledby="account-passkey-title">
       <div class="account__section-heading">

--- a/rust/tonk-ui/src/account.html
+++ b/rust/tonk-ui/src/account.html
@@ -65,6 +65,8 @@
     <p id="account-success-message" class="account__status">Signed in on this device.</p>
     <p id="account-activation-notice" class="account__hint" role="status" hidden></p>
     <button id="account-resend-activation" class="account__button account__button--quiet" type="button" hidden>Resend activation email</button>
+    <p id="account-backup-notice" class="account__hint" role="status" hidden></p>
+    <button id="account-backup-publish" class="account__button account__button--quiet" type="button" hidden>Finish backup with your passkey</button>
 
     <section class="account__section account__passkey" aria-labelledby="account-passkey-title">
       <div class="account__section-heading">

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -283,45 +283,70 @@ fn load_activation_notice(host: HtmlElement) {
                 }
             }
         }
-        // The facts row always answers; the banner below only nags while
-        // an activation is actually pending.
-        let label = match state["status"].as_str() {
-            Some("Active") => "Active",
-            Some("Registered") => "Waiting for email confirmation",
-            Some("Suspended") => "Suspended",
-            _ => "Not registered",
-        };
-        set_text(&host, "#account-registration-value", label);
-        // The worker drains the queued backup itself once activation
-        // lands — the ceremony pre-signed the publish. Nothing to
-        // raise; just say so while it is still on its way.
-        if state["status"].as_str() == Some("Active") {
-            note_pending_backup(&host).await;
-        }
-        if state["status"].as_str() != Some("Registered") {
-            if let Ok(Some(resend)) = host.query_selector("#account-resend-activation") {
-                let _ = resend.set_attribute("hidden", "");
+        // Render whatever the state says now, and while an activation is
+        // pending keep asking: the link is opened in another tab (or on
+        // the phone the email is on), and a dashboard that only learns
+        // about it on a manual reload looks stuck at "pending" long
+        // after the account is live.
+        loop {
+            render_registration(&host, &state).await;
+            if state["status"].as_str() != Some("Registered") {
+                return;
             }
-            return;
-        }
-        let Ok(Some(notice)) = host.query_selector("#account-activation-notice") else {
-            return;
-        };
-        let message = match state["email"].as_str() {
-            Some(email) => {
-                format!("Sync activation pending: open the link we emailed to {email}.")
+            wait_for(5_000).await;
+            if let Ok(fresh) = crate::api::customer_state().await {
+                state = fresh;
             }
-            None => "Sync activation pending: open the link in your activation email.".to_string(),
-        };
-        notice.set_text_content(Some(&message));
-        let _ = notice.remove_attribute("hidden");
-        // The way out of a stuck Registered: enrollment is idempotent
-        // while Registered and resends the link, which is also the
-        // recovery for one that expired.
-        if let Ok(Some(resend)) = host.query_selector("#account-resend-activation") {
-            let _ = resend.remove_attribute("hidden");
         }
     });
+}
+
+/// Render the registration facts row, the activation banner, and the
+/// resend button from one customer state, so the pending → active flip
+/// also clears what pending showed.
+async fn render_registration(host: &HtmlElement, state: &serde_json::Value) {
+    // The facts row always answers; the banner below only nags while
+    // an activation is actually pending.
+    let label = match state["status"].as_str() {
+        Some("Active") => "Active",
+        Some("Registered") => "Waiting for email confirmation",
+        Some("Suspended") => "Suspended",
+        _ => "Not registered",
+    };
+    set_text(host, "#account-registration-value", label);
+    // The worker drains the queued backup itself once activation
+    // lands — the ceremony pre-signed the publish. Nothing to raise;
+    // just say so while it is still on its way.
+    if state["status"].as_str() == Some("Active") {
+        note_pending_backup(host).await;
+    }
+    if state["status"].as_str() != Some("Registered") {
+        let _ = hide(host, "#account-activation-notice");
+        let _ = hide(host, "#account-resend-activation");
+        return;
+    }
+    let message = match state["email"].as_str() {
+        Some(email) => {
+            format!("Sync activation pending: open the link we emailed to {email}.")
+        }
+        None => "Sync activation pending: open the link in your activation email.".to_string(),
+    };
+    set_text(host, "#account-activation-notice", &message);
+    let _ = show(host, "#account-activation-notice");
+    // The way out of a stuck Registered: enrollment is idempotent
+    // while Registered and resends the link, which is also the
+    // recovery for one that expired.
+    let _ = show(host, "#account-resend-activation");
+}
+
+/// Resolve after `ms` milliseconds.
+async fn wait_for(ms: i32) {
+    let promise = js_sys::Promise::new(&mut |resolve, _reject| {
+        if let Some(win) = window() {
+            let _ = win.set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, ms);
+        }
+    });
+    let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
 }
 
 fn set_text(host: &HtmlElement, selector: &str, value: &str) {
@@ -1317,13 +1342,25 @@ async fn complete_remote(
         return Ok(());
     }
     settle(host);
-    if initialize_name && is_unhydrated(&status) {
+    // An unhydrated account right after signup is the expected state
+    // while the email activation is pending — the access service
+    // refuses the pull until then, the activation banner already says
+    // so, and the background sweep hydrates once it lands. The alert is
+    // for the unexpected case: activation is not what's in the way.
+    if initialize_name && is_unhydrated(&status) && !activation_pending().await {
         show_error(
             host,
             "Your account was created, but its initial name could not be synchronized. Reload /account to retry account hydration.",
         );
     }
     Ok(())
+}
+
+/// Whether the customer is registered but not yet email-activated.
+async fn activation_pending() -> bool {
+    crate::api::customer_state()
+        .await
+        .is_ok_and(|state| state["status"].as_str() == Some("Registered"))
 }
 
 fn on_click(host: &HtmlElement, selector: &str, callback: impl Fn(HtmlElement) + 'static) {

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -199,23 +199,22 @@ fn show_success(host: &HtmlElement) {
 /// deployment without registration should not decorate the panel with
 /// its absence.
 /// Publish every custody cell queued while the account was waiting on
-/// email confirmation.
+/// email confirmation. Returns the first failure, leaving the failed
+/// entry (and everything after it) queued.
 ///
-/// Each publish needs a fresh passkey assertion, which is a user
-/// prompt, so this runs only when there is something queued — an
-/// activated account with nothing waiting must never see a passkey
-/// dialog it did not ask for. Failures stay queued for the next load.
-async fn publish_queued_custody() {
-    let queue = match crate::api::pending_work().await {
-        Ok(queue) => queue,
-        Err(error) => {
-            web_sys::console::warn_1(&format!("pending work unreadable: {error}").into());
-            return;
-        }
-    };
-    let endpoint = match proposed_remote() {
-        Ok(endpoint) => endpoint,
-        Err(error) => return web_sys::console::warn_1(&format!("no remote: {error}").into()),
+/// Each publish is a passkey assertion, pinned to the root record's
+/// credential so a browser holding several passkeys for this origin
+/// cannot assert one that derives a different custody space. Only ever
+/// called from the backup button's click: the assertion needs the user
+/// gesture, and a prompt nobody asked for reads as phishing.
+async fn publish_queued_custody() -> Result<(), String> {
+    let queue = crate::api::pending_work()
+        .await
+        .map_err(|error| format!("pending work unreadable: {error}"))?;
+    let endpoint = proposed_remote()?;
+    let credential_id = match crate::api::root_status().await {
+        Ok(tonk_worker_api::RootStatus::Ready { credential_id, .. }) => Some(credential_id),
+        _ => None,
     };
     for work in queue.entries() {
         let tonk_account::pending::PendingWork::PublishCustody {
@@ -225,30 +224,97 @@ async fn publish_queued_custody() {
         else {
             continue;
         };
-        match crate::identity_bridge::publish_queued_custody(
+        crate::identity_bridge::publish_queued_custody(
             crate::identity_bridge::PublishQueuedCustodyInput {
                 custody_did: custody.clone(),
                 sealed_hex: sealed_hex.clone(),
                 endpoint: endpoint.clone(),
+                credential_id: credential_id.clone(),
             },
         )
         .await
-        {
-            Ok(()) => {
-                if let Err(error) = crate::api::complete_custody_publish(custody).await {
+        // Stop at the first failure: a later entry must not overtake
+        // one that is still waiting on provisioning.
+        .map_err(|error| error.to_string())?;
+        if let Err(error) = crate::api::complete_custody_publish(custody).await {
+            web_sys::console::warn_1(
+                &format!("custody published but still queued: {error}").into(),
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Whether any custody publish is waiting on this device.
+async fn has_queued_custody() -> bool {
+    crate::api::pending_work().await.is_ok_and(|queue| {
+        queue.entries().iter().any(|work| {
+            matches!(
+                work,
+                tonk_account::pending::PendingWork::PublishCustody { .. }
+            )
+        })
+    })
+}
+
+/// Offer the queued custody publish instead of springing an assertion:
+/// activation unblocked it, but only a click can supply the gesture and
+/// the context. The notice says what is waiting; the button runs it and
+/// then says what happened.
+async fn offer_queued_custody(host: &HtmlElement) {
+    if !has_queued_custody().await {
+        return;
+    }
+    set_text(
+        host,
+        "#account-backup-notice",
+        "Your account's backup record is ready to publish. It takes one passkey confirmation.",
+    );
+    let _ = show(host, "#account-backup-notice");
+    let _ = show(host, "#account-backup-publish");
+    on_click(host, "#account-backup-publish", |host| {
+        set_text(&host, "#account-backup-notice", "Waiting for your passkey…");
+        let _ = hide(&host, "#account-backup-publish");
+        spawn_local(async move {
+            match publish_queued_custody().await {
+                Ok(()) => {
+                    set_text(
+                        &host,
+                        "#account-backup-notice",
+                        "Backup published. Your account can now be recovered with this passkey.",
+                    );
+                }
+                Err(error) => {
                     web_sys::console::warn_1(
-                        &format!("custody published but still queued: {error}").into(),
+                        &format!("custody publish still pending: {error}").into(),
+                    );
+                    set_text(
+                        &host,
+                        "#account-backup-notice",
+                        "The backup could not be published. Reload this page to try again.",
                     );
                 }
             }
-            Err(error) => {
-                web_sys::console::warn_1(&format!("custody publish still pending: {error}").into());
-                // Stop at the first failure: a later entry must not
-                // overtake one that is still waiting on provisioning.
-                break;
-            }
-        }
-    }
+        });
+    });
+}
+
+/// Unhide the element `selector` names.
+fn show(host: &HtmlElement, selector: &str) -> Option<()> {
+    host.query_selector(selector)
+        .ok()
+        .flatten()?
+        .remove_attribute("hidden")
+        .ok()
+}
+
+/// Hide the element `selector` names.
+fn hide(host: &HtmlElement, selector: &str) -> Option<()> {
+    host.query_selector(selector)
+        .ok()
+        .flatten()?
+        .set_attribute("hidden", "")
+        .ok()
 }
 
 fn load_activation_notice(host: HtmlElement) {
@@ -306,9 +372,9 @@ fn load_activation_notice(host: HtmlElement) {
         // Activation is what unblocks the queued custody publish, and
         // only a page can sign it — the custody key lives inside a
         // passkey assertion. This notice is the one place that both
-        // learns about activation and can raise one.
+        // learns about activation and can offer it.
         if state["status"].as_str() == Some("Active") {
-            publish_queued_custody().await;
+            offer_queued_custody(&host).await;
         }
         if state["status"].as_str() != Some("Registered") {
             if let Ok(Some(resend)) = host.query_selector("#account-resend-activation") {

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -198,105 +198,28 @@ fn show_success(host: &HtmlElement) {
 /// every other answer: an active customer needs no notice, and a
 /// deployment without registration should not decorate the panel with
 /// its absence.
-/// Publish every custody cell queued while the account was waiting on
-/// email confirmation. Returns the first failure, leaving the failed
-/// entry (and everything after it) queued.
-///
-/// Each publish is a passkey assertion, pinned to the root record's
-/// credential so a browser holding several passkeys for this origin
-/// cannot assert one that derives a different custody space. Only ever
-/// called from the backup button's click: the assertion needs the user
-/// gesture, and a prompt nobody asked for reads as phishing.
-async fn publish_queued_custody() -> Result<(), String> {
-    let queue = crate::api::pending_work()
-        .await
-        .map_err(|error| format!("pending work unreadable: {error}"))?;
-    let endpoint = proposed_remote()?;
-    let credential_id = match crate::api::root_status().await {
-        Ok(tonk_worker_api::RootStatus::Ready { credential_id, .. }) => Some(credential_id),
-        _ => None,
-    };
-    for work in queue.entries() {
-        let tonk_account::pending::PendingWork::PublishCustody {
-            custody,
-            sealed_hex,
-        } = work
-        else {
-            continue;
-        };
-        crate::identity_bridge::publish_queued_custody(
-            crate::identity_bridge::PublishQueuedCustodyInput {
-                custody_did: custody.clone(),
-                sealed_hex: sealed_hex.clone(),
-                endpoint: endpoint.clone(),
-                credential_id: credential_id.clone(),
-            },
-        )
-        .await
-        // Stop at the first failure: a later entry must not overtake
-        // one that is still waiting on provisioning.
-        .map_err(|error| error.to_string())?;
-        if let Err(error) = crate::api::complete_custody_publish(custody).await {
-            web_sys::console::warn_1(
-                &format!("custody published but still queued: {error}").into(),
-            );
-        }
-    }
-    Ok(())
-}
-
-/// Whether any custody publish is waiting on this device.
-async fn has_queued_custody() -> bool {
-    crate::api::pending_work().await.is_ok_and(|queue| {
+/// Say when the account's backup is still on its way. The ceremony
+/// pre-signed the publish, the worker drains it on activation, and no
+/// interaction is needed — this only keeps the wait legible.
+async fn note_pending_backup(host: &HtmlElement) {
+    let waiting = crate::api::pending_work().await.is_ok_and(|queue| {
         queue.entries().iter().any(|work| {
             matches!(
                 work,
                 tonk_account::pending::PendingWork::PublishCustody { .. }
             )
         })
-    })
-}
-
-/// Offer the queued custody publish instead of springing an assertion:
-/// activation unblocked it, but only a click can supply the gesture and
-/// the context. The notice says what is waiting; the button runs it and
-/// then says what happened.
-async fn offer_queued_custody(host: &HtmlElement) {
-    if !has_queued_custody().await {
+    });
+    if !waiting {
+        let _ = hide(host, "#account-backup-notice");
         return;
     }
     set_text(
         host,
         "#account-backup-notice",
-        "Your account's backup record is ready to publish. It takes one passkey confirmation.",
+        "Finishing your account's backup…",
     );
     let _ = show(host, "#account-backup-notice");
-    let _ = show(host, "#account-backup-publish");
-    on_click(host, "#account-backup-publish", |host| {
-        set_text(&host, "#account-backup-notice", "Waiting for your passkey…");
-        let _ = hide(&host, "#account-backup-publish");
-        spawn_local(async move {
-            match publish_queued_custody().await {
-                Ok(()) => {
-                    set_text(
-                        &host,
-                        "#account-backup-notice",
-                        "Backup published. Your account can now be recovered with this passkey.",
-                    );
-                }
-                Err(error) => {
-                    web_sys::console::warn_1(
-                        &format!("custody publish still pending: {error}").into(),
-                    );
-                    set_text(
-                        &host,
-                        "#account-backup-notice",
-                        "The backup could not be published. Reload this page to try again.",
-                    );
-                }
-            }
-        });
-    });
 }
 
 /// Unhide the element `selector` names.
@@ -369,12 +292,11 @@ fn load_activation_notice(host: HtmlElement) {
             _ => "Not registered",
         };
         set_text(&host, "#account-registration-value", label);
-        // Activation is what unblocks the queued custody publish, and
-        // only a page can sign it — the custody key lives inside a
-        // passkey assertion. This notice is the one place that both
-        // learns about activation and can offer it.
+        // The worker drains the queued backup itself once activation
+        // lands — the ceremony pre-signed the publish. Nothing to
+        // raise; just say so while it is still on its way.
         if state["status"].as_str() == Some("Active") {
-            offer_queued_custody(&host).await;
+            note_pending_backup(&host).await;
         }
         if state["status"].as_str() != Some("Registered") {
             if let Ok(Some(resend)) = host.query_selector("#account-resend-activation") {
@@ -1548,9 +1470,12 @@ fn bind(host: &HtmlElement) {
                         &format!("custody provisioning deferred: {error}").into(),
                     );
                 }
-                if let Some(sealed_hex) = &created.sealed_hex
-                    && let Err(error) =
-                        crate::api::queue_custody_publish(&created.custody_did, sealed_hex).await
+                if let Err(error) = crate::api::queue_custody_publish(
+                    &created.custody_did,
+                    &created.sealed_hex,
+                    &created.publish_invocation_hex,
+                )
+                .await
                 {
                     // The sealed secret is only in this page's memory
                     // until it is recorded, so failing to queue it is
@@ -1627,12 +1552,16 @@ fn bind(host: &HtmlElement) {
                         &format!("custody provisioning deferred: {error}").into(),
                     );
                 }
-                // The ceremony hands back sealed bytes when its publish
-                // was refused. Retry now that provisioning has run, and
-                // queue what still will not land.
-                if let Some(sealed_hex) = &enrolled.sealed_hex
-                    && let Err(error) =
-                        crate::api::queue_custody_publish(&enrolled.custody_did, sealed_hex).await
+                // The cell is recorded on profile main either way; the
+                // pre-signed invocation rides along when the ceremony's
+                // own publish was refused, and the worker drains it once
+                // the provisioning deposit lands.
+                if let Err(error) = crate::api::queue_custody_publish(
+                    &enrolled.custody_did,
+                    &enrolled.sealed_hex,
+                    enrolled.publish_invocation_hex.as_deref().unwrap_or(""),
+                )
+                .await
                 {
                     return Err(format!(
                         "could not record the sealed account secret: {error}"
@@ -1678,9 +1607,10 @@ fn bind(host: &HtmlElement) {
                 // One assertion derives the custody keypair, one
                 // presigned GET fetches the sealed envelope, and the
                 // unwrapped secret self-issues this device's delegation.
-                // Unlocking reads the custody cell, which stays queued
-                // while the customer is unactivated.
-                publish_queued_custody().await;
+                // A cell still queued from before activation is the
+                // worker's to drain — it holds the ceremony's
+                // pre-signed publish and runs it on boot and on
+                // activation.
                 let ceremony = unlock_with_passkey(UnlockWithPasskeyInput {
                     device_did,
                     device_name,
@@ -1735,12 +1665,6 @@ fn bind(host: &HtmlElement) {
                                 })?;
                         }
                     }
-                    // Unlocking the account reads the custody cell, which
-                    // stays queued while the customer is unactivated. A
-                    // browser that activated without returning to the
-                    // dashboard still has it waiting, so drain before
-                    // asking the ceremony to resolve it.
-                    publish_queued_custody().await;
                     set_busy(&host, true, "Waiting for your passkey…");
                     // The descriptor must name the same sync remote signup
                     // established — the page's own `/ucan/` endpoint — or the

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -239,6 +239,26 @@ mod tests {
         driver.goto(&link).await?;
         element(driver, "#activate-accept").await?.click().await?;
         element(driver, "#activate-done").await?;
+        // The custody publish that activation unblocks is offered, not
+        // sprung: the dashboard shows a backup button and only a click
+        // runs the assertion. Drain it the way a person does, so every
+        // later unlock finds the cell published — the auto-published
+        // era left this to a race the CLI-link tests kept losing.
+        let pending = get_json(driver, "/api/customer/pending").await?;
+        if successful_body("pending work", &pending)
+            .as_array()
+            .is_some_and(|queue| !queue.is_empty())
+        {
+            driver.goto(env.tonk_web.join("account")?.as_str()).await?;
+            click(driver, "#account-backup-publish").await?;
+            poll_json(
+                driver,
+                "/api/customer/pending",
+                "the queued custody publish",
+                |body| body.as_array().is_some_and(|queue| queue.is_empty()),
+            )
+            .await?;
+        }
         // Back to where the caller was: activation is a detour, not a
         // navigation the caller asked for.
         driver.goto(account.as_str()).await?;

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -239,40 +239,16 @@ mod tests {
         driver.goto(&link).await?;
         element(driver, "#activate-accept").await?.click().await?;
         element(driver, "#activate-done").await?;
-        // The custody publish that activation unblocks is offered, not
-        // sprung: the dashboard shows a backup button and only a click
-        // runs the assertion. Drain it the way a person does, so every
-        // later unlock finds the cell published — the auto-published
-        // era left this to a race the CLI-link tests kept losing.
-        let pending = get_json(driver, "/api/customer/pending").await?;
-        // The first click can fail benignly: the publish waits on the
-        // custody space's provisioning, which lands moments after
-        // activation. A person reloads and clicks again; so does the
-        // drain.
-        if successful_body("pending work", &pending)
-            .as_array()
-            .is_some_and(|queue| !queue.is_empty())
-        {
-            let deadline = tokio::time::Instant::now() + Duration::from_secs(90);
-            loop {
-                driver.goto(env.tonk_web.join("account")?.as_str()).await?;
-                click(driver, "#account-backup-publish").await?;
-                let drained = poll_json_briefly(
-                    driver,
-                    "/api/customer/pending",
-                    Duration::from_secs(10),
-                    |body| body.as_array().is_some_and(|queue| queue.is_empty()),
-                )
-                .await;
-                if drained {
-                    break;
-                }
-                anyhow::ensure!(
-                    tokio::time::Instant::now() < deadline,
-                    "the queued custody publish never drained"
-                );
-            }
-        }
+        // The ceremony pre-signed the custody publish and the worker
+        // drains it on activation — no page, no click. All that is
+        // left is to wait for the queue to empty.
+        poll_json(
+            driver,
+            "/api/customer/pending",
+            "the queued custody publish to drain",
+            |body| body.as_array().is_some_and(|queue| queue.is_empty()),
+        )
+        .await?;
         // Back to where the caller was: activation is a detour, not a
         // navigation the caller asked for.
         driver.goto(account.as_str()).await?;
@@ -2117,30 +2093,6 @@ mod tests {
             }
             if tokio::time::Instant::now() >= deadline {
                 return Err(anyhow!("timed out waiting for {what}: {response}"));
-            }
-            tokio::time::sleep(Duration::from_millis(250)).await;
-        }
-    }
-
-    /// [`poll_json`] with a caller-chosen bound and a boolean answer,
-    /// for waits where "not yet" is an outcome to act on rather than a
-    /// failure to report.
-    async fn poll_json_briefly(
-        driver: &WebDriver,
-        path: &str,
-        bound: Duration,
-        accept: impl Fn(&serde_json::Value) -> bool,
-    ) -> bool {
-        let deadline = tokio::time::Instant::now() + bound;
-        loop {
-            if let Ok(response) = get_json(driver, path).await
-                && response.get("error").is_none()
-                && accept(&response["body"])
-            {
-                return true;
-            }
-            if tokio::time::Instant::now() >= deadline {
-                return false;
             }
             tokio::time::sleep(Duration::from_millis(250)).await;
         }

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -245,19 +245,33 @@ mod tests {
         // later unlock finds the cell published — the auto-published
         // era left this to a race the CLI-link tests kept losing.
         let pending = get_json(driver, "/api/customer/pending").await?;
+        // The first click can fail benignly: the publish waits on the
+        // custody space's provisioning, which lands moments after
+        // activation. A person reloads and clicks again; so does the
+        // drain.
         if successful_body("pending work", &pending)
             .as_array()
             .is_some_and(|queue| !queue.is_empty())
         {
-            driver.goto(env.tonk_web.join("account")?.as_str()).await?;
-            click(driver, "#account-backup-publish").await?;
-            poll_json(
-                driver,
-                "/api/customer/pending",
-                "the queued custody publish",
-                |body| body.as_array().is_some_and(|queue| queue.is_empty()),
-            )
-            .await?;
+            let deadline = tokio::time::Instant::now() + Duration::from_secs(90);
+            loop {
+                driver.goto(env.tonk_web.join("account")?.as_str()).await?;
+                click(driver, "#account-backup-publish").await?;
+                let drained = poll_json_briefly(
+                    driver,
+                    "/api/customer/pending",
+                    Duration::from_secs(10),
+                    |body| body.as_array().is_some_and(|queue| queue.is_empty()),
+                )
+                .await;
+                if drained {
+                    break;
+                }
+                anyhow::ensure!(
+                    tokio::time::Instant::now() < deadline,
+                    "the queued custody publish never drained"
+                );
+            }
         }
         // Back to where the caller was: activation is a detour, not a
         // navigation the caller asked for.
@@ -2108,6 +2122,30 @@ mod tests {
         }
     }
 
+    /// [`poll_json`] with a caller-chosen bound and a boolean answer,
+    /// for waits where "not yet" is an outcome to act on rather than a
+    /// failure to report.
+    async fn poll_json_briefly(
+        driver: &WebDriver,
+        path: &str,
+        bound: Duration,
+        accept: impl Fn(&serde_json::Value) -> bool,
+    ) -> bool {
+        let deadline = tokio::time::Instant::now() + bound;
+        loop {
+            if let Ok(response) = get_json(driver, path).await
+                && response.get("error").is_none()
+                && accept(&response["body"])
+            {
+                return true;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+    }
+
     /// A device linked before the account's encryption key existed has
     /// nothing to seal a new space's seed to. Creating one from a page makes
     /// the worker ask that page for a passkey assertion; the page answers by
@@ -2169,33 +2207,52 @@ mod tests {
         .await?;
         successful_body("create space command", &created);
 
-        // The worker's request raises a consent card; the assertion only
-        // runs from its button, inside a user gesture.
+        // Two correct outcomes race here. When the account pull has
+        // already delivered the published `AccountEncryptionKey`, the
+        // worker seals straight to it and no assertion is needed. When
+        // it has not, the worker asks this page: a consent card
+        // appears, and its button runs the assertion that records the
+        // key with the root. Both paths end with the space custodied
+        // under the account; only the root record differs.
         let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
-        let consent = loop {
+        let mut asserted = false;
+        loop {
             if let Ok(button) = creator.find(By::Css("#tonk-custody-continue")).await {
-                break button;
+                button.click().await?;
+                asserted = true;
+                break;
+            }
+            let profile = get_json(&creator, "/api/profile").await?;
+            if profile["body"]["space"]
+                .as_array()
+                .is_some_and(|spaces| !spaces.is_empty())
+            {
+                break;
             }
             anyhow::ensure!(
                 tokio::time::Instant::now() < deadline,
-                "the custody consent card never appeared"
+                "neither the consent card nor the created space appeared"
             );
             tokio::time::sleep(Duration::from_millis(250)).await;
-        };
-        consent.click().await?;
+        }
 
-        let root = poll_json(
-            &creator,
-            "/api/identity/root",
-            "the assertion to record the key",
-            |body| body.get("encryptionKey").is_some(),
-        )
-        .await?;
-        let recipient = root["encryptionKey"]
-            .as_str()
-            .context("root status omitted the key")?
-            .to_string();
-        assert!(recipient.starts_with("did:key:z6LS"), "{recipient}");
+        let asserted_recipient = if asserted {
+            let root = poll_json(
+                &creator,
+                "/api/identity/root",
+                "the assertion to record the key",
+                |body| body.get("encryptionKey").is_some(),
+            )
+            .await?;
+            let recipient = root["encryptionKey"]
+                .as_str()
+                .context("root status omitted the key")?
+                .to_string();
+            assert!(recipient.starts_with("did:key:z6LS"), "{recipient}");
+            Some(recipient)
+        } else {
+            None
+        };
 
         let profile = poll_json(
             &creator,
@@ -2239,9 +2296,17 @@ mod tests {
             rows.iter().any(|row| {
                 let subject = row["fields"]["subject"].as_str().unwrap_or_default();
                 let sealed_to = row["fields"]["recipient"].as_str().unwrap_or_default();
-                subject.ends_with(&key) && sealed_to == recipient
+                subject.ends_with(&key)
+                    && match &asserted_recipient {
+                        // The page's assertion derived the recipient;
+                        // the seed must be sealed to exactly that key.
+                        Some(recipient) => sealed_to == recipient,
+                        // The pulled fact supplied it; any X25519
+                        // recipient is the account's published key.
+                        None => sealed_to.starts_with("did:key:z6LS"),
+                    }
             }),
-            "the new space's seed is sealed to the key the assertion derived: {rows:?}"
+            "the new space's seed is sealed to the account's key: {rows:?}"
         );
 
         creator.quit().await?;

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -643,13 +643,18 @@ pub async fn pending_work() -> Result<tonk_account::pending::PendingQueue, TonkU
 
 /// Queue a custody cell that could not be published yet, so it is
 /// republished once provisioning and email activation let it through.
-pub async fn queue_custody_publish(custody: &str, sealed_hex: &str) -> Result<(), TonkUiError> {
+pub async fn queue_custody_publish(
+    custody: &str,
+    sealed_hex: &str,
+    invocation_hex: &str,
+) -> Result<(), TonkUiError> {
     tonk_host::ready::wait().await;
     let response = reqwest::Client::new()
         .post(format!("{}/api/custody/queue", origin()))
         .json(&serde_json::json!({
             "custody": custody,
             "sealedHex": sealed_hex,
+            "invocationHex": invocation_hex,
         }))
         .send()
         .await
@@ -661,27 +666,6 @@ pub async fn queue_custody_publish(custody: &str, sealed_hex: &str) -> Result<()
         let text = response.text().await.unwrap_or_default();
         Err(TonkUiError::ApiError(format!(
             "POST /api/custody/queue returned {status}: {text}"
-        )))
-    }
-}
-
-/// Tell the worker a queued custody publish is done, so it drops the
-/// entry and drains whatever it was holding back.
-pub async fn complete_custody_publish(custody: &str) -> Result<(), TonkUiError> {
-    tonk_host::ready::wait().await;
-    let response = reqwest::Client::new()
-        .post(format!("{}/api/customer/pending/custody", origin()))
-        .json(&serde_json::json!({ "custody": custody }))
-        .send()
-        .await
-        .map_err(into_api_error)?;
-    if response.status().is_success() {
-        Ok(())
-    } else {
-        let status = response.status();
-        let text = response.text().await.unwrap_or_default();
-        Err(TonkUiError::ApiError(format!(
-            "POST /api/customer/pending/custody returned {status}: {text}"
         )))
     }
 }

--- a/rust/tonk-ui/src/custody_relay.rs
+++ b/rust/tonk-ui/src/custody_relay.rs
@@ -70,7 +70,10 @@ pub(crate) async fn publish_encryption_key() -> Result<bool, String> {
     }
     let endpoint = crate::account::proposed_remote()?;
     let published = crate::identity_bridge::publish_encryption_key(
-        crate::identity_bridge::PublishEncryptionKeyInput { endpoint },
+        crate::identity_bridge::PublishEncryptionKeyInput {
+            endpoint,
+            credential_id: Some(credential_id.clone()),
+        },
     )
     .await
     .map_err(|error| error.to_string())?;

--- a/rust/tonk-ui/src/identity_bridge.rs
+++ b/rust/tonk-ui/src/identity_bridge.rs
@@ -46,10 +46,12 @@ pub(crate) struct CreateAccountOutput {
     pub deposits_hex: Vec<String>,
     pub custody_did: String,
     pub consent_hex: String,
-    /// The sealed account secret, queued until provisioning and
-    /// activation let it publish.
-    #[serde(default)]
-    pub sealed_hex: Option<String>,
+    /// The sealed account secret, recorded on profile main and queued
+    /// for the vault publish.
+    pub sealed_hex: String,
+    /// The ceremony's pre-signed publish invocation, drained by the
+    /// worker once activation lands.
+    pub publish_invocation_hex: String,
 }
 
 /// Input for enrolling a custody passkey for a locally held account.
@@ -72,10 +74,12 @@ pub(crate) struct EnrollCustodyOutput {
     pub custody_did: String,
     pub credential_id: String,
     pub consent_hex: String,
-    /// Present when the cell could not publish yet, because the new
-    /// custody DID is not provisioned until the consent is deposited.
+    /// The sealed account secret — recorded on profile main either way.
+    pub sealed_hex: String,
+    /// Pre-signed publish invocation, present when the ceremony's own
+    /// publish was refused (the custody DID awaits provisioning).
     #[serde(default)]
-    pub sealed_hex: Option<String>,
+    pub publish_invocation_hex: Option<String>,
 }
 
 /// Input for unlocking an account with a custody passkey on this browser.
@@ -208,28 +212,6 @@ pub(crate) async fn enroll_custody_passkey(
     input: EnrollCustodyInput,
 ) -> Result<EnrollCustodyOutput, IdentityBridgeError> {
     call("enrollCustodyPasskey", input).await
-}
-
-/// Input for publishing a custody cell that was queued when its
-/// ceremony could not write it.
-#[derive(Clone, Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct PublishQueuedCustodyInput {
-    pub custody_did: String,
-    pub sealed_hex: String,
-    /// The access service's `/ucan/` endpoint.
-    pub endpoint: String,
-    /// Hex credential id to pin the assertion to, from the root record.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub credential_id: Option<String>,
-}
-
-pub(crate) async fn publish_queued_custody(
-    input: PublishQueuedCustodyInput,
-) -> Result<(), IdentityBridgeError> {
-    call::<_, serde::de::IgnoredAny>("publishQueuedCustody", input)
-        .await
-        .map(|_| ())
 }
 
 pub(crate) async fn unlock_with_passkey(

--- a/rust/tonk-ui/src/identity_bridge.rs
+++ b/rust/tonk-ui/src/identity_bridge.rs
@@ -219,6 +219,9 @@ pub(crate) struct PublishQueuedCustodyInput {
     pub sealed_hex: String,
     /// The access service's `/ucan/` endpoint.
     pub endpoint: String,
+    /// Hex credential id to pin the assertion to, from the root record.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credential_id: Option<String>,
 }
 
 pub(crate) async fn publish_queued_custody(
@@ -241,6 +244,9 @@ pub(crate) async fn unlock_with_passkey(
 #[serde(rename_all = "camelCase")]
 pub(crate) struct PublishEncryptionKeyInput {
     pub endpoint: String,
+    /// Hex credential id to pin the assertion to, from the root record.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credential_id: Option<String>,
 }
 
 /// The account's X25519 recipient, derived through one assertion.

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -18,7 +18,7 @@ pub use claim::{AssertPath, AssertResponse, ClaimQuery, ClaimResponse, QueryResp
 
 mod account;
 mod account_deletion;
-mod customer;
+pub(crate) mod customer;
 
 pub(crate) mod account_state;
 pub use account_state::AccountKeys;
@@ -184,10 +184,6 @@ pub fn api_router_from_state(state: AppState) -> (Router, Arc<LspHub>) {
         .route("/api/customer/enroll", post(customer::enroll))
         .route("/api/customer/activated", post(customer::activated))
         .route("/api/customer/pending", get(customer::get_pending))
-        .route(
-            "/api/customer/pending/custody",
-            post(customer::complete_pending_custody),
-        )
         .route("/api/custody/provision", post(customer::provision_custody))
         .route("/api/custody/queue", post(customer::queue_custody))
         .route("/api/account/devices", get(account_devices::list))

--- a/rust/tonk-worker/src/router/customer.rs
+++ b/rust/tonk-worker/src/router/customer.rs
@@ -308,27 +308,71 @@ pub struct QueueCustodyRequest {
     pub custody: String,
     /// Hex-encoded sealed envelope to publish.
     pub sealed_hex: String,
+    /// Hex-encoded pre-signed publish invocation, minted by the
+    /// ceremony that sealed the envelope.
+    pub invocation_hex: String,
 }
 
 /// POST `/api/custody/queue` → record a custody cell for publication
 /// once its space is provisioned and the account confirms its email.
-/// The page publishes it — only a fresh passkey assertion can sign for
-/// the custody key — so this records rather than performs.
+/// The ceremony pre-signed the publish invocation, so the worker drains
+/// this itself — no page, no assertion. The cell is also recorded on
+/// profile main right away: the account's own sync is the durability
+/// channel, and the vault copy only bootstraps a brand-new browser.
 #[wasm_compat]
 pub async fn queue_custody(
     State(state): State<AppState>,
     Json(request): Json<QueueCustodyRequest>,
 ) -> Result<Json<()>, TonkWorkerError> {
     let state = state.read().await;
-    defer(
-        &state,
-        PendingWork::PublishCustody {
-            custody: request.custody,
-            sealed_hex: request.sealed_hex,
-        },
-    )
-    .await?;
+    record_custody_cell(&state, &request.custody, &request.sealed_hex).await?;
+    // An empty invocation means the ceremony already published the cell
+    // (a passkey enrolled on an active account): the record above is
+    // all that was left to do.
+    if !request.invocation_hex.is_empty() {
+        defer(
+            &state,
+            PendingWork::PublishCustody {
+                custody: request.custody,
+                sealed_hex: request.sealed_hex,
+                invocation_hex: request.invocation_hex,
+            },
+        )
+        .await?;
+        // Nothing may be waiting on activation at all: a provisioning
+        // deposit queued just ahead of this can land right away.
+        drain_pending(&state).await;
+    }
     Ok(Json(()))
+}
+
+/// Record `custody`'s sealed cell on profile main, so the account's own
+/// sync carries the recovery envelope to every device that holds the
+/// profile.
+async fn record_custody_cell(
+    state: &crate::worker::TonkState,
+    custody: &str,
+    sealed_hex: &str,
+) -> Result<(), TonkWorkerError> {
+    let custody: dialog_varsig::Did = custody
+        .parse()
+        .map_err(|error| TonkWorkerError::Router(format!("custody DID is invalid: {error:?}")))?;
+    let cell = hex::decode(sealed_hex)
+        .map_err(|error| TonkWorkerError::Router(format!("sealed cell is not hex: {error}")))?;
+    let account = super::identity::root_did(state).await?;
+    state
+        .reactor
+        .profile_repository()
+        .branch(tonk_account::MAIN_BRANCH)
+        .transaction()
+        .assert(tonk_schema::CustodyCell::new(custody, account, cell))
+        .commit()
+        .perform(&state.operator)
+        .await
+        .map_err(|error| {
+            TonkWorkerError::Internal(format!("failed to record the custody cell: {error}"))
+        })?;
+    Ok(())
 }
 
 /// Provision `consumer`, or queue it when the account has not yet
@@ -814,51 +858,56 @@ async fn run_pending(
                 })?;
             provision_consumer(state, &consumer, &consent, consumer_kind.as_deref()).await
         }
-        PendingWork::PublishCustody { custody, .. } => Err(TonkWorkerError::Router(format!(
-            "custody publish for {custody} needs a passkey assertion, so a page must run it"
-        ))),
+        PendingWork::PublishCustody {
+            custody,
+            sealed_hex,
+            invocation_hex,
+        } => {
+            if invocation_hex.is_empty() {
+                // An entry from before invocations were queued: nothing
+                // can sign for it any more, so it is void rather than a
+                // block on the queue.
+                log!("dropping a custody publish for {custody} queued without an invocation");
+                return Ok(());
+            }
+            let invocation = hex::decode(invocation_hex).map_err(|error| {
+                TonkWorkerError::Router(format!("queued invocation is not hex: {error}"))
+            })?;
+            let sealed = hex::decode(sealed_hex).map_err(|error| {
+                TonkWorkerError::Router(format!("queued cell is not hex: {error}"))
+            })?;
+            #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+            {
+                let origin = service_origin()?;
+                let endpoint = ucan_endpoint(&origin)?;
+                tonk_identity::custody::submit_publish(&invocation, &sealed, endpoint.as_str())
+                    .await
+                    .map_err(|error| {
+                        TonkWorkerError::Internal(format!("custody publish for {custody}: {error}"))
+                    })?;
+                log!("custody cell for {custody} published from the queued invocation");
+                Ok(())
+            }
+            #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+            {
+                let _ = (invocation, sealed);
+                Err(TonkWorkerError::Internal(format!(
+                    "the custody publish for {custody} drains in the worker runtime"
+                )))
+            }
+        }
     }
 }
 
-/// `GET /api/customer/pending` → the queued work a page may have to
-/// run: the account panel reads this to learn whether it must raise a
-/// passkey assertion and publish a custody cell.
+/// `GET /api/customer/pending` → the queued work still waiting: the
+/// account panel reads this to say a backup is on its way; the worker
+/// itself drains it.
 #[wasm_compat]
 pub async fn get_pending(
     State(state): State<AppState>,
 ) -> Result<Json<PendingQueue>, TonkWorkerError> {
     let state = state.read().await;
     Ok(Json(load_pending(&state).await?))
-}
-
-/// `POST /api/customer/pending/custody` request body: the custody DID
-/// whose queued publish a page just completed.
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CompletedCustodyRequest {
-    /// The custody space whose cell is now published.
-    pub custody: String,
-}
-
-/// `POST /api/customer/pending/custody` → drop the queued publish for
-/// `custody`, which a page completed with its own assertion, then drain
-/// whatever it was holding back.
-#[wasm_compat]
-pub async fn complete_pending_custody(
-    State(state): State<AppState>,
-    Json(request): Json<CompletedCustodyRequest>,
-) -> Result<Json<()>, TonkWorkerError> {
-    let state = state.read().await;
-    let mut queue = load_pending(&state).await?;
-    let before = queue.len();
-    queue.0.retain(|work| {
-        !matches!(work, PendingWork::PublishCustody { custody, .. } if custody == &request.custody)
-    });
-    if queue.len() != before {
-        save_pending(&state, &queue).await?;
-    }
-    drain_pending(&state).await;
-    Ok(Json(()))
 }
 
 /// Record a customer at `status`, so a test can put the profile in the

--- a/rust/tonk-worker/src/router/route_table.rs
+++ b/rust/tonk-worker/src/router/route_table.rs
@@ -31,7 +31,6 @@ const ROUTES: &[&str] = &[
     "/api/customer/activated",
     "/api/customer/enroll",
     "/api/customer/pending",
-    "/api/customer/pending/custody",
     "/api/identify",
     "/api/identity/root",
     "/api/inspect/repository/{repo}/archive/index/{hash}",

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -1828,6 +1828,10 @@ impl TonkServiceWorker {
                 // already have — the grandfathering path.
                 crate::router::profiles::upsert_active_entry(&tonk, None).await;
                 crate::router::account_state::ensure_account_state(&tonk).await;
+                // Queued work whose moment has come — above all the
+                // ceremony's pre-signed custody publish, which drains
+                // with no page once activation happened anywhere.
+                crate::router::customer::drain_pending(&tonk).await;
                 // Custody left under the onboarding account is picked
                 // back up here: the link-time rotation is best-effort,
                 // and a failure there (an unhydrated account, a closed


### PR DESCRIPTION
Stacked on #772.

Live testing: after opening the activation email, /account kept saying "Sync activation pending" until manually reloaded, and right after signup a red "initial name could not be synchronized" alert latched even though the failure was just the activation gate doing its job (a background sweep healed it seconds later).

The dashboard now polls customer state while an activation is pending and re-renders on the flip: banner and resend button clear, the facts row reads Active, and the queued backup offer appears — no reload. The hydration alert only shows when activation is not what's in the way.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `base64` dependency and enhances the custody management system by adding support for pre-signed publish invocations. It modifies several files to streamline custody cell handling and improve account activation processes.

### Detailed summary
- Added `base64` dependency in `Cargo.lock` and `Cargo.toml`.
- Updated `custody` module to include `CustodyCell`.
- Enhanced `queue_custody_publish` function to accept an `invocation_hex`.
- Removed the `complete_pending_custody` endpoint.
- Modified `publish_queued_custody` to use a pre-signed invocation.
- Updated UI components to reflect custody backup status.
- Refactored account activation logic to streamline user experience.
- Added logging for custody publish actions and errors.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->