### PR TITLE
fix(cli): preserve account state across login timeout

### DIFF
--- a/rust/tonk-cli/src/account.rs
+++ b/rust/tonk-cli/src/account.rs
@@ -65,9 +65,43 @@ pub const ACCOUNT_LINK_SITE: &str = tonk_account::ACCOUNT_PROVIDER_CREDENTIAL_SI
 // Linking is complete once credentials are durable; repository hydration is
 // best-effort and must not leave the link command waiting indefinitely.
 
-/// How long the post-link hydration phase may run before the command
-/// reports "waiting for first sync" and returns.
-const HYDRATION_DEADLINE: Duration = Duration::from_secs(10);
+/// How long retryable post-link account synchronization may run before the
+/// command reports the durable local lifecycle state and returns.
+const POST_LINK_SYNC_DEADLINE: Duration = Duration::from_secs(10);
+
+async fn ensure_after_link(
+    profile: &Profile,
+    operator: dialog_operator::Operator<NativeSpace>,
+    store: crate::space::SpaceStore,
+    deadline: Duration,
+) -> Result<crate::account_state::EnsureOutcome> {
+    let status_operator = operator.clone();
+    match tokio::time::timeout(
+        deadline,
+        crate::account_state::ensure_with_operator_and_store(profile, operator, store.clone()),
+    )
+    .await
+    {
+        Ok(outcome) => outcome,
+        Err(_) => {
+            let status =
+                crate::account_state::status_with_operator_in(profile, &status_operator, &store)
+                    .await?;
+            let warning = match status {
+                AccountStateStatus::Ready => {
+                    "latest account synchronization did not finish within 10 seconds; committed changes will retry"
+                }
+                AccountStateStatus::Unconfigured | AccountStateStatus::Unhydrated => {
+                    "the account repository did not answer within 10 seconds; first sync will retry"
+                }
+            };
+            Ok(crate::account_state::EnsureOutcome {
+                status,
+                warning: Some(warning.to_string()),
+            })
+        }
+    }
+}
 
 /// Descriptive registration name for a native CLI device.
 pub fn default_device_name() -> String {
@@ -438,11 +472,11 @@ async fn project_staged_account(
     profile: &Profile,
     operator: &dialog_operator::Operator<NativeSpace>,
     account: &crate::account_session::ActiveAccount,
-) -> Result<Vec<u8>> {
+) -> Result<()> {
     if account.attachment_id.trim().is_empty() {
         bail!("staged account activation has no service attachment generation");
     }
-    let (grant_bytes, chain) = recorded_account_grant(profile, account).await?;
+    let (_, chain) = recorded_account_grant(profile, account).await?;
     let root_did: Did = account
         .root_did
         .parse()
@@ -485,7 +519,7 @@ async fn project_staged_account(
         .perform(operator)
         .await
         .context("failed to persist the account link")?;
-    Ok(grant_bytes)
+    Ok(())
 }
 
 /// Resume or complete one exact staged generation. The activation guard keeps
@@ -495,81 +529,37 @@ async fn complete_staged_account(
     operator: &dialog_operator::Operator<NativeSpace>,
     store: &crate::space::SpaceStore,
     account: &crate::account_session::ActiveAccount,
-) -> Result<Vec<u8>> {
+) -> Result<()> {
     let guard =
         crate::account_session::stage_activation(profile, operator, store, account.clone()).await?;
-    let grant_bytes = project_staged_account(profile, operator, account).await?;
+    project_staged_account(profile, operator, account).await?;
     crate::account_session::finalize_activation(profile, operator, guard, account).await?;
-    Ok(grant_bytes)
+    Ok(())
 }
 
-/// Hydrate and retain authority after the canonical account is already active.
+/// Hydrate and converge authority after the canonical account is already active.
 /// Failure here never reopens the browser ceremony.
 async fn hydrate_activated_account(
     profile: &Profile,
     operator: &dialog_operator::Operator<NativeSpace>,
     store: &crate::space::SpaceStore,
     account: &crate::account_session::ActiveAccount,
-    grant_bytes: &[u8],
     url: String,
 ) -> Result<LinkOutcome> {
-    let account_did: Did = account
-        .root_did
-        .parse()
-        .context("active account root DID is invalid")?;
-    let hydration = tokio::time::timeout(HYDRATION_DEADLINE, async {
-        let account_state = match crate::account_state::ensure_with_operator_and_store(
-            profile,
-            operator.clone(),
-            store.clone(),
-        )
-        .await
-        {
-            Ok(outcome) => outcome.status,
-            Err(_) => AccountStateStatus::Unhydrated,
-        };
-        let mut warning = None;
-        if let Some(branch) =
-            crate::account_state::open_account_branch_in(profile, operator, store).await?
-        {
-            let signer = profile.signer().signer().clone();
-            let union =
-                tonk_account::delegations::mint_account_union(&signer, &account_did).await?;
-            let inbound = DelegationChain::try_from(grant_bytes)
-                .context("account grant is not a delegation container")?;
-            for (label, chain) in [("account grant", inbound), ("profile union", union)] {
-                if let Err(error) =
-                    tonk_account::delegations::retain_space_delegation(&branch, &chain, operator)
-                        .await
-                {
-                    warning = Some(format!(
-                        "{label} was not retained into the account: {error}"
-                    ));
-                }
-            }
-            if warning.is_none()
-                && let Err(error) = branch.push().perform(operator).await
-            {
-                warning = Some(format!("account was authorized but not pushed: {error}"));
-            }
-        }
-        Ok::<_, anyhow::Error>((account_state, warning))
-    })
-    .await;
-    let (account_state, warning) = match hydration {
-        Ok(result) => result?,
-        Err(_) => (
-            AccountStateStatus::Unhydrated,
-            Some("the account repository did not answer in time; sync will retry".to_string()),
-        ),
-    };
+    let ensured = ensure_after_link(
+        profile,
+        operator.clone(),
+        store.clone(),
+        POST_LINK_SYNC_DEADLINE,
+    )
+    .await?;
 
     Ok(LinkOutcome {
         url,
         root_did: account.root_did.clone(),
         device_did: profile.did().to_string(),
-        account_state,
-        warning,
+        account_state: ensured.status,
+        warning: ensured.warning,
         service_url: account.provider.clone(),
     })
 }
@@ -630,8 +620,8 @@ async fn link_via_callback(
     let authorization: CallbackAuthorization =
         serde_json::from_slice(&bytes).context("authorization payload is not readable")?;
     let account = account_from_callback(profile, options, authorization).await?;
-    let grant_bytes = complete_staged_account(profile, operator, store, &account).await?;
-    hydrate_activated_account(profile, operator, store, &account, &grant_bytes, url).await
+    complete_staged_account(profile, operator, store, &account).await?;
+    hydrate_activated_account(profile, operator, store, &account, url).await
 }
 
 /// What the authorizing page posts back to the waiting CLI.
@@ -699,29 +689,13 @@ pub async fn link_with_operator(
         crate::account_session::load_guarded(profile, operator, &guard).await?
     };
     if let Some(account) = state.active {
-        let (grant_bytes, _) = recorded_account_grant(profile, &account).await?;
-        return hydrate_activated_account(
-            profile,
-            operator,
-            &store,
-            &account,
-            &grant_bytes,
-            String::new(),
-        )
-        .await;
+        recorded_account_grant(profile, &account).await?;
+        return hydrate_activated_account(profile, operator, &store, &account, String::new()).await;
     }
     match state.pending_login {
         Some(crate::account_session::PendingLogin::Activating { account }) => {
-            let grant_bytes = complete_staged_account(profile, operator, &store, &account).await?;
-            hydrate_activated_account(
-                profile,
-                operator,
-                &store,
-                &account,
-                &grant_bytes,
-                String::new(),
-            )
-            .await
+            complete_staged_account(profile, operator, &store, &account).await?;
+            hydrate_activated_account(profile, operator, &store, &account, String::new()).await
         }
         Some(crate::account_session::PendingLogin::Waiting { .. }) => {
             bail!(
@@ -994,7 +968,7 @@ async fn freshen_account(
         return;
     }
     match tokio::time::timeout(
-        HYDRATION_DEADLINE,
+        POST_LINK_SYNC_DEADLINE,
         crate::account_state::ensure_with_operator_and_store(
             profile,
             operator.clone(),
@@ -1283,6 +1257,141 @@ pub async fn revoke_in(
 mod tests {
     use super::*;
     use dialog_operator::DeriveOperator as _;
+
+    async fn account_state_fixture(
+        ready: bool,
+    ) -> (
+        tempfile::TempDir,
+        Profile,
+        dialog_operator::Operator<NativeSpace>,
+        crate::space::SpaceStore,
+    ) {
+        use dialog_capability::Subject;
+        use dialog_effects::storage::Directory;
+        use dialog_storage::provider::storage::Storage;
+        use dialog_varsig::Principal as _;
+
+        let temp = tempfile::tempdir().unwrap();
+        let store = crate::space::SpaceStore::at(temp.path().join("state"));
+        let profile_dir = Directory::At(temp.path().join("profiles").to_string_lossy().into());
+        let profile_name = format!("cli-account-timeout-test-{}", rand::random::<u64>());
+        let storage = Storage::<NativeSpace>::default();
+        let profile = Profile::open(&profile_name)
+            .at(profile_dir)
+            .perform(&storage)
+            .await
+            .unwrap();
+        std::fs::create_dir_all(store.account_dir()).unwrap();
+        let account_dir = store.account_dir().canonicalize().unwrap();
+        let operator = profile
+            .derive(b"tonk/account-state/v1")
+            .allow(Subject::any())
+            .base(Directory::At(account_dir.to_string_lossy().into()))
+            .build(storage)
+            .await
+            .unwrap();
+        let root = dialog_credentials::Ed25519Signer::generate().await.unwrap();
+        let root_did = root.did();
+        let link = tonk_identity::delegation::mint_device_delegation(root.clone(), &profile.did())
+            .await
+            .unwrap();
+        let delegation_cid = link.proof_cids()[0].to_string();
+        let delegation_hex = hex::encode(link.to_bytes().unwrap());
+        let descriptor = tonk_account::AccountRepositoryDescriptorV1::sign(
+            &root,
+            "https://content.example/ucan/",
+        )
+        .await
+        .unwrap();
+        let provider = AccountProviderRecord::attach(
+            "https://accounts.example",
+            descriptor.bytes(),
+            &root_did,
+            1,
+        )
+        .await
+        .unwrap();
+        let account = crate::account_session::ActiveAccount {
+            provider: provider.provider().to_owned(),
+            credential_id: "credential".to_owned(),
+            root_did: root_did.to_string(),
+            delegation_cid,
+            delegation_hex,
+            descriptor_hex: Some(hex::encode(descriptor.bytes())),
+            attachment_id: "attachment".to_owned(),
+            attached_at: 1,
+        };
+        let guard =
+            crate::account_session::stage_activation(&profile, &operator, &store, account.clone())
+                .await
+                .unwrap();
+        crate::identity::save_local_root_with_operator(
+            &profile,
+            &operator,
+            "credential".to_string(),
+            account.delegation_hex.clone(),
+        )
+        .await
+        .unwrap();
+        profile
+            .access()
+            .save(dialog_ucan::UcanDelegation(link))
+            .perform(&operator)
+            .await
+            .unwrap();
+        profile
+            .credential()
+            .site(ACCOUNT_LINK_SITE)
+            .save(provider.encode().unwrap())
+            .perform(&operator)
+            .await
+            .unwrap();
+        crate::account_session::finalize_activation(&profile, &operator, guard, &account)
+            .await
+            .unwrap();
+        if ready {
+            profile
+                .credential()
+                .site(tonk_account::TRUSTED_BASE_CREDENTIAL_SITE)
+                .save(descriptor.content_hash().to_vec())
+                .perform(&operator)
+                .await
+                .unwrap();
+        }
+        (temp, profile, operator, store)
+    }
+
+    #[dialog_common::test]
+    async fn it_preserves_ready_when_post_link_sync_times_out() {
+        let (_temp, profile, operator, store) = account_state_fixture(true).await;
+
+        let outcome = ensure_after_link(&profile, operator, store, Duration::ZERO)
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.status, AccountStateStatus::Ready);
+        assert_eq!(
+            outcome.warning.as_deref(),
+            Some(
+                "latest account synchronization did not finish within 10 seconds; committed changes will retry"
+            )
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_keeps_unhydrated_when_first_sync_times_out() {
+        let (_temp, profile, operator, store) = account_state_fixture(false).await;
+
+        let outcome = ensure_after_link(&profile, operator, store, Duration::ZERO)
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.status, AccountStateStatus::Unhydrated);
+        assert_eq!(
+            outcome.warning.as_deref(),
+            Some("the account repository did not answer within 10 seconds; first sync will retry")
+        );
+    }
 
     #[test]
     fn it_formats_the_cli_device_name_with_os_version() {

--- a/rust/tonk-cli/src/account_state.rs
+++ b/rust/tonk-cli/src/account_state.rs
@@ -30,14 +30,14 @@ const ACCOUNT_OPERATOR_CONTEXT: &[u8] = b"tonk/account-state/v1";
 /// Remote name for the account's access branch in the profile repository.
 const ACCOUNT_ACCESS_REMOTE: &str = "account-access";
 
-/// Result of an ensure attempt. Remote failures are a durable Unhydrated
-/// status plus diagnostics, not a failure of the already-persisted account
-/// link.
+/// Result of an ensure attempt. Remote failures preserve the durable local
+/// lifecycle status and return diagnostics rather than changing account-link
+/// state.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnsureOutcome {
     /// Durable lifecycle status after the attempt.
     pub status: AccountStateStatus,
-    /// Remote/local diagnostic when readiness was not acquired.
+    /// Ordered remote/local diagnostics from the latest ensure attempt.
     pub warning: Option<String>,
 }
 
@@ -119,10 +119,19 @@ pub async fn status_in(
     store: &crate::space::SpaceStore,
 ) -> Result<AccountStateStatus> {
     let operator = credential_operator_for_store(profile, store).await?;
-    let Some(descriptor) = descriptor_in(profile, &operator, store).await? else {
+    status_with_operator_in(profile, &operator, store).await
+}
+
+/// Read durable account state through an already-mounted local operator.
+pub(crate) async fn status_with_operator_in(
+    profile: &Profile,
+    operator: &Operator<NativeSpace>,
+    store: &crate::space::SpaceStore,
+) -> Result<AccountStateStatus> {
+    let Some(descriptor) = descriptor_in(profile, operator, store).await? else {
         return Ok(AccountStateStatus::Unconfigured);
     };
-    if marker_matches(marker(profile, &operator).await?.as_deref(), &descriptor) {
+    if marker_matches(marker(profile, operator).await?.as_deref(), &descriptor) {
         Ok(AccountStateStatus::Ready)
     } else {
         Ok(AccountStateStatus::Unhydrated)
@@ -662,13 +671,9 @@ async fn mount(
 
 async fn hydrate(
     repository: &Repository<dialog_credentials::SignerCredential>,
+    branch: &dialog_repository::Branch,
     operator: &crate::account_authority::AccountBoundOperator,
 ) -> Result<()> {
-    let branch = repository
-        .branch(tonk_account::MAIN_BRANCH)
-        .open()
-        .perform(operator)
-        .await?;
     let remote = repository
         .remote(tonk_account::ORIGIN_REMOTE)
         .load()
@@ -690,7 +695,7 @@ async fn hydrate(
         Ok(RemotePresence::Absent) => {
             branch.transaction().commit().perform(operator).await?;
             if let CreateGenesis::Loser(_) =
-                publish_genesis_if_absent(&branch, &remote, operator).await?
+                publish_genesis_if_absent(branch, &remote, operator).await?
             {
                 // Adopt the winner by pulling: the pull integrates the
                 // established head AND records it as this branch's sync
@@ -704,6 +709,78 @@ async fn hydrate(
         Err(error) => return Err(error.into()),
     }
     Ok(())
+}
+
+/// Retain both directions of the durable account/profile authority union.
+///
+/// The browser grant is stable and can be retained on every ensure. The
+/// return edge is not: Dialog gives every newly minted delegation a random
+/// nonce, so prove the semantic capability before minting to keep retries
+/// idempotent.
+async fn converge_account_union(
+    profile: &Profile,
+    operator: &Operator<NativeSpace>,
+    descriptor: &AccountRepositoryDescriptorV1,
+    branch: &dialog_repository::Branch,
+) -> Result<bool> {
+    let local_root = crate::identity::local_root_with_operator(profile, operator)
+        .await?
+        .context("account link has no local root")?;
+    let root_did: dialog_varsig::Did = local_root
+        .root_did
+        .parse()
+        .context("stored account root DID is invalid")?;
+    if &root_did != descriptor.account_subject() {
+        bail!(
+            "stored account root {} does not match repository {}",
+            root_did,
+            descriptor.account_subject()
+        );
+    }
+    let grant_bytes = hex::decode(&local_root.delegation_hex)
+        .context("stored account-to-profile grant is not hex")?;
+    let inbound = crate::account::validate_account_grant(profile, &grant_bytes)
+        .await
+        .context("stored account-to-profile grant is invalid")?;
+    if inbound.issuer() != descriptor.account_subject()
+        || inbound.proof_cids()[0].to_string() != local_root.delegation_cid
+    {
+        bail!("stored account-to-profile grant does not match the local root");
+    }
+
+    trace("ensure: retaining account-to-profile edge");
+    let mut changed =
+        tonk_account::delegations::retain_space_delegation(branch, &inbound, operator)
+            .await
+            .context("failed to retain account-to-profile grant")?;
+    trace("ensure: retained account-to-profile edge");
+
+    let return_scope = dialog_ucan::Scope {
+        subject: dialog_ucan_core::subject::Subject::Specific(profile.did()),
+        command: dialog_ucan_core::command::Command::parse("/")
+            .expect("the root command always parses"),
+        parameters: dialog_ucan::Parameters::default(),
+    };
+    if branch
+        .delegations()
+        .prove(root_did.clone(), return_scope)
+        .perform(operator)
+        .await
+        .is_err()
+    {
+        let signer = profile.signer().signer().clone();
+        let returning = tonk_account::delegations::mint_account_union(&signer, &root_did)
+            .await
+            .context("failed to mint profile-to-account return edge")?;
+        trace("ensure: retaining profile-to-account edge");
+        changed |= tonk_account::delegations::retain_space_delegation(branch, &returning, operator)
+            .await
+            .context("failed to retain profile-to-account return edge")?;
+        trace("ensure: retained profile-to-account edge");
+    } else {
+        trace("ensure: profile-to-account edge already proves");
+    }
+    Ok(changed)
 }
 
 /// Ensure the native account repository after linking or on demand.
@@ -764,71 +841,79 @@ pub async fn ensure_with_operator_and_store(
     let operator =
         crate::account_authority::wrap(operator, profile.clone(), store.clone(), true).await?;
     trace("ensure: operator wrapped");
-
-    if marker_matches(
+    let branch = repository
+        .branch(tonk_account::MAIN_BRANCH)
+        .open()
+        .perform(&operator)
+        .await
+        .context("failed to open account main branch")?;
+    let already_ready = marker_matches(
         marker(profile, operator.local()).await?.as_deref(),
         &descriptor,
-    ) {
-        trace("ensure: marker matches, syncing");
+    );
+    let mut warnings = Vec::new();
+    let (status, may_push) = if already_ready {
+        trace("ensure: marker matches, pulling");
         // Ready remains ready offline. A best-effort normal sync catches up
         // without clearing the durable trust marker on failure.
-        let branch = repository
-            .branch(tonk_account::MAIN_BRANCH)
-            .open()
-            .perform(&operator)
-            .await?;
-        trace("ensure: branch open, pulling");
-        let warning = match branch.pull().download().perform(&operator).await {
+        let may_push = match branch.pull().download().perform(&operator).await {
             Ok(_) => {
-                trace("ensure: pulled, pushing");
-                branch
-                    .push()
-                    .perform(&operator)
-                    .await
-                    .err()
-                    .map(|error| error.to_string())
+                trace("ensure: pulled");
+                true
             }
-            Err(error) => Some(error.to_string()),
+            Err(error) => {
+                warnings.push(format!("account pull failed: {error}"));
+                false
+            }
         };
-        trace(&format!("ensure: sync done ({warning:?}), adopting"));
-        // Adopting the account as the access branch's upstream is what makes
-        // recovered authority usable: the operator proves from the access
-        // branch, not the account's. Best-effort, like the sync above — a
-        // device that cannot reach the account is still ready with whatever
-        // it already holds.
-        let warning = match adopt_account_access_in(profile, operator.local(), &store).await {
-            Ok(_) => warning,
-            Err(error) => warning.or_else(|| Some(error.to_string())),
-        };
-        trace("ensure: adopted");
-        return Ok(EnsureOutcome {
-            status: AccountStateStatus::Ready,
-            warning,
-        });
+        (AccountStateStatus::Ready, may_push)
+    } else {
+        trace("ensure: first hydration starting");
+        match hydrate(&repository, &branch, &operator).await {
+            Ok(()) => {
+                trace("ensure: first hydration finished");
+                save_marker(profile, operator.local(), &descriptor).await?;
+                trace("ensure: trusted-base marker saved");
+                (AccountStateStatus::Ready, true)
+            }
+            Err(error) => {
+                warnings.push(format!("account hydration failed: {error}"));
+                trace("ensure: first hydration failed");
+                (AccountStateStatus::Unhydrated, false)
+            }
+        }
+    };
+
+    // Adopting the account as the access branch's upstream is what makes
+    // recovered authority usable: the operator proves from the access
+    // branch, not the account's. It remains best-effort so durable Ready
+    // state survives an offline retry.
+    trace("ensure: account-access adoption starting");
+    if let Err(error) = adopt_account_access_in(profile, operator.local(), &store).await {
+        warnings.push(format!("account access adoption failed: {error}"));
+    }
+    trace("ensure: account-access adoption finished");
+
+    if let Err(error) =
+        converge_account_union(profile, operator.local(), &descriptor, &branch).await
+    {
+        warnings.push(format!("account authority convergence failed: {error:#}"));
     }
 
-    match hydrate(&repository, &operator).await {
-        Ok(()) => {
-            save_marker(profile, operator.local(), &descriptor).await?;
-            // A device reaching Ready for the FIRST time needs the access
-            // upstream just as much as one that was already ready — more so,
-            // since this is the path a fresh link takes. Adopting only in the
-            // marker-matched branch above left exactly that device unable to
-            // use the authority it had just been granted.
-            let warning = adopt_account_access_in(profile, operator.local(), &store)
-                .await
-                .err()
-                .map(|error| error.to_string());
-            Ok(EnsureOutcome {
-                status: AccountStateStatus::Ready,
-                warning,
-            })
+    if may_push {
+        trace("ensure: final push starting");
+        if let Err(error) = branch.push().perform(&operator).await {
+            warnings.push(format!("account push failed: {error}"));
         }
-        Err(error) => Ok(EnsureOutcome {
-            status: AccountStateStatus::Unhydrated,
-            warning: Some(error.to_string()),
-        }),
+        trace("ensure: final push finished");
+    } else {
+        trace("ensure: final push skipped after remote failure");
     }
+
+    Ok(EnsureOutcome {
+        status,
+        warning: (!warnings.is_empty()).then(|| warnings.join("; ")),
+    })
 }
 
 #[cfg(test)]

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -1492,6 +1492,18 @@ fn account_state_label(status: tonk_account::AccountStateStatus) -> &'static str
     }
 }
 
+fn account_login_warning(status: tonk_account::AccountStateStatus, warning: &str) -> String {
+    match status {
+        tonk_account::AccountStateStatus::Ready => {
+            format!("warning: latest account synchronization is incomplete: {warning}")
+        }
+        tonk_account::AccountStateStatus::Unconfigured
+        | tonk_account::AccountStateStatus::Unhydrated => {
+            format!("warning: account repository is not synchronized: {warning}")
+        }
+    }
+}
+
 /// Best-effort registration line, quiet about being offline: status
 /// must answer without the network. Registration itself is web-only —
 /// the browser enrolls during its passkey ceremonies, which is where
@@ -1687,7 +1699,7 @@ async fn link_account(
                 account_state_label(outcome.account_state)
             );
             if let Some(warning) = outcome.warning {
-                eprintln!("warning: account repository is not synchronized: {warning}");
+                eprintln!("{}", account_login_warning(outcome.account_state, &warning));
             }
             // The device is signed in either way. Say what is missing and
             // what restores it, rather than reporting a failure for a link
@@ -3969,6 +3981,35 @@ async fn open_selected(
 #[cfg(test)]
 mod account_spaces_parser_tests {
     use super::*;
+
+    #[test]
+    fn account_login_warning_for_ready_names_the_latest_sync() {
+        let warning = account_login_warning(
+            tonk_account::AccountStateStatus::Ready,
+            "latest account synchronization did not finish within 10 seconds",
+        );
+
+        assert_eq!(
+            warning,
+            "warning: latest account synchronization is incomplete: latest account synchronization did not finish within 10 seconds"
+        );
+        assert!(!warning.contains("repository is not synchronized"));
+        assert_eq!(
+            account_state_label(tonk_account::AccountStateStatus::Ready),
+            "synced"
+        );
+    }
+
+    #[test]
+    fn account_login_warning_for_unhydrated_names_the_repository() {
+        assert_eq!(
+            account_login_warning(
+                tonk_account::AccountStateStatus::Unhydrated,
+                "the account repository did not answer within 10 seconds",
+            ),
+            "warning: account repository is not synchronized: the account repository did not answer within 10 seconds"
+        );
+    }
 
     #[test]
     fn unavailable_account_context_does_not_invent_a_device_identifier() {

--- a/rust/tonk-cli/tests/account_authority.rs
+++ b/rust/tonk-cli/tests/account_authority.rs
@@ -139,6 +139,77 @@ async fn it_retains_a_created_space_into_the_account_space(
     Ok(())
 }
 
+/// Every account ensure repairs both halves of the account/profile union.
+///
+/// Login can be cancelled after its durable handoff but before these edges
+/// are retained. Keeping convergence in ensure means `account status` and
+/// `account sync` repair that interrupted work without minting another
+/// semantically identical return edge on every retry.
+#[dialog_common::test]
+async fn it_converges_the_linked_account_union_during_every_ensure(
+    env: AccessServiceAddress,
+) -> Result<()> {
+    let remote = format!("{}/", env.access_service_url.trim_end_matches('/'));
+    let fixture = common::AccountFixture::with_account_remote(&remote).await?;
+    fixture.activate_with(&env).await?;
+    let operator = fixture.operator().await?;
+    let account = fixture.account_branch().await?;
+    let root = fixture.link.issuer().clone();
+    let return_scope = dialog_ucan::Scope {
+        subject: dialog_ucan_core::subject::Subject::Specific(fixture.profile.did()),
+        command: dialog_ucan_core::command::Command::parse("/")?,
+        parameters: dialog_ucan::Parameters::default(),
+    };
+
+    assert!(
+        account
+            .delegations()
+            .prove(root.clone(), return_scope.clone())
+            .perform(&operator)
+            .await
+            .is_err(),
+        "the fixture must begin without the profile return edge"
+    );
+
+    let outcome = tonk_cli::account_state::ensure_with_operator_and_store(
+        &fixture.profile,
+        operator.clone(),
+        fixture.store.clone(),
+    )
+    .await?;
+    assert_eq!(outcome.status, tonk_account::AccountStateStatus::Ready);
+    let account = fixture.account_branch().await?;
+    assert!(
+        !tonk_account::delegations::retain_space_delegation(&account, &fixture.link, &operator)
+            .await?,
+        "ensure must already have retained the exact account-to-profile grant"
+    );
+    assert!(
+        account
+            .delegations()
+            .prove(root, return_scope)
+            .perform(&operator)
+            .await
+            .is_ok(),
+        "ensure must retain a profile-to-account return edge"
+    );
+
+    let revision = account.revision();
+    tonk_cli::account_state::ensure_with_operator_and_store(
+        &fixture.profile,
+        operator,
+        fixture.store.clone(),
+    )
+    .await?;
+    let account = fixture.account_branch().await?;
+    assert_eq!(
+        account.revision(),
+        revision,
+        "a repeated ensure must not mint a duplicate return edge"
+    );
+    Ok(())
+}
+
 /// `account link --via` installs the authority a browser hands back.
 ///
 /// The ceremony itself needs a browser, but the CONTRACT does not: the page

--- a/rust/tonk-worker/src/router/transact.rs
+++ b/rust/tonk-worker/src/router/transact.rs
@@ -391,6 +391,7 @@ mod profile_write_boundary {
                 branch: "main".to_owned(),
             }),
             Some(Extension(client_id)),
+            None,
             HeaderMap::new(),
             body_bytes,
         )

--- a/rust/tonk-worker/src/router/transact.rs
+++ b/rust/tonk-worker/src/router/transact.rs
@@ -67,6 +67,7 @@ pub async fn transact(
     State(state): State<AppState>,
     Path(path): Path<TransactPath>,
     client: Option<Extension<super::ClientId>>,
+    lifetime: Option<Extension<crate::worker::FetchLifetime>>,
     _headers: HeaderMap,
     body: Bytes,
 ) -> Result<Json<TransactResponse>, TonkWorkerError> {
@@ -122,8 +123,8 @@ pub async fn transact(
     // subscription, which the command's scheduled poll broadcasts when it lands.
     // Awaiting the dispatch here serialized the iframe boot behind the command;
     // detaching it returns the commit (~40ms) immediately and lets the command
-    // finish in the background, like an `event.waitUntil`.
-    spawn_dispatch(state, origin, transients.unwrap_or_default()).await;
+    // finish in the background under the fetch event's `waitUntil` lifetime.
+    spawn_dispatch(state, origin, transients.unwrap_or_default(), lifetime).await;
     Ok(response)
 }
 
@@ -133,6 +134,7 @@ pub async fn transact_profile(
     State(state): State<AppState>,
     Path(path): Path<ProfileTransactPath>,
     client: Option<Extension<super::ClientId>>,
+    lifetime: Option<Extension<crate::worker::FetchLifetime>>,
     _headers: HeaderMap,
     body: Bytes,
 ) -> Result<Json<TransactResponse>, TonkWorkerError> {
@@ -166,7 +168,7 @@ pub async fn transact_profile(
     // Detached like the repository-scoped `transact` above: the commit returns
     // now, the command providers + poll drain run in the background and broadcast
     // their writes to subscribers when they land.
-    spawn_dispatch(state, origin, transients.unwrap_or_default()).await;
+    spawn_dispatch(state, origin, transients.unwrap_or_default(), lifetime).await;
     Ok(response)
 }
 
@@ -188,10 +190,6 @@ fn announce_local_commit(branch: &str, response: &TransactResponse) {
     }
 }
 
-/// Run [`super::dispatch`] as detached background work so it never blocks the
-/// transact response. On wasm the SW keeps the spawned task alive on its event
-/// loop and the returned future is immediately ready; native builds (tests) run
-/// the dispatch inline so commands complete deterministically before assertions.
 /// A millisecond wall-clock stamp for sync-queue activity priority. `Date.now()`
 /// in the SW event context; native (tests) has no clock dependency, so 0.
 fn now_millis() -> f64 {
@@ -205,17 +203,35 @@ fn now_millis() -> f64 {
     }
 }
 
+/// Run [`super::dispatch`] as background work so it never blocks the transact
+/// response. The service worker attaches the dispatch promise to the originating
+/// fetch event; native builds run it inline so tests remain deterministic.
 async fn spawn_dispatch(
     state: AppState,
     origin: super::CommandOrigin,
     transients: dialog_artifacts::Changes,
+    lifetime: Option<Extension<crate::worker::FetchLifetime>>,
 ) {
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-    wasm_bindgen_futures::spawn_local(async move {
-        super::dispatch(&state, origin, transients).await;
-    });
+    match lifetime {
+        Some(Extension(lifetime)) => {
+            let promise = wasm_bindgen_futures::future_to_promise(async move {
+                super::dispatch(&state, origin, transients).await;
+                Ok(wasm_bindgen::JsValue::UNDEFINED)
+            });
+            if let Err(error) = lifetime.extend(&promise) {
+                log!("transact: failed to extend fetch lifetime for command dispatch: {error:?}");
+            }
+        }
+        None => wasm_bindgen_futures::spawn_local(async move {
+            super::dispatch(&state, origin, transients).await;
+        }),
+    }
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-    super::dispatch(&state, origin, transients).await;
+    {
+        let _ = lifetime;
+        super::dispatch(&state, origin, transients).await;
+    }
 }
 
 async fn transact_on_branch<'a>(

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -18,6 +18,7 @@ use axum::{
 use dialog_operator::{Operator, Profile};
 use dialog_storage::provider::storage::Storage;
 use js_sys::Promise;
+use send_wrapper::SendWrapper;
 use tokio::sync::Mutex;
 use tonk_common::log;
 use tower_service::Service;
@@ -26,6 +27,32 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_futures::future_to_promise;
 use web_sys::{FetchEvent, Request, Response};
+
+/// The fetch event whose lifetime owns background work started by one of its
+/// routed handlers.
+///
+/// Axum request extensions require `Send + Sync`, while browser event handles
+/// are confined to the service-worker thread. `SendWrapper` makes that
+/// confinement explicit and lets a handler add its completion promise to the
+/// originating event before the response promise settles.
+#[derive(Clone)]
+pub(crate) struct FetchLifetime(SendWrapper<FetchEvent>);
+
+impl FetchLifetime {
+    fn new(event: FetchEvent) -> Self {
+        Self(SendWrapper::new(event))
+    }
+
+    /// Keep the originating service-worker event alive until `promise`
+    /// settles.
+    pub(crate) fn extend(&self, promise: &Promise) -> Result<(), JsValue> {
+        use wasm_bindgen::JsCast as _;
+
+        let event: &FetchEvent = &self.0;
+        let extendable: &web_sys::ExtendableEvent = event.unchecked_ref();
+        extendable.wait_until(promise)
+    }
+}
 
 // Global `self.fetch(...)` in the service-worker scope. Fetches
 // issued from an SW bypass the SW's own `onfetch` listener (per
@@ -154,6 +181,7 @@ async fn handle_via_router(
     router: Arc<Mutex<Router>>,
     browser_request: Request,
     client_id: String,
+    lifetime: FetchLifetime,
     rewritten_path: Option<String>,
 ) -> Result<JsValue, JsValue> {
     let mut request: axum::http::Request<Body> = RequestConversion::from(browser_request)
@@ -175,6 +203,7 @@ async fn handle_via_router(
     if !client_id.is_empty() {
         request.extensions_mut().insert(ClientId(client_id.clone()));
     }
+    request.extensions_mut().insert(lifetime);
 
     let method = request.method().clone();
     let path = request.uri().path().to_owned();
@@ -1993,7 +2022,9 @@ impl TonkServiceWorker {
             .starts_with("/api/")
             .then(|| self.sync_scheduler.enter_loading(js_sys::Date::now()));
 
-        future_to_promise(async move {
+        let lifetime = FetchLifetime::new(event);
+        let routed_lifetime = lifetime.clone();
+        let response = future_to_promise(async move {
             #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
             let _loading_guard = loading_guard;
             // Opportunistic cleanup of stale bridge sessions and view
@@ -2003,12 +2034,25 @@ impl TonkServiceWorker {
 
             match route_for(&path, &effective_client_id, &state).await {
                 Route::Handle { rewritten_path } => {
-                    handle_via_router(router, request, effective_client_id, rewritten_path).await
+                    handle_via_router(
+                        router,
+                        request,
+                        effective_client_id,
+                        routed_lifetime,
+                        rewritten_path,
+                    )
+                    .await
                 }
                 Route::Passthrough => passthrough(request, is_navigation).await,
                 Route::Reject => reject_404(),
             }
-        })
+        });
+        // Register the response synchronously so handlers may add further
+        // lifetime promises while routing is in progress. `respondWith` keeps
+        // the response itself alive, but only `waitUntil` permits the detached
+        // command dispatch registered by `/transact` to outlive that response.
+        let _ = lifetime.extend(&response);
+        response
     }
 
     /// Handles `message` events from view clients. Routes the


### PR DESCRIPTION
## Summary

- converge account and profile authority through every account ensure
- preserve durable lifecycle state when post-login sync reaches the ten-second timeout
- render lifecycle-aware warnings for ready accounts versus accounts awaiting their first sync
- keep transient service-worker command dispatch alive through the originating fetch event

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p tonk-cli`
- `cargo test -p tonk-cli --features integration-tests --test account_authority -- --test-threads=1`
- `cargo clippy -p tonk-cli --all-targets --features integration-tests -- -D warnings`
- `cargo test -p tonk-worker --lib -- --test-threads=1`
- `cargo clippy -p tonk-worker --all-targets -- -D warnings`
- `nix develop . -c cargo check -p tonk-worker --target wasm32-unknown-unknown`
- focused custody-consent browser E2E (1 passed)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances account synchronization handling in the `tonk` application, introducing warnings for incomplete synchronizations and improving the management of account states. It also refines the testing framework for these functionalities.

### Detailed summary
- Added `account_login_warning` function to format warnings based on account state.
- Updated `link_account` to use the new warning function.
- Introduced tests for `account_login_warning` for different account states.
- Enhanced `ensure` function to handle account union convergence and warnings.
- Modified `spawn_dispatch` to utilize `FetchLifetime` for better promise management.
- Updated `hydrate_activated_account` to use `ensure_after_link` for synchronization handling.
- Renamed `HYDRATION_DEADLINE` to `POST_LINK_SYNC_DEADLINE` for clarity.
- Added tests for timeout scenarios in account state handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->