### PR TITLE
fix(fab): dedupe space switcher rows

### DIFF
--- a/rust/tonk-fab/src/logic.rs
+++ b/rust/tonk-fab/src/logic.rs
@@ -1375,6 +1375,7 @@ pub fn space_list_query_body() -> String {
 }
 
 /// Replace a subscription's keyed snapshot while preserving delivery order.
+#[cfg(any(target_arch = "wasm32", test))]
 pub(crate) fn reset_keyed_rows<T>(
     rows: &mut Vec<(String, T)>,
     conclusions: impl IntoIterator<Item = (String, T)>,

--- a/rust/tonk-fab/src/logic.rs
+++ b/rust/tonk-fab/src/logic.rs
@@ -1374,6 +1374,20 @@ pub fn space_list_query_body() -> String {
     .to_string()
 }
 
+/// Replace a subscription's keyed snapshot while preserving delivery order.
+pub(crate) fn reset_keyed_rows<T>(
+    rows: &mut Vec<(String, T)>,
+    conclusions: impl IntoIterator<Item = (String, T)>,
+) {
+    rows.clear();
+    for (id, row) in conclusions {
+        match rows.iter_mut().find(|(existing_id, _)| existing_id == &id) {
+            Some(existing) => existing.1 = row,
+            None => rows.push((id, row)),
+        }
+    }
+}
+
 #[cfg(test)]
 mod space_list {
     use super::*;
@@ -1388,6 +1402,21 @@ mod space_list {
         assert!(body.contains("\"this\":{\"?\""));
         // No concept named — nothing seeded is consulted.
         assert!(!body.contains("tonk:space"));
+    }
+
+    #[test]
+    fn a_reset_keeps_one_row_per_replica_entity() {
+        let mut rows = vec![("stale".to_owned(), "stale")];
+
+        reset_keyed_rows(
+            &mut rows,
+            [
+                ("replica:space".to_owned(), "first"),
+                ("replica:space".to_owned(), "latest"),
+            ],
+        );
+
+        assert_eq!(rows, vec![("replica:space".to_owned(), "latest")]);
     }
 }
 

--- a/rust/tonk-fab/src/space_switcher.rs
+++ b/rust/tonk-fab/src/space_switcher.rs
@@ -37,7 +37,7 @@ use js_sys::Reflect;
 use wasm_bindgen::prelude::*;
 use web_sys::{HtmlElement, window};
 
-use crate::logic::space_list_query_body;
+use crate::logic::{reset_keyed_rows, space_list_query_body};
 use crate::stack_rows;
 use crate::subscribing;
 
@@ -121,12 +121,13 @@ impl subscribing::Subscribing for SpaceSwitcherBehaviour {
     fn render_reset(&self, host: &HtmlElement, payload: &JsValue) {
         let conclusions = js_sys::Array::from(payload);
         let mut rows = self.rows.borrow_mut();
-        rows.clear();
+        let mut delivered = Vec::new();
         for i in 0..conclusions.length() {
             if let Some(row) = read_row(&conclusions.get(i)) {
-                rows.push(row);
+                delivered.push(row);
             }
         }
+        reset_keyed_rows(&mut rows, delivered);
         render_menu(host, &rows);
     }
 

--- a/rust/tonk-fab/tests/space_name_element.rs
+++ b/rust/tonk-fab/tests/space_name_element.rs
@@ -672,6 +672,36 @@ async fn it_renders_rows_from_delivered_frames_filtering_self_and_the_active_spa
 }
 
 #[dialog_common::test]
+async fn it_renders_each_replica_once_when_a_reset_repeats_a_conclusion() {
+    let el = mount_switcher();
+
+    deliver_switcher(
+        &el,
+        "reset",
+        &switcher_reset_payload(&[
+            (
+                "replica:other",
+                OTHER_SPACE,
+                "tonk:repository",
+                "tonk:active",
+            ),
+            (
+                "replica:other",
+                OTHER_SPACE,
+                "tonk:repository",
+                "tonk:active",
+            ),
+        ]),
+    );
+
+    assert_eq!(
+        rendered_row_subjects(&el),
+        vec![OTHER_SPACE.to_string()],
+        "a reset may repeat a query conclusion, but the switcher must render one row per replica"
+    );
+}
+
+#[dialog_common::test]
 async fn it_inserts_rows_before_the_authored_more_action() {
     let el = mount_switcher();
     deliver_switcher(


### PR DESCRIPTION
## Summary

- collapse repeated reset conclusions by replica entity before rendering the FABB space switcher
- preserve stable delivery order while keeping the latest row value
- add native and DOM regression coverage for duplicated conclusions

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p tonk-fab --lib` (107 passed)
- `cargo test --target wasm32-unknown-unknown -p tonk-fab --test space_name_element --no-run`
- `git diff --check origin/staging...HEAD`

Browser runtime execution remains unverified locally: the Wasm runner launched ChromeDriver 150 against Chrome 152 and failed with HTTP 404 before assertions.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces functionality to reset and manage rows in a space switcher, ensuring that each replica is rendered correctly and that the rows are updated in a way that preserves the delivery order.

### Detailed summary
- Added a new test `it_renders_each_replica_once_when_a_reset_repeats_a_conclusion` to verify rendering behavior after a reset.
- Modified `render_reset` in `SpaceSwitcherBehaviour` to use a temporary `delivered` vector for rows.
- Introduced `reset_keyed_rows` function to manage row updates while preserving delivery order.
- Added a test `a_reset_keeps_one_row_per_replica_entity` to validate row management after resets.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->