### PR TITLE
The endless loader was an SRI-blocked bundle

### DIFF
--- a/rust/tonk-ui/index.html
+++ b/rust/tonk-ui/index.html
@@ -401,12 +401,22 @@
          static assets, you will want to modify this condiguration here. -->
         <!-- `data-initializer` gives the static boot shell (see <body>) real
          progress callbacks for the multi-megabyte wasm fetch. -->
+        <!-- `data-integrity="none"`: trunk otherwise stamps SRI hashes
+         into this page, and any rebuild window where the served page
+         and the served bundle come from different builds makes the
+         browser BLOCK the app script — the boot shell then shows
+         "loading…" forever with only a console error to explain. The
+         content-hashed filename already pins which bytes belong to
+         this page, so the SRI added no protection worth that failure
+         mode, in dev (where trunk watch rebuilds constantly) or in a
+         deploy window. -->
         <link
             data-trunk
             rel="rust"
             data-bin="ui"
             data-type="main"
             data-wasm-opt="z"
+            data-integrity="none"
             data-initializer="assets/boot-progress.mjs"
         />
         <link
@@ -416,6 +426,7 @@
             data-type="worker"
             data-bindgen-target="web"
             data-wasm-opt="z"
+            data-integrity="none"
         />
 
         <!-- Bridge module injected by host::wrap_html_body into iframe srcdoc.


### PR DESCRIPTION
Live-debugged: the eternal "loading…" screen that a refresh fixes is the browser refusing the app script — trunk stamps SRI hashes into index.html, and any rebuild window (dev watch, deploys) can pair a page from one build with a bundle from another. The mismatch BLOCKS the script, the wasm never boots, and the static boot shell sits there forever with only a console error to explain. Filenames are already content-hashed, which pins the page↔bundle pairing; the SRI added nothing worth this failure mode, so both rust links now carry data-integrity="none".

Whether the boot shell itself earns its keep (the progress plumbing, the idle-callback deferrals) is a separate performance question — this removes the thing that made it hang.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `index.html` file to include `data-integrity="none"` attributes in the `<link>` tags, which prevents issues with Subresource Integrity (SRI) during development and deployment, ensuring smoother loading of the application.

### Detailed summary
- Added `data-integrity="none"` to the `<link>` tag for the main Rust binary to prevent SRI-related loading issues.
- Added `data-integrity="none"` to the `<link>` tag for the worker to avoid similar SRI problems. 
- Updated comments to clarify the purpose of the `data-initializer` and the implications of using `data-integrity="none"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->