### PR TITLE
CLI-created spaces put their seeds under account custody

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4863,6 +4863,7 @@ dependencies = [
  "urlencoding",
  "wasm-bindgen-test",
  "webbrowser",
+ "zeroize",
 ]
 
 [[package]]

--- a/rust/tonk-cli/Cargo.toml
+++ b/rust/tonk-cli/Cargo.toml
@@ -187,6 +187,7 @@ tonk-account = { workspace = true }
 tonk-analytics = { workspace = true }
 tonk-evaluator = { workspace = true }
 tonk-identity = { workspace = true }
+zeroize = { workspace = true }
 tonk-invite = { workspace = true }
 tonk-notation = { workspace = true }
 tonk-render = { workspace = true }

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -1700,6 +1700,32 @@ async fn link_account(
                     "spaces stay local-only until `tonk account logout` and `tonk account login` reach it"
                 );
             }
+            // Custody moves with the sign-in, the way browser accreditation
+            // rotates: every local space this account may own gets its
+            // authority and sealed seed onto the account. Hosting does not
+            // move — `tonk space link` remains the boundary that provisions
+            // and attaches a remote.
+            match site::default_config() {
+                Ok(config) => {
+                    match tonk_cli::custody::accredit_local_spaces(store, &config).await {
+                        Ok(outcomes) => {
+                            for (name, outcome) in outcomes {
+                                match outcome {
+                                    tonk_cli::custody::Accreditation::Moved => {
+                                        println!("custody: '{name}' moved to the account");
+                                    }
+                                    tonk_cli::custody::Accreditation::Already => {}
+                                    tonk_cli::custody::Accreditation::Skipped(reason) => {
+                                        eprintln!("custody: '{name}' not moved: {reason}");
+                                    }
+                                }
+                            }
+                        }
+                        Err(error) => eprintln!("warning: space custody did not move: {error:#}"),
+                    }
+                }
+                Err(error) => eprintln!("warning: space custody did not move: {error:#}"),
+            }
             print_customer_line(&profile, store).await;
             ExitCode::Success
         }

--- a/rust/tonk-cli/src/custody.rs
+++ b/rust/tonk-cli/src/custody.rs
@@ -1,0 +1,87 @@
+//! Sealing a space's seed to the account — the CLI half of the custody
+//! model the worker follows.
+//!
+//! A space's signing seed must survive this machine: any device on the
+//! account can then re-issue the space after a passkey ceremony opens
+//! the seed. The account publishes an X25519 recipient
+//! ([`AccountEncryptionKey`]) exactly so that sealing needs no passkey —
+//! the CLI reads the public half from the account branch it already
+//! syncs, seals, and records a [`CustodiedSeed`] row beside the
+//! directory entries it writes today. Only a ceremony holding the
+//! account secret can ever open the row again.
+
+use anyhow::{Context, Result};
+use dialog_operator::Operator;
+use dialog_query::{Output as _, Query, Term};
+use dialog_repository::Branch;
+use dialog_storage::provider::storage::NativeSpace;
+use dialog_varsig::Did;
+use tonk_identity::sealed::RecipientKey;
+use tonk_schema::{AccountEncryptionKey, CustodiedSeed, SeedKind, prelude::DidExt as _};
+use zeroize::Zeroizing;
+
+/// The account's published X25519 recipient, read from the account
+/// branch. `None` when the account predates the encryption key — a
+/// signed-in browser publishes it on its next visit.
+pub async fn account_recipient(
+    account: &Branch,
+    root: &Did,
+    operator: &Operator<NativeSpace>,
+) -> Result<Option<Did>> {
+    let rows: Vec<AccountEncryptionKey> = account
+        .query()
+        .select(Query::<AccountEncryptionKey> {
+            this: Term::from(root.this()),
+            key: Term::var("key"),
+        })
+        .perform(operator)
+        .try_vec()
+        .await
+        .map_err(|error| anyhow::anyhow!("failed to read the account encryption key: {error:?}"))?;
+    rows.into_iter()
+        .next()
+        .map(|row| {
+            row.key
+                .0
+                .to_string()
+                .parse()
+                .context("the published account encryption key is not a DID")
+        })
+        .transpose()
+}
+
+/// Seal `seed` (deriving `subject`) to `recipient` and record the
+/// custody row. The row is what the account's other devices recover the
+/// space from, so it is pushed right away — but like the directory
+/// record, a failed push warns rather than fails: the row is committed
+/// locally and the next account push carries it.
+pub async fn custody_space_seed(
+    account: &Branch,
+    subject: &Did,
+    recipient: &Did,
+    seed: &Zeroizing<[u8; 32]>,
+    operator: &Operator<NativeSpace>,
+) -> Result<()> {
+    let key = RecipientKey::from_did(recipient)
+        .map_err(|error| anyhow::anyhow!("the account encryption key is unusable: {error}"))?;
+    let sealed = key
+        .seal(seed, subject)
+        .map_err(|error| anyhow::anyhow!("failed to seal the space seed: {error}"))?
+        .encode();
+    account
+        .transaction()
+        .assert(CustodiedSeed::new(
+            subject.clone(),
+            SeedKind::Space,
+            recipient.clone(),
+            sealed,
+        ))
+        .commit()
+        .perform(operator)
+        .await
+        .context("failed to record the custodied seed")?;
+    if let Err(error) = account.push().perform(operator).await {
+        eprintln!("warning: custodied seed recorded locally; push failed: {error:#}");
+    }
+    Ok(())
+}

