### PR TITLE
fix(cli): make account activation recoverable

### DIFF
--- a/rust/tonk-cli/src/account.rs
+++ b/rust/tonk-cli/src/account.rs
@@ -377,6 +377,203 @@ pub async fn validate_account_grant(profile: &Profile, bytes: &[u8]) -> Result<D
     Ok(chain)
 }
 
+/// Turn one validated browser response into the immutable generation that is
+/// checkpointed and replayed after a crash. This performs no local writes.
+async fn account_from_callback(
+    profile: &Profile,
+    options: &LinkOptions,
+    authorization: CallbackAuthorization,
+) -> Result<crate::account_session::ActiveAccount> {
+    let grant_bytes = hex::decode(&authorization.delegation_hex)
+        .context("authorization delegation is not hex")?;
+    let chain = validate_account_grant(profile, &grant_bytes).await?;
+    let account_did = chain.issuer().clone();
+    let attachment_id = authorization.attachment_id.trim();
+    if attachment_id.is_empty() {
+        bail!("authorization is missing its service attachment generation");
+    }
+    let provider_url = Some(authorization.service_url.trim())
+        .filter(|value| !value.is_empty())
+        .unwrap_or(&options.service_url);
+    let descriptor = hex::decode(&authorization.descriptor_hex)
+        .context("authorization descriptor is not hex")?;
+    let attached_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let provider =
+        AccountProviderRecord::attach(provider_url, &descriptor, &account_did, attached_at)
+            .await
+            .context("authorization returned an unusable repository descriptor")?;
+    Ok(crate::account_session::ActiveAccount {
+        provider: provider.provider().to_owned(),
+        credential_id: authorization.credential_id,
+        root_did: account_did.to_string(),
+        delegation_cid: chain.proof_cids()[0].to_string(),
+        delegation_hex: hex::encode(grant_bytes),
+        descriptor_hex: Some(hex::encode(descriptor)),
+        attachment_id: attachment_id.to_owned(),
+        attached_at,
+    })
+}
+
+async fn recorded_account_grant(
+    profile: &Profile,
+    account: &crate::account_session::ActiveAccount,
+) -> Result<(Vec<u8>, DelegationChain)> {
+    let grant_bytes =
+        hex::decode(&account.delegation_hex).context("recorded account delegation is not hex")?;
+    let chain = validate_account_grant(profile, &grant_bytes).await?;
+    if chain.issuer().as_ref() != account.root_did
+        || chain.proof_cids()[0].to_string() != account.delegation_cid
+    {
+        bail!("recorded account delegation does not match its recorded generation");
+    }
+    Ok((grant_bytes, chain))
+}
+
+/// Validate and project one exact staged generation into the compatibility
+/// credential records. Replaying the same values is idempotent.
+async fn project_staged_account(
+    profile: &Profile,
+    operator: &dialog_operator::Operator<NativeSpace>,
+    account: &crate::account_session::ActiveAccount,
+) -> Result<Vec<u8>> {
+    if account.attachment_id.trim().is_empty() {
+        bail!("staged account activation has no service attachment generation");
+    }
+    let (grant_bytes, chain) = recorded_account_grant(profile, account).await?;
+    let root_did: Did = account
+        .root_did
+        .parse()
+        .context("staged account root DID is invalid")?;
+    let descriptor_hex = account
+        .descriptor_hex
+        .as_deref()
+        .context("staged account activation has no repository descriptor")?;
+    let descriptor =
+        hex::decode(descriptor_hex).context("staged account repository descriptor is not hex")?;
+    let provider = AccountProviderRecord::attach(
+        &account.provider,
+        &descriptor,
+        &root_did,
+        account.attached_at,
+    )
+    .await
+    .context("staged account repository descriptor is unusable")?;
+    if provider.provider() != account.provider {
+        bail!("staged account provider is not canonical");
+    }
+
+    profile
+        .access()
+        .save(UcanDelegation(chain))
+        .perform(operator)
+        .await
+        .context("failed to install the account grant")?;
+    crate::identity::save_local_root_with_operator(
+        profile,
+        operator,
+        account.credential_id.clone(),
+        account.delegation_hex.clone(),
+    )
+    .await?;
+    profile
+        .credential()
+        .site(ACCOUNT_LINK_SITE)
+        .save(provider.encode()?)
+        .perform(operator)
+        .await
+        .context("failed to persist the account link")?;
+    Ok(grant_bytes)
+}
+
+/// Resume or complete one exact staged generation. The activation guard keeps
+/// logout and other login attempts behind projection and final promotion.
+async fn complete_staged_account(
+    profile: &Profile,
+    operator: &dialog_operator::Operator<NativeSpace>,
+    store: &crate::space::SpaceStore,
+    account: &crate::account_session::ActiveAccount,
+) -> Result<Vec<u8>> {
+    let guard =
+        crate::account_session::stage_activation(profile, operator, store, account.clone()).await?;
+    let grant_bytes = project_staged_account(profile, operator, account).await?;
+    crate::account_session::finalize_activation(profile, operator, guard, account).await?;
+    Ok(grant_bytes)
+}
+
+/// Hydrate and retain authority after the canonical account is already active.
+/// Failure here never reopens the browser ceremony.
+async fn hydrate_activated_account(
+    profile: &Profile,
+    operator: &dialog_operator::Operator<NativeSpace>,
+    store: &crate::space::SpaceStore,
+    account: &crate::account_session::ActiveAccount,
+    grant_bytes: &[u8],
+    url: String,
+) -> Result<LinkOutcome> {
+    let account_did: Did = account
+        .root_did
+        .parse()
+        .context("active account root DID is invalid")?;
+    let hydration = tokio::time::timeout(HYDRATION_DEADLINE, async {
+        let account_state = match crate::account_state::ensure_with_operator_and_store(
+            profile,
+            operator.clone(),
+            store.clone(),
+        )
+        .await
+        {
+            Ok(outcome) => outcome.status,
+            Err(_) => AccountStateStatus::Unhydrated,
+        };
+        let mut warning = None;
+        if let Some(branch) =
+            crate::account_state::open_account_branch_in(profile, operator, store).await?
+        {
+            let signer = profile.signer().signer().clone();
+            let union =
+                tonk_account::delegations::mint_account_union(&signer, &account_did).await?;
+            let inbound = DelegationChain::try_from(grant_bytes)
+                .context("account grant is not a delegation container")?;
+            for (label, chain) in [("account grant", inbound), ("profile union", union)] {
+                if let Err(error) =
+                    tonk_account::delegations::retain_space_delegation(&branch, &chain, operator)
+                        .await
+                {
+                    warning = Some(format!(
+                        "{label} was not retained into the account: {error}"
+                    ));
+                }
+            }
+            if warning.is_none()
+                && let Err(error) = branch.push().perform(operator).await
+            {
+                warning = Some(format!("account was authorized but not pushed: {error}"));
+            }
+        }
+        Ok::<_, anyhow::Error>((account_state, warning))
+    })
+    .await;
+    let (account_state, warning) = match hydration {
+        Ok(result) => result?,
+        Err(_) => (
+            AccountStateStatus::Unhydrated,
+            Some("the account repository did not answer in time; sync will retry".to_string()),
+        ),
+    };
+
+    Ok(LinkOutcome {
+        url,
+        root_did: account.root_did.clone(),
+        device_did: profile.did().to_string(),
+        account_state,
+        warning,
+        service_url: account.provider.clone(),
+    })
+}
+
 /// Authorize this device through a loopback callback.
 ///
 /// The browser runs the ceremony and posts the grant straight back to a
