### PR TITLE
Update styles.css

### DIFF
--- a/rust/tonk-ui/styles.css
+++ b/rust/tonk-ui/styles.css
@@ -50,42 +50,14 @@ wa-tree-item:not(:defined) {
     visibility: hidden;
 }
 
-/* Self-hosted brutalist-theme fonts: Space Grotesk (body),
-   IBM Plex Sans Condensed (heading), Space Mono (code). Files
+/* Self-hosted brutalist-theme fonts:
+   IBM Plex Sans Condensed (heading). Files
    live under `/fonts/` (copied into the dist by Trunk's
    `copy-dir` on `./assets/fonts`). Self-hosting means no
    cross-origin font fetch and the files flow through the SW
    cache automatically once the offline-support milestone lands.
    `font-display: swap` keeps the page legible (fallback face)
    if the .woff2 hasn't downloaded yet. */
-@font-face {
-    font-family: "Space Grotesk";
-    font-style: normal;
-    font-weight: 400;
-    font-display: swap;
-    src: url("/fonts/space-grotesk-latin-400-normal.woff2") format("woff2");
-}
-@font-face {
-    font-family: "Space Grotesk";
-    font-style: normal;
-    font-weight: 500;
-    font-display: swap;
-    src: url("/fonts/space-grotesk-latin-500-normal.woff2") format("woff2");
-}
-@font-face {
-    font-family: "Space Grotesk";
-    font-style: normal;
-    font-weight: 600;
-    font-display: swap;
-    src: url("/fonts/space-grotesk-latin-600-normal.woff2") format("woff2");
-}
-@font-face {
-    font-family: "Space Grotesk";
-    font-style: normal;
-    font-weight: 700;
-    font-display: swap;
-    src: url("/fonts/space-grotesk-latin-700-normal.woff2") format("woff2");
-}
 @font-face {
     font-family: "IBM Plex Sans Condensed";
     font-style: normal;
@@ -218,12 +190,12 @@ body {
 }
 
 /* We stay on the default WA theme but borrow two things from the
-   brutalist theme: its font stack (Space Grotesk / IBM Plex Sans
-   Condensed / Space Mono) and a zero border-radius. Drop-shadows
+   brutalist theme: its font stack (IBM Plex Sans
+   Condensed) and a zero border-radius. Drop-shadows
    are also zeroed out so cards and panels read as flat blocks of
    color. Fonts themselves are loaded via a `<link>` in index.html. */
 :where(.wa-theme-default) {
-    --wa-font-family-body: "Space Grotesk", sans-serif;
+    --wa-font-family-body: "IBM Plex Sans Condensed", sans-serif;
     --wa-font-family-heading: "IBM Plex Sans Condensed", sans-serif;
     --wa-font-family-code: "Space Mono", monospace;
 
@@ -694,8 +666,11 @@ tonk-display > .site-pending:not([hidden]) {
     flex-direction: column;
     gap: var(--wa-space-s);
 }
-/* Opt out of the global heading highlight-cover (the dark filled box):
-   the Hub title is a plain heading like the mock. */
+/* The Hub title is a plain heading like the mock, in the theme's
+   heading face rather than the system default. (This predates the
+   plain heading default and once opted out of the global
+   highlight-cover; the explicit resets are kept for independence
+   from the default.) */
 .hub-title {
     display: block;
     margin: 0;
@@ -1491,31 +1466,38 @@ tonk-notation .tonk-notation-error {
     align-items: center;
     gap: var(--wa-space-xs);
 }
-/* Headline-cover treatment after Tachyons'
-   `title-highlight-header-cover` example: the dark fill wraps
-   the *text* (an inner `<span>`) rather than the heading box.
-   That way the box hugs each line of text when it wraps, and
-   any padding affects only the highlighted span — not the
-   heading's outer rhythm. `box-decoration-break: clone` makes
-   each wrapped line its own complete box (with consistent
-   padding on both sides) instead of leaving an unpainted
-   sliver at line breaks. */
-/* Tachyons' headline-cover treatment, baked in as the default
-   look for headings: a dark filled box hugging the text. The
-   heading goes `display: inline-block` so the box shrinks to
-   the text width instead of stretching across its container,
-   `line-height: 1.5` provides the vertical breathing room
-   that keeps the text from looking cramped at the box edges,
-   and `box-decoration-break: clone` makes every wrapped line
-   render as a complete padded box (rather than a sliced one).
-   System-font stack matches Tachyons; tracking is tightened
-   per the original example. */
+/* Default headings: plain system bold — no decoration. Chosen
+   over the former Tachyons headline-cover after comparing the
+   candidates side by side (the "Heading presets" page in the
+   staging-demo space): uncustomized markup in a guest should
+   read as text, not chrome. Sizes and line-height stay with the
+   Web Awesome base (`text-wrap: balance` included); apps that
+   want their own face override locally, and chrome that wants
+   a cover on purpose declares it (the space banner below, the
+   query-table concept header). */
 h1,
 h2,
 h3,
 h4,
 h5,
 h6 {
+    font-family:
+        -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI",
+        system-ui, sans-serif;
+    font-weight: 700;
+    letter-spacing: -0.021em;
+}
+
+/* The space banner keeps the Tachyons headline-cover the default
+   used to carry: a dark filled box hugging the text. Inline-block
+   shrinks the box to the text width, `line-height: 1.5` gives the
+   text breathing room at the box edges, and
+   `box-decoration-break: clone` renders every wrapped line as a
+   complete padded box rather than a sliced one. System-font stack
+   and tightened tracking match the original Tachyons example. */
+.space-banner h1 {
+    margin: 0;
+    font-size: var(--wa-font-size-3xl);
     display: inline-block;
     background: var(--wa-color-text-normal);
     color: var(--wa-color-neutral-fill-quiet);
@@ -1528,11 +1510,6 @@ h6 {
     padding: var(--wa-space-2xs) var(--wa-space-xs);
     -webkit-box-decoration-break: clone;
     box-decoration-break: clone;
-}
-
-.space-banner h1 {
-    margin: 0;
-    font-size: var(--wa-font-size-3xl);
 }
 
 /* Space view padding; WA's `wa-stack` handles vertical gaps
@@ -2327,10 +2304,14 @@ tonk-code:focus-within {
 }
 
 /* The concept-name header sits in a span painted in inverse
-   colors (page foreground as background) — the same
-   headline-cover treatment the page's `h1` uses. The cover hugs
-   the text, not the whole cell. It is the table's title, so it
-   reads a notch larger than the plain field headers. */
+   colors (page foreground as background) — the Tachyons
+   headline-cover treatment the space banner's `h1` also keeps
+   (no longer the default heading look). The dark fill wraps the
+   *text* rather than the cell, so the box hugs each line when it
+   wraps, padding affects only the highlighted span, and
+   `box-decoration-break: clone` renders every wrapped line as a
+   complete padded box. It is the table's title, so it reads a
+   notch larger than the plain field headers. */
 .query-table th.query-table-this > span {
     background: var(--wa-color-text-normal);
     color: var(--wa-color-neutral-fill-quiet);


### PR DESCRIPTION
- remove Space Grotesk
- change default stylesheet to system Sans

## What changed

Replace the Tachyons headline-cover as the default look for bare
h1-h6 with plain system bold (SF/Segoe 700, -0.021em tracking, no
decoration), chosen from the side-by-side comparison on the
'Heading presets' page in the staging-demo space: uncustomized
markup in a guest should read as text, not chrome.

The cover itself is kept where it is deliberate - it moves onto
.space-banner h1 explicitly (that rule had silently relied on the
global default, adding only size and margin), and the query-table
concept header keeps its own span cover. Apps still override
locally, as the vault wiki and welcome page already do.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on simplifying the font usage in the `styles.css` file, removing references to `Space Grotesk` and streamlining the theme's typography.

### Detailed summary
- Removed `Space Grotesk` font-face declarations.
- Updated body font to `IBM Plex Sans Condensed`.
- Revised comments regarding font usage and heading styles.
- Changed `.hub-title` and default headings to reflect new font choices.
- Adjusted styles for `.space-banner h1` and `.query-table` headers.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->