### PR TITLE
test(ui): harden account browser state transitions

### DIFF
--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -423,13 +423,6 @@ mod tests {
             );
         }
 
-        let select_all = || {
-            if cfg!(target_os = "macos") {
-                Key::Meta + "a"
-            } else {
-                Key::Control + "a"
-            }
-        };
         // The name write lands in the account state, whose first sync
         // races this test right after activation — until the pull lands
         // the worker refuses it as account_state_unavailable, and the
@@ -441,7 +434,18 @@ mod tests {
             // A save in flight disables the input, and typing into a
             // disabled input errors — that too reads as "not yet".
             let typed = async {
-                display_name.send_keys(select_all()).await?;
+                driver
+                    .execute(
+                        r#"const input = document.querySelector('#account-display-name');
+                        input.focus();
+                        input.select();
+                        if (input.selectionStart !== 0 || input.selectionEnd !== input.value.length) {
+                            throw new Error('display name was not fully selected');
+                        }
+                        return true;"#,
+                        Vec::new(),
+                    )
+                    .await?;
                 display_name.send_keys("Settings Name").await?;
                 display_name.send_keys(Key::Enter).await?;
                 Ok::<(), thirtyfour::error::WebDriverError>(())
@@ -1762,6 +1766,11 @@ mod tests {
              directory; last `account space` output was: {last_seen}"
         );
 
+        // Clearing origin storage unregisters the service worker, but the
+        // worker controlling the current page can stay alive with the linked
+        // profile in memory. Leave its scope first, then stop that surviving
+        // process after the clear so the next visit really is a fresh device.
+        goto(&claimer, "about:blank").await?;
         let devtools = ChromeDevTools::new(claimer.handle.clone());
         devtools
             .execute_cdp_with_params(
@@ -1772,6 +1781,8 @@ mod tests {
                 }),
             )
             .await?;
+        devtools.execute_cdp("ServiceWorker.enable").await?;
+        devtools.execute_cdp("ServiceWorker.stopAllWorkers").await?;
         goto(&claimer, env.tonk_web.as_str()).await?;
         wait_for_service_worker(&claimer).await?;
         goto(&claimer, env.tonk_web.join("settings")?.as_str()).await?;


### PR DESCRIPTION
## Summary

- select the prefilled account display name in place before typing, avoiding platform shortcut delivery and the blur handler that restores empty values
- leave the controlled origin and stop its surviving service worker after clearing storage, so the fresh-device login cannot reuse an in-memory linked profile

## Root cause

The earlier PR run exposed two harness races after the broader account fixes landed in staging via #785. WebDriver clear triggers the production blur handler, while a Ctrl/Cmd+A chord is not reliable enough for a retry loop. Separately, clearing origin storage unregisters a service worker but does not guarantee that the worker controlling the current page stops; that live worker can retain the old profile in memory.

## Verification

- exact matched Chrome 150 E2E: account_flow::tests::it_signs_up_through_the_account_panels passed
- repository lint suite passed: Clippy, rustfmt, nixfmt, and shared-workspace dependencies
- web-debug test archive built successfully
- cargo fmt --all -- --check
- git diff --check

The full local backup test still stops earlier at the spawned tonk account space --json timeout, before it reaches the browser reset. The GitHub account job is the authoritative full-path check for that transition.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of the `display_name` input field in the web application, ensuring that the input is fully selected before further actions are performed. It also enhances service worker management during testing.

### Detailed summary
- Removed the `select_all` closure and replaced it with a direct JavaScript execution to focus and select the `#account-display-name` input.
- Added a check to ensure the input is fully selected; throws an error if not.
- Introduced service worker management by enabling and stopping all workers during tests.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->