--- a/rust/tonk-cli/src/custody.rs
+++ b/rust/tonk-cli/src/custody.rs
@@ -85,3 +85,154 @@ pub async fn custody_space_seed(
     }
     Ok(())
 }
+
+/// Whether the account branch already holds a custody row for `subject`.
+pub async fn has_custody(
+    account: &Branch,
+    subject: &Did,
+    operator: &Operator<NativeSpace>,
+) -> Result<bool> {
+    let rows: Vec<CustodiedSeed> = account
+        .query()
+        .select(Query::<CustodiedSeed> {
+            this: Term::var("this"),
+            subject: Term::from(tonk_schema::domain::custody::Subject(subject.this())),
+            kind: Term::var("kind"),
+            recipient: Term::var("recipient"),
+            sealed: Term::var("sealed"),
+        })
+        .perform(operator)
+        .try_vec()
+        .await
+        .map_err(|error| anyhow::anyhow!("failed to read custodied seeds: {error:?}"))?;
+    Ok(!rows.is_empty())
+}
+
+/// The signing seed a locally created space's stored credential carries.
+/// `None` for a space this machine only ever held a verifier for — a
+/// joined or delegated space, whose seed is someone else's to custody.
+pub async fn site_seed(site: &crate::site::TonkSite) -> Result<Option<Zeroizing<[u8; 32]>>> {
+    let Some(signer) = site.repository.credential().signer() else {
+        return Ok(None);
+    };
+    // `Signer` gains arms only when dialog-credentials is built with
+    // another algorithm, which this crate never enables.
+    let dialog_credentials::Signer::Ed25519(signer) = signer;
+    let exported = signer
+        .export()
+        .await
+        .map_err(|error| anyhow::anyhow!("failed to export the space signer: {error:?}"))?;
+    let dialog_credentials::KeyExport::Extractable(bytes) = exported;
+    let seed: [u8; 32] = bytes
+        .as_slice()
+        .try_into()
+        .context("the exported space seed is not 32 bytes")?;
+    Ok(Some(Zeroizing::new(seed)))
+}
+
+/// One space's outcome under [`accredit_local_spaces`].
+#[derive(Debug)]
+pub enum Accreditation {
+    /// Authority and custody now reach the account.
+    Moved,
+    /// Nothing to do: the account already holds this space's custody.
+    Already,
+    /// Skipped, with the reason: no signer (a joined space), or a
+    /// founder row naming a different account.
+    Skipped(String),
+}
+
+/// Move custody of every registered local space to the signed-in
+/// account — the CLI's accreditation, mirroring what the browser's
+/// rotation does at sign-in. Authority (`space → root`, retained into
+/// the account) and the sealed seed move; hosting does not: a space
+/// gains its remote and provisioning through `tonk space link`.
+///
+/// Best-effort per space: a failure is reported and the rest continue,
+/// and running again converges.
+pub async fn accredit_local_spaces(
+    store: &crate::space::SpaceStore,
+    config: &crate::site::SiteConfig,
+) -> Result<Vec<(String, Accreditation)>> {
+    let registry = store.load()?;
+    let Some(account) = registry.account.clone() else {
+        return Ok(Vec::new());
+    };
+    let account_root: Did = account
+        .root
+        .parse()
+        .context("the signed-in account root is invalid")?;
+
+    let mut outcomes = Vec::new();
+    for (name, entry) in &registry.spaces {
+        let mut site_config = config.clone();
+        site_config.require_account = false;
+        let site = match crate::site::TonkSite::open_with(&entry.site, site_config).await {
+            Ok(site) => site,
+            Err(error) => {
+                outcomes.push((
+                    name.clone(),
+                    Accreditation::Skipped(format!("could not open: {error:#}")),
+                ));
+                continue;
+            }
+        };
+        match accredit_site(&site, &account_root, store).await {
+            Ok(outcome) => outcomes.push((name.clone(), outcome)),
+            Err(error) => outcomes.push((
+                name.clone(),
+                Accreditation::Skipped(format!("failed: {error:#}")),
+            )),
+        }
+    }
+    Ok(outcomes)
+}
+
+async fn accredit_site(
+    site: &crate::site::TonkSite,
+    account_root: &Did,
+    store: &crate::space::SpaceStore,
+) -> Result<Accreditation> {
+    let subject = site.repository.did();
+    // Ownership is the space's own answer: a founder row naming another
+    // account is final — a synced space stays with its owner.
+    let roster = crate::inventory::read_roster(site).await?;
+    if let Some(founder) = roster.founder()
+        && founder.did != account_root.to_string()
+    {
+        return Ok(Accreditation::Skipped(format!("owned by {}", founder.did)));
+    }
+    let Some(seed) = site_seed(site).await? else {
+        return Ok(Accreditation::Skipped(
+            "no local signer (a joined space)".to_string(),
+        ));
+    };
+
+    let operator =
+        crate::account_state::credential_operator_for_store(&site.profile, store).await?;
+    let account = crate::account_state::open_account_branch_in(&site.profile, &operator, store)
+        .await?
+        .context("the account repository is not ready to custody spaces")?;
+    let recipient = account_recipient(&account, account_root, &operator)
+        .await?
+        .context(
+            "the account has not published its encryption key yet; \
+             open /account in a signed-in browser once, then run `tonk account status`",
+        )?;
+
+    let prefix = crate::site::adopt_account_root_prefix_for(
+        &site.profile,
+        site.operator.local(),
+        &subject,
+        account_root,
+    )
+    .await?;
+    crate::account_state::retain_space_delegation_in(&site.profile, &operator, store, &prefix)
+        .await?;
+
+    if has_custody(&account, &subject, &operator).await? {
+        return Ok(Accreditation::Already);
+    }
+    custody_space_seed(&account, &subject, &recipient, &seed, &operator).await?;
+    Ok(Accreditation::Moved)
+}

