### PR TITLE
chore: release 0.6.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "dialog-reactor"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4630,7 +4630,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-access-service"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-account"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "anyhow",
  "blake3",
@@ -4711,7 +4711,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-account-service"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "anyhow",
  "blake3",
@@ -4745,7 +4745,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-analytics"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "dialog-common",
  "hex",
@@ -4761,7 +4761,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-analyzer"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4786,7 +4786,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-board"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "custom-elements",
  "js-sys",
@@ -4801,7 +4801,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-cli"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4868,7 +4868,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-code"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-common"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "dialog-common",
  "futures-util",
@@ -4890,7 +4890,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-core"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "base58",
  "dialog-artifacts",
@@ -4909,7 +4909,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-display"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4934,7 +4934,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-email"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -4943,7 +4943,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-evaluator"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "anyhow",
  "dialog-artifacts",
@@ -4966,7 +4966,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-fab"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4987,7 +4987,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-guest"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "console_error_panic_hook",
  "custom-elements",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-host"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "bytes",
  "custom-elements",
@@ -5033,7 +5033,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-identity"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -5068,7 +5068,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-inspector"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "bs58",
  "custom-elements",
@@ -5087,7 +5087,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-invite"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "anyhow",
  "bs58",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-language-server"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -5124,7 +5124,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-macros"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5137,7 +5137,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-notation"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "dialog-common",
  "lsp-types",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-portal"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "anyhow",
  "bs58",
@@ -5180,7 +5180,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-prose"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5189,7 +5189,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-render"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "async-trait",
  "dialog-common",
@@ -5206,7 +5206,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-router"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "dialog-common",
  "tokio",
@@ -5215,7 +5215,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-schema"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5252,7 +5252,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-sigil"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "blake3",
  "bs58",
@@ -5264,7 +5264,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-table"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5273,7 +5273,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-template"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "dialog-common",
  "indexmap",
@@ -5287,7 +5287,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-tree"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "custom-elements",
  "js-sys",
@@ -5301,7 +5301,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-ui"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5350,7 +5350,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-worker"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5423,7 +5423,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-worker-api"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "dialog-artifacts",
  "dialog-capability",
@@ -5441,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-workspace"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "custom-elements",
  "dialog-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.8"
+version = "0.6.9"
 authors = ["Tonk Labs"]
 edition = "2024"
 license = "MIT"


### PR DESCRIPTION
## Summary

- bump the workspace package version from 0.6.8 to 0.6.9
- refresh inherited workspace package versions in Cargo.lock

## Verification

- cargo check -p tonk-cli
- cargo pkgid -p tonk-cli
- cargo fmt --all -- --check
- git diff --check origin/staging...HEAD

## Incomplete local check

- cargo test -p tonk-cli -- --test-threads=1 compiled the workspace but remained silent in the final build/link stage for several minutes and was interrupted before test execution; CI remains the full-suite verification

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily updates the versioning across multiple packages and introduces significant changes to the handling of view anchors in the `tonk` CLI, enhancing functionality and error handling.

### Detailed summary
- Updated version from `0.6.8` to `0.6.9` in `Cargo.toml` and related packages.
- Added `Clipboard` and `Navigator` features to `web-sys`.
- Introduced `debug` module in `rust/tonk-inspector/src/lib.rs`.
- Changed `view_add` function to use `anchor` instead of `name` for view creation.
- Implemented `validate_view_anchor` function to reject entity-like anchors.
- Updated documentation and tests to reflect new anchor handling.
- Enhanced CLI command help to guide anchor usage.
- Improved rendering logic to support multiple views in entity order.

> The following files were skipped due to too many changes: `rust/tonk-render/src/page/orchestrate.rs`, `plan/inspector-debug-tools.md`, `docs/storybook/verification/cli-spaces-ui.md`, `plan/view-anchor-render-parity.md`, `rust/tonk-inspector/src/debug.rs`, `rust/tonk-cli/src/callback.rs`, `rust/tonk-inspector/src/element.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->