@@ -387,6 +584,7 @@ pub async fn validate_account_grant(profile: &Profile, bytes: &[u8]) -> Result<D
 async fn link_via_callback(
     profile: &Profile,
     operator: &dialog_operator::Operator<NativeSpace>,
+    store: &crate::space::SpaceStore,
     options: &LinkOptions,
     page: &str,
 ) -> Result<LinkOutcome> {
@@ -431,132 +629,9 @@ async fn link_via_callback(
     };
     let authorization: CallbackAuthorization =
         serde_json::from_slice(&bytes).context("authorization payload is not readable")?;
-    let grant_bytes = hex::decode(&authorization.delegation_hex)
-        .context("authorization delegation is not hex")?;
-    let chain = validate_account_grant(profile, &grant_bytes).await?;
-    let account_did = chain.issuer().clone();
-    let root_did = account_did.to_string();
-
-    // Install the inbound half so this device can act, and record the root
-    // the way a linked device does.
-    profile
-        .access()
-        .save(UcanDelegation(chain))
-        .perform(operator)
-        .await
-        .context("failed to install the account grant")?;
-    crate::identity::save_local_root_with_operator(
-        profile,
-        operator,
-        authorization.credential_id.clone(),
-        authorization.delegation_hex.clone(),
-    )
-    .await?;
-
-    // The descriptor tells this device WHERE the account repository lives; a
-    // delegation only says who may act. Persisting it is what lets the
-    // account mount and sync at all. The provider URL prefers what the
-    // page delivered — the page knows its deployment — over the flag,
-    // whose default names production regardless of where the ceremony ran.
-    let provider_url = Some(authorization.service_url.trim())
-        .filter(|value| !value.is_empty())
-        .unwrap_or(&options.service_url)
-        .to_owned();
-    let provider = AccountProviderRecord::attach(
-        &provider_url,
-        &hex::decode(&authorization.descriptor_hex)
-            .context("authorization descriptor is not hex")?,
-        &account_did,
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs(),
-    )
-    .await
-    .context("authorization returned an unusable repository descriptor")?;
-    profile
-        .credential()
-        .site(ACCOUNT_LINK_SITE)
-        .save(provider.encode()?)
-        .perform(operator)
-        .await
-        .context("failed to persist the account link")?;
-
-    let store = match options.store.clone() {
-        Some(store) => store,
-        None => crate::space::SpaceStore::open().context("failed to locate account state")?,
-    };
-    // The canonical session was initialized empty before the ceremony ran,
-    // so the persisted root and record must be projected into an active
-    // session explicitly — everything account-bound reads through it.
-    let attachment_id = Some(authorization.attachment_id.clone()).filter(|id| !id.is_empty());
-    crate::account_session::activate_link(profile, operator, &store, attachment_id).await?;
-
-    // Mount the account, then retain BOTH halves of the union into it and
-    // push. The page mints only the inbound grant; storing both ends here
-    // keeps the writes where the account repository is already mounted, and
-    // means a later device pulling the account inherits what this profile
-    // holds rather than only what the account issued.
-    // `ensure` mounts the account, adopts it as the access upstream, and
-    // syncs — the dance that turns a grant into usable, shared authority.
-    // The whole phase runs under a hard deadline: the link is complete
-    // once credentials are durable, and a slow or unreachable remote must
-    // degrade to "waiting for first sync" rather than hang the command.
-    let hydration = tokio::time::timeout(HYDRATION_DEADLINE, async {
-        let account_state = match crate::account_state::ensure_with_operator_and_store(
-            profile,
-            operator.clone(),
-            store.clone(),
-        )
-        .await
-        {
-            Ok(outcome) => outcome.status,
-            Err(_) => AccountStateStatus::Unhydrated,
-        };
-        let mut warning = None;
-        if let Some(branch) =
-            crate::account_state::open_account_branch_in(profile, operator, &store).await?
-        {
-            let signer = profile.signer().signer().clone();
-            let union =
-                tonk_account::delegations::mint_account_union(&signer, &account_did).await?;
-            let inbound = DelegationChain::try_from(grant_bytes.as_slice())
-                .context("account grant is not a delegation container")?;
-            for (label, chain) in [("account grant", inbound), ("profile union", union)] {
-                if let Err(error) =
-                    tonk_account::delegations::retain_space_delegation(&branch, &chain, operator)
-                        .await
-                {
-                    warning = Some(format!(
-                        "{label} was not retained into the account: {error}"
-                    ));
-                }
-            }
-            if warning.is_none()
-                && let Err(error) = branch.push().perform(operator).await
-            {
-                warning = Some(format!("account was authorized but not pushed: {error}"));
-            }
-        }
-        Ok::<_, anyhow::Error>((account_state, warning))
-    })
-    .await;
-    let (account_state, warning) = match hydration {
-        Ok(result) => result?,
-        Err(_) => (
-            AccountStateStatus::Unhydrated,
-            Some("the account repository did not answer in time; sync will retry".to_string()),
-        ),
-    };
-
-    Ok(LinkOutcome {
-        url,
-        root_did,
-        device_did: profile.did().to_string(),
-        account_state,
-        warning,
-        service_url: provider_url,
-    })
+    let account = account_from_callback(profile, options, authorization).await?;
+    let grant_bytes = complete_staged_account(profile, operator, store, &account).await?;
+    hydrate_activated_account(profile, operator, store, &account, &grant_bytes, url).await
 }
 
 /// What the authorizing page posts back to the waiting CLI.