--- a/rust/tonk-cli/src/lib.rs
+++ b/rust/tonk-cli/src/lib.rs
@@ -44,6 +44,7 @@ pub mod blob;
 /// A loopback callback server for browser authorization ceremonies.
 pub mod callback;
 pub mod context;
+pub mod custody;
 pub mod customer;
 pub mod data;
 pub mod data_ops;

--- a/rust/tonk-cli/src/site.rs
+++ b/rust/tonk-cli/src/site.rs
@@ -547,13 +547,6 @@ async fn bootstrap_repository(
     require_account: bool,
     provision_account_spaces: bool,
 ) -> Result<Repository> {
-    let signer_repo = profile
-        .repository(REPO_NAME)
-        .create()
-        .perform(operator)
-        .await
-        .context("failed to create repository")?;
-
     let local_root = crate::identity::local_root_with_operator(profile, operator).await?;
     let account_operator = if require_account {
         crate::account::require_account_with_operator_in(profile, operator, account_store).await?;
@@ -568,6 +561,47 @@ async fn bootstrap_repository(
         .root_did
         .parse()
         .context("stored root DID is invalid")?;
+
+    // The signer comes from an explicit seed so the seed can be sealed
+    // to the account BEFORE the space exists: the custody row is the
+    // copy the account's other devices recover the space from, and a
+    // create that cannot record it must not produce a space that only
+    // this machine can ever re-derive.
+    let seed = zeroize::Zeroizing::new(rand::random::<[u8; 32]>());
+    let signer = Ed25519Signer::import(&*seed)
+        .await
+        .context("failed to derive the space signer")?;
+    if require_account {
+        let account_operator = account_operator
+            .as_ref()
+            .expect("account operator exists when an account is required");
+        let account =
+            crate::account_state::open_account_branch_in(profile, account_operator, account_store)
+                .await?
+                .context("the account repository is not ready to custody this space")?;
+        let recipient = crate::custody::account_recipient(&account, &durable_did, account_operator)
+            .await?
+            .context(
+                "the account has not published its encryption key yet; \
+                     open /account in a signed-in browser once, then retry",
+            )?;
+        crate::custody::custody_space_seed(
+            &account,
+            &signer.did(),
+            &recipient,
+            &seed,
+            account_operator,
+        )
+        .await?;
+    }
+
+    let signer_repo = profile
+        .repository(REPO_NAME)
+        .create()
+        .with_credential(signer)
+        .perform(operator)
+        .await
+        .context("failed to create repository")?;
     let delegation = signer_repo
         .access()
         .claim(&signer_repo)

--- a/rust/tonk-cli/src/space_link.rs
+++ b/rust/tonk-cli/src/space_link.rs
@@ -125,14 +125,37 @@ pub async fn execute(store: &SpaceStore, config: &SiteConfig, name: &str) -> Res
 
     let operator =
         crate::account_state::credential_operator_for_store(&site.profile, store).await?;
-    if crate::account_state::open_account_branch_in(&site.profile, &operator, store)
-        .await?
-        .is_none()
-    {
+    let Some(account_branch) =
+        crate::account_state::open_account_branch_in(&site.profile, &operator, store).await?
+    else {
         bail!("the account repository is not ready to hold this space");
-    }
+    };
     crate::account_state::retain_space_delegation_in(&site.profile, &operator, store, &prefix)
         .await?;
+    // The seed rides the same boundary: a space the account hosts is a
+    // space the account can re-derive. Sealing needs only the published
+    // public key; an account that predates it links anyway — custody
+    // catches up at the next `tonk account login`.
+    if !crate::custody::has_custody(&account_branch, &subject, &operator).await? {
+        match crate::custody::account_recipient(&account_branch, &account_root, &operator).await? {
+            Some(recipient) => {
+                if let Some(seed) = crate::custody::site_seed(&site).await? {
+                    crate::custody::custody_space_seed(
+                        &account_branch,
+                        &subject,
+                        &recipient,
+                        &seed,
+                        &operator,
+                    )
+                    .await?;
+                }
+            }
+            None => eprintln!(
+                "warning: the account has not published its encryption key; \
+                 the space seed stays uncustodied until it does"
+            ),
+        }
+    }
     crate::account_spaces::record_site_pushed(name, &site, store).await?;
 
     if crate::inventory::role_for_site(&site).await? != SpaceRole::Owner {

--- a/rust/tonk-cli/tests/account_authority.rs
+++ b/rust/tonk-cli/tests/account_authority.rs
@@ -739,3 +739,66 @@ async fn it_denies_ordinary_sync_for_a_space_created_before_the_account_existed(
     );
     Ok(())
 }
+
+/// An account-backed create seals the space's seed to the account's
+/// published encryption key and records it on the account branch — the
+/// copy any of the account's devices recovers the space from after a
+/// ceremony opens it.
+#[dialog_common::test]
+async fn it_custodies_the_created_space_seed() -> Result<()> {
+    use dialog_query::{Output as _, Query, Term};
+    use tonk_schema::{CustodiedSeed, prelude::DidExt as _};
+
+    let fixture = common::AccountFixture::new().await?;
+    let site = TonkSite::init_at_with(
+        &fixture.tmp.path().join("custodied"),
+        account_config(&fixture),
+    )
+    .await?;
+    let subject = site.repository.did();
+
+    let account_operator =
+        tonk_cli::account_state::credential_operator_for_store(&fixture.profile, &fixture.store)
+            .await?;
+    let account = tonk_cli::account_state::open_account_branch_in(
+        &fixture.profile,
+        &account_operator,
+        &fixture.store,
+    )
+    .await?
+    .context("the fixture account branch mounts")?;
+    let rows: Vec<CustodiedSeed> = account
+        .query()
+        .select(Query::<CustodiedSeed> {
+            this: Term::var("this"),
+            subject: Term::from(subject.this()),
+            kind: Term::var("kind"),
+            recipient: Term::var("recipient"),
+            sealed: Term::var("sealed"),
+        })
+        .perform(&account_operator)
+        .try_vec()
+        .await
+        .map_err(|error| anyhow::anyhow!("read custodied seeds: {error:?}"))?;
+    assert_eq!(rows.len(), 1, "the created space's seed is custodied");
+    assert_eq!(rows[0].kind.0.to_string(), tonk_schema::SeedKind::SPACE);
+
+    // The account secret opens the row and derives the space itself.
+    let secret = tonk_identity::envelope::AccountSecret::from_bytes(zeroize::Zeroizing::new(
+        fixture.root_prf,
+    ));
+    let sealed = tonk_identity::sealed::Sealed::decode(&rows[0].sealed.0)
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+    let seed = secret
+        .encryption_key()
+        .open(&sealed, &subject)
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+    let signer = dialog_credentials::Ed25519Signer::import(&*seed).await?;
+    use dialog_varsig::Principal as _;
+    assert_eq!(
+        signer.did(),
+        subject,
+        "the custodied seed derives the space"
+    );
+    Ok(())
+}

--- a/rust/tonk-cli/tests/account_authority.rs
+++ b/rust/tonk-cli/tests/account_authority.rs
@@ -802,3 +802,86 @@ async fn it_custodies_the_created_space_seed() -> Result<()> {
     );
     Ok(())
 }
+
+/// A space created before the account existed moves under the account's
+/// custody at sign-in: authority reaches the root and the seed is
+/// sealed to the account's key. Hosting does not move — that stays
+/// `tonk space link`'s boundary.
+#[dialog_common::test]
+async fn it_moves_local_space_custody_at_sign_in() -> Result<()> {
+    use dialog_query::{Output as _, Query, Term};
+    use tonk_cli::custody::{Accreditation, accredit_local_spaces};
+    use tonk_schema::{CustodiedSeed, prelude::DidExt as _};
+
+    let fixture = common::AccountFixture::new().await?;
+    // What `tonk account login` records once the ceremony succeeds.
+    let root_did_string = fixture.link.issuer().to_string();
+    fixture
+        .store
+        .set_account(Some(tonk_cli::space::AccountRecord::new(root_did_string)))?;
+    let mut local_config = fixture.config.clone();
+    local_config.require_account = false;
+    let created =
+        tonk_cli::space::create(&fixture.store, "premade", None, None, local_config).await?;
+    let subject: dialog_varsig::Did = created.did.parse()?;
+
+    let outcomes = accredit_local_spaces(&fixture.store, &fixture.config).await?;
+    assert!(
+        outcomes
+            .iter()
+            .any(|(name, outcome)| name == "premade" && matches!(outcome, Accreditation::Moved)),
+        "sign-in moves the local space's custody: {outcomes:?}"
+    );
+
+    let account_operator =
+        tonk_cli::account_state::credential_operator_for_store(&fixture.profile, &fixture.store)
+            .await?;
+    let account = tonk_cli::account_state::open_account_branch_in(
+        &fixture.profile,
+        &account_operator,
+        &fixture.store,
+    )
+    .await?
+    .context("the fixture account branch mounts")?;
+    let rows: Vec<CustodiedSeed> = account
+        .query()
+        .select(Query::<CustodiedSeed> {
+            this: Term::var("this"),
+            subject: Term::from(tonk_schema::domain::custody::Subject(subject.this())),
+            kind: Term::var("kind"),
+            recipient: Term::var("recipient"),
+            sealed: Term::var("sealed"),
+        })
+        .perform(&account_operator)
+        .try_vec()
+        .await
+        .map_err(|error| anyhow::anyhow!("read custodied seeds: {error:?}"))?;
+    assert_eq!(rows.len(), 1, "the moved space's seed is custodied");
+
+    let secret = tonk_identity::envelope::AccountSecret::from_bytes(zeroize::Zeroizing::new(
+        fixture.root_prf,
+    ));
+    let sealed = tonk_identity::sealed::Sealed::decode(&rows[0].sealed.0)
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+    let seed = secret
+        .encryption_key()
+        .open(&sealed, &subject)
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+    let signer = dialog_credentials::Ed25519Signer::import(&*seed).await?;
+    use dialog_varsig::Principal as _;
+    assert_eq!(
+        signer.did(),
+        subject,
+        "the custodied seed derives the space"
+    );
+
+    // Running again converges: nothing is moved twice.
+    let again = accredit_local_spaces(&fixture.store, &fixture.config).await?;
+    assert!(
+        again
+            .iter()
+            .any(|(name, outcome)| name == "premade" && matches!(outcome, Accreditation::Already)),
+        "a second sign-in finds custody already moved: {again:?}"
+    );
+    Ok(())
+}

--- a/rust/tonk-cli/tests/common.rs
+++ b/rust/tonk-cli/tests/common.rs
@@ -95,7 +95,7 @@ pub struct AccountFixture {
     pub link: dialog_ucan_core::DelegationChain,
     pub config: SiteConfig,
     pub descriptor: Vec<u8>,
-    root_prf: [u8; 32],
+    pub root_prf: [u8; 32],
     pub tmp: TempDir,
 }
 
@@ -193,6 +193,33 @@ impl AccountFixture {
                 .save(validated.content_hash().to_vec())
                 .perform(&test.site.operator)
                 .await?;
+
+            // Real accounts publish their encryption key: the ceremony
+            // saves it with the root and the account sweep publishes the
+            // fact. The fixture publishes directly, so account-backed
+            // creates can seal their seeds into custody.
+            use tonk_schema::prelude::DidExt as _;
+            let recipient = tonk_identity::envelope::AccountSecret::from_bytes(
+                zeroize::Zeroizing::new(root_prf),
+            )
+            .encryption_key()
+            .recipient()
+            .did();
+            let root_did: dialog_varsig::Did = ceremony.root_did.parse()?;
+            if let Some(account) =
+                tonk_cli::account_state::open_account_branch_in(&profile, &account_operator, &store)
+                    .await?
+            {
+                account
+                    .transaction()
+                    .assert(tonk_schema::AccountEncryptionKey::new(
+                        root_did.this(),
+                        recipient.this(),
+                    ))
+                    .commit()
+                    .perform(&account_operator)
+                    .await?;
+            }
         }
 
         Ok(Self {


### PR DESCRIPTION
The CLI mirrors the browser's custody model end to end.

**Create.** A `tonk space new` under a signed-in account generates the signer from an explicit seed, seals the seed to the account's published `AccountEncryptionKey` (public half only — no passkey), and commits the `CustodiedSeed` on the account branch BEFORE the space exists: a create that cannot record the account's copy refuses instead of producing a space only one machine can re-derive. Signed out, the create stays local-only, exactly as before.

**Sign-in.** `tonk account login` now finishes the way browser accreditation does: it walks the registry and moves every local space this account may own — the `space → root` prefix is minted and retained into the account, and the seed is sealed into custody. Hosting does not move. Ownership stays the space's own answer: a founder row naming another account is final, and joined spaces (verifier-only credentials) are skipped.

**`tonk space link`.** Remains the hosting boundary — provision, remote, upstream, founder membership, push, directory record — and now also seals custody when the row is missing, so pre-existing linked spaces converge.

An account that predates the encryption key gets clear guidance (open /account in a signed-in browser once, which publishes it) instead of a silent gap. Custody pushes are best-effort with a warning, matching the directory record's semantics.

Tests: the fixture publishes an encryption key like real accounts; new coverage proves the create-time round trip (row read back, opened with the account secret, space DID re-derived from the seed) and the sign-in move (custody appears for a pre-account space, and a second run reports it already moved).


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `custody` module in the `tonk-cli` project, enhancing the management of space seeds by linking them to account custody. It adds functionality for sealing space seeds to accounts and accrediting local spaces upon sign-in.

### Detailed summary
- Added `pub mod custody;` in `lib.rs`.
- Introduced functions for managing custody of space seeds in `custody.rs`.
- Implemented logic for accrediting local spaces during sign-in.
- Updated tests in `account_authority.rs` to validate new custody features.
- Refactored existing code to integrate custody functionality.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->