### PR TITLE
The sync disc must not paint during a connect callback

### DIFF
--- a/rust/tonk-workspace/src/ui_sync_status.rs
+++ b/rust/tonk-workspace/src/ui_sync_status.rs
@@ -258,12 +258,22 @@ fn paint(host: &HtmlElement, status: &str) {
     // tag, so this element stays ignorant of who is using it.
     if host.has_attribute("headless") {
         if let Some(parent) = host.parent_element() {
-            let _ = parent.set_attribute("state", disc_state(status));
-            // The disc has three shapes but sync has eight states, so the
-            // precise one travels alongside it for the accessible name —
-            // "revoked" and "conflict" both draw a hollow ring, and losing
-            // the distinction from the label would make them unreportable.
-            let _ = parent.set_attribute("data-sync-status", status);
+            // DEFERRED, not written inline. `paint` runs from
+            // `connected_callback`, and the parent is itself a custom element:
+            // writing an observed attribute on it synchronously re-enters that
+            // element's `attributeChangedCallback` while `custom_elements`
+            // still holds this one's state mutex, which panics with "cannot
+            // recursively acquire mutex" and takes the whole guest down.
+            // A microtask lands the same write once the callback has returned.
+            let status = status.to_owned();
+            spawn_local(async move {
+                let _ = parent.set_attribute("state", disc_state(&status));
+                // The disc has three shapes but sync has eight states, so the
+                // precise one travels alongside it for the accessible name —
+                // "revoked" and "conflict" both draw a hollow ring, and losing
+                // the distinction from the label would make them unreportable.
+                let _ = parent.set_attribute("data-sync-status", &status);
+            });
         }
         return;
     }


### PR DESCRIPTION
The sealed guest panics on mount and takes the whole page down with it:

```
panicked at .../sys/sync/mutex/no_threads.rs:19:9:
assertion `left == right` failed: cannot recursively acquire mutex
  at std::sync::poison::mutex::Mutex<T>::lock
  at custom_elements::CustomElement::define::{{closure}}
  at attributeChangedCallback
  at tonk_workspace::ui_sync_status::paint
  at UiSyncStatus::connected_callback
  at TonkFab::inject_children  →  set_inner_html
```

## Why

`paint()` in its headless branch writes `state` and `data-sync-status` onto its **parent**, and it does so from `connected_callback`. The parent is itself a custom element that observes those attributes, so the write synchronously re-enters that element's `attributeChangedCallback` while `custom_elements` still holds this element's state mutex. `Mutex::lock` on the single-threaded wasm target asserts rather than deadlocking, so it panics.

The chain is entirely internal: `<tonk-fab>`'s `inject_children` sets `innerHTML`, which upgrades a headless `<ui-sync-status>` inside it, whose `connected_callback` paints onto the fab.

The panic aborts guest startup, so nothing downstream of it registers or renders — a blank page with an `unreachable` trap in the console.

## How

Defer the parent write to a microtask. Same attributes, same values, one turn later — after the custom-element callback has returned and released the lock. The disc is a status indicator, so a microtask's delay is not observable.

Introduced by #746 (`371c24ee`), which moved the sync disc to reporting onto its parent.

## Verification

Reproduced in Chrome against a local dev server: before, the guest panics twice on load and the page renders nothing; after, the console is clean and the space renders. `cargo clippy --target wasm32-unknown-unknown -p tonk-workspace -- -D warnings` is clean.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying how the `parent` element's attributes are set when the `host` has the "headless" attribute. It changes the synchronous attribute setting to an asynchronous approach to avoid panics caused by mutex acquisition.

### Detailed summary
- Changed synchronous setting of `state` and `data-sync-status` attributes to an asynchronous approach using `spawn_local`.
- Added comments explaining the reason for the change and the potential issues with synchronous attribute updates.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->