@@ -572,8 +647,8 @@ struct CallbackAuthorization {
     #[serde(default)]
     credential_id: String,
     /// The service-issued attachment generation the approving page
-    /// registered this device under. Absent from pages that predate
-    /// registration-at-approval; the delegation CID stands in then.
+    /// registered this device under. Required so recovery and detach target
+    /// the exact service row rather than guessing from the delegation CID.
     #[serde(default)]
     attachment_id: String,
     /// The account service the approving page's deployment uses. Absent
@@ -623,11 +698,41 @@ pub async fn link_with_operator(
         let guard = crate::account_session::shared_remote_guard(&store)?;
         crate::account_session::load_guarded(profile, operator, &guard).await?
     };
-    if state.active.is_some() {
-        bail!("an account is already active; run `tonk account logout` before linking another");
+    if let Some(account) = state.active {
+        let (grant_bytes, _) = recorded_account_grant(profile, &account).await?;
+        return hydrate_activated_account(
+            profile,
+            operator,
+            &store,
+            &account,
+            &grant_bytes,
+            String::new(),
+        )
+        .await;
     }
-    let page = options.via.as_deref().unwrap_or(DEFAULT_LINK_PAGE);
-    link_via_callback(profile, operator, options, page).await
+    match state.pending_login {
+        Some(crate::account_session::PendingLogin::Activating { account }) => {
+            let grant_bytes = complete_staged_account(profile, operator, &store, &account).await?;
+            hydrate_activated_account(
+                profile,
+                operator,
+                &store,
+                &account,
+                &grant_bytes,
+                String::new(),
+            )
+            .await
+        }
+        Some(crate::account_session::PendingLogin::Waiting { .. }) => {
+            bail!(
+                "an older account login is pending but cannot be resumed; run `tonk account logout` and try again"
+            )
+        }
+        None => {
+            let page = options.via.as_deref().unwrap_or(DEFAULT_LINK_PAGE);
+            link_via_callback(profile, operator, &store, options, page).await
+        }
+    }
 }
 
 /// One device row, from the account space's own facts.
@@ -1424,6 +1529,307 @@ mod tests {
         assert!(
             error.to_string().contains("subject-open"),
             "the error must say what shape was required, got {error}"
+        );
+    }
+
+    /// A modern callback must name the exact service generation. Without it,
+    /// restart recovery and logout would have to guess which row to target.
+    #[dialog_common::test]
+    async fn it_refuses_a_callback_without_an_attachment_generation() {
+        use dialog_credentials::Ed25519Signer;
+        use dialog_effects::storage::Directory;
+
+        let temp = tempfile::tempdir().unwrap();
+        let storage = dialog_storage::provider::storage::Storage::<NativeSpace>::default();
+        let profile = Profile::open(format!("link-generation-test-{}", rand::random::<u64>()))
+            .at(Directory::At(
+                temp.path().join("profiles").to_string_lossy().into(),
+            ))
+            .perform(&storage)
+            .await
+            .unwrap();
+        let service_url = "https://accounts.example/ucan/".to_string();
+        let account = Ed25519Signer::generate().await.unwrap();
+        let authorized =
+            tonk_identity::ceremony::authorize_device(account, profile.did(), &service_url)
+                .await
+                .unwrap();
+
+        let error = account_from_callback(
+            &profile,
+            &LinkOptions {
+                service_url: service_url.clone(),
+                device_name: "generation test".to_owned(),
+                open_browser: false,
+                store: None,
+                announce: None,
+                via: None,
+            },
+            CallbackAuthorization {
+                delegation_hex: authorized.delegation_hex,
+                descriptor_hex: authorized.descriptor_hex,
+                credential_id: authorized.root_did,
+                attachment_id: "  ".to_owned(),
+                service_url,
+            },
+        )
+        .await
+        .expect_err("a callback without an exact generation must be refused");
+
+        assert!(
+            error.to_string().contains("attachment generation"),
+            "unexpected missing-generation error: {error:#}"
+        );
+    }
+
+    struct RecoveryFixture {
+        _temp: tempfile::TempDir,
+        store: crate::space::SpaceStore,
+        profile_dir: dialog_effects::storage::Directory,
+        profile_name: String,
+        account_dir: std::path::PathBuf,
+        service_url: String,
+        account: crate::account_session::ActiveAccount,
+    }
+
+    impl RecoveryFixture {
+        async fn new() -> (Self, Profile, dialog_operator::Operator<NativeSpace>) {
+            use dialog_capability::Subject;
+            use dialog_credentials::Ed25519Signer;
+            use dialog_effects::storage::Directory;
+            use dialog_storage::provider::storage::Storage;
+
+            let temp = tempfile::tempdir().unwrap();
+            let store = crate::space::SpaceStore::at(temp.path().join("state"));
+            let profile_dir = Directory::At(temp.path().join("profiles").to_string_lossy().into());
+            let profile_name = format!("cli-account-recovery-test-{}", rand::random::<u64>());
+            let storage = Storage::<NativeSpace>::default();
+            let profile = Profile::open(&profile_name)
+                .at(profile_dir.clone())
+                .perform(&storage)
+                .await
+                .unwrap();
+            std::fs::create_dir_all(store.account_dir()).unwrap();
+            let account_dir = store.account_dir().canonicalize().unwrap();
+            let operator = profile
+                .derive(b"tonk/account-state/v1")
+                .allow(Subject::any())
+                .base(Directory::At(account_dir.to_string_lossy().into()))
+                .build(storage)
+                .await
+                .unwrap();
+            let service_url = "http://127.0.0.1:9/ucan/".to_string();
+            let signer = Ed25519Signer::generate().await.unwrap();
+            let authorized =
+                tonk_identity::ceremony::authorize_device(signer, profile.did(), &service_url)
+                    .await
+                    .unwrap();
+            let grant_bytes = hex::decode(&authorized.delegation_hex).unwrap();
+            let grant = validate_account_grant(&profile, &grant_bytes)
+                .await
+                .unwrap();
+            let account = crate::account_session::ActiveAccount {
+                provider: service_url.trim_end_matches('/').to_owned(),
+                credential_id: authorized.root_did,
+                root_did: grant.issuer().to_string(),
+                delegation_cid: grant.proof_cids()[0].to_string(),
+                delegation_hex: hex::encode(grant_bytes),
+                descriptor_hex: Some(authorized.descriptor_hex),
+                attachment_id: "service-generation-7".to_owned(),
+                attached_at: 7,
+            };
+            (
+                Self {
+                    _temp: temp,
+                    store,
+                    profile_dir,
+                    profile_name,
+                    account_dir,
+                    service_url,
+                    account,
+                },
+                profile,
+                operator,
+            )
+        }
+
+        async fn reopen(&self) -> (Profile, dialog_operator::Operator<NativeSpace>) {
+            use dialog_capability::Subject;
+            use dialog_effects::storage::Directory;
+            use dialog_storage::provider::storage::Storage;
+
+            let storage = Storage::<NativeSpace>::default();
+            let profile = Profile::open(&self.profile_name)
+                .at(self.profile_dir.clone())
+                .perform(&storage)
+                .await
+                .unwrap();
+            let operator = profile
+                .derive(b"tonk/account-state/v1")
+                .allow(Subject::any())
+                .base(Directory::At(self.account_dir.to_string_lossy().into()))
+                .build(storage)
+                .await
+                .unwrap();
+            (profile, operator)
+        }
+
+        fn options(
+            &self,
+            announce: Option<tokio::sync::mpsc::UnboundedSender<String>>,
+        ) -> LinkOptions {
+            LinkOptions {
+                service_url: self.service_url.clone(),
+                device_name: "recovery test".to_owned(),
+                open_browser: false,
+                store: Some(self.store.clone()),
+                announce,
+                via: Some("http://127.0.0.1:3000/link".to_owned()),
+            }
+        }
+    }
+
+    fn assert_no_browser_announcement(
+        announced: &mut tokio::sync::mpsc::UnboundedReceiver<String>,
+    ) {
+        assert!(
+            matches!(
+                announced.try_recv(),
+                Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+                    | Err(tokio::sync::mpsc::error::TryRecvError::Disconnected)
+            ),
+            "recovery must not announce a new browser handoff"
+        );
+    }
+
+    /// A process reopening after the browser callback finishes the exact
+    /// durable generation instead of starting another handoff.
+    #[dialog_common::test]
+    async fn it_resumes_the_exact_pending_attachment_after_reopen() {
+        let (fixture, profile, operator) = RecoveryFixture::new().await;
+        let staged = crate::account_session::stage_activation(
+            &profile,
+            &operator,
+            &fixture.store,
+            fixture.account.clone(),
+        )
+        .await
+        .unwrap();
+        drop(staged);
+        drop(operator);
+        drop(profile);
+
+        let (profile, operator) = fixture.reopen().await;
+        let (announce, mut announced) = tokio::sync::mpsc::unbounded_channel();
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(1),
+            link_with_operator(&profile, &operator, &fixture.options(Some(announce))),
+        )
+        .await
+        .expect("pending recovery must not wait for a browser")
+        .unwrap();
+
+        assert_eq!(outcome.root_did, fixture.account.root_did);
+        assert_no_browser_announcement(&mut announced);
+        let guard = crate::account_session::shared_remote_guard(&fixture.store).unwrap();
+        let state = crate::account_session::load_guarded(&profile, &operator, &guard)
+            .await
+            .unwrap();
+        assert_eq!(state.active, Some(fixture.account.clone()));
+        assert!(state.pending_login.is_none());
+    }
+
+    /// Replaying all compatibility writes after a failed final commit must be
+    /// idempotent and must preserve the exact staged generation.
+    #[dialog_common::test]
+    async fn it_replays_projection_after_a_pre_commit_finalization_failure() {
+        let (fixture, profile, operator) = RecoveryFixture::new().await;
+        let staged = crate::account_session::stage_activation(
+            &profile,
+            &operator,
+            &fixture.store,
+            fixture.account.clone(),
+        )
+        .await
+        .unwrap();
+        drop(staged);
+        let state_file = std::fs::read_dir(fixture.store.account_dir())
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .find(|path| {
+                path.file_name()
+                    .is_some_and(|name| name.to_string_lossy().ends_with(".json"))
+            })
+            .unwrap();
+        let tmp = state_file.with_extension("json.tmp");
+        std::fs::create_dir(&tmp).unwrap();
+
+        let error = link_with_operator(&profile, &operator, &fixture.options(None))
+            .await
+            .expect_err("the obstructed final commit must fail after projection");
+        assert!(error.to_string().contains("account-session temp file"));
+        assert!(
+            crate::identity::local_root_with_operator(&profile, &operator)
+                .await
+                .unwrap()
+                .is_some(),
+            "the projection reached the local-root write before finalization"
+        );
+        std::fs::remove_dir(&tmp).unwrap();
+        drop(operator);
+        drop(profile);
+
+        let (profile, operator) = fixture.reopen().await;
+        let outcome = link_with_operator(&profile, &operator, &fixture.options(None))
+            .await
+            .expect("replaying the completed projection must converge");
+        assert_eq!(outcome.root_did, fixture.account.root_did);
+    }
+
+    /// A crash after Active but before the outer command's registry write
+    /// reconciles from the canonical generation without another browser.
+    #[dialog_common::test]
+    async fn it_reconciles_an_active_generation_after_outer_command_restart() {
+        let (fixture, profile, operator) = RecoveryFixture::new().await;
+        complete_staged_account(&profile, &operator, &fixture.store, &fixture.account)
+            .await
+            .unwrap();
+        drop(operator);
+        drop(profile);
+
+        let (profile, operator) = fixture.reopen().await;
+        let (announce, mut announced) = tokio::sync::mpsc::unbounded_channel();
+        let outcome = link_with_operator(&profile, &operator, &fixture.options(Some(announce)))
+            .await
+            .expect("active recovery must finish the interrupted outer command");
+        assert_eq!(outcome.root_did, fixture.account.root_did);
+        assert_no_browser_announcement(&mut announced);
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_active_state_whose_grant_names_another_root() {
+        let (fixture, profile, operator) = RecoveryFixture::new().await;
+        let mut corrupt = fixture.account.clone();
+        corrupt.root_did = profile.did().to_string();
+        let guard = crate::account_session::stage_activation(
+            &profile,
+            &operator,
+            &fixture.store,
+            corrupt.clone(),
+        )
+        .await
+        .unwrap();
+        crate::account_session::finalize_activation(&profile, &operator, guard, &corrupt)
+            .await
+            .unwrap();
+
+        let error = link_with_operator(&profile, &operator, &fixture.options(None))
+            .await
+            .expect_err("active recovery must bind its grant to the recorded root");
+        assert!(
+            error.to_string().contains("recorded generation"),
+            "unexpected corrupt-active error: {error:#}"
         );
     }
 }

