### PR TITLE
feat(cli): make space sync device-first

### DIFF
--- a/rust/tonk-cli/README.md
+++ b/rust/tonk-cli/README.md
@@ -183,16 +183,19 @@ The CLI holds at most one account at a time. `tonk account login` (also spelled
 someone else is `tonk account logout` followed by `tonk account login`. Linking
 an account never enrolls the spaces already on this device.
 
-Creating a space while signed out stays offline. Creating while signed in
-provisions and publishes only that new space. `tonk space link <space>` moves
-one local-only space into your account: it keeps its name, site, and binding,
-and gains hosting, retained authority, and a row in the account directory your
-other devices pull from. Nothing is deleted along the way, so an interrupted
-link leaves a working local space and can simply be re-run.
+Every `tonk space new` is device-first and local, whether signed out or signed
+in. Creation keeps the space signer on this device and does not contact an
+account, create custody, provision hosting, or publish a directory row.
+`tonk space link <space>` is the only ownership and hosting boundary: it keeps
+the subject, name, site, bytes, and binding; moves encrypted key custody to the
+account; establishes direct `space → account` authority; provisions and pushes
+the remote; revokes the old device grant; demotes the stored signer; and finally
+publishes the account-directory row. An interrupted link leaves local data
+editable and can be re-run to converge.
 
-The signed-in account parameterizes account-service operations and nothing
-else: creating a hosted space, linking, pulling the directory, listing and
-revoking devices, deletion. Editing is unrestricted — every replica this
+The signed-in account parameterizes account-service and remote operations and
+nothing else: linking, pulling the directory, listing and revoking devices,
+and deletion. Editing is unrestricted — every replica this
 device holds opens, reads, and writes whether you are signed out, signed in,
 or signed into an account other than the space's owner. Spaces that belong to
 another account stay on disk and stay listed across a switch; the `OWNER`
@@ -208,15 +211,22 @@ device may have been revoked. The reason is the part that came from the
 boundary that actually said no; the fix is this CLI's inference from local
 state, and it can be wrong.
 
-`tonk account space` reads the signed remote directory of the account you are
-signed in to. `tonk account space pull <name-or-subject>` mounts one of those
-spaces here as an owner or member replica; a name works when it identifies one
-directory row, while the subject DID disambiguates duplicate names.
+`tonk account space` refreshes and reads only the signed account inventory; it
+does not create a local replica or pull user-space content. `tonk account space
+pull <name-or-subject>` is the explicit materialization boundary: it mounts and
+pulls one verified owner/member replica, then registers it locally. A name
+works when it identifies one directory row, while the subject DID
+disambiguates duplicate names.
 
 `tonk space rm` removes only the local replica (and, unless `--keep-data` is
 used, its local bytes). It does not remove signed account directory facts,
 revoke memberships or invitations, deprovision hosting, delete remote objects,
 or erase a peer's replica.
+
+Deleting a hosted space or the account from the browser removes Tonk hosting
+and the shared account-directory projection. Existing copies on this and other
+devices stay local and editable; later remote sync receives the service's
+deleted/deprovisioned refusal.
 
 Interrupting `tonk account login` leaves the handoff recorded so the next run
 resumes it. A link token is one-time, so a service that refuses to reissue it

--- a/rust/tonk-cli/src/account.rs
+++ b/rust/tonk-cli/src/account.rs
@@ -124,18 +124,6 @@ pub enum AccountStatus {
     },
 }
 
