### PR TITLE
fix(account): rotate profile after account deletion

### DIFF
--- a/plan/account-deletion-profile-transition.md
+++ b/plan/account-deletion-profile-transition.md
@@ -1,0 +1,27 @@
+# Account deletion profile transition
+
+## Observed failure
+
+- Permanent account deletion releases the email remotely, then calls the
+  ordinary local sign-out path.
+- Sign-out preserves the profile root and writes an attachment tombstone so a
+  different account cannot silently inherit that profile's retained spaces.
+- The account page still offers account creation on that retired profile. A
+  newly created passkey has a different root, so `POST /api/identity/root`
+  correctly rejects it with `409 Conflict`.
+
+## Plan
+
+- [x] Extend the real-browser deletion regression to recreate an account with
+  the released email and observe the current conflict.
+- [x] After successful permanent deletion, preserve the retired local profile
+  and rotate the active browser state to a fresh profile.
+- [x] Run the focused regression, nearby tests, formatting, and diff checks.
+
+## Verification
+
+- The focused real-browser regression failed before the production change at
+  `POST /api/identity/root` with the reported `409 Conflict`, then passed after
+  the profile transition change.
+- `nix develop path:. -c test:web:debug`: 1,357 passed, 1 skipped.
+- `cargo fmt --all -- --check` and `git diff --check` passed.

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -1307,7 +1307,9 @@ mod tests {
     /// passkey user-verification gesture is UI-side and out of scope;
     /// everything destructive runs here exactly as in production.
     #[dialog_common::test]
-    async fn it_deletes_the_account_and_its_hosted_spaces(env: TestEnvironment) -> Result<()> {
+    async fn it_deletes_the_account_and_releases_its_email_and_profile(
+        env: TestEnvironment,
+    ) -> Result<()> {
         let driver = driver_with_prf(&env).await?;
         let email = "goner@example.com";
         sign_up(&driver, &env, email).await?;
@@ -1381,6 +1383,18 @@ mod tests {
         assert_eq!(
             after["status"], 404,
             "a deleted account leaves nothing to plan against: {after}"
+        );
+
+        // Permanent deletion retires this account's local profile rather
+        // than rebinding its retained authority to another root. The browser
+        // must already be on a fresh profile so the released email can create
+        // a genuinely new account without the user finding the hidden
+        // "different account" root conflict.
+        sign_up(&driver, &env, email).await?;
+        let recreated = get_json(&driver, "/api/account/summary").await?;
+        assert_eq!(
+            successful_body("load the recreated account", &recreated)["email"],
+            email
         );
 
         driver.quit().await?;

--- a/rust/tonk-worker/src/router/account_deletion.rs
+++ b/rust/tonk-worker/src/router/account_deletion.rs
@@ -286,6 +286,11 @@ pub async fn delete(
         super::customer::clear_customer(&current_state).await?;
     }
     let _ = super::account::unlink(State(state.clone())).await?;
+    // Permanent deletion retires this account's profile rather than
+    // rebinding its retained joined spaces and delegations to another root.
+    // Unlike ordinary sign-out, finish on a fresh profile so the released
+    // email can immediately create a genuinely new account.
+    let _ = super::profiles::add(State(state.clone())).await?;
 
     Ok(Json(AccountDeletionResult {
         deleted_spaces: request.spaces.len(),


### PR DESCRIPTION
## Summary

- retire the deleted account profile after local unlink and activate a fresh browser profile
- preserve retained joined spaces under the old root while allowing the released email to create a new account immediately
- extend the real-browser deletion regression through account recreation with the same email

## Testing

- `nix develop -c cargo test -p tonk-ui --features integration-tests it_deletes_the_account_and_releases_its_email_and_profile -- --nocapture --test-threads=1` (1 passed)
- `nix develop path:. -c test:web:debug` (1,357 passed, 1 skipped)
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the account deletion process by ensuring that a deleted account's email can be reused for a new account immediately, and it modifies the profile handling during deletion to prevent conflicts.

### Detailed summary
- Added profile retirement during account deletion to allow immediate email reuse.
- Updated the test function name for clarity on account deletion behavior.
- Enhanced tests to ensure recreated accounts function correctly after deletion.
- Documented observed failures and planned improvements in `plan/account-deletion-profile-transition.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->