--- a/rust/tonk-cli/src/account_session.rs
+++ b/rust/tonk-cli/src/account_session.rs
@@ -26,7 +26,7 @@ pub struct AccountSessionState {
     pub version: u8,
     /// The only attachment authorized for remote account access.
     pub active: Option<ActiveAccount>,
-    /// Crash-recoverable browser handoff phase.
+    /// Crash-recoverable activation or a legacy browser handoff.
     pub pending_login: Option<PendingLogin>,
 }
 
@@ -38,6 +38,19 @@ impl Default for AccountSessionState {
             pending_login: None,
         }
     }
+}
+
+fn validate_state(state: &AccountSessionState) -> Result<()> {
+    if state.version != VERSION {
+        anyhow::bail!(
+            "unsupported account-session state version {}",
+            state.version
+        );
+    }
+    if state.active.is_some() && state.pending_login.is_some() {
+        anyhow::bail!("account-session state cannot be active and pending simultaneously");
+    }
+    Ok(())
 }
 
 /// Provider sign-in phase visible without opening a Dialog profile.
@@ -75,12 +88,7 @@ pub fn inspect_local(store: &SpaceStore) -> Result<LocalPhase> {
         let bytes = std::fs::read(entry.path())?;
         let state: AccountSessionState =
             serde_json::from_slice(&bytes).context("stored account-session state is malformed")?;
-        if state.version != VERSION {
-            anyhow::bail!(
-                "unsupported account-session state version {}",
-                state.version
-            );
-        }
+        validate_state(&state)?;
         return Ok(if state.active.is_some() {
             LocalPhase::Active
         } else if state.pending_login.is_some() {
@@ -92,11 +100,12 @@ pub fn inspect_local(store: &SpaceStore) -> Result<LocalPhase> {
     Ok(LocalPhase::SignedOut)
 }
 
-/// Durable browser handoff phase.
+/// Durable login recovery phase.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum PendingLogin {
-    /// The browser has not completed the handoff yet.
+    /// A legacy browser handoff whose process-local callback cannot be
+    /// resumed. A new client reports this state and asks the user to log out.
     Waiting {
         /// Provider service URL.
         provider: String,
@@ -107,10 +116,6 @@ pub enum PendingLogin {
     },
     /// Grant material is durable locally and activation can be replayed.
     Activating {
-        /// Provider service URL.
-        provider: String,
-        /// Raw secret retained for recovery diagnostics/re-consumption.
-        secret: String,
         /// Exact completed account generation.
         account: ActiveAccount,
     },
@@ -147,6 +152,14 @@ pub struct AccountSessionReadGuard {
 pub struct AccountSessionWriteGuard {
     _file: File,
     store: SpaceStore,
+}
+
+/// Exclusive token retained from durable activation staging through final
+/// promotion. Its contents are intentionally private: only this module may
+/// decide which staged generation the token authorizes.
+pub struct AccountActivationGuard {
+    _guard: AccountSessionWriteGuard,
+    pending: PendingLogin,
 }
 
 fn lock_file(store: &SpaceStore) -> Result<File> {
@@ -191,6 +204,16 @@ fn state_path(profile: &Profile, store: &SpaceStore) -> Result<PathBuf> {
         .join(format!("{STATE_FILE_PREFIX}-{profile_key}.json")))
 }
 
+fn legacy_provider_bytes(
+    result: std::result::Result<Vec<u8>, dialog_effects::credential::CredentialError>,
+) -> Result<Option<Vec<u8>>> {
+    match result {
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(error) if crate::account_state::credential_is_missing(&error) => Ok(None),
+        Err(error) => Err(error).context("failed to load the legacy account provider"),
+    }
+}
+
 async fn load_raw(
     profile: &Profile,
     _operator: &Operator<NativeSpace>,
@@ -207,12 +230,7 @@ async fn load_raw(
     };
     let state: AccountSessionState =
         serde_json::from_slice(&bytes).context("stored account-session state is malformed")?;
-    if state.version != VERSION {
-        anyhow::bail!(
-            "unsupported account-session state version {}",
-            state.version
-        );
-    }
+    validate_state(&state)?;
     Ok(Some(state))
 }
 
@@ -259,10 +277,9 @@ async fn save_raw(
     Ok(())
 }
 
-/// Project the persisted root and provider record into an active
-/// session, when both are present. This is what the legacy migration in
-/// [`ensure_initialized`] reads, and what a completed callback link
-/// activates from.
+/// Project the persisted root and provider record into an active session,
+/// when both are present. This is used only to migrate legacy installs that
+/// predate canonical account-session state.
 async fn projected_active(
     profile: &Profile,
     operator: &Operator<NativeSpace>,
@@ -274,13 +291,15 @@ async fn projected_active(
         .root_did
         .parse()
         .context("stored root DID is invalid")?;
-    let bytes = profile
-        .credential()
-        .site(crate::account::ACCOUNT_LINK_SITE)
-        .load::<Vec<u8>>()
-        .perform(operator)
-        .await;
-    let Ok(bytes) = bytes else {
+    let Some(bytes) = legacy_provider_bytes(
+        profile
+            .credential()
+            .site(crate::account::ACCOUNT_LINK_SITE)
+            .load::<Vec<u8>>()
+            .perform(operator)
+            .await,
+    )?
+    else {
         return Ok(None);
     };
     if bytes.is_empty() {
@@ -323,27 +342,59 @@ pub async fn ensure_initialized(
     save_raw(profile, operator, &guard.store, &state).await
 }
 
-/// Activate the session for a link that just persisted its root and
-/// provider record: the callback flow's counterpart to the legacy
-/// migration above, which only runs when no canonical state exists yet.
-pub async fn activate_link(
+/// Persist the exact post-callback account generation before compatibility
+/// projection writes begin, retaining the exclusive transition lock.
+pub async fn stage_activation(
     profile: &Profile,
     operator: &Operator<NativeSpace>,
     store: &SpaceStore,
-    attachment_id: Option<String>,
-) -> Result<()> {
+    account: ActiveAccount,
+) -> Result<AccountActivationGuard> {
     let guard = exclusive_transition_guard(store)?;
     ensure_initialized(profile, operator, &guard).await?;
-    let mut active = projected_active(profile, operator)
-        .await?
-        .context("link completed but its root and provider record did not persist")?;
-    if let Some(attachment_id) = attachment_id {
-        active.attachment_id = attachment_id;
-    }
     let mut state = load_raw(profile, operator, store)
         .await?
         .unwrap_or_default();
-    state.active = Some(active);
+    let pending = PendingLogin::Activating { account };
+    match (&state.active, &state.pending_login) {
+        (None, None) => {
+            state.pending_login = Some(pending.clone());
+            save_raw(profile, operator, store, &state).await?;
+        }
+        (None, Some(existing)) if existing == &pending => {}
+        _ => {
+            anyhow::bail!(
+                "cannot stage account activation while another account transition exists"
+            );
+        }
+    }
+    Ok(AccountActivationGuard {
+        _guard: guard,
+        pending,
+    })
+}
+
+/// Atomically promote the exact staged callback generation to active.
+pub async fn finalize_activation(
+    profile: &Profile,
+    operator: &Operator<NativeSpace>,
+    guard: AccountActivationGuard,
+    account: &ActiveAccount,
+) -> Result<()> {
+    let expected = PendingLogin::Activating {
+        account: account.clone(),
+    };
+    if guard.pending != expected {
+        anyhow::bail!("activation guard belongs to a different account generation");
+    }
+    let store = &guard._guard.store;
+    let mut state = load_raw(profile, operator, store)
+        .await?
+        .context("account-session state has not been initialized")?;
+    if state.active.is_some() || state.pending_login.as_ref() != Some(&expected) {
+        anyhow::bail!("staged account activation changed before finalization");
+    }
+    state.active = Some(account.clone());
     state.pending_login = None;
     save_raw(profile, operator, store, &state).await
 }
@@ -382,6 +433,7 @@ pub async fn logout_transition_for_store(
     let mut state = load_raw(profile, operator, store)
         .await?
         .unwrap_or_default();
+    let existed = state.active.is_some() || state.pending_login.is_some();
     let mut detached = Vec::new();
     if let Some(active) = state.active.take() {
         detached.push(active);
@@ -389,7 +441,6 @@ pub async fn logout_transition_for_store(
     if let Some(PendingLogin::Activating { account, .. }) = state.pending_login.take() {
         detached.push(account);
     }
-    let existed = !detached.is_empty() || state.pending_login.is_some();
     state.pending_login = None;
     if existed {
         save_raw(profile, operator, store, &state).await?;
@@ -445,4 +496,351 @@ pub(crate) async fn install_for_integration_test(
     let store = operator.store();
     let _guard = exclusive_transition_guard(store)?;
     save_raw(profile, operator.local(), store, state).await
+}
+
+#[cfg(test)]
+mod tests {
+    use dialog_capability::Subject;
+    use dialog_effects::storage::Directory;
+    use dialog_operator::DeriveOperator as _;
+    use dialog_storage::provider::storage::Storage;
+
+    use super::*;
+
+    async fn isolated_session() -> (
+        tempfile::TempDir,
+        SpaceStore,
+        Profile,
+        Operator<NativeSpace>,
+    ) {
+        let temp = tempfile::tempdir().unwrap();
+        let store = SpaceStore::at(temp.path().join("state"));
+        let profile_dir = Directory::At(temp.path().join("profiles").to_string_lossy().into());
+        let storage = Storage::<NativeSpace>::default();
+        let profile = Profile::open(format!("account-session-test-{}", rand::random::<u64>()))
+            .at(profile_dir)
+            .perform(&storage)
+            .await
+            .unwrap();
+        std::fs::create_dir_all(store.account_dir()).unwrap();
+        let account_dir = store.account_dir().canonicalize().unwrap();
+        let operator = profile
+            .derive(b"tonk/account-session-test/v1")
+            .allow(Subject::any())
+            .base(Directory::At(account_dir.to_string_lossy().into()))
+            .build(storage)
+            .await
+            .unwrap();
+        (temp, store, profile, operator)
+    }
+
+    fn active_account(attachment_id: &str) -> ActiveAccount {
+        ActiveAccount {
+            provider: "https://accounts.example".to_string(),
+            credential_id: "credential".to_string(),
+            root_did: "did:key:z6MkhFDyBYNT1Y1jNj8RJKVc7CWurCVPmrnGEGmbYxvwHJkX".to_string(),
+            delegation_cid: "bafk-delegation".to_string(),
+            delegation_hex: "00".to_string(),
+            descriptor_hex: Some("01".to_string()),
+            attachment_id: attachment_id.to_string(),
+            attached_at: 42,
+        }
+    }
+
+    #[dialog_common::test]
+    fn activating_decodes_the_legacy_duplicate_fields_but_does_not_reemit_them() {
+        let account = active_account("legacy-generation");
+        let legacy = serde_json::json!({
+            "activating": {
+                "provider": "https://accounts.example",
+                "secret": "legacy-unused-secret",
+                "account": account,
+            }
+        });
+
+        let decoded: PendingLogin = serde_json::from_value(legacy).unwrap();
+
+        assert_eq!(
+            serde_json::to_value(decoded).unwrap(),
+            serde_json::json!({
+                "activating": {
+                    "account": active_account("legacy-generation"),
+                }
+            })
+        );
+    }
+
+    #[dialog_common::test]
+    fn legacy_migration_distinguishes_absence_from_storage_failure() {
+        use dialog_effects::credential::CredentialError;
+
+        assert_eq!(
+            legacy_provider_bytes(Err(CredentialError::NotFound("missing".to_owned()))).unwrap(),
+            None
+        );
+        let error = legacy_provider_bytes(Err(CredentialError::Storage(
+            "permission denied".to_owned(),
+        )))
+        .expect_err("a transient provider read failure must not become signed out");
+        assert!(error.to_string().contains("legacy account provider"));
+    }
+
+    #[dialog_common::test]
+    async fn inspect_local_distinguishes_signed_out_pending_and_active_states() {
+        let (_temp, store, profile, operator) = isolated_session().await;
+
+        assert_eq!(inspect_local(&store).unwrap(), LocalPhase::SignedOut);
+
+        save_raw(&profile, &operator, &store, &AccountSessionState::default())
+            .await
+            .unwrap();
+        assert_eq!(inspect_local(&store).unwrap(), LocalPhase::SignedOut);
+
+        let mut state = AccountSessionState {
+            pending_login: Some(PendingLogin::Waiting {
+                provider: "https://accounts.example".to_string(),
+                secret: "one-time-secret".to_string(),
+                token_hash: "token-hash".to_string(),
+            }),
+            ..Default::default()
+        };
+        save_raw(&profile, &operator, &store, &state).await.unwrap();
+        assert_eq!(inspect_local(&store).unwrap(), LocalPhase::Pending);
+
+        state.pending_login = Some(PendingLogin::Activating {
+            account: active_account("pending-generation"),
+        });
+        save_raw(&profile, &operator, &store, &state).await.unwrap();
+        assert_eq!(inspect_local(&store).unwrap(), LocalPhase::Pending);
+
+        state.pending_login = None;
+        state.active = Some(active_account("active-generation"));
+        save_raw(&profile, &operator, &store, &state).await.unwrap();
+        assert_eq!(inspect_local(&store).unwrap(), LocalPhase::Active);
+    }
+
+    #[dialog_common::test]
+    async fn active_and_pending_authority_fails_closed() {
+        let (_temp, store, profile, operator) = isolated_session().await;
+        let state = AccountSessionState {
+            active: Some(active_account("active-generation")),
+            pending_login: Some(PendingLogin::Activating {
+                account: active_account("pending-generation"),
+            }),
+            ..Default::default()
+        };
+        save_raw(&profile, &operator, &store, &state).await.unwrap();
+
+        let error =
+            inspect_local(&store).expect_err("contradictory state must not be reported as active");
+        assert!(error.to_string().contains("active and pending"));
+
+        let guard = shared_remote_guard(&store).unwrap();
+        let error = load_guarded(&profile, &operator, &guard)
+            .await
+            .expect_err("contradictory state must not authorize a remote request");
+        assert!(error.to_string().contains("active and pending"));
+    }
+
+    #[dialog_common::test]
+    async fn stage_activation_is_the_first_durable_post_callback_write() {
+        let (_temp, store, profile, operator) = isolated_session().await;
+        let account = active_account("callback-generation");
+
+        let guard = stage_activation(&profile, &operator, &store, account.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            load_raw(&profile, &operator, &store).await.unwrap(),
+            Some(AccountSessionState {
+                version: VERSION,
+                active: None,
+                pending_login: Some(PendingLogin::Activating { account }),
+            })
+        );
+        drop(guard);
+        assert_eq!(inspect_local(&store).unwrap(), LocalPhase::Pending);
+    }
+
+    #[dialog_common::test]
+    async fn activation_resume_is_idempotent_and_rejects_a_different_generation() {
+        let (_temp, store, profile, operator) = isolated_session().await;
+        let account = active_account("callback-generation");
+        let mut other = account.clone();
+        other.delegation_cid = "fresh-delegation".to_owned();
+        other.delegation_hex = "02".to_owned();
+
+        drop(
+            stage_activation(&profile, &operator, &store, account.clone())
+                .await
+                .unwrap(),
+        );
+        drop(
+            stage_activation(&profile, &operator, &store, account.clone())
+                .await
+                .expect("reopening the exact generation is idempotent"),
+        );
+
+        let error = match stage_activation(&profile, &operator, &store, other).await {
+            Ok(_) => panic!("a different callback generation must not replace pending state"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("another account transition"));
+        assert_eq!(
+            load_raw(&profile, &operator, &store).await.unwrap(),
+            Some(AccountSessionState {
+                version: VERSION,
+                active: None,
+                pending_login: Some(PendingLogin::Activating { account }),
+            })
+        );
+    }
+
+    #[dialog_common::test]
+    async fn finalize_activation_promotes_only_the_exact_staged_generation() {
+        let (_temp, store, profile, operator) = isolated_session().await;
+        let account = active_account("callback-generation");
+        let other = active_account("other-generation");
+
+        let guard = stage_activation(&profile, &operator, &store, account.clone())
+            .await
+            .unwrap();
+        let error = finalize_activation(&profile, &operator, guard, &other)
+            .await
+            .expect_err("a stale finalizer must not promote another generation");
+        assert!(error.to_string().contains("different account generation"));
+
+        assert_eq!(
+            load_raw(&profile, &operator, &store).await.unwrap(),
+            Some(AccountSessionState {
+                version: VERSION,
+                active: None,
+                pending_login: Some(PendingLogin::Activating {
+                    account: account.clone(),
+                }),
+            })
+        );
+
+        let guard = stage_activation(&profile, &operator, &store, account.clone())
+            .await
+            .expect("the exact generation remains resumable");
+        finalize_activation(&profile, &operator, guard, &account)
+            .await
+            .expect("the exact generation is promoted");
+        assert_eq!(
+            load_raw(&profile, &operator, &store).await.unwrap(),
+            Some(AccountSessionState {
+                version: VERSION,
+                active: Some(account),
+                pending_login: None,
+            })
+        );
+    }
+
+    #[dialog_common::test]
+    async fn pre_commit_final_save_failure_preserves_the_pending_generation() {
+        let (_temp, store, profile, operator) = isolated_session().await;
+        let account = active_account("callback-generation");
+        let guard = stage_activation(&profile, &operator, &store, account.clone())
+            .await
+            .unwrap();
+        let tmp = state_path(&profile, &store)
+            .unwrap()
+            .with_extension("json.tmp");
+        std::fs::create_dir(&tmp).unwrap();
+
+        let error = finalize_activation(&profile, &operator, guard, &account)
+            .await
+            .expect_err("an obstructed atomic replacement must fail");
+        assert!(
+            error
+                .to_string()
+                .contains("failed to create account-session temp file"),
+            "unexpected save failure: {error:#}"
+        );
+        assert_eq!(
+            load_raw(&profile, &operator, &store).await.unwrap(),
+            Some(AccountSessionState {
+                version: VERSION,
+                active: None,
+                pending_login: Some(PendingLogin::Activating { account }),
+            })
+        );
+    }
+
+    #[dialog_common::test]
+    async fn stage_activation_resumes_the_identical_generation_after_restart() {
+        let (_temp, store, profile, operator) = isolated_session().await;
+        let account = active_account("callback-generation");
+        let first = stage_activation(&profile, &operator, &store, account.clone())
+            .await
+            .unwrap();
+        drop(first);
+        let before = load_raw(&profile, &operator, &store).await.unwrap();
+
+        let resumed = stage_activation(&profile, &operator, &store, account)
+            .await
+            .unwrap();
+
+        assert_eq!(load_raw(&profile, &operator, &store).await.unwrap(), before);
+        drop(resumed);
+    }
+
+    #[dialog_common::test]
+    async fn logout_clears_a_durable_waiting_handoff() {
+        let (_temp, store, profile, operator) = isolated_session().await;
+        let state = AccountSessionState {
+            pending_login: Some(PendingLogin::Waiting {
+                provider: "https://accounts.example".to_string(),
+                secret: "one-time-secret".to_string(),
+                token_hash: "token-hash".to_string(),
+            }),
+            ..Default::default()
+        };
+        save_raw(&profile, &operator, &store, &state).await.unwrap();
+        assert_eq!(inspect_local(&store).unwrap(), LocalPhase::Pending);
+
+        let detached = logout_transition_for_store(&profile, &operator, &store)
+            .await
+            .unwrap();
+
+        assert!(detached.is_empty());
+        assert_eq!(inspect_local(&store).unwrap(), LocalPhase::SignedOut);
+        assert_eq!(
+            load_raw(&profile, &operator, &store)
+                .await
+                .unwrap()
+                .unwrap()
+                .pending_login,
+            None
+        );
+    }
+
+    #[dialog_common::test]
+    async fn logout_detaches_a_durable_activating_generation_exactly_once() {
+        let (_temp, store, profile, operator) = isolated_session().await;
+        let pending_account = active_account("pending-generation");
+        let state = AccountSessionState {
+            pending_login: Some(PendingLogin::Activating {
+                account: pending_account.clone(),
+            }),
+            ..Default::default()
+        };
+        save_raw(&profile, &operator, &store, &state).await.unwrap();
+
+        assert_eq!(
+            logout_transition_for_store(&profile, &operator, &store)
+                .await
+                .unwrap(),
+            vec![pending_account]
+        );
+        assert_eq!(inspect_local(&store).unwrap(), LocalPhase::SignedOut);
+        assert!(
+            logout_transition_for_store(&profile, &operator, &store)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
 }

--- a/rust/tonk-cli/tests/account_authority.rs
+++ b/rust/tonk-cli/tests/account_authority.rs
@@ -171,6 +171,7 @@ async fn it_installs_authority_from_a_callback_authorization(
         "delegationHex": authorized.delegation_hex,
         "descriptorHex": authorized.descriptor_hex,
         "credentialId": authorized.root_did,
+        "attachmentId": "4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d",
     })
     .to_string();
     let encoded = base64::engine::general_purpose::STANDARD.encode(&payload);

--- a/rust/tonk-cli/tests/common.rs
+++ b/rust/tonk-cli/tests/common.rs
@@ -462,6 +462,7 @@ pub async fn authorizing_page(
             "delegationHex": authorized.delegation_hex,
             "descriptorHex": authorized.descriptor_hex,
             "credentialId": authorized.root_did,
+            "attachmentId": "0707070707070707070707070707070707070707070707070707070707070707",
         })
         .to_string();
         let encoded = base64::engine::general_purpose::STANDARD.encode(payload);

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -2447,10 +2447,16 @@ mod tests {
         assert_eq!(field, "authorize", "approving must deliver a grant");
 
         // What arrived is what the CLI decodes: base64 over a payload
-        // carrying both the delegation and the descriptor.
+        // carrying the delegation, descriptor, exact service attachment, and
+        // provider needed for a crash-safe CLI activation.
         let decoded = base64::engine::general_purpose::STANDARD.decode(&value)?;
         let payload: serde_json::Value = serde_json::from_slice(&decoded)?;
-        for field in ["delegationHex", "descriptorHex"] {
+        for field in [
+            "delegationHex",
+            "descriptorHex",
+            "attachmentId",
+            "serviceUrl",
+        ] {
             assert!(
                 payload
                     .get(field)


### PR DESCRIPTION
## Summary

- persist the exact validated callback generation as a durable `Activating` checkpoint before compatibility projection
- finalize activation with exact compare-and-set semantics and resume either `Activating` or already-promoted `Active` state after process restart
- bind stored grants to their recorded root DID and proof CID, require a non-empty callback attachment, and fail closed on contradictory state
- clear durable pending login state during logout and distinguish absent legacy credentials from storage failures
- strengthen the browser callback handoff assertion and add focused state-machine, restart, failure-injection, and corrupt-state tests

## TDD evidence

The new tests were observed failing before their corresponding implementation for staged/final activation, restart recovery, missing attachments, contradictory state, active-root corruption, and pending-state logout.

## Verification

- `cargo test -p tonk-cli --lib -- --test-threads=1`: 181 passed
- `cargo test -p tonk-cli --features integration-tests --test account_authority -- --test-threads=1`: 10 passed
- `cargo test -p tonk-cli --features integration-tests --test account_interrupt -- --test-threads=1`: 2 passed
- CLI and UI Clippy with integration features and `-D warnings`
- `cargo test -p tonk-ui --features integration-tests --no-run`
- `cargo fmt --all -- --check`
- `git diff --check`

The focused live-browser test remains environment-blocked before behavior: ChromeDriver supports Chrome 150 while the installed browser is Chrome 152.

## Stack

Depends on #788.

Base: `feat/storybook`.

## Deferred boundaries

- replay and acknowledgement before callback delivery
- atomic settlement between post-activation hydration and concurrent logout
- same-device browser relink generation binding, tracked as B-06 in the Storybook

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the account activation process within the `tonk` application by adding new fields, refining state validation, and improving error handling for account linking and activation.

### Detailed summary
- Added `attachmentId` fields in `common.rs` and `account_authority.rs`.
- Updated comments in `account_flow.rs` for clarity.
- Introduced `validate_state` function in `account_session.rs` to ensure proper state validation.
- Enhanced `PendingLogin` documentation.
- Implemented account activation staging and finalization in `account.rs`.
- Added tests for attachment generation and recovery scenarios.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->