-/// Local sign-in phase, readable without opening a Dialog profile.
-pub use crate::account_session::LocalPhase as SignInPhase;
-
-/// Inspect one store's sign-in phase without creating profile state.
-///
-/// Cheap enough for read-only commands: it reads the session sidecar and
-/// nothing else, so bare `tonk space` can say whether an account is signed in
-/// without provisioning an identity for an installation that has none.
-pub fn sign_in_phase(store: &crate::space::SpaceStore) -> Result<SignInPhase> {
-    crate::account_session::inspect_local(store)
-}
-
 /// Inputs controlling a browser handoff.
 #[derive(Debug, Clone)]
 pub struct LinkOptions {
@@ -291,7 +279,7 @@ async fn logout_with_operator_in(
     {
         if let Err(error) = crate::account_session::deliver_detach(profile, &account, now).await {
             eprintln!(
-                "warning: logged out locally; the provider was not notified                  and may list this device until it is revoked: {error:#}"
+                "warning: logged out locally; the provider was not notified and may list this device until it is revoked: {error:#}"
             );
         }
     }
@@ -930,7 +918,7 @@ async fn account_branch(
 /// syncs through. Every endpoint must accept it: a partial publication
 /// is the dangerous outcome, so a refusal anywhere is reported rather
 /// than swallowed.
-async fn publish_revocation(
+pub(crate) async fn publish_revocation(
     profile: &Profile,
     branch: &dialog_repository::Branch,
     operator: &dialog_operator::Operator<NativeSpace>,

--- a/rust/tonk-cli/src/account_authority.rs
+++ b/rust/tonk-cli/src/account_authority.rs
@@ -1,6 +1,6 @@
 //! Account-bound authorization and remote-dispatch boundary.
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use dialog_capability::access::{Access, Authorize, AuthorizeError, Prove, Retain, TimeRange};
 use dialog_capability::{
     Capability, Command, Effect, Fork, ForkInvocation, Policy as _, Provider, Site, SiteFork,
@@ -281,12 +281,7 @@ impl Provider<Authorize<Ucan>> for AccountBoundOperator {
         &self,
         input: Capability<Authorize<Ucan>>,
     ) -> Result<UcanAuthorization, AuthorizeError> {
-        let guard = crate::account_session::shared_remote_guard(&self.store).map_err(|error| {
-            AuthorizeError::Unavailable {
-                detail: error.to_string(),
-            }
-        })?;
-        self.authorize_guarded(input, &guard).await
+        input.perform(&self.inner).await
     }
 }
 
@@ -358,7 +353,7 @@ where
     Network: Provider<ForkInvocation<At, Fx>> + ConditionalSync,
 {
     async fn execute(&self, input: Fork<At, Fx>) -> Fx::Output {
-        let guard = match crate::account_session::shared_remote_guard(&self.store) {
+        let mut guard = match crate::account_session::shared_remote_guard(&self.store) {
             Ok(guard) => guard,
             Err(error) => {
                 return FromAuthError::from_auth_error(AuthorizeError::Unavailable {
@@ -366,6 +361,54 @@ where
                 });
             }
         };
+        if self.require_account {
+            let initialized = match crate::account_session::load_optional_guarded(
+                &self.profile,
+                &self.inner,
+                &guard,
+            )
+            .await
+            {
+                Ok(state) => state.is_some(),
+                Err(error) => {
+                    return FromAuthError::from_auth_error(AuthorizeError::Unavailable {
+                        detail: error.to_string(),
+                    });
+                }
+            };
+            if !initialized {
+                drop(guard);
+                let exclusive =
+                    match crate::account_session::exclusive_transition_guard(&self.store) {
+                        Ok(guard) => guard,
+                        Err(error) => {
+                            return FromAuthError::from_auth_error(AuthorizeError::Unavailable {
+                                detail: error.to_string(),
+                            });
+                        }
+                    };
+                if let Err(error) = crate::account_session::ensure_initialized(
+                    &self.profile,
+                    &self.inner,
+                    &exclusive,
+                )
+                .await
+                {
+                    return FromAuthError::from_auth_error(AuthorizeError::Unavailable {
+                        detail: error.to_string(),
+                    });
+                }
+                drop(exclusive);
+                guard = match crate::account_session::shared_remote_guard(&self.store) {
+                    Ok(guard) => guard,
+                    Err(error) => {
+                        return FromAuthError::from_auth_error(AuthorizeError::Unavailable {
+                            detail: error.to_string(),
+                        });
+                    }
+                };
+            }
+        }
         let env = Guarded {
             operator: self,
             guard: &guard,
@@ -377,20 +420,14 @@ where
     }
 }
 
-/// Initialize canonical session state before exposing an account-bound
-/// operator.
+/// Wrap a local operator. Account-session state is initialized lazily at the
+/// remote fork boundary.
 pub async fn wrap(
     inner: Operator<NativeSpace>,
     profile: Profile,
     store: SpaceStore,
     require_account: bool,
 ) -> Result<AccountBoundOperator> {
-    if require_account {
-        let guard = crate::account_session::exclusive_transition_guard(&store)?;
-        crate::account_session::ensure_initialized(&profile, &inner, &guard)
-            .await
-            .context("failed to initialize account-session state")?;
-    }
     Ok(AccountBoundOperator::new(
         inner,
         profile,

--- a/rust/tonk-cli/src/account_session.rs
+++ b/rust/tonk-cli/src/account_session.rs
@@ -40,58 +40,6 @@ impl Default for AccountSessionState {
     }
 }
 
-/// Provider sign-in phase visible without opening a Dialog profile.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum LocalPhase {
-    /// No canonical session state exists or it is inactive.
-    SignedOut,
-    /// A browser handoff is durable but not active yet.
-    Pending,
-    /// One provider attachment is active.
-    Active,
-}
-
-/// Inspect a profile store without creating locks, directories, or profiles.
-pub fn inspect_local(store: &SpaceStore) -> Result<LocalPhase> {
-    let account = store.account_dir();
-    let entries = match std::fs::read_dir(&account) {
-        Ok(entries) => entries,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return Ok(LocalPhase::SignedOut);
-        }
-        Err(error) => {
-            return Err(error).with_context(|| {
-                format!("failed to inspect account state at {}", account.display())
-            });
-        }
-    };
-    for entry in entries {
-        let entry = entry?;
-        let name = entry.file_name();
-        let name = name.to_string_lossy();
-        if !name.starts_with(STATE_FILE_PREFIX) || !name.ends_with(".json") {
-            continue;
-        }
-        let bytes = std::fs::read(entry.path())?;
-        let state: AccountSessionState =
-            serde_json::from_slice(&bytes).context("stored account-session state is malformed")?;
-        if state.version != VERSION {
-            anyhow::bail!(
-                "unsupported account-session state version {}",
-                state.version
-            );
-        }
-        return Ok(if state.active.is_some() {
-            LocalPhase::Active
-        } else if state.pending_login.is_some() {
-            LocalPhase::Pending
-        } else {
-            LocalPhase::SignedOut
-        });
-    }
-    Ok(LocalPhase::SignedOut)
-}
-
 /// Durable browser handoff phase.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -184,7 +132,7 @@ pub fn exclusive_transition_guard(store: &SpaceStore) -> Result<AccountSessionWr
     })
 }
 
-fn state_path(profile: &Profile, store: &SpaceStore) -> Result<PathBuf> {
+pub(crate) fn state_path(profile: &Profile, store: &SpaceStore) -> Result<PathBuf> {
     let profile_key = blake3::hash(profile.did().as_ref().as_bytes()).to_hex();
     Ok(store
         .account_dir()
@@ -357,6 +305,16 @@ pub async fn load_guarded(
     load_raw(profile, operator, &guard.store)
         .await?
         .context("account-session state has not been initialized")
+}
+
+/// Read canonical state under a shared lock without requiring that the
+/// exact-profile sidecar has already been initialized.
+pub(crate) async fn load_optional_guarded(
+    profile: &Profile,
+    operator: &Operator<NativeSpace>,
+    guard: &AccountSessionReadGuard,
+) -> Result<Option<AccountSessionState>> {
+    load_raw(profile, operator, &guard.store).await
 }
 
 /// Read the sole active attachment under an existing shared guard.

--- a/rust/tonk-cli/src/account_spaces.rs
+++ b/rust/tonk-cli/src/account_spaces.rs
@@ -62,6 +62,9 @@ pub enum RecordOutcome {
     /// The site has no `main` upstream yet — a local-only space is
     /// deliberately not listed as mountable anywhere else.
     NoUpstream,
+    /// The active account has no provable owner/member relationship to this
+    /// space, so ordinary remote use does not enroll it.
+    NotLinked,
     /// The directory already holds exactly this configuration.
     Unchanged,
     /// The directory was updated (and the change pushed best-effort).
@@ -513,6 +516,35 @@ async fn record_site_for_profile(
     let name = repository_name(site)
         .await
         .unwrap_or_else(|| registry_name.to_string());
+
+    let Some(connection) = crate::account::optional_connection_in(account_profile, store).await?
+    else {
+        return Ok(RecordOutcome::NoAccount);
+    };
+    let roster = crate::inventory::read_roster(site).await?;
+    let linked_role = roster
+        .row_for(connection.root_did.as_ref())
+        .and_then(|row| row.role.as_deref())
+        .is_some_and(|role| {
+            matches!(
+                role,
+                tonk_schema::MemberRole::FOUNDER
+                    | tonk_schema::MemberRole::ADMIN
+                    | tonk_schema::MemberRole::MEMBER
+            )
+        });
+    if !linked_role
+        || crate::site::load_account_root_prefix_for(
+            &site.profile,
+            site.operator.local(),
+            &subject,
+            &connection.root_did,
+        )
+        .await
+        .is_err()
+    {
+        return Ok(RecordOutcome::NotLinked);
+    }
 
     let operator =
         crate::account_state::credential_operator_for_store(account_profile, store).await?;

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -680,10 +680,9 @@ enum RemoteCommand {
 enum SpaceCommand {
     /// Create (or adopt) a space, register it, and use it here
     ///
-    /// Signed out, the space is local-only until `tonk space link`
-    /// hands it to an account. Signed in, it belongs to that account
-    /// from the start: hosted, synced, and listed for your other
-    /// devices.
+    /// The space is local-only until `tonk space link` hands it to an
+    /// account. Creation has the same device-local result whether this
+    /// installation is signed in or signed out.
     ///
     /// The site lands in the canonical store
     /// (`~/Library/Application Support/tonk/spaces/<name>` on macOS)
@@ -1629,21 +1628,6 @@ async fn link_account(
     no_open: bool,
     via: Option<String>,
 ) -> ExitCode {
-    let signed_in = match store.account() {
-        Ok(account) => account,
-        Err(error) => return print_failure(error),
-    };
-    if let Some(account) = &signed_in
-        && matches!(
-            tonk_cli::account::sign_in_phase(store),
-            Ok(tonk_cli::account::SignInPhase::Active)
-        )
-    {
-        return print_error(format!(
-            "already signed in as {}\nrun `tonk account logout` first to sign in as another account",
-            account.root
-        ));
-    }
     let profile = match identity::open().await {
         Ok(profile) => profile,
         Err(error) => return print_failure(error),
@@ -1699,32 +1683,6 @@ async fn link_account(
                 eprintln!(
                     "spaces stay local-only until `tonk account logout` and `tonk account login` reach it"
                 );
-            }
-            // Custody moves with the sign-in, the way browser accreditation
-            // rotates: every local space this account may own gets its
-            // authority and sealed seed onto the account. Hosting does not
-            // move — `tonk space link` remains the boundary that provisions
-            // and attaches a remote.
-            match site::default_config() {
-                Ok(config) => {
-                    match tonk_cli::custody::accredit_local_spaces(store, &config).await {
-                        Ok(outcomes) => {
-                            for (name, outcome) in outcomes {
-                                match outcome {
-                                    tonk_cli::custody::Accreditation::Moved => {
-                                        println!("custody: '{name}' moved to the account");
-                                    }
-                                    tonk_cli::custody::Accreditation::Already => {}
-                                    tonk_cli::custody::Accreditation::Skipped(reason) => {
-                                        eprintln!("custody: '{name}' not moved: {reason}");
-                                    }
-                                }
-                            }
-                        }
-                        Err(error) => eprintln!("warning: space custody did not move: {error:#}"),
-                    }
-                }
-                Err(error) => eprintln!("warning: space custody did not move: {error:#}"),
             }
             print_customer_line(&profile, store).await;
             ExitCode::Success
@@ -2022,29 +1980,11 @@ async fn space_op(command: Option<SpaceCommand>, json: bool, flag: Option<&str>)
             unreachable!("taken above")
         }
         Some(SpaceCommand::New { name, site }) => {
-            // Signed in, a new space is the account's from birth: it is
-            // provisioned, pushed, and listed for the account's other
-            // devices. Signed out, it is local-only until `tonk space link`
-            // says otherwise.
-            let account = match account_for_new_space(&store) {
-                Ok(account) => account,
-                Err(exit) => return exit,
-            };
             let Some(cwd) = working_directory() else {
                 return print_error("could not read the current directory".to_owned());
             };
-            let mut create_config = config.clone();
-            create_config.require_account =
-                account.is_some() && std::env::var_os("TONK_UNSAFE_ALLOW_DEVICE_ROOT").is_none();
-            create_config.provision_account_spaces = account.is_some();
-            match tonk_cli::space::create(
-                &store,
-                &name,
-                site.as_deref(),
-                None,
-                create_config.clone(),
-            )
-            .await
+            match tonk_cli::space::create(&store, &name, site.as_deref(), None, config.clone())
+                .await
             {
                 Ok(outcome) => {
                     if let Err(error) = tonk_cli::space::bind(&store, &outcome.name, &cwd) {
@@ -2062,45 +2002,7 @@ async fn space_op(command: Option<SpaceCommand>, json: bool, flag: Option<&str>)
                     println!("DID: {}", outcome.did);
                     println!("binding: {}", cwd.display());
                     print_active_space_resolution(&store, flag, Some(&cwd));
-                    let Some(account) = account else {
-                        return ExitCode::Success;
-                    };
-                    let Some(access) = &account.access_remote else {
-                        unreachable!("checked before the space was created");
-                    };
-                    match site::TonkSite::open_with(&outcome.site, create_config).await {
-                        Ok(site) => {
-                            if let Err(error) = site::record_founder_membership(&site).await {
-                                return print_failure(error);
-                            }
-                            if let Err(error) = remote::add(
-                                &site,
-                                remote::DEFAULT_REMOTE,
-                                access,
-                                Some(site.repository.did()),
-                            )
-                            .await
-                            {
-                                return print_failure(error);
-                            }
-                            if let Err(error) =
-                                remote::set_upstream(&site, remote::DEFAULT_REMOTE).await
-                            {
-                                return print_failure(error);
-                            }
-                            if let Err(error) = sync::push(&site).await {
-                                return print_failure(error);
-                            }
-                            if let Err(error) =
-                                account_spaces::record_site_in(&outcome.name, &site, &store).await
-                            {
-                                return print_failure(error);
-                            }
-                            println!("account: {}", account.root);
-                            ExitCode::Success
-                        }
-                        Err(error) => print_failure(error),
-                    }
+                    ExitCode::Success
                 }
                 Err(err) => print_failure(err),
             }
@@ -2172,42 +2074,6 @@ async fn space_op(command: Option<SpaceCommand>, json: bool, flag: Option<&str>)
             }
         }
     }
-}
-
-/// The account a fresh `tonk space new` should belong to.
-///
-/// A recorded account that is not actually signed in is an error rather than
-/// a quiet fallback to local-only: creating a local space when the user
-/// expects an account-owned one is exactly the surprise `tonk space link`
-/// exists to undo.
-fn account_for_new_space(
-    store: &tonk_cli::space::SpaceStore,
-) -> Result<Option<tonk_cli::space::AccountRecord>, ExitCode> {
-    let account = match store.account() {
-        Ok(account) => account,
-        Err(error) => return Err(print_failure(error)),
-    };
-    let Some(account) = account else {
-        return Ok(None);
-    };
-    match tonk_cli::account::sign_in_phase(store) {
-        Ok(tonk_cli::account::SignInPhase::Active) => {}
-        Ok(_) => {
-            return Err(print_error(format!(
-                "this device is signed out of {}; run `tonk account login`",
-                account.root
-            )));
-        }
-        Err(error) => return Err(print_failure(error)),
-    }
-    // Checked before the space exists: creating one and only then finding
-    // out it cannot be hosted leaves a half-made thing to explain.
-    if account.access_remote.is_none() {
-        return Err(print_error(
-            "the account has no content endpoint; sign in again".to_owned(),
-        ));
-    }
-    Ok(Some(account))
 }
 
 fn print_active_space_resolution(

--- a/rust/tonk-cli/src/custody.rs
+++ b/rust/tonk-cli/src/custody.rs
@@ -51,10 +51,8 @@ pub async fn account_recipient(
 }
 
 /// Seal `seed` (deriving `subject`) to `recipient` and record the
-/// custody row. The row is what the account's other devices recover the
-/// space from, so it is pushed right away — but like the directory
-/// record, a failed push warns rather than fails: the row is committed
-/// locally and the next account push carries it.
+/// custody row. The explicit link sequence owns the mandatory account-branch
+/// push after this commit.
 pub async fn custody_space_seed(
     account: &Branch,
     subject: &Did,
@@ -80,16 +78,15 @@ pub async fn custody_space_seed(
         .perform(operator)
         .await
         .context("failed to record the custodied seed")?;
-    if let Err(error) = account.push().perform(operator).await {
-        eprintln!("warning: custodied seed recorded locally; push failed: {error:#}");
-    }
     Ok(())
 }
 
-/// Whether the account branch already holds a custody row for `subject`.
+/// Whether the account branch already holds a decodable custody row for
+/// `subject` under the account's current published recipient.
 pub async fn has_custody(
     account: &Branch,
     subject: &Did,
+    recipient: &Did,
     operator: &Operator<NativeSpace>,
 ) -> Result<bool> {
     let rows: Vec<CustodiedSeed> = account
@@ -105,7 +102,10 @@ pub async fn has_custody(
         .try_vec()
         .await
         .map_err(|error| anyhow::anyhow!("failed to read custodied seeds: {error:?}"))?;
-    Ok(!rows.is_empty())
+    Ok(rows.iter().any(|row| {
+        row.recipient.0.to_string() == recipient.to_string()
+            && tonk_identity::sealed::Sealed::decode(&row.sealed.0).is_ok()
+    }))
 }
 
 /// The signing seed a locally created space's stored credential carries.
@@ -128,111 +128,4 @@ pub async fn site_seed(site: &crate::site::TonkSite) -> Result<Option<Zeroizing<
         .try_into()
         .context("the exported space seed is not 32 bytes")?;
     Ok(Some(Zeroizing::new(seed)))
-}
-
-/// One space's outcome under [`accredit_local_spaces`].
-#[derive(Debug)]
-pub enum Accreditation {
-    /// Authority and custody now reach the account.
-    Moved,
-    /// Nothing to do: the account already holds this space's custody.
-    Already,
-    /// Skipped, with the reason: no signer (a joined space), or a
-    /// founder row naming a different account.
-    Skipped(String),
-}
-
-/// Move custody of every registered local space to the signed-in
-/// account — the CLI's accreditation, mirroring what the browser's
-/// rotation does at sign-in. Authority (`space → root`, retained into
-/// the account) and the sealed seed move; hosting does not: a space
-/// gains its remote and provisioning through `tonk space link`.
-///
-/// Best-effort per space: a failure is reported and the rest continue,
-/// and running again converges.
-pub async fn accredit_local_spaces(
-    store: &crate::space::SpaceStore,
-    config: &crate::site::SiteConfig,
-) -> Result<Vec<(String, Accreditation)>> {
-    let registry = store.load()?;
-    let Some(account) = registry.account.clone() else {
-        return Ok(Vec::new());
-    };
-    let account_root: Did = account
-        .root
-        .parse()
-        .context("the signed-in account root is invalid")?;
-
-    let mut outcomes = Vec::new();
-    for (name, entry) in &registry.spaces {
-        let mut site_config = config.clone();
-        site_config.require_account = false;
-        let site = match crate::site::TonkSite::open_with(&entry.site, site_config).await {
-            Ok(site) => site,
-            Err(error) => {
-                outcomes.push((
-                    name.clone(),
-                    Accreditation::Skipped(format!("could not open: {error:#}")),
-                ));
-                continue;
-            }
-        };
-        match accredit_site(&site, &account_root, store).await {
-            Ok(outcome) => outcomes.push((name.clone(), outcome)),
-            Err(error) => outcomes.push((
-                name.clone(),
-                Accreditation::Skipped(format!("failed: {error:#}")),
-            )),
-        }
-    }
-    Ok(outcomes)
-}
-
-async fn accredit_site(
-    site: &crate::site::TonkSite,
-    account_root: &Did,
-    store: &crate::space::SpaceStore,
-) -> Result<Accreditation> {
-    let subject = site.repository.did();
-    // Ownership is the space's own answer: a founder row naming another
-    // account is final — a synced space stays with its owner.
-    let roster = crate::inventory::read_roster(site).await?;
-    if let Some(founder) = roster.founder()
-        && founder.did != account_root.to_string()
-    {
-        return Ok(Accreditation::Skipped(format!("owned by {}", founder.did)));
-    }
-    let Some(seed) = site_seed(site).await? else {
-        return Ok(Accreditation::Skipped(
-            "no local signer (a joined space)".to_string(),
-        ));
-    };
-
-    let operator =
-        crate::account_state::credential_operator_for_store(&site.profile, store).await?;
-    let account = crate::account_state::open_account_branch_in(&site.profile, &operator, store)
-        .await?
-        .context("the account repository is not ready to custody spaces")?;
-    let recipient = account_recipient(&account, account_root, &operator)
-        .await?
-        .context(
-            "the account has not published its encryption key yet; \
-             open /account in a signed-in browser once, then run `tonk account status`",
-        )?;
-
-    let prefix = crate::site::adopt_account_root_prefix_for(
-        &site.profile,
-        site.operator.local(),
-        &subject,
-        account_root,
-    )
-    .await?;
-    crate::account_state::retain_space_delegation_in(&site.profile, &operator, store, &prefix)
-        .await?;
-
-    if has_custody(&account, &subject, &operator).await? {
-        return Ok(Accreditation::Already);
-    }
-    custody_space_seed(&account, &subject, &recipient, &seed, &operator).await?;
-    Ok(Accreditation::Moved)
 }

--- a/rust/tonk-cli/src/inventory.rs
+++ b/rust/tonk-cli/src/inventory.rs
@@ -295,7 +295,7 @@ async fn inspect_replica(
     identity: &mut Option<crate::site::Identity>,
 ) -> Result<(LocalSpaceInventoryRow, Option<String>)> {
     let mut config = config.clone();
-    config.require_account = false;
+    config.authorize_remote_with_account = false;
     let site = crate::site::TonkSite::open_with(&entry.site, config)
         .await
         .with_context(|| format!("could not open {}", entry.site.display()))?;

--- a/rust/tonk-cli/src/site.rs
+++ b/rust/tonk-cli/src/site.rs
@@ -29,7 +29,8 @@ use dialog_ucan::UcanDelegation;
 use dialog_ucan_core::DelegationChain;
 use dialog_ucan_core::time::Timestamp;
 use dialog_ucan_core::time::timestamp::{Duration, SystemTime};
-use dialog_varsig::{Did, Principal};
+use dialog_varsig::Did;
+use serde::{Deserialize, Serialize};
 use tonk_account::prefix::{
     SPACE_ROOT_SITE_PREFIX, space_root_site, validate_prefix as verify_prefix,
 };
@@ -130,6 +131,32 @@ const OPERATOR_CONTEXT: &[u8] = b"slide";
 
 /// Name of the `.tonk/` sub-directory holding repository data.
 pub const SITE_DIRNAME: &str = ".tonk";
+
+const LINK_CUTOVER_SITE_PREFIX: &str = "tonk-link-cutover-v1/";
+
+/// Durable, signer-free state for an explicit account ownership cutover.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LinkCutoverV1 {
+    /// Record schema version.
+    pub version: u8,
+    /// Space DID being transferred.
+    pub subject: String,
+    /// Account root receiving direct authority.
+    pub account_root: String,
+    /// Serialized direct delegation prefix, hex encoded.
+    pub direct_prefix_hex: String,
+    /// CID of the superseded space-to-profile grant.
+    pub old_grant_cid: String,
+    /// Space-signed revocation artifact, hex encoded.
+    pub revocation_hex: String,
+    /// Whether every known access service accepted the revocation.
+    pub revocation_published: bool,
+}
+
+fn link_cutover_site(subject: &Did, account_root: &Did) -> String {
+    format!("{LINK_CUTOVER_SITE_PREFIX}{subject}/{account_root}")
+}
 
 /// Whether `root` already holds site data.
 ///
@@ -236,7 +263,7 @@ impl TonkSite {
             operator,
             profile.clone(),
             config.account_store.clone(),
-            config.require_account,
+            config.authorize_remote_with_account,
         )
         .await?;
 
@@ -300,15 +327,9 @@ impl TonkSite {
         {
             Ok(repository) => (repository, false),
             Err(_) => (
-                bootstrap_repository(
-                    &profile,
-                    &operator,
-                    &config.account_store,
-                    config.require_account,
-                    config.provision_account_spaces,
-                )
-                .await
-                .with_context(|| format!("failed to bootstrap repository '{REPO_NAME}'"))?,
+                bootstrap_repository(&profile, &operator)
+                    .await
+                    .with_context(|| format!("failed to bootstrap repository '{REPO_NAME}'"))?,
                 true,
             ),
         };
@@ -318,7 +339,7 @@ impl TonkSite {
             operator,
             profile.clone(),
             config.account_store.clone(),
-            config.require_account,
+            config.authorize_remote_with_account,
         )
         .await?;
 
@@ -543,57 +564,13 @@ pub async fn record_founder_membership_for(site: &TonkSite, member: Did) -> Resu
 async fn bootstrap_repository(
     profile: &Profile,
     operator: &Operator<NativeSpace>,
-    account_store: &crate::space::SpaceStore,
-    require_account: bool,
-    provision_account_spaces: bool,
 ) -> Result<Repository> {
-    let local_root = crate::identity::local_root_with_operator(profile, operator).await?;
-    let account_operator = if require_account {
-        crate::account::require_account_with_operator_in(profile, operator, account_store).await?;
-        let account_operator =
-            crate::account_state::credential_operator_for_store(profile, account_store).await?;
-        Some(account_operator)
-    } else {
-        None
-    };
-    let durable_did: dialog_varsig::Did = local_root
-        .context("local root provisioning did not produce a record")?
-        .root_did
-        .parse()
-        .context("stored root DID is invalid")?;
-
-    // The signer comes from an explicit seed so the seed can be sealed
-    // to the account BEFORE the space exists: the custody row is the
-    // copy the account's other devices recover the space from, and a
-    // create that cannot record it must not produce a space that only
-    // this machine can ever re-derive.
+    // Keep the signer in the repository credential until explicit linking
+    // has durably moved encrypted custody to an account.
     let seed = zeroize::Zeroizing::new(rand::random::<[u8; 32]>());
     let signer = Ed25519Signer::import(&*seed)
         .await
         .context("failed to derive the space signer")?;
-    if require_account {
-        let account_operator = account_operator
-            .as_ref()
-            .expect("account operator exists when an account is required");
-        let account =
-            crate::account_state::open_account_branch_in(profile, account_operator, account_store)
-                .await?
-                .context("the account repository is not ready to custody this space")?;
-        let recipient = crate::custody::account_recipient(&account, &durable_did, account_operator)
-            .await?
-            .context(
-                "the account has not published its encryption key yet; \
-                     open /account in a signed-in browser once, then retry",
-            )?;
-        crate::custody::custody_space_seed(
-            &account,
-            &signer.did(),
-            &recipient,
-            &seed,
-            account_operator,
-        )
-        .await?;
-    }
 
     let signer_repo = profile
         .repository(REPO_NAME)
@@ -605,7 +582,7 @@ async fn bootstrap_repository(
     let delegation = signer_repo
         .access()
         .claim(&signer_repo)
-        .delegate(durable_did.clone())
+        .delegate(profile.did())
         .perform(operator)
         .await
         .context("failed to mint repo→profile delegation")?;
@@ -615,7 +592,7 @@ async fn bootstrap_repository(
         .context("failed to serialize repo→root delegation")?;
     profile
         .credential()
-        .site(space_root_site(&signer_repo.did(), &durable_did))
+        .site(space_root_site(&signer_repo.did(), &profile.did()))
         .save(prefix_bytes)
         .perform(operator)
         .await
@@ -627,30 +604,6 @@ async fn bootstrap_repository(
         .perform(operator)
         .await
         .context("failed to persist repo→profile delegation")?;
-
-    if require_account {
-        let account_operator = account_operator
-            .as_ref()
-            .expect("account operator exists when an account is required");
-        if crate::account_state::open_account_branch_in(profile, account_operator, account_store)
-            .await?
-            .is_none()
-        {
-            bail!("the account repository is not ready to retain this space");
-        }
-        crate::account_state::retain_space_delegation_in(
-            profile,
-            account_operator,
-            account_store,
-            &prefix,
-        )
-        .await?;
-        if provision_account_spaces {
-            crate::customer::provision_in(profile, account_store, &signer_repo.did(), &prefix)
-                .await
-                .context("failed to provision the account-owned space")?;
-        }
-    }
 
     profile
         .repository(REPO_NAME)
@@ -704,7 +657,7 @@ async fn mount_delegated_inner(
     require_reusable: bool,
 ) -> Result<TonkSite> {
     let local_root = crate::identity::local_root_with_operator(&profile, &operator).await?;
-    let require_account = config.require_account && require_reusable;
+    let require_account = config.authorize_remote_with_account && require_reusable;
     if require_account {
         crate::account::require_account_with_operator_in(
             &profile,
@@ -718,9 +671,6 @@ async fn mount_delegated_inner(
             .root_did
             .parse()
             .context("stored root DID is invalid")?,
-        None if require_reusable => {
-            bail!("local root provisioning did not produce a record")
-        }
         None => profile.did(),
     };
     let subject = chain
@@ -800,6 +750,163 @@ pub async fn account_root_prefix(site: &TonkSite, account_root: &Did) -> Result<
         account_root,
     )
     .await
+}
+
+/// Load a saved explicit-link cutover, if this profile has started one.
+pub async fn load_link_cutover(
+    site: &TonkSite,
+    account_root: &Did,
+) -> Result<Option<LinkCutoverV1>> {
+    let Some(bytes) = optional_credential(
+        &site.profile,
+        site.operator.local(),
+        link_cutover_site(&site.repository.did(), account_root),
+    )
+    .await?
+    else {
+        return Ok(None);
+    };
+    let record: LinkCutoverV1 =
+        serde_json::from_slice(&bytes).context("stored link cutover is malformed")?;
+    if record.version != 1
+        || record.subject != site.repository.did().to_string()
+        || record.account_root != account_root.to_string()
+    {
+        bail!("stored link cutover does not match this space and account");
+    }
+    Ok(Some(record))
+}
+
+async fn save_link_cutover(site: &TonkSite, record: &LinkCutoverV1) -> Result<()> {
+    site.profile
+        .credential()
+        .site(link_cutover_site(
+            &site.repository.did(),
+            &record.account_root.parse()?,
+        ))
+        .save(serde_json::to_vec(record)?)
+        .perform(site.operator.local())
+        .await
+        .context("failed to persist link cutover")?;
+    Ok(())
+}
+
+/// Mint the direct, full `space -> account root` ownership prefix.
+pub async fn mint_direct_account_prefix_for(
+    site: &TonkSite,
+    account_root: &Did,
+) -> Result<DelegationChain> {
+    let access = site.repository.try_access().context(
+        "the local space signer is unavailable; complete migration on a device that still holds it",
+    )?;
+    let delegation = access
+        .claim(&site.repository)
+        .delegate(account_root.clone())
+        .perform(site.operator.local())
+        .await
+        .context("failed to mint direct space-to-account authority")?;
+    Ok(delegation.into_chain())
+}
+
+/// Persist all signer-dependent cutover artifacts before any remote effect.
+pub async fn prepare_link_cutover(
+    site: &TonkSite,
+    account_root: &Did,
+) -> Result<(LinkCutoverV1, DelegationChain)> {
+    if let Some(record) = load_link_cutover(site, account_root).await? {
+        let bytes = hex::decode(&record.direct_prefix_hex)
+            .context("stored direct account prefix is not hex")?;
+        let prefix = validate_prefix(bytes.clone(), account_root)
+            .await
+            .context("stored direct account prefix is invalid")?;
+        if prefix.proof_cids().len() != 1 || prefix.issuer() != &site.repository.did() {
+            bail!("stored account authority is not a direct space-to-account prefix");
+        }
+        save_prefix(
+            &site.profile,
+            site.operator.local(),
+            &space_root_site(&site.repository.did(), account_root),
+            bytes,
+        )
+        .await
+        .context("failed to restore the direct account-root prefix")?;
+        return Ok((record, prefix));
+    }
+
+    let signer = site.repository.credential().signer().cloned().context(
+        "the local space signer is unavailable; complete migration on a device that still holds it",
+    )?;
+    let old_prefix = load_account_root_prefix_for(
+        &site.profile,
+        site.operator.local(),
+        &site.repository.did(),
+        &site.profile.did(),
+    )
+    .await
+    .context("failed to load the original device grant")?;
+    let old_grant = *old_prefix
+        .proof_cids()
+        .first()
+        .context("the original device grant is empty")?;
+    let prefix = mint_direct_account_prefix_for(site, account_root).await?;
+    if prefix.proof_cids().len() != 1 || prefix.issuer() != &site.repository.did() {
+        bail!("minted account authority is not a direct space-to-account prefix");
+    }
+    let revocation =
+        tonk_identity::revocation::mint_root_revocation(signer, &old_prefix, &old_grant)
+            .await
+            .context("failed to sign the old device-grant revocation")?;
+    let record = LinkCutoverV1 {
+        version: 1,
+        subject: site.repository.did().to_string(),
+        account_root: account_root.to_string(),
+        direct_prefix_hex: hex::encode(prefix.to_bytes()?),
+        old_grant_cid: old_grant.to_string(),
+        revocation_hex: hex::encode(revocation),
+        revocation_published: false,
+    };
+    save_link_cutover(site, &record).await?;
+    save_prefix(
+        &site.profile,
+        site.operator.local(),
+        &space_root_site(&site.repository.did(), account_root),
+        prefix.to_bytes()?,
+    )
+    .await
+    .context("failed to persist the direct account-root prefix")?;
+    Ok((record, prefix))
+}
+
+/// Mark the saved revocation as published after every access service accepts it.
+pub async fn mark_link_revocation_published(
+    site: &TonkSite,
+    record: &mut LinkCutoverV1,
+) -> Result<()> {
+    record.revocation_published = true;
+    save_link_cutover(site, record).await
+}
+
+/// Replace the stored repository signer with its verifier-only credential.
+pub async fn demote_repository_signer(site: &TonkSite) -> Result<()> {
+    use dialog_effects::credential::prelude::{
+        CredentialCapabilityExt as _, CredentialKeyExt as _, CredentialSubjectExt as _,
+    };
+
+    let Some(signer) = site.repository.credential().signer() else {
+        return Ok(());
+    };
+    let credential = Credential::Verifier(dialog_credentials::VerifierCredential::from(
+        signer.verifier(),
+    ));
+    site.repository
+        .did()
+        .credential()
+        .key("self")
+        .save(credential)
+        .perform(site.operator.local())
+        .await
+        .context("failed to demote the local space signer")?;
+    Ok(())
 }
 
 /// Decode a stored prefix for `account_root`.
@@ -1011,15 +1118,9 @@ pub struct SiteConfig {
     /// is the platform default; tests pick `Directory::At(...)`
     /// to redirect onto a temp dir.
     pub profile_directory: Directory,
-    /// Whether minting durable authority must have an account behind it.
-    /// Production enables this; legacy-isolation test fixtures disable it,
-    /// and get a software-generated root instead (see
-    /// [`build_profile_and_operator`]).
-    pub require_account: bool,
-    /// Whether fresh account-owned repositories call `/provider/add`.
-    /// Production account profiles enable this; authority-only fixtures may
-    /// disable it while still exercising account-bound authorization.
-    pub provision_account_spaces: bool,
+    /// Whether remote forks authorize through the active account session.
+    /// Local repository construction and local operations ignore this switch.
+    pub authorize_remote_with_account: bool,
     /// Profile-scoped account repository and session state.
     pub account_store: crate::space::SpaceStore,
 }
@@ -1032,8 +1133,7 @@ impl SiteConfig {
         Ok(Self {
             profile_name: name.into(),
             profile_directory: Directory::Profile,
-            require_account: false,
-            provision_account_spaces: false,
+            authorize_remote_with_account: false,
             account_store: crate::space::SpaceStore::open()
                 .context("failed to locate account state")?,
         })
@@ -1049,8 +1149,7 @@ pub fn default_config() -> Result<SiteConfig> {
     Ok(SiteConfig {
         profile_name: PROFILE_NAME.to_string(),
         profile_directory: Directory::Profile,
-        require_account: std::env::var_os("TONK_UNSAFE_ALLOW_DEVICE_ROOT").is_none(),
-        provision_account_spaces: true,
+        authorize_remote_with_account: true,
         account_store: crate::space::SpaceStore::open()
             .context("failed to locate account state")?,
     })
@@ -1113,43 +1212,6 @@ pub(crate) async fn build_profile_and_operator(
         .await
         .with_context(|| format!("failed to open profile '{}'", config.profile_name))?;
     let operator = derive_operator_for_profile(root, &profile, storage).await?;
-
-    // Isolated legacy test fixtures opt into a software-generated root so they
-    // still exercise the same space → root → device chain shape. Production
-    // never enters this path and requires a browser/passkey handoff.
-    if !config.require_account
-        && crate::identity::local_root_with_operator(&profile, &operator)
-            .await?
-            .is_none()
-    {
-        let root = Ed25519Signer::generate()
-            .await
-            .context("failed to generate the isolated fixture root")?;
-        let delegation =
-            tonk_identity::delegation::mint_device_delegation(root.clone(), &profile.did()).await?;
-        let bytes = delegation
-            .to_bytes()
-            .context("failed to serialize fixture root")?;
-        let record = crate::identity::LocalRoot {
-            credential_id: "isolated-software-root".to_string(),
-            root_did: root.did().to_string(),
-            delegation_cid: delegation.proof_cids()[0].to_string(),
-            delegation_hex: hex::encode(&bytes),
-        };
-        profile
-            .access()
-            .save(UcanDelegation(delegation))
-            .perform(&operator)
-            .await
-            .context("failed to install fixture root grant")?;
-        profile
-            .credential()
-            .site(crate::identity::LOCAL_ROOT_SITE)
-            .save(serde_json::to_vec(&record)?)
-            .perform(&operator)
-            .await
-            .context("failed to persist fixture root")?;
-    }
 
     Ok((profile, operator))
 }

--- a/rust/tonk-cli/src/space_link.rs
+++ b/rust/tonk-cli/src/space_link.rs
@@ -18,6 +18,7 @@ use anyhow::{Context as _, Result, bail};
 use dialog_capability::Subject;
 use dialog_query::{Output as _, Query, Term};
 use dialog_repository::Branch;
+use dialog_ucan::UcanDelegation;
 use dialog_varsig::Did;
 use tonk_schema::Invitation;
 
@@ -64,17 +65,12 @@ pub async fn execute(store: &SpaceStore, config: &SiteConfig, name: &str) -> Res
         .get(name)
         .with_context(|| format!("unknown space '{name}'"))?
         .clone();
-    if crate::account::sign_in_phase(store)? != crate::account::SignInPhase::Active {
-        bail!("this account is signed out; run `tonk account login` first");
-    }
     let account_root: Did = account
         .root
         .parse()
         .context("the signed-in account root is invalid")?;
 
-    let mut site_config = config.clone();
-    site_config.require_account = false;
-    let site = crate::site::TonkSite::open_with(&entry.site, site_config).await?;
+    let site = crate::site::TonkSite::open_with(&entry.site, config.clone()).await?;
     let subject = site.repository.did();
 
     // Ownership is the space's own answer, not the registry's, and it is
@@ -88,40 +84,41 @@ pub async fn execute(store: &SpaceStore, config: &SiteConfig, name: &str) -> Res
         if founder.did != account.root {
             bail!(already_owned_message(name, &founder.did));
         }
-        if holds_account_chain(&site, &subject, &account_root).await {
-            return Ok(LinkOutcome {
-                subject: subject.to_string(),
-                name: name.to_owned(),
-                site: site.root,
-                account: account.root,
-                already_linked: true,
-            });
-        }
+    }
+    let connection = crate::account::optional_connection_in(&site.profile, store)
+        .await?
+        .context("this account is signed out; run `tonk account login` first")?;
+    if connection.root_did != account_root {
+        bail!(
+            "the active account does not match the registry; run `tonk account logout` and sign in again"
+        );
     }
 
     let access = account
         .access_remote
         .as_deref()
         .context("the account has no content endpoint; sign in again")?;
-    preflight(&site, &roster, access).await?;
-
-    // Authority first: the account root can only host what it can prove it
-    // was given, and this is the one boundary allowed to mint that grant.
-    let prefix = crate::site::adopt_account_root_prefix_for(
-        &site.profile,
-        site.operator.local(),
-        &subject,
-        &account_root,
-    )
-    .await?;
-    crate::customer::provision_in(&site.profile, store, &subject, &prefix).await?;
-
-    if crate::remote::upstream_remote(&site).await?.is_none() {
-        crate::remote::add(&site, DEFAULT_REMOTE, access, Some(subject.clone())).await?;
-        crate::remote::set_upstream(&site, DEFAULT_REMOTE).await?;
+    let existing_cutover = crate::site::load_link_cutover(&site, &account_root).await?;
+    let already_linked = roster
+        .founder()
+        .is_some_and(|founder| founder.did == account.root)
+        && existing_cutover
+            .as_ref()
+            .is_some_and(|cutover| cutover.revocation_published)
+        && site.repository.credential().signer().is_none();
+    if !already_linked {
+        preflight(&site, &roster, access).await?;
     }
-    crate::site::record_founder_membership(&site).await?;
-    crate::sync::push(&site).await?;
+
+    // Every signer-dependent artifact is durable before account or network
+    // state changes. A retry after demotion loads this record.
+    let (mut cutover, prefix) = crate::site::prepare_link_cutover(&site, &account_root).await?;
+    site.profile
+        .access()
+        .save(UcanDelegation(prefix.clone()))
+        .perform(site.operator.local())
+        .await
+        .context("failed to retain direct account authority locally")?;
 
     let operator =
         crate::account_state::credential_operator_for_store(&site.profile, store).await?;
@@ -132,31 +129,64 @@ pub async fn execute(store: &SpaceStore, config: &SiteConfig, name: &str) -> Res
     };
     crate::account_state::retain_space_delegation_in(&site.profile, &operator, store, &prefix)
         .await?;
-    // The seed rides the same boundary: a space the account hosts is a
-    // space the account can re-derive. Sealing needs only the published
-    // public key; an account that predates it links anyway — custody
-    // catches up at the next `tonk account login`.
-    if !crate::custody::has_custody(&account_branch, &subject, &operator).await? {
-        match crate::custody::account_recipient(&account_branch, &account_root, &operator).await? {
-            Some(recipient) => {
-                if let Some(seed) = crate::custody::site_seed(&site).await? {
-                    crate::custody::custody_space_seed(
-                        &account_branch,
-                        &subject,
-                        &recipient,
-                        &seed,
-                        &operator,
-                    )
-                    .await?;
-                }
-            }
-            None => eprintln!(
-                "warning: the account has not published its encryption key; \
-                 the space seed stays uncustodied until it does"
-            ),
-        }
+
+    let recipient = crate::custody::account_recipient(&account_branch, &account_root, &operator)
+        .await?
+        .context(
+            "the account has not published its encryption key; open /account in a signed-in browser, then retry",
+        )?;
+    if !crate::custody::has_custody(&account_branch, &subject, &recipient, &operator).await? {
+        let seed = crate::custody::site_seed(&site)
+            .await?
+            .context("the space seed is not custodied and the local signer is unavailable")?;
+        crate::custody::custody_space_seed(&account_branch, &subject, &recipient, &seed, &operator)
+            .await?;
     }
-    crate::account_spaces::record_site_pushed(name, &site, store).await?;
+    account_branch
+        .push()
+        .perform(&operator)
+        .await
+        .context("failed to push account authority and custody")?;
+
+    crate::customer::provision_in(&site.profile, store, &subject, &prefix).await?;
+
+    if crate::remote::upstream_remote(&site).await?.is_none() {
+        crate::remote::add(&site, DEFAULT_REMOTE, access, Some(subject.clone())).await?;
+        crate::remote::set_upstream(&site, DEFAULT_REMOTE).await?;
+    }
+    crate::site::record_founder_membership_for(&site, account_root.clone()).await?;
+    crate::sync::push(&site).await?;
+
+    if !cutover.revocation_published {
+        let artifact =
+            hex::decode(&cutover.revocation_hex).context("stored link revocation is not hex")?;
+        crate::account::publish_revocation(
+            &site.profile,
+            &account_branch,
+            &operator,
+            store,
+            &artifact,
+        )
+        .await
+        .context("the old device grant was not revoked; retry `tonk space link`")?;
+        crate::site::mark_link_revocation_published(&site, &mut cutover).await?;
+    }
+
+    crate::site::demote_repository_signer(&site)
+        .await
+        .context("the local signer was not demoted; retry `tonk space link`")?;
+    let reopened = crate::site::TonkSite::open_with(&entry.site, config.clone()).await?;
+    if reopened.repository.credential().signer().is_some() {
+        bail!("the local space signer is still present; retry `tonk space link`");
+    }
+
+    // Directory publication is last: discovery implies the authority,
+    // custody, remote, revocation, and signer cutover are complete.
+    match crate::account_spaces::record_site_pushed(name, &site, store).await? {
+        crate::account_spaces::RecordOutcome::Recorded
+        | crate::account_spaces::RecordOutcome::Unchanged => {}
+        outcome => bail!("account directory publication did not complete: {outcome:?}"),
+    }
 
     if crate::inventory::role_for_site(&site).await? != SpaceRole::Owner {
         bail!("the space is not signed as owned by this device after linking");
@@ -166,30 +196,8 @@ pub async fn execute(store: &SpaceStore, config: &SiteConfig, name: &str) -> Res
         name: name.to_owned(),
         site: site.root,
         account: account.root,
-        already_linked: false,
+        already_linked,
     })
-}
-
-/// Whether the retained `subject → … → account root` chain is on this device.
-///
-/// The chain is what the access service validates and the roster is its
-/// legible, synced mirror, so a founder row with no chain behind it is an
-/// unfinished link rather than an ownership claim. This reads only what the
-/// profile already holds — it never mints, so it cannot answer yes by
-/// establishing the ownership it was asked to confirm.
-async fn holds_account_chain(
-    site: &crate::site::TonkSite,
-    subject: &Did,
-    account_root: &Did,
-) -> bool {
-    crate::site::load_account_root_prefix_for(
-        &site.profile,
-        site.operator.local(),
-        subject,
-        account_root,
-    )
-    .await
-    .is_ok()
 }
 
 /// Refuse anything that is not genuinely local-only.

--- a/rust/tonk-cli/tests/account_authority.rs
+++ b/rust/tonk-cli/tests/account_authority.rs
@@ -12,7 +12,7 @@ use tonk_cli::site::{SiteConfig, TonkSite};
 /// that tests without an account can still run.
 fn account_config(fixture: &common::AccountFixture) -> SiteConfig {
     SiteConfig {
-        require_account: true,
+        authorize_remote_with_account: true,
         ..fixture.config.clone()
     }
 }
@@ -36,8 +36,10 @@ async fn it_pushes_a_space_whose_account_prefix_was_never_stored(
     // The access service serves nothing for an account that has not
     // confirmed its email.
     fixture.activate_with(&env).await?;
-    let site = TonkSite::init_at_with(
+    let (_, legacy_prefix) = fixture.space_chain(76).await?;
+    let site = tonk_cli::site::mount_delegated_at(
         &fixture.tmp.path().join("upgraded"),
+        legacy_prefix,
         account_config(&fixture),
     )
     .await?;
@@ -71,14 +73,14 @@ async fn it_pushes_a_space_whose_account_prefix_was_never_stored(
     Ok(())
 }
 
-/// Creating a space retains its authority into the account space.
+/// Retaining an explicit grant writes it into the account space exactly once.
 ///
 /// The retain itself is `tonk_account::delegations`, shared with the worker so
 /// the two adapters cannot drift into retaining different things. This pins
 /// the CLI's half of that wiring; `it_recovers_space_access_on_a_second_device`
 /// proves the retained facts actually travel.
 #[dialog_common::test]
-async fn it_retains_a_created_space_into_the_account_space(
+async fn it_retains_an_explicit_grant_into_the_account_space(
     env: AccessServiceAddress,
 ) -> Result<()> {
     let remote = format!("{}/", env.access_service_url.trim_end_matches('/'));
@@ -300,7 +302,7 @@ async fn it_syncs_a_claimed_space_after_linking_an_account(
     let claimer_config = common::isolated_config(&claimer_parent)?;
     let joined_root = claimer_parent.join("claimed-before-link");
     let mut production_config = claimer_config.clone();
-    production_config.require_account = true;
+    production_config.authorize_remote_with_account = true;
     let claimed =
         tonk_cli::invite::claim(&joined_root, &invitation.url, production_config.clone()).await?;
 
@@ -360,8 +362,8 @@ async fn it_syncs_a_claimed_space_after_linking_an_account(
 /// Discovering a space through the account: the flow that makes linking
 /// worth anything.
 ///
-/// One device creates a space and delegates it to the account, retained in
-/// the account repository. A SECOND profile — which never created that space
+/// One device creates a space and explicitly delegates it to the account,
+/// retained in the account repository. A SECOND profile — which never created that space
 /// and holds no authority over it — links to the same account, pulls, and can
 /// then reach it. That is the whole promise of the account being the durable
 /// home of delegations, and unlike the tests above it isolates the received
@@ -378,7 +380,8 @@ async fn it_discovers_a_space_through_the_account(env: AccessServiceAddress) -> 
     let owner_operator = owner.pre_account_site.operator.inner();
     let account_root = owner.link.issuer().clone();
 
-    // The owner creates a space and puts its authority in the account.
+    // The owner creates a space, then explicitly puts direct authority in the
+    // account. Creation by itself is deliberately account-independent.
     let site = TonkSite::init_at_with(
         &owner.tmp.path().join("shared-space"),
         account_config(&owner),
@@ -386,20 +389,14 @@ async fn it_discovers_a_space_through_the_account(env: AccessServiceAddress) -> 
     .await?;
     configure_upstream(&site, &env.access_service_url).await?;
     let subject = site.repository.did();
-    let prefix = tonk_cli::site::account_root_prefix_for(
-        &owner.profile,
-        owner_operator,
-        &subject,
-        &account_root,
-    )
-    .await?;
+    let prefix = tonk_cli::site::mint_direct_account_prefix_for(&site, &account_root).await?;
     let account = tonk_cli::account_state::open_account_branch(&owner.profile, owner_operator)
         .await?
         .expect("the owner's account is hydrated");
     assert!(
-        !tonk_account::delegations::retain_space_delegation(&account, &prefix, owner_operator)
+        tonk_account::delegations::retain_space_delegation(&account, &prefix, owner_operator)
             .await?,
-        "creation already retained the space authority into the account"
+        "the explicit direct grant must be new to the account"
     );
     account.push().perform(owner_operator).await?;
 
@@ -557,7 +554,7 @@ async fn it_discovers_a_space_through_the_account(env: AccessServiceAddress) -> 
 /// the account.
 ///
 /// This is the design end to end — `space -> account -> profile`. Device one
-/// retains its space authority into the account and pushes. Device two is a
+/// explicitly retains its space authority into the account and pushes. Device two is a
 /// genuinely separate install (its own profile directory and storage) that
 /// derives the SAME account root, which is the property a shared passkey
 /// gives it. It adopts the account as its access-branch upstream, pulls, and
@@ -585,14 +582,12 @@ async fn it_recovers_space_access_on_a_second_device(env: AccessServiceAddress) 
     let account = tonk_cli::account_state::open_account_branch(&first.profile, operator)
         .await?
         .expect("device one has a hydrated account");
-    // The space -> account-root prefix: the authority device two needs and
-    // cannot mint for itself. `tonk space create` retains exactly this.
-    let chain =
-        tonk_cli::site::account_root_prefix_for(&first.profile, operator, &subject, &account_root)
-            .await?;
+    // The direct space -> account-root prefix is the authority device two
+    // needs and cannot mint for itself. Explicit link retains exactly this.
+    let chain = tonk_cli::site::mint_direct_account_prefix_for(&site, &account_root).await?;
     assert!(
-        !tonk_account::delegations::retain_space_delegation(&account, &chain, operator).await?,
-        "creation already retained device one's space authority into the account"
+        tonk_account::delegations::retain_space_delegation(&account, &chain, operator).await?,
+        "the explicit direct grant must be new to the account"
     );
     account.push().perform(operator).await?;
 
@@ -740,12 +735,73 @@ async fn it_denies_ordinary_sync_for_a_space_created_before_the_account_existed(
     Ok(())
 }
 
-/// An account-backed create seals the space's seed to the account's
-/// published encryption key and records it on the account branch — the
-/// copy any of the account's devices recovers the space from after a
-/// ceremony opens it.
+/// Account state is consulted only once a repository crosses a network fork:
+/// the same direct account chain reaches the service while active and is
+/// refused locally, with the login remedy, after logout.
 #[dialog_common::test]
-async fn it_custodies_the_created_space_seed() -> Result<()> {
+async fn remote_push_requires_the_exact_active_account(env: AccessServiceAddress) -> Result<()> {
+    use dialog_ucan::UcanDelegation;
+    use tonk_schema::prelude::DidExt as _;
+
+    let remote = format!("{}/", env.access_service_url.trim_end_matches('/'));
+    let fixture = common::AccountFixture::with_account_remote(&remote).await?;
+    fixture.activate_with(&env).await?;
+    let path = fixture.pre_account_site.root.clone();
+    let site = TonkSite::open_with(&path, account_config(&fixture)).await?;
+    let account_root = fixture.link.issuer().clone();
+    let prefix = tonk_cli::site::mint_direct_account_prefix_for(&site, &account_root).await?;
+    site.profile
+        .access()
+        .save(UcanDelegation(prefix))
+        .perform(site.operator.inner())
+        .await?;
+    configure_upstream(&site, &env.access_service_url).await?;
+    env.provision_subject(site.repository.did().as_str())
+        .await?;
+
+    tokio::time::timeout(
+        std::time::Duration::from_secs(15),
+        tonk_cli::sync::push(&site),
+    )
+    .await
+    .context("active matching account push timed out")?
+    .context("an active matching account reaches the access service")?;
+    tokio::time::timeout(
+        std::time::Duration::from_secs(15),
+        tonk_cli::account::logout_in(&fixture.profile, &fixture.store),
+    )
+    .await
+    .context("account logout timed out")??;
+    site.branch()
+        .await?
+        .handle()
+        .transaction()
+        .assert(tonk_schema::RepositoryName {
+            this: site.repository.did().this(),
+            name: tonk_schema::domain::repo::Name("after-logout".to_string()),
+        })
+        .commit()
+        .perform(&site.operator)
+        .await
+        .context("local commits remain available after logout")?;
+    let error = tokio::time::timeout(
+        std::time::Duration::from_secs(15),
+        tonk_cli::sync::push(&site),
+    )
+    .await
+    .context("signed-out push timed out")?
+    .expect_err("a signed-out remote fork must be refused");
+    assert!(
+        error.to_string().contains("tonk account login"),
+        "{error:#}"
+    );
+    Ok(())
+}
+
+/// Even with an active account, creation is local and does not enroll the
+/// space into account custody.
+#[dialog_common::test]
+async fn account_backed_creation_does_not_custody_the_space_seed() -> Result<()> {
     use dialog_query::{Output as _, Query, Term};
     use tonk_schema::{CustodiedSeed, prelude::DidExt as _};
 
@@ -780,37 +836,14 @@ async fn it_custodies_the_created_space_seed() -> Result<()> {
         .try_vec()
         .await
         .map_err(|error| anyhow::anyhow!("read custodied seeds: {error:?}"))?;
-    assert_eq!(rows.len(), 1, "the created space's seed is custodied");
-    assert_eq!(rows[0].kind.0.to_string(), tonk_schema::SeedKind::SPACE);
-
-    // The account secret opens the row and derives the space itself.
-    let secret = tonk_identity::envelope::AccountSecret::from_bytes(zeroize::Zeroizing::new(
-        fixture.root_prf,
-    ));
-    let sealed = tonk_identity::sealed::Sealed::decode(&rows[0].sealed.0)
-        .map_err(|error| anyhow::anyhow!("{error}"))?;
-    let seed = secret
-        .encryption_key()
-        .open(&sealed, &subject)
-        .map_err(|error| anyhow::anyhow!("{error}"))?;
-    let signer = dialog_credentials::Ed25519Signer::import(&*seed).await?;
-    use dialog_varsig::Principal as _;
-    assert_eq!(
-        signer.did(),
-        subject,
-        "the custodied seed derives the space"
-    );
+    assert!(rows.is_empty(), "creation must not custody a space seed");
     Ok(())
 }
 
-/// A space created before the account existed moves under the account's
-/// custody at sign-in: authority reaches the root and the seed is
-/// sealed to the account's key. Hosting does not move — that stays
-/// `tonk space link`'s boundary.
+/// A local space present at sign-in remains outside account custody.
 #[dialog_common::test]
-async fn it_moves_local_space_custody_at_sign_in() -> Result<()> {
+async fn sign_in_does_not_move_local_space_custody() -> Result<()> {
     use dialog_query::{Output as _, Query, Term};
-    use tonk_cli::custody::{Accreditation, accredit_local_spaces};
     use tonk_schema::{CustodiedSeed, prelude::DidExt as _};
 
     let fixture = common::AccountFixture::new().await?;
@@ -820,18 +853,10 @@ async fn it_moves_local_space_custody_at_sign_in() -> Result<()> {
         .store
         .set_account(Some(tonk_cli::space::AccountRecord::new(root_did_string)))?;
     let mut local_config = fixture.config.clone();
-    local_config.require_account = false;
+    local_config.authorize_remote_with_account = false;
     let created =
         tonk_cli::space::create(&fixture.store, "premade", None, None, local_config).await?;
     let subject: dialog_varsig::Did = created.did.parse()?;
-
-    let outcomes = accredit_local_spaces(&fixture.store, &fixture.config).await?;
-    assert!(
-        outcomes
-            .iter()
-            .any(|(name, outcome)| name == "premade" && matches!(outcome, Accreditation::Moved)),
-        "sign-in moves the local space's custody: {outcomes:?}"
-    );
 
     let account_operator =
         tonk_cli::account_state::credential_operator_for_store(&fixture.profile, &fixture.store)
@@ -856,32 +881,6 @@ async fn it_moves_local_space_custody_at_sign_in() -> Result<()> {
         .try_vec()
         .await
         .map_err(|error| anyhow::anyhow!("read custodied seeds: {error:?}"))?;
-    assert_eq!(rows.len(), 1, "the moved space's seed is custodied");
-
-    let secret = tonk_identity::envelope::AccountSecret::from_bytes(zeroize::Zeroizing::new(
-        fixture.root_prf,
-    ));
-    let sealed = tonk_identity::sealed::Sealed::decode(&rows[0].sealed.0)
-        .map_err(|error| anyhow::anyhow!("{error}"))?;
-    let seed = secret
-        .encryption_key()
-        .open(&sealed, &subject)
-        .map_err(|error| anyhow::anyhow!("{error}"))?;
-    let signer = dialog_credentials::Ed25519Signer::import(&*seed).await?;
-    use dialog_varsig::Principal as _;
-    assert_eq!(
-        signer.did(),
-        subject,
-        "the custodied seed derives the space"
-    );
-
-    // Running again converges: nothing is moved twice.
-    let again = accredit_local_spaces(&fixture.store, &fixture.config).await?;
-    assert!(
-        again
-            .iter()
-            .any(|(name, outcome)| name == "premade" && matches!(outcome, Accreditation::Already)),
-        "a second sign-in finds custody already moved: {again:?}"
-    );
+    assert!(rows.is_empty(), "sign-in must not custody a local space");
     Ok(())
 }

--- a/rust/tonk-cli/tests/account_interrupt.rs
+++ b/rust/tonk-cli/tests/account_interrupt.rs
@@ -32,7 +32,6 @@ fn spawn_link(home: &std::path::Path) -> Child {
         .env("NO_PROXY", "127.0.0.1,localhost")
         .env_remove("TONK_TELEMETRY")
         .env_remove("TONK_SPACE")
-        .env_remove("TONK_UNSAFE_ALLOW_DEVICE_ROOT")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
@@ -105,6 +104,48 @@ fn wait_for_exit(child: &mut Child, timeout: Duration) -> Option<ExitStatus> {
     }
 }
 
+fn session_files(home: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let account = home.join("spaces/account");
+    let mut paths: Vec<_> = std::fs::read_dir(account)
+        .expect("account-session directory")
+        .map(|entry| entry.expect("account-session entry").path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| {
+                    name.starts_with("tonk-account-session-v1-") && name.ends_with(".json")
+                })
+        })
+        .collect();
+    paths.sort();
+    paths
+}
+
+fn signed_out_state() -> serde_json::Value {
+    serde_json::json!({
+        "version": 1,
+        "active": null,
+        "pending_login": null
+    })
+}
+
+fn active_state() -> serde_json::Value {
+    serde_json::json!({
+        "version": 1,
+        "active": {
+            "provider": "https://account.invalid/",
+            "credential_id": "stale-credential",
+            "root_did": "did:key:z6MkStaleAccount",
+            "delegation_cid": "stale-cid",
+            "delegation_hex": "00",
+            "descriptor_hex": null,
+            "attachment_id": "stale-attachment",
+            "attached_at": 1
+        },
+        "pending_login": null
+    })
+}
+
 #[test]
 fn account_link_can_be_interrupted_during_the_callback_wait() {
     let temp = tempfile::tempdir().expect("temporary profile");
@@ -145,5 +186,67 @@ fn account_link_starts_fresh_after_an_interrupt() {
     assert_ne!(
         first_url, second_url,
         "each attempt binds its own loopback callback"
+    );
+}
+
+/// Account lifecycle decisions are scoped to the exact current profile, not
+/// whichever sidecar happens to sort first in the shared store.
+#[test]
+fn account_login_uses_only_the_current_profiles_session() {
+    let temp = tempfile::tempdir().expect("temporary profile");
+
+    let mut bootstrap = spawn_link(temp.path());
+    approval_url(&mut bootstrap);
+    std::thread::sleep(Duration::from_millis(100));
+    interrupt(&mut bootstrap);
+
+    let files = session_files(temp.path());
+    assert_eq!(files.len(), 1, "one exact-profile session sidecar");
+    let current = files[0].clone();
+    std::fs::write(
+        &current,
+        serde_json::to_vec(&signed_out_state()).expect("serialize signed-out state"),
+    )
+    .expect("write current signed-out state");
+    let stale = current
+        .parent()
+        .expect("sidecar parent")
+        .join("tonk-account-session-v1-000-stale.json");
+    std::fs::write(
+        &stale,
+        serde_json::to_vec(&active_state()).expect("serialize stale active state"),
+    )
+    .expect("write stale active sidecar");
+
+    let mut current_signed_out = spawn_link(temp.path());
+    approval_url(&mut current_signed_out);
+    std::thread::sleep(Duration::from_millis(100));
+    interrupt(&mut current_signed_out);
+
+    std::fs::write(
+        &current,
+        serde_json::to_vec(&active_state()).expect("serialize current active state"),
+    )
+    .expect("write current active state");
+    std::fs::write(
+        &stale,
+        serde_json::to_vec(&signed_out_state()).expect("serialize stale signed-out state"),
+    )
+    .expect("write stale signed-out sidecar");
+
+    let mut current_active = spawn_link(temp.path());
+    let status = wait_for_exit(&mut current_active, Duration::from_secs(5))
+        .expect("an active current profile is refused without waiting for a callback");
+    let mut stderr = String::new();
+    current_active
+        .stderr
+        .take()
+        .expect("piped stderr")
+        .read_to_string(&mut stderr)
+        .expect("read stderr");
+    assert!(!status.success(), "active login must be refused");
+    assert!(
+        stderr.contains("an account is already active"),
+        "stderr: {stderr}"
     );
 }

--- a/rust/tonk-cli/tests/account_spaces.rs
+++ b/rust/tonk-cli/tests/account_spaces.rs
@@ -12,6 +12,41 @@ use tonk_cli::space::SpaceEntry;
 use tonk_schema::RepositoryName;
 use tonk_schema::prelude::DidExt as _;
 
+async fn record_account_relationship(
+    fixture: &common::AccountFixture,
+    site: &TonkSite,
+    founder: bool,
+) -> Result<()> {
+    use dialog_ucan::UcanDelegation;
+    use tonk_schema::{MemberRole, Membership};
+
+    let root = fixture.link.issuer().clone();
+    if site.repository.credential().signer().is_some() {
+        let prefix = tonk_cli::site::mint_direct_account_prefix_for(site, &root).await?;
+        site.profile
+            .access()
+            .save(UcanDelegation(prefix))
+            .perform(site.operator.inner())
+            .await?;
+    }
+    let membership = Membership::new(root, site.repository.did());
+    let role = if founder {
+        MemberRole::founder(membership.this().clone())
+    } else {
+        MemberRole::member(membership.this().clone())
+    };
+    site.branch()
+        .await?
+        .handle()
+        .transaction()
+        .assert(membership)
+        .assert(role)
+        .commit()
+        .perform(&site.operator)
+        .await?;
+    Ok(())
+}
+
 #[tokio::test]
 async fn list_reports_named_unnamed_and_pullable_rows() -> Result<()> {
     let fixture = common::AccountFixture::new().await?;
@@ -39,6 +74,55 @@ async fn list_reports_named_unnamed_and_pullable_rows() -> Result<()> {
 }
 
 #[tokio::test]
+async fn directory_removal_is_scoped_and_idempotent() -> Result<()> {
+    let fixture = common::AccountFixture::new().await?;
+    let subject = fixture
+        .record_directory_space(80, Some("garden"), Some("http://127.0.0.1:9/ucan/"))
+        .await?;
+    let operator = fixture.operator().await?;
+    let account = fixture.account_branch().await?;
+    account
+        .transaction()
+        .assert(RepositoryName {
+            this: subject.this(),
+            name: tonk_schema::domain::repo::Name("unrelated".to_string()),
+        })
+        .commit()
+        .perform(&operator)
+        .await?;
+
+    tonk_schema::directory::remove(&account, &subject, &operator).await?;
+    tonk_schema::directory::remove(&account, &subject, &operator).await?;
+
+    assert!(
+        tonk_schema::directory::spaces(&account, &operator)
+            .await
+            .map_err(|error| anyhow::anyhow!("directory query: {error:?}"))?
+            .iter()
+            .all(|row| row.subject != subject)
+    );
+    assert!(
+        tonk_schema::directory::mount_record(&account, &subject, &operator)
+            .await
+            .map_err(|error| anyhow::anyhow!("mount query: {error:?}"))?
+            .is_none()
+    );
+    let names: Vec<RepositoryName> = account
+        .query()
+        .select(Query::<RepositoryName> {
+            this: Term::from(subject.this()),
+            name: Term::var("name"),
+        })
+        .perform(&operator)
+        .try_vec()
+        .await
+        .map_err(|error| anyhow::anyhow!("repository-name query: {error:?}"))?;
+    assert_eq!(names.len(), 1);
+    assert_eq!(names[0].name.0, "unrelated");
+    Ok(())
+}
+
+#[tokio::test]
 async fn list_and_pull_choose_the_first_alias_for_a_local_subject() -> Result<()> {
     let fixture = common::AccountFixture::new().await?;
     let site = TonkSite::init_at_with(
@@ -47,6 +131,7 @@ async fn list_and_pull_choose_the_first_alias_for_a_local_subject() -> Result<()
     )
     .await?;
     configure_upstream(&site, "http://127.0.0.1:9/ucan/").await?;
+    record_account_relationship(&fixture, &site, true).await?;
     let canonical = site.root.canonicalize()?;
     let mut registry = fixture.store.load()?;
     for name in ["zeta", "alpha"] {
@@ -190,6 +275,7 @@ async fn pull_requires_a_directory_row_and_returns_an_adopted_site() -> Result<(
     let adopted = TonkSite::init_at_with(&adopted_root, fixture.config.clone()).await?;
     let adopted_subject = adopted.repository.did();
     configure_upstream(&adopted, "http://127.0.0.1:9/ucan/").await?;
+    record_account_relationship(&fixture, &adopted, true).await?;
     let mut registry = fixture.store.load()?;
     registry
         .spaces
@@ -254,6 +340,7 @@ async fn pull_from_a_live_access_service_syncs_the_canonical_unbound_site(
         .perform(&source.operator)
         .await?;
     tonk_cli::site::record_founder_membership(&source).await?;
+    record_account_relationship(&fixture, &source, true).await?;
     tonk_cli::remote::add(
         &source,
         "origin",
@@ -363,6 +450,7 @@ async fn record_lists_owned_joined_and_newly_remote_sites() -> Result<()> {
     .await?;
     name_repository(&owned, "synced-owned").await?;
     configure_upstream(&owned, dead_remote).await?;
+    record_account_relationship(&fixture, &owned, true).await?;
     tonk_cli::space::register_existing_unbound(&fixture.store, "owned-alias", &owned.root)?;
     assert_eq!(
         account_spaces::record_site_in("owned-alias", &owned, &fixture.store).await?,
@@ -382,6 +470,7 @@ async fn record_lists_owned_joined_and_newly_remote_sites() -> Result<()> {
     )
     .await?;
     configure_upstream(&joined, dead_remote).await?;
+    record_account_relationship(&fixture, &joined, false).await?;
     tonk_cli::space::register_existing_unbound(&fixture.store, "joined-alias", &joined.root)?;
     assert_eq!(
         account_spaces::record_site_in("joined-alias", &joined, &fixture.store).await?,
@@ -407,11 +496,11 @@ async fn record_lists_owned_joined_and_newly_remote_sites() -> Result<()> {
     configure_upstream(&local_only, dead_remote).await?;
     assert_eq!(
         account_spaces::record_site_in("local-fallback", &local_only, &fixture.store).await?,
-        RecordOutcome::Recorded
+        RecordOutcome::NotLinked
     );
 
     let rows = account_spaces::list(&fixture.profile, &fixture.store).await?;
-    assert_eq!(rows.len(), 3);
+    assert_eq!(rows.len(), 2);
     assert_eq!(
         rows.iter()
             .find(|row| row.subject == owned.repository.did().to_string())
@@ -430,20 +519,12 @@ async fn record_lists_owned_joined_and_newly_remote_sites() -> Result<()> {
         Some("joined-alias"),
         "an unnamed repository falls back to its registry name"
     );
-    assert_eq!(
-        rows.iter()
-            .find(|row| row.subject == local_only.repository.did().to_string())
-            .unwrap()
-            .remote_name
-            .as_deref(),
-        Some("local-fallback")
-    );
     assert!(rows.iter().all(|row| row.pullable));
     Ok(())
 }
 
 #[tokio::test]
-async fn record_sweep_uses_the_first_alias_once() -> Result<()> {
+async fn record_sweep_does_not_enroll_an_unlinked_remote_space() -> Result<()> {
     let fixture = common::AccountFixture::new().await?;
     let site = TonkSite::init_at_with(
         &fixture.tmp.path().join("sweep-aliased-site"),
@@ -463,15 +544,12 @@ async fn record_sweep_uses_the_first_alias_once() -> Result<()> {
     let warnings = account_spaces::record_registered(&fixture.profile, &fixture.store).await;
     assert!(warnings.is_empty(), "{warnings:?}");
     let rows = account_spaces::list(&fixture.profile, &fixture.store).await?;
-    assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0].subject, site.repository.did().to_string());
-    assert_eq!(rows[0].remote_name.as_deref(), Some("alpha"));
+    assert!(rows.is_empty());
 
     let warnings = account_spaces::record_registered(&fixture.profile, &fixture.store).await;
     assert!(warnings.is_empty(), "{warnings:?}");
     let rows = account_spaces::list(&fixture.profile, &fixture.store).await?;
-    assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0].remote_name.as_deref(), Some("alpha"));
+    assert!(rows.is_empty());
     Ok(())
 }
 

--- a/rust/tonk-cli/tests/cli_space.rs
+++ b/rust/tonk-cli/tests/cli_space.rs
@@ -36,9 +36,6 @@ fn tonk_cmd(state_dir: &Path, args: &[&str], extra_env: &[(&str, &str)]) -> Comm
         .env("TONK_NO_UPDATE_CHECK", "1")
         .env("TONK_UPDATE_STATE", state_dir)
         .env("HOME", state_dir)
-        // These fixtures exercise remote selection, not identity provisioning.
-        // Production omits this explicit unsafe compatibility override.
-        .env("TONK_UNSAFE_ALLOW_DEVICE_ROOT", "1")
         .env_remove("TONK_SPACE");
     for (key, value) in extra_env {
         cmd.env(key, value);
@@ -190,7 +187,7 @@ mod when_no_account_is_signed_in {
     }
 
     #[dialog_common::test]
-    fn a_new_space_is_local_only_until_it_is_linked() {
+    fn when_space_is_created_without_account_it_is_local_only_until_linked() {
         let state = tempfile::tempdir().expect("tempdir");
         let site = state.path().join("scratch-site");
         let output = run(
@@ -222,6 +219,114 @@ mod when_no_account_is_signed_in {
             spaces["account"].is_null(),
             "no account is signed in: {spaces}"
         );
+    }
+}
+
+mod when_space_is_created_with_account_state {
+    use super::*;
+    use std::collections::BTreeMap;
+    use tonk_cli::space::{AccountRecord, SpaceStore};
+
+    fn snapshot(path: &Path) -> BTreeMap<std::path::PathBuf, Vec<u8>> {
+        fn visit(root: &Path, path: &Path, files: &mut BTreeMap<std::path::PathBuf, Vec<u8>>) {
+            let Ok(entries) = std::fs::read_dir(path) else {
+                return;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    visit(root, &path, files);
+                } else {
+                    files.insert(
+                        path.strip_prefix(root).expect("under root").to_path_buf(),
+                        std::fs::read(path).expect("snapshot file"),
+                    );
+                }
+            }
+        }
+        let mut files = BTreeMap::new();
+        visit(path, path, &mut files);
+        files
+    }
+
+    fn recorded_account(state: &Path, active: bool) -> SpaceStore {
+        let store = SpaceStore::at(state);
+        let mut account =
+            AccountRecord::new("did:key:z6MkAccountAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+        account.access_remote = Some("http://127.0.0.1:9/ucan/".to_string());
+        store.set_account(Some(account)).expect("record account");
+        if active {
+            std::fs::create_dir_all(store.account_dir()).expect("account dir");
+            let session = serde_json::json!({
+                "version": 1,
+                "active": {
+                    "provider": "http://127.0.0.1:9",
+                    "credential_id": "fixture",
+                    "root_did": "did:key:z6MkAccountAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "delegation_cid": "bafyfixture",
+                    "delegation_hex": "00",
+                    "descriptor_hex": null,
+                    "attachment_id": "fixture",
+                    "attached_at": 1
+                },
+                "pending_login": null
+            });
+            std::fs::write(
+                store
+                    .account_dir()
+                    .join("tonk-account-session-v1-fixture.json"),
+                serde_json::to_vec(&session).expect("session JSON"),
+            )
+            .expect("write session");
+        }
+        store
+    }
+
+    fn assert_local_create_with_account_state(active: bool) {
+        let state = tempfile::tempdir().expect("tempdir");
+        let store = recorded_account(state.path(), active);
+        let before = snapshot(&store.account_dir());
+        let site = state.path().join("scratch-site");
+
+        let output = run(
+            state.path(),
+            &[
+                "space",
+                "new",
+                "scratch",
+                "--site",
+                site.to_str().expect("utf-8 site"),
+            ],
+            &[],
+        );
+        assert!(output.status.success(), "{}", stderr_of(&output));
+        assert_eq!(snapshot(&store.account_dir()), before);
+
+        let registry: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(store.registry_path()).expect("registry"))
+                .expect("registry JSON");
+        assert_eq!(
+            registry["spaces"]["scratch"]
+                .as_object()
+                .expect("space entry")
+                .keys()
+                .collect::<Vec<_>>(),
+            vec!["site"]
+        );
+        assert_eq!(
+            registry["account"]["root"],
+            "did:key:z6MkAccountAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        );
+    }
+
+    #[dialog_common::test]
+    fn when_space_is_created_with_an_active_account_it_stays_local() {
+        assert_local_create_with_account_state(true);
+    }
+
+    #[dialog_common::test]
+    fn when_space_is_created_with_a_stale_account_record_it_stays_local() {
+        assert_local_create_with_account_state(false);
     }
 }
 
@@ -442,7 +547,6 @@ mod when_resolving_with_precedence {
             .env("DO_NOT_TRACK", "1")
             .env("TONK_NO_UPDATE_CHECK", "1")
             .env("HOME", state.path())
-            .env("TONK_UNSAFE_ALLOW_DEVICE_ROOT", "1")
             .env("TONK_SPACE", "a");
         let output = cmd.output().expect("run tonk");
         assert!(!output.status.success());

--- a/rust/tonk-cli/tests/common.rs
+++ b/rust/tonk-cli/tests/common.rs
@@ -78,8 +78,7 @@ pub fn isolated_config(parent: &std::path::Path) -> Result<SiteConfig> {
     Ok(SiteConfig {
         profile_name: format!("tonk-test-{suffix:x}"),
         profile_directory: Directory::At(profile_dir.to_string_lossy().into_owned()),
-        require_account: false,
-        provision_account_spaces: false,
+        authorize_remote_with_account: false,
         account_store: tonk_cli::space::SpaceStore::at(parent.join("_state")),
     })
 }

--- a/rust/tonk-cli/tests/join_profile.rs
+++ b/rust/tonk-cli/tests/join_profile.rs
@@ -22,7 +22,7 @@ async fn it_claims_to_the_profile_without_a_linked_account() -> Result<()> {
     let mut claimer_config = common::isolated_config(&claimer_parent)?;
     // Match production's account precondition while keeping every file in
     // the fixture. Claiming is not an account-owned creation operation.
-    claimer_config.require_account = true;
+    claimer_config.authorize_remote_with_account = true;
 
     // SAFETY: this integration-test binary contains exactly one test, so no
     // other thread can observe the process-wide store override.

--- a/rust/tonk-cli/tests/site.rs
+++ b/rust/tonk-cli/tests/site.rs
@@ -381,7 +381,7 @@ mod when_claiming_before_account_linking {
         let claimer_parent = claimer_tmp.path().canonicalize()?;
         let claimer_root = claimer_parent.join("joined-site");
         let mut claimer_config = common::isolated_config(&claimer_parent)?;
-        claimer_config.require_account = true;
+        claimer_config.authorize_remote_with_account = true;
 
         let outcome = invite::claim(&claimer_root, &invitation.url, claimer_config).await?;
 
@@ -584,16 +584,8 @@ mod when_recording_roster_facts {
         assert_eq!(roles.len(), 1);
         assert_eq!(roles[0].this, memberships[0].this);
         assert_eq!(roles[0].role.0.to_string(), MemberRole::MEMBER);
-        let root_bytes = joined
-            .profile
-            .credential()
-            .site(tonk_cli::identity::LOCAL_ROOT_SITE)
-            .load::<Vec<u8>>()
-            .perform(&joined.operator)
-            .await?;
-        let root: tonk_cli::identity::LocalRoot = serde_json::from_slice(&root_bytes)?;
-        let root_did: dialog_varsig::Did = root.root_did.parse()?;
-        assert_eq!(memberships[0].member.0, root_did.this());
+        let member_did = joined.profile.did();
+        assert_eq!(memberships[0].member.0, member_did.this());
 
         let stamps: Vec<InvitedVia> = claimer_content
             .query()
@@ -614,7 +606,7 @@ mod when_recording_roster_facts {
         let proof = claimer_content
             .delegations()
             .prove(
-                root_did.clone(),
+                member_did.clone(),
                 dialog_ucan::Scope {
                     subject: dialog_ucan_core::subject::Subject::Specific(
                         joined.repository.did().clone(),
@@ -629,7 +621,7 @@ mod when_recording_roster_facts {
             .proofs
             .last()
             .expect("the claimed chain reaches the member");
-        assert_eq!(leaf.0.audience(), &root_did, "the leaf admits the member");
+        assert_eq!(leaf.0.audience(), &member_did, "the leaf admits the member");
         assert!(
             proof.proofs.len() > 1,
             "the member's own hop sits below the invite hop"
@@ -1263,31 +1255,45 @@ mod when_listing_views {
 
 mod when_a_device_has_no_account {
     use anyhow::Result;
+    use dialog_credentials::Credential;
+    use dialog_ucan_core::DelegationChain;
+    use tonk_account::prefix::{space_root_site, validate_prefix};
     use tonk_cli::site::TonkSite;
 
     use crate::common;
 
-    /// Creating a space mints durable authority: a `space → root` chain that a
-    /// later `tonk invite` delegates from. Rooted in an anonymous key that
-    /// chain has no owner, nothing can revoke it, and nothing backs up what it
-    /// creates — so the account is the precondition, not the passkey.
-    ///
-    /// The error has to name the command that fixes it. `tonk identity link`,
-    /// which the old message named, no longer exists.
     #[dialog_common::test]
-    async fn it_refuses_to_create_a_space() -> Result<()> {
+    async fn fresh_space_uses_device_profile() -> Result<()> {
         let tmp = tempfile::tempdir()?;
         let parent = tmp.path().canonicalize()?;
         let mut config = common::isolated_config(&parent)?;
-        config.require_account = true;
+        config.authorize_remote_with_account = true;
 
-        let Err(error) = TonkSite::init_with(&parent, config).await else {
-            panic!("a device with no account cannot create a space");
-        };
-        let rendered = format!("{error:#}");
+        let site = TonkSite::init_with(&parent, config).await?;
+        assert!(matches!(
+            site.repository.credential(),
+            Credential::Signer(_)
+        ));
+
+        let subject = site.repository.did();
+        let profile = site.profile.did();
+        let bytes = site
+            .profile
+            .credential()
+            .site(space_root_site(&subject, &profile))
+            .load::<Vec<u8>>()
+            .perform(&site.operator)
+            .await?;
+        let prefix: DelegationChain = validate_prefix(&bytes, &profile).await?.chain;
+        assert_eq!(prefix.subject(), Some(&subject));
+        assert_eq!(prefix.audience(), &profile);
         assert!(
-            rendered.contains("tonk account login"),
-            "the refusal must name the command that fixes it: {rendered}"
+            tonk_cli::remote::upstream_remote(&site).await?.is_none(),
+            "fresh local creation must not configure a hosted upstream"
+        );
+        assert!(
+            tonk_cli::inventory::read_roster(&site).await?.is_empty(),
+            "fresh local creation must not write an account founder"
         );
         Ok(())
     }
@@ -1417,18 +1423,6 @@ mod when_mounting_account_authority {
 
     use crate::common;
 
-    async fn local_root(site: &TonkSite) -> Result<dialog_varsig::Did> {
-        let bytes = site
-            .profile
-            .credential()
-            .site(tonk_cli::identity::LOCAL_ROOT_SITE)
-            .load::<Vec<u8>>()
-            .perform(&site.operator)
-            .await?;
-        let root: tonk_cli::identity::LocalRoot = serde_json::from_slice(&bytes)?;
-        Ok(root.root_did.parse()?)
-    }
-
     async fn delegated_prefix(
         account_root: &dialog_varsig::Did,
     ) -> Result<(dialog_varsig::Did, DelegationChain)> {
@@ -1450,7 +1444,7 @@ mod when_mounting_account_authority {
         let parent = tmp.path().canonicalize()?;
         let config = common::isolated_config(&parent)?;
         let seed = TonkSite::init_at_with(&parent.join("seed"), config.clone()).await?;
-        let account_root = local_root(&seed).await?;
+        let account_root = seed.profile.did();
         let (subject, chain) = delegated_prefix(&account_root).await?;
         let expected = chain.to_bytes()?;
         let root = parent.join("mounted");
@@ -1531,7 +1525,7 @@ mod when_mounting_account_authority {
     #[dialog_common::test]
     async fn it_recovers_a_pre_feature_prefix_from_profile_authority() -> Result<()> {
         let test = common::TestSite::new().await?;
-        let root = local_root(&test.site).await?;
+        let root = test.site.profile.did();
         let key = space_root_site(&test.site.repository.did(), &root);
         test.site
             .profile
@@ -1564,7 +1558,7 @@ mod when_mounting_account_authority {
     async fn it_adopts_a_space_whose_authority_reaches_no_account_root() -> Result<()> {
         let test = common::TestSite::new().await?;
         let account_root = Ed25519Signer::import(&[73; 32]).await?.did();
-        assert_ne!(local_root(&test.site).await?, account_root);
+        assert_ne!(test.site.profile.did(), account_root);
 
         let adopted = site::account_root_prefix(&test.site, &account_root).await?;
 

--- a/rust/tonk-cli/tests/space_access.rs
+++ b/rust/tonk-cli/tests/space_access.rs
@@ -51,6 +51,29 @@ async fn founded_by(
 mod when_opening_a_replica {
     use super::*;
 
+    #[dialog_common::test]
+    async fn local_operations_ignore_account_session() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let (store, mut config) = fixture(tmp.path())?;
+        config.authorize_remote_with_account = true;
+
+        let outcome = tonk_cli::space::create(&store, "garden", None, None, config.clone()).await?;
+        let site = TonkSite::open_with(&outcome.site, config).await?;
+        let session = site.branch().await?;
+        session
+            .handle()
+            .transaction()
+            .commit()
+            .perform(&site.operator)
+            .await?;
+
+        assert!(
+            !store.account_dir().exists(),
+            "local work must not initialize account-session state"
+        );
+        Ok(())
+    }
+
     /// Possession is not permission, but it is not a lock either: a replica
     /// on this device opens signed out, signed into its own account, and
     /// signed into somebody else's. Nothing consults the account slot.

--- a/rust/tonk-cli/tests/space_link.rs
+++ b/rust/tonk-cli/tests/space_link.rs
@@ -29,6 +29,11 @@ async fn local_space(store: &SpaceStore, config: &SiteConfig, name: &str) -> Res
 async fn it_links_a_local_space_into_the_signed_in_account(
     env: AccessServiceAddress,
 ) -> Result<()> {
+    use dialog_credentials::Credential;
+    use dialog_query::{Output as _, Query, Term};
+    use dialog_varsig::Principal as _;
+    use tonk_schema::{CustodiedSeed, prelude::DidExt as _};
+
     let remote = format!("{}/", env.access_service_url.trim_end_matches('/'));
     let fixture = common::AccountFixture::with_account_remote(&remote).await?;
     fixture.activate_with(&env).await?;
@@ -50,6 +55,22 @@ async fn it_links_a_local_space_into_the_signed_in_account(
     assert_eq!(entry.site, outcome.site);
     let site = TonkSite::open_with(&entry.site, config.clone()).await?;
     assert_eq!(site.repository.did().to_string(), outcome.subject);
+    assert!(
+        matches!(site.repository.credential(), Credential::Verifier(_)),
+        "completed linking removes the locally stored space signer"
+    );
+
+    let account_root: dialog_varsig::Did = account.root.parse()?;
+    let prefix = tonk_cli::site::load_account_root_prefix_for(
+        &site.profile,
+        site.operator.inner(),
+        &site.repository.did(),
+        &account_root,
+    )
+    .await?;
+    assert_eq!(prefix.proof_cids().len(), 1, "ownership is one direct hop");
+    assert_eq!(prefix.issuer(), &site.repository.did());
+    assert_eq!(prefix.audience(), &account_root);
 
     // Ownership is on the space's own content branch, keyed on the account
     // root so it converges across every device on that account.
@@ -73,6 +94,35 @@ async fn it_links_a_local_space_into_the_signed_in_account(
     assert!(row.owner_is_you);
     assert_eq!(row.role, SpaceRole::Owner);
     assert!(rendered.contains("you ("), "{rendered}");
+
+    let account_operator = fixture.operator().await?;
+    let account_branch = fixture.account_branch().await?;
+    let subject = site.repository.did();
+    let custody: Vec<CustodiedSeed> = account_branch
+        .query()
+        .select(Query::<CustodiedSeed> {
+            this: Term::var("this"),
+            subject: Term::from(tonk_schema::domain::custody::Subject(subject.this())),
+            kind: Term::var("kind"),
+            recipient: Term::var("recipient"),
+            sealed: Term::var("sealed"),
+        })
+        .perform(&account_operator)
+        .try_vec()
+        .await
+        .map_err(|error| anyhow::anyhow!("read custodied seeds: {error:?}"))?;
+    assert_eq!(custody.len(), 1);
+    let secret = tonk_identity::envelope::AccountSecret::from_bytes(zeroize::Zeroizing::new(
+        fixture.root_prf,
+    ));
+    let sealed = tonk_identity::sealed::Sealed::decode(&custody[0].sealed.0)
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+    let seed = secret
+        .encryption_key()
+        .open(&sealed, &subject)
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+    let signer = dialog_credentials::Ed25519Signer::import(&*seed).await?;
+    assert_eq!(signer.did(), subject);
 
     let listed = tonk_cli::account_spaces::list(&fixture.profile, &store).await?;
     assert!(
@@ -103,6 +153,151 @@ async fn it_reports_an_already_linked_space_without_relinking_it(
     assert!(again.already_linked);
     assert_eq!(again.subject, first.subject);
     assert_eq!(std::fs::read(store.registry_path())?, after_first);
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_upgrades_a_legacy_profile_hop_when_the_signer_is_present(
+    env: AccessServiceAddress,
+) -> Result<()> {
+    let remote = format!("{}/", env.access_service_url.trim_end_matches('/'));
+    let fixture = common::AccountFixture::with_account_remote(&remote).await?;
+    fixture.activate_with(&env).await?;
+    let store = fixture.store.clone();
+    let config = fixture.config.clone();
+    local_space(&store, &config, "garden").await?;
+    store.set_account(Some(signed_in(&fixture, &env)?))?;
+    let entry = store.load()?.spaces["garden"].clone();
+    let site = TonkSite::open_with(&entry.site, config.clone()).await?;
+    let account_root = fixture.link.issuer().clone();
+    let legacy = tonk_cli::site::account_root_prefix(&site, &account_root).await?;
+    assert!(
+        legacy.proof_cids().len() > 1,
+        "legacy authority uses a profile hop"
+    );
+    tonk_cli::site::record_founder_membership_for(&site, account_root.clone()).await?;
+
+    let outcome = tonk_cli::space_link::execute(&store, &config, "garden").await?;
+
+    assert!(
+        !outcome.already_linked,
+        "legacy founder state is incomplete"
+    );
+    let reopened = TonkSite::open_with(&entry.site, config).await?;
+    let direct = tonk_cli::site::load_account_root_prefix_for(
+        &reopened.profile,
+        reopened.operator.inner(),
+        &reopened.repository.did(),
+        &account_root,
+    )
+    .await?;
+    assert_eq!(direct.proof_cids().len(), 1);
+    assert!(reopened.repository.credential().signer().is_none());
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_reports_that_a_signerless_legacy_link_needs_its_origin_device(
+    env: AccessServiceAddress,
+) -> Result<()> {
+    let remote = format!("{}/", env.access_service_url.trim_end_matches('/'));
+    let fixture = common::AccountFixture::with_account_remote(&remote).await?;
+    let store = fixture.store.clone();
+    let config = fixture.config.clone();
+    local_space(&store, &config, "garden").await?;
+    store.set_account(Some(signed_in(&fixture, &env)?))?;
+    let entry = store.load()?.spaces["garden"].clone();
+    let site = TonkSite::open_with(&entry.site, config.clone()).await?;
+    let account_root = fixture.link.issuer().clone();
+    let legacy = tonk_cli::site::account_root_prefix(&site, &account_root).await?;
+    assert!(
+        legacy.proof_cids().len() > 1,
+        "legacy authority uses a profile hop"
+    );
+    tonk_cli::site::record_founder_membership_for(&site, account_root).await?;
+    tonk_cli::site::demote_repository_signer(&site).await?;
+
+    let error = tonk_cli::space_link::execute(&store, &config, "garden")
+        .await
+        .expect_err("a verifier-only legacy link cannot mint direct authority");
+    assert!(
+        error.to_string().contains("device that still holds it"),
+        "{error:#}"
+    );
+    assert!(
+        TonkSite::open_with(&entry.site, config)
+            .await?
+            .repository
+            .credential()
+            .signer()
+            .is_none()
+    );
+    Ok(())
+}
+
+#[dialog_common::test]
+async fn it_retries_from_saved_cutover_artifacts_after_signer_demotion(
+    env: AccessServiceAddress,
+) -> Result<()> {
+    let remote = format!("{}/", env.access_service_url.trim_end_matches('/'));
+    let fixture = common::AccountFixture::with_account_remote(&remote).await?;
+    fixture.activate_with(&env).await?;
+    let store = fixture.store.clone();
+    let config = fixture.config.clone();
+    local_space(&store, &config, "garden").await?;
+    store.set_account(Some(signed_in(&fixture, &env)?))?;
+    let entry = store.load()?.spaces["garden"].clone();
+    let site = TonkSite::open_with(&entry.site, config.clone()).await?;
+    let account_root = fixture.link.issuer().clone();
+
+    let (cutover, direct) = tonk_cli::site::prepare_link_cutover(&site, &account_root).await?;
+    assert!(!cutover.revocation_published);
+    assert_eq!(direct.proof_cids().len(), 1);
+    assert!(
+        tonk_cli::account_spaces::list(&fixture.profile, &store)
+            .await?
+            .iter()
+            .all(|row| row.subject != site.repository.did().to_string()),
+        "saved security artifacts alone must not publish discovery"
+    );
+    let account_operator = fixture.operator().await?;
+    let account_branch = fixture.account_branch().await?;
+    let recipient =
+        tonk_cli::custody::account_recipient(&account_branch, &account_root, &account_operator)
+            .await?
+            .expect("fixture account publishes an encryption recipient");
+    let seed = tonk_cli::custody::site_seed(&site)
+        .await?
+        .expect("the pre-demotion signer exports its seed");
+    tonk_cli::custody::custody_space_seed(
+        &account_branch,
+        &site.repository.did(),
+        &recipient,
+        &seed,
+        &account_operator,
+    )
+    .await?;
+    account_branch.push().perform(&account_operator).await?;
+    tonk_cli::site::demote_repository_signer(&site).await?;
+
+    site.branch()
+        .await?
+        .handle()
+        .transaction()
+        .commit()
+        .perform(&site.operator)
+        .await?;
+    let linked = tonk_cli::space_link::execute(&store, &config, "garden").await?;
+    assert!(!linked.already_linked);
+    assert_eq!(linked.subject, site.repository.did().to_string());
+    assert!(
+        TonkSite::open_with(&entry.site, config)
+            .await?
+            .repository
+            .credential()
+            .signer()
+            .is_none()
+    );
     Ok(())
 }
 

--- a/rust/tonk-schema/src/directory.rs
+++ b/rust/tonk-schema/src/directory.rs
@@ -71,6 +71,17 @@ pub struct MountRecord {
     pub branches: Vec<MountBranch>,
 }
 
+/// Failure while retracting a directory entry.
+#[derive(Debug, thiserror::Error)]
+pub enum RemoveError {
+    /// Existing directory facts could not be queried.
+    #[error("directory query failed: {0:?}")]
+    Query(#[from] EvaluationError),
+    /// The retraction transaction could not commit.
+    #[error("directory retraction failed: {0}")]
+    Commit(#[from] CommitError),
+}
+
 /// Anchor wrapper so branch concepts can hang off the space's
 /// directory entity (`subject.this()`), giving every device the same
 /// derived entities.
@@ -146,6 +157,141 @@ where
                 .assert(upstream.clone())
                 .assert(TrackingBranch::new(&local, &upstream));
         }
+    }
+    transaction.commit().perform(env).await?;
+    Ok(())
+}
+
+/// Retract one account-directory entry without touching unrelated facts on
+/// the space entity. Repeating removal is a no-op.
+pub async fn remove<Env>(account: &Branch, subject: &Did, env: &Env) -> Result<(), RemoveError>
+where
+    Env: Provider<Get>
+        + Provider<Put>
+        + Provider<Import>
+        + Provider<Resolve>
+        + Provider<Publish>
+        + Provider<Identify>
+        + Provider<Attest>
+        + Provider<Fork<RemoteSite, Get>>
+        + Provider<Fork<RemoteSite, Resolve>>
+        + ConditionalSync
+        + 'static,
+{
+    let anchor = subject.this();
+    let spaces: Vec<Space> = account
+        .query()
+        .select(Query::<Space> {
+            this: Term::from(anchor.clone()),
+            subject: Term::var("subject"),
+            status: Term::var("status"),
+        })
+        .perform(env)
+        .try_vec()
+        .await?;
+    let names: Vec<SpaceName> = account
+        .query()
+        .select(Query::<SpaceName> {
+            this: Term::from(anchor.clone()),
+            name: Term::var("name"),
+        })
+        .perform(env)
+        .try_vec()
+        .await?;
+    let remotes: Vec<Remote> = account
+        .query()
+        .select(Query::<Remote> {
+            this: Term::var("this"),
+            name: Term::var("name"),
+            origin: Term::from(RemoteOrigin::from(anchor.clone())),
+            subject: Term::var("subject"),
+            address: Term::var("address"),
+        })
+        .perform(env)
+        .try_vec()
+        .await?;
+    let local_branches: Vec<BranchConcept> = account
+        .query()
+        .select(Query::<BranchConcept> {
+            this: Term::var("this"),
+            name: Term::var("name"),
+            origin: Term::from(BranchOrigin::from(anchor)),
+        })
+        .perform(env)
+        .try_vec()
+        .await?;
+
+    let mut executions = Vec::new();
+    let mut remote_branches = Vec::new();
+    for remote in &remotes {
+        executions.extend(
+            account
+                .query()
+                .select(Query::<RemoteExecution> {
+                    this: Term::from(remote.this.clone()),
+                    revocation_url: Term::var("revocation_url"),
+                })
+                .perform(env)
+                .try_vec()
+                .await?,
+        );
+        remote_branches.extend(
+            account
+                .query()
+                .select(Query::<BranchConcept> {
+                    this: Term::var("this"),
+                    name: Term::var("name"),
+                    origin: Term::from(BranchOrigin::from(remote.this.clone())),
+                })
+                .perform(env)
+                .try_vec()
+                .await?,
+        );
+    }
+    let mut tracking = Vec::new();
+    for branch in &local_branches {
+        tracking.extend(
+            account
+                .query()
+                .select(Query::<TrackingBranch> {
+                    this: Term::from(branch.this.clone()),
+                    upstream: Term::var("upstream"),
+                    origin: Term::var("origin"),
+                })
+                .perform(env)
+                .try_vec()
+                .await?,
+        );
+    }
+
+    if spaces.is_empty()
+        && names.is_empty()
+        && remotes.is_empty()
+        && executions.is_empty()
+        && local_branches.is_empty()
+        && remote_branches.is_empty()
+        && tracking.is_empty()
+    {
+        return Ok(());
+    }
+    let mut transaction = account.transaction();
+    for row in spaces {
+        transaction = transaction.retract(row);
+    }
+    for row in names {
+        transaction = transaction.retract(row);
+    }
+    for row in executions {
+        transaction = transaction.retract(row);
+    }
+    for row in tracking {
+        transaction = transaction.retract(row);
+    }
+    for row in local_branches.into_iter().chain(remote_branches) {
+        transaction = transaction.retract(row);
+    }
+    for row in remotes {
+        transaction = transaction.retract(row);
     }
     transaction.commit().perform(env).await?;
     Ok(())

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -368,7 +368,7 @@ fn configure_deletion_entry(host: &HtmlElement) {
     set_text(
         host,
         "#account-delete-boundary",
-        "Tonk cannot erase copies that other devices have already replicated.",
+        "Copies on this and other devices stay local and editable; Tonk hosting and future sync are removed.",
     );
     set_text(
         host,
@@ -1863,7 +1863,7 @@ fn bind(host: &HtmlElement) {
         }
         let final_confirmation = if requested.is_some() {
             format!(
-                "Permanently delete {} and its hosted content from Tonk services?\n\nYour account and every other space will remain. Copies already replicated to other devices cannot be erased by Tonk. This cannot be undone.",
+                "Permanently delete {} and its hosted content from Tonk services?\n\nYour account and every other space will remain. Copies on this and other devices stay local and editable, but future sync is removed. This cannot be undone.",
                 destructive[0]
                     .name
                     .as_deref()
@@ -1871,7 +1871,7 @@ fn bind(host: &HtmlElement) {
             )
         } else {
             format!(
-                "Permanently delete {} owned space{}, their hosted content from Tonk services, all account backups, and the account for {}?\n\nJoined spaces will not be deleted. Copies already replicated to other devices cannot be erased by Tonk. This cannot be undone.",
+                "Permanently delete {} owned space{}, their hosted content from Tonk services, all account backups, and the account for {}?\n\nJoined spaces will not be deleted. Copies on this and other devices stay local and editable, but future sync is removed. This cannot be undone.",
                 destructive.len(),
                 if destructive.len() == 1 { "" } else { "s" },
                 plan.email,
@@ -1946,7 +1946,7 @@ fn bind(host: &HtmlElement) {
                 Ok((Some(subject), None)) => {
                     let _ = window().map(|window| {
                         window.alert_with_message(&format!(
-                            "Owned space {subject} deleted from Tonk services. Your account and other spaces remain. Tonk cannot erase copies already replicated to other devices."
+                            "Owned space {subject} deleted from Tonk services. Your account and other spaces remain. Copies on this and other devices stay local and editable; future sync is removed."
                         ))
                     });
                     if let Some(window) = window() {
@@ -2447,7 +2447,7 @@ mod tests {
         assert!(copy.contains("syncing will stop until you sign in again"));
         assert!(copy.contains("This is not sign out"));
         assert!(copy.contains("Spaces created by other people will not be deleted"));
-        assert!(copy.contains("cannot erase copies that other devices have already replicated"));
+        assert!(copy.contains("Copies on this and other devices stay local and editable"));
         for technical in ["authority", "grant", "relink required"] {
             assert!(
                 !copy.contains(technical),

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -444,8 +444,7 @@ mod tests {
             .env("DO_NOT_TRACK", "1")
             .env("NO_PROXY", "127.0.0.1,localhost,tonk.network")
             .env_remove("TONK_TELEMETRY")
-            .env_remove("TONK_SPACE")
-            .env_remove("TONK_UNSAFE_ALLOW_DEVICE_ROOT");
+            .env_remove("TONK_SPACE");
         command
     }
 
@@ -1376,6 +1375,27 @@ mod tests {
         let receipt = successful_body("delete the account", &deleted);
         assert_eq!(receipt["deletedSpaces"], 1, "one hosted space purged");
         assert_eq!(receipt["retainedJoinedSpaces"], 0);
+
+        let local = get_json(&driver, &format!("/api/repository/{key}")).await?;
+        assert_eq!(
+            local["status"], 200,
+            "account deletion must leave this device's local replica open: {local}"
+        );
+        let local_write = post_yaml(
+            &driver,
+            &format!("/api/repository/{key}/branch/main/evaluate"),
+            r#"attribute!: &after-account-deletion
+  the:         xyz.tonk.e2e/after-account-deletion
+  as:          text
+  cardinality: one
+  description: local survival after hosted deletion
+"#,
+        )
+        .await?;
+        assert_eq!(
+            local_write["status"], 200,
+            "the surviving local replica must remain editable: {local_write}"
+        );
 
         // The profile is unlinked: the deletion plan is no longer
         // reviewable because there is no account to review.

--- a/rust/tonk-worker/src/router/account_deletion.rs
+++ b/rust/tonk-worker/src/router/account_deletion.rs
@@ -126,6 +126,35 @@ async fn load_plan(
     })
 }
 
+async fn remove_directory_entry(
+    state: &AppState,
+    subject: &dialog_varsig::Did,
+) -> Result<(), TonkWorkerError> {
+    let tonk = state.read().await;
+    let main = tonk
+        .reactor
+        .profile_repository()
+        .branch(tonk_account::MAIN_BRANCH)
+        .acquire(&tonk.operator)
+        .await
+        .map_err(|error| {
+            TonkWorkerError::Internal(format!("open the account directory: {error}"))
+        })?;
+    tonk_schema::directory::remove(main.handle(), subject, &tonk.operator)
+        .await
+        .map_err(|error| {
+            TonkWorkerError::Internal(format!("remove the account directory entry: {error}"))
+        })?;
+    main.handle()
+        .push()
+        .perform(&tonk.operator)
+        .await
+        .map_err(|error| {
+            TonkWorkerError::Internal(format!("push the account directory removal: {error}"))
+        })?;
+    Ok(())
+}
+
 /// GET `/api/account/deletion/plan` returns the exact destructive scope.
 #[wasm_compat]
 pub async fn plan(
@@ -156,21 +185,15 @@ pub async fn delete_space(
         .iter()
         .find(|space| space.subject == request.subject)
         .ok_or_else(|| TonkWorkerError::Forbidden("space is not owned by this account".into()))?;
-    if selected.state == "deleted" {
-        return Ok(Json(HostedSpaceDeletionResult {
-            subject: request.subject,
-        }));
-    }
     let subject: dialog_varsig::Did = request.subject.parse().map_err(|error| {
         TonkWorkerError::Internal(format!("reviewed space DID became invalid: {error:?}"))
     })?;
-    {
+    if selected.state != "deleted" {
         let state = state.read().await;
         super::customer::deprovision_consumer(&state, origin.url(), &subject).await?;
     }
 
-    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-    super::repository::remove_space_inner(&state, &subject).await?;
+    remove_directory_entry(&state, &subject).await?;
     Ok(Json(HostedSpaceDeletionResult {
         subject: request.subject,
     }))
@@ -215,12 +238,15 @@ pub async fn delete(
     // account's chain reaches this device, and possession of that
     // chain is the deletion policy. The passkey assertion the UI
     // performed is a user-verification gate, not a signing ceremony.
-    for space in &request.spaces {
+    for space in &current.spaces {
         let subject: dialog_varsig::Did = space.subject.parse().map_err(|error| {
             TonkWorkerError::Internal(format!("reviewed space DID became invalid: {error:?}"))
         })?;
-        let state = state.read().await;
-        super::customer::deprovision_consumer(&state, origin.url(), &subject).await?;
+        if space.state != "deleted" {
+            let current_state = state.read().await;
+            super::customer::deprovision_consumer(&current_state, origin.url(), &subject).await?;
+        }
+        remove_directory_entry(&state, &subject).await?;
     }
     let (link, device) = {
         let state = state.read().await;
@@ -274,13 +300,6 @@ pub async fn delete(
     .map_err(|error| TonkWorkerError::Internal(format!("build account deletion: {error}")))?;
     super::http::post_cbor(&account_endpoint, &account).await?;
 
-    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-    for space in &request.spaces {
-        let subject = space.subject.parse().map_err(|error| {
-            TonkWorkerError::Internal(format!("reviewed space DID became invalid: {error}"))
-        })?;
-        super::repository::remove_space_inner(&state, &subject).await?;
-    }
     {
         let current_state = state.read().await;
         super::customer::clear_customer(&current_state).await?;

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -1972,82 +1972,25 @@ async fn remove_replica_from_profile(
         .await
         .map_err(|e| RepositoryError::Internal(format!("open profile meta: {e}")))?;
 
-    // Removal is account-wide: profile main is shared account state, so
-    // EVERY device's replica row for this subject is swept, not just
-    // this device's — a surviving foreign row would resurrect the
-    // directory entry through the next sweep's backfill. This device's
-    // derived entity rides along in case its row is gone but stray
-    // stamps remain.
-    let rows: Vec<Replica> = meta
-        .handle()
-        .query()
-        .select(Query::<Replica> {
-            this: Term::var("this"),
-            subject: Term::from(tonk_schema::domain::replica::Subject(subject.this())),
-            profile: Term::var("profile"),
-            kind: Term::var("kind"),
-        })
-        .perform(&tonk.operator)
-        .try_vec()
-        .await
-        .map_err(|e| RepositoryError::Internal(format!("replica rows query: {e:?}")))?;
-    let mut entities: Vec<dialog_artifacts::Entity> =
-        rows.into_iter().map(|row| row.this).collect();
-    if !entities.contains(&entity) {
-        entities.push(entity);
-    }
-
     let mut transaction = tonk
         .reactor
         .profile_repository()
         .branch(PROFILE_BRANCH)
         .transaction();
     let mut found = false;
-    for row_entity in entities {
-        let stream = meta
-            .handle()
-            .claims()
-            .select(ArtifactSelector::new().of(row_entity))
-            .perform(&tonk.operator)
-            .await
-            .map_err(|e| RepositoryError::Internal(format!("select replica claims: {e}")))?;
-        tokio::pin!(stream);
-        while let Some(artifact) = stream.next().await {
-            let artifact = artifact
-                .map_err(|e| RepositoryError::Internal(format!("read replica claim: {e}")))?
-                .to_owned()
-                .map_err(|e| RepositoryError::Internal(format!("read replica claim: {e}")))?;
-            found = true;
-            transaction = transaction.retract(super::claim::RawClaim {
-                the: artifact.the,
-                of: artifact.of,
-                is: artifact.is,
-                unique: false,
-            });
-        }
-    }
-
-    // The account-level directory entry hangs on the repository's own
-    // entity, so it needs its own sweep — filtered to the space
-    // namespace, because other facts may key on that entity too.
-    // Removing it is what makes "delete spot" account-wide: every
-    // device's Hub lists the directory, not this device's replica row.
-    let directory = meta
+    let stream = meta
         .handle()
         .claims()
-        .select(ArtifactSelector::new().of(subject.this()))
+        .select(ArtifactSelector::new().of(entity))
         .perform(&tonk.operator)
         .await
-        .map_err(|e| RepositoryError::Internal(format!("select directory claims: {e}")))?;
-    tokio::pin!(directory);
-    while let Some(artifact) = directory.next().await {
+        .map_err(|e| RepositoryError::Internal(format!("select replica claims: {e}")))?;
+    tokio::pin!(stream);
+    while let Some(artifact) = stream.next().await {
         let artifact = artifact
-            .map_err(|e| RepositoryError::Internal(format!("read directory claim: {e}")))?
+            .map_err(|e| RepositoryError::Internal(format!("read replica claim: {e}")))?
             .to_owned()
-            .map_err(|e| RepositoryError::Internal(format!("read directory claim: {e}")))?;
-        if !artifact.the.to_string().starts_with("xyz.tonk.space/") {
-            continue;
-        }
+            .map_err(|e| RepositoryError::Internal(format!("read replica claim: {e}")))?;
         found = true;
         transaction = transaction.retract(super::claim::RawClaim {
             the: artifact.the,


### PR DESCRIPTION
## Summary

- make native space creation local and device-owned, regardless of account state
- make `tonk space link` the explicit, retryable cutover to account authority, encrypted seed custody, hosted sync, old-grant revocation, and verifier-only local signing
- gate account inventory on exact active membership and separate local removal from hosted/account deletion
- update CLI documentation and account-deletion copy for the device-first lifecycle

## Testing

- `cargo fmt --all -- --check`
- `git diff origin/staging...HEAD --check`
- `cargo check -p tonk-cli --features integration-tests --tests`
- native CLI suites: 118 tests passed across `cli_space`, `site`, and `space_access`
- integration CLI suites: 35 tests passed across `account_authority`, `account_spaces`, `space_link`, and `account_interrupt`
- `cargo test -p tonk-schema` (117 unit tests and 6 doctests passed; 1 test ignored)
- `cargo test -p tonk-worker --features integration-tests` (99 tests passed)
- `cargo check --target wasm32-unknown-unknown -p tonk-worker -p tonk-ui`
- `cargo check -p tonk-ui --features integration-tests --tests`
- `cargo check -p tonk-worker --features integration-tests`

## Not completed

- the focused browser account-flow run compiled its test binary but was interrupted while Nix rebuilt the UI test server; no browser scenario completed
- `nix flake check` evaluated successfully and passed its rustfmt/nixfmt checks, but clippy and shared dependency checks were cancelled after the host filesystem ran out of space
- `nix develop . -c test:e2e` was not run because of the same Nix disk-space blocker

## Follow-up

- the pre-link signer remains in the existing local credential store; further at-rest hardening is outside this change


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the account management system in the `tonk-cli` and `tonk-ui` projects, particularly around account authorization, space creation, and directory management, to improve user experience and functionality.

### Detailed summary
- Replaced `require_account` with `authorize_remote_with_account` in configuration.
- Updated tests to reflect changes in account authorization logic.
- Added tests for local operations ignoring account sessions.
- Improved error messages and handling for account deletion.
- Adjusted README to clarify space creation behavior.
- Refactored account session management, including removal of legacy code.
- Enhanced directory management functions for idempotency and scoping.

> The following files were skipped due to too many changes: `rust/tonk-cli/tests/space_link.rs`, `rust/tonk-cli/src/space_link.rs`, `rust/tonk-cli/tests/account_authority.rs`, `rust/tonk-cli/src/site.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->