### PR TITLE
Minting an invite ensures the consumer is provisioned

### DIFF
--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -1049,6 +1049,29 @@ async fn run_invite(
             }
         };
 
+    // A share is a promise the recipient can actually pull, and an
+    // upstream can outlive its provisioning (a space created before the
+    // account had an active customer keeps its remote while the service
+    // refuses every presign). Ensure the consumer row exists before any
+    // key material is minted: `/provider/add` is idempotent — an already
+    // provided consumer answers `ConsumerProvided`, treated as success —
+    // so every share self-heals that half-state. Best effort like the
+    // enable-sync attach: a foreign remote (self-hosted, a test server)
+    // is not our access service, and refusing the mint over it would
+    // make those unshareable.
+    match space_root_prefix(&tonk, &repository.did()).await {
+        Ok(prefix) => {
+            if let Err(error) =
+                super::customer::provision_consumer(&tonk, &repository.did(), &prefix, None).await
+            {
+                log!("Invite for repo '{repo_name}': provisioning skipped: {error}");
+            }
+        }
+        Err(error) => {
+            log!("Invite for repo '{repo_name}': no prefix to provision with: {error}");
+        }
+    }
+
     // A ready-to-append URL query suffix (`&remote=<percent-encoded-url>`).
     // The share view appends it verbatim between `?access=…` and the `#seed`.
     let encoded_access: String =


### PR DESCRIPTION
Live-debugged with a dead invite: a space carried an attached upstream but no consumer row (created before the account had an active customer), the share button minted links for it anyway — the gate only asks whether an upstream exists — and every recipient's pull failed with "subject is provisioned by an active customer (the subject is not provisioned)".

A share is a promise the recipient can actually pull, so the mint now ensures the consumer row before generating any key material. `/provider/add` is idempotent (an already-provided consumer answers ConsumerProvided, treated as success), which turns every share into a self-heal for the upstream-without-provisioning half-state, whatever put the space there — creation racing activation, a reset dev service, a deferred rotation. Best effort like the enable-sync attach: a foreign remote (self-hosted, a test server) is not our access service to provision against, and refusing the mint over it would make those unshareable.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds documentation and error handling related to provisioning a consumer in the `repository.rs` file. It emphasizes the importance of ensuring a consumer row exists before minting key material and includes logging for error scenarios during the provisioning process.

### Detailed summary
- Added documentation explaining the share and upstream provisioning process.
- Implemented a `match` statement to handle the result of `space_root_prefix`.
- Added error handling for the `provision_consumer` function call, logging messages for skipped provisioning and lack of prefix.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->