### PR TITLE
fix(ui): harden mobile runtime flows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5451,6 +5451,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tonk-common",
+ "tonk-fab",
  "tonk-host",
  "tonk-schema",
  "tonk-worker-api",

--- a/flake.lock
+++ b/flake.lock
@@ -87,11 +87,11 @@
     },
     "nixpkgs-chromedriver": {
       "locked": {
-        "lastModified": 1785251445,
-        "narHash": "sha256-hzAykM03D1MQw6cOUPmM9TLSpxgfGwYc43RfvvIPwJs=",
+        "lastModified": 1787930035,
+        "narHash": "sha256-PAiMlDmXJCbpPwkqAo2qSIunA5FrBPCpquLbrqYEYs4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4c11dbad74b3939056d84906c6cf3131e73d451a",
+        "rev": "40af305ea0ef20a0683718cfaf7635a8ac246246",
         "type": "github"
       },
       "original": {

--- a/plan/tonk-ui-mobile-hardening.md
+++ b/plan/tonk-ui-mobile-hardening.md
@@ -1,0 +1,677 @@
+# Tonk UI mobile hardening implementation plan
+
+**Goal:** Make the audited Tonk UI journeys usable, internally consistent, and
+accessible at phone widths without changing the approved compact FABB design or
+folding runtime/performance incidents into presentation work.
+
+**Approach:** Fix each observable behavior at the component that owns it, with a
+focused failing browser or Wasm test before production changes. Prefer platform
+modal and form semantics over hand-built approximations, keep desktop geometry
+unchanged unless the same correctness defect applies there, and finish with
+clean-profile checks at both audited phone sizes.
+
+**Pinned source:** `498bca7e2` on `fix/harden-mobile`, audited 2026-08-28.
+
+## Implementation status (2026-08-28)
+
+The source work for Tasks 1-9 and 11 is implemented in this worktree. Task 10
+remains intentionally blocked by the canonical-terms decision gate, so
+`SIGNUP_TERMS = "2026-08"` and the unlinked activation copy are unchanged.
+
+| Task | Status | Current evidence |
+| --- | --- | --- |
+| 1 | Runtime verified | Hub, Join, Activation, Settings, registration, and space-removal surfaces stay inside the `320x568` and `390x844` viewports. The activated-account destructive dialog keeps both actions visible and focusable at both audited sizes. |
+| 2 | Runtime verified | Registration is a native modal with initial focus/narration and Escape dismissal. Focus returns to the exact Settings control and crosses the sealed Hub boundary back to the exact guest opener. |
+| 3 | Runtime verified; Storybook pending | Registration retries the committed address after sequential WebAuthn rejection while same-turn registration and activation submissions remain single-flight. Storybook `B-05` remains unverified. |
+| 4 | Runtime verified | Repeated Tab stays within the composed shared-dialog order in the sealed Hub; Escape closes the native dialog and restores the remove opener. |
+| 5 | Runtime verified | At exact CDP `320x568x2` and `390x844x2` viewports, Join's wordmark/input and every visible actionable target meet the `44x44` floor without horizontal overflow. |
+| 6 | Chromium verified; Safari unavailable | Editable inputs compute to `16px` in Chromium. Real iOS Safari visual-viewport zoom remains unverified because no device or simulator is available. |
+| 7 | Runtime emulation unavailable | Normal-motion computed styles were inspected, but both isolated Chrome reduced-motion launch flags were ignored (`matchMedia` stayed false). |
+| 8 | Partially browser-verified | Compact FABB disclosure naming, focus, Escape restoration, dark/light pressed state, and `44x44` controls pass. The attached-account Hub menu remains unreachable without completing WebAuthn registration. |
+| 9 | Runtime verified | A freshly created local space replaces `GENERATING LINK…` with the `sharing unavailable` refusal; the stale async no-entity diagnostic cannot overwrite a newer ready frame. |
+| 10 | Blocked by product/legal input | No canonical, versioned terms document was supplied; no legal copy or recorded version was invented. |
+| 11 | Implemented and smoke-tested | A fresh disposable-snapshot `build:web` succeeds; `dev:web` served the isolated browser run after unsetting the inherited incompatible `NO_COLOR=1`. |
+| 12 | Focused runtime verified; full gate limited | ChromeDriver `152.0.7977.65` matches Chrome 152. All five focused WebDriver regressions, the destructive-dialog and exact-CDP settings geometry checks, adjacent retry/single-flight checks, focused Wasm tests, native suites, and the direct production build pass. The full-gate limitations below remain. |
+
+The repository `test:web:debug` and `build:web` wrappers evaluate an inner
+`git+file:` flake, which omits the untracked `ui_space_remove.rs` source and
+fails with `E0583`; the direct `path:.` production build passes. The equivalent
+direct full Wasm workspace suite compiled and executed in Chrome, but one
+pre-existing fallback-observer test failed in the full order and passed
+immediately in isolation. These are recorded as gate limitations rather than
+claimed green.
+
+The canonical serialized `test:e2e` run reached 51/57. Its two non-CLI UI
+failures were then corrected and pass exactly: initial registration focus now
+waits for the dialog's deferred focus task, and compact Settings geometry uses
+the exact CDP phone viewport plus a real `44px` width floor. The four remaining
+failures are CLI-backed account-link/backup/revocation cases: their native CLI
+processes resolve `tonk.network` to public Cloudflare addresses instead of the
+loopback harness, so the full-suite checkbox remains open.
+
+### Fresh verification evidence (2026-08-28)
+
+- `cargo fmt --all -- --check`, `git diff --check`, Storybook generation/link
+  checks, Wasm checks, integration-test compilation, and `build:web` pass.
+- Native tests pass: `tonk-worker` standard library 15, `tonk-workspace` 18,
+  `tonk-fab` 109, and `tonk-display` 73.
+- The isolated Chromium matrix covered Hub, Join, Activation, Settings,
+  registration, space removal, fresh-space creation, FABB overflow, light/dark
+  appearance, horizontal overflow, target geometry, input font size, focus,
+  Escape, and held-request duplicate-submission probes.
+- Runtime failures closed: registration restores both opener kinds; a failed
+  WebAuthn ceremony retries the committed address; space-removal Tab focus stays
+  inside the sealed native dialog; Join meets the target floor; and a fresh
+  space renders only the settled refusal after it replaces pending progress.
+- Manual-only coverage remains: real iOS Safari focus/keyboard/safe-area
+  behavior, real passkey account lifecycle and destructive account dialog,
+  valid invitation completion, genuine OS reduced motion, and the production
+  artifact's device matrix. Task 10 still requires the canonical terms document.
+
+**Constraints:**
+
+- The fresh-space runtime failure is owned by
+  `plan/fresh-space-runtime-panic.md`; do not hide its console failures in this
+  work or treat a still-visible canvas as recovery.
+- Cold-boot bundle and request work is owned by
+  `plan/mobile-cold-boot-audit.md`; Web Awesome, PostHog, Wasm splitting, and
+  bundle budgets are outside this plan.
+- Preserve the approved fit-driven compact FABB behavior in
+  `plan/fabb-mobile.md`: `44px` compact cells, overflow behavior, safe-area
+  docking, and intentional collapse to the sync disc.
+- Preserve local/offline state. Browser verification uses disposable profiles;
+  it must not clear a person's normal Tonk storage.
+- Do not add a UI framework, motion library, icon package, or a second modal
+  primitive.
+- Use native `<dialog>` for modal focus/inert/Escape behavior. The sealed guest
+  already registers `<tonk-dialog>` through `tonk-fab`; the top-page
+  registration ceremony uses its own native `<dialog>` because it does not load
+  the guest component tree.
+- `44px` means both dimensions of an actionable target unless the visible
+  control is a checkbox/radio inside a label whose hit rectangle is at least
+  `44x44`.
+- Mobile text-entry controls use a computed font size of at least `16px` to
+  avoid iOS focus zoom. Surrounding labels and display text keep the existing
+  type scale.
+- Keep `SIGNUP_TERMS = "2026-08"` unchanged unless the canonical terms
+  document names a different version. Legal copy is external product content,
+  not something an implementer should invent.
+- Generated Storybook files remain generated. Read `docs/storybook/README.md`
+  and `docs/storybook/goal.md` before changing triage, then run the commands
+  required by `docs/storybook/AGENTS.md`.
+- Use `path:.` for Nix checks so the build sees uncommitted plan implementation
+  files.
+
+## Finding coverage
+
+| Audited finding | Planned work |
+| --- | --- |
+| Short-phone destructive account dialog clips its footer | Task 1 |
+| `100vh` surfaces ignore dynamic mobile browser chrome | Task 1 |
+| Registration overlay lacks modal focus/inert/Escape semantics | Task 2 |
+| Registration narrator initially renders as a blank block | Task 2 |
+| Registration and activation accept duplicate async submissions | Task 3 |
+| Hub removal uses labels/radios as an inaccessible modal mechanism | Task 4 |
+| Hub/account/join actions have inconsistent sub-44px targets | Task 5 |
+| Existing mobile target test checks the larger dimension | Task 5 |
+| Inputs below `16px` can trigger iOS focus zoom | Task 6 |
+| Registration transitions/cursors ignore reduced motion | Task 7 |
+| FABB advertises menus but implements disclosure/Tab behavior | Task 8 |
+| Hub account menu lacks menu keyboard behavior | Task 8 |
+| New-space share state shows “Generating link” beside a refusal | Task 9 |
+| Share refusal copy points to a condition banner that may not exist | Task 9 |
+| Activation claims terms acceptance without a reachable document | Decision gate and Task 10 |
+| Tonk UI README names nonexistent `nix run` apps | Task 11 |
+
+## File map
+
+- `rust/tonk-ui/src/account.css`: account/activation mobile geometry, touch
+  sizes, input font size, and short-viewport modal bounds.
+- `rust/tonk-ui/styles.css`: top-page registration ceremony geometry, motion,
+  touch/input rules, and board dynamic viewport sizing.
+- `rust/tonk-ui/src/register_dialog.rs`: registration native-dialog lifecycle,
+  initial narration, focus restoration, and one-submit gate.
+- `rust/tonk-ui/src/activate.html`: activation narration, terms link, and
+  accessible button/status relationship.
+- `rust/tonk-ui/src/activate.rs`: activation one-submit state and terminal
+  result ordering.
+- `rust/tonk-ui/Cargo.toml`: `web-sys` support for `HtmlDialogElement`.
+- `rust/tonk-ui/src/account_flow.rs`: real-browser regressions at `320x568`
+  and `390x844`, including corrected target-size checks.
+- `rust/tonk-core/assets/library/profile.yaml`: Hub/remove/join markup and
+  phone CSS.
+- `rust/tonk-core/assets/library/core.yaml`: blank-canvas pending/refusal
+  lifecycle and refusal copy.
+- `rust/tonk-workspace/src/ui_space_remove.rs`: Hub remove-dialog opener and
+  modal lifecycle.
+- `rust/tonk-workspace/src/lib.rs`: register `<ui-space-remove>`.
+- `rust/tonk-workspace/src/ui_hub_account.html`: Hub account menu semantics.
+- `rust/tonk-workspace/src/ui_hub_account.rs`: menu focus and arrow/Home/End
+  keyboard behavior.
+- `rust/tonk-fab/src/dialog.rs`: compact native-dialog target sizing used by
+  Hub removal.
+- `rust/tonk-fab/src/markup.rs`: FABB disclosure names and overflow-mode state.
+- `rust/tonk-fab/src/menu.rs`: disclosure group semantics and propagation.
+- `rust/tonk-fab/src/mi.rs`: reflect overflow appearance state onto its real
+  shadow button.
+- `rust/tonk-fab/src/bar.rs`: update reflected appearance pressed state.
+- `rust/tonk-fab/src/field.rs`: compact input target and iOS-safe font sizing.
+- `rust/tonk-fab/tests/responsive_overflow.rs`: FABB accessibility and compact
+  control regression coverage.
+- `rust/tonk-display/src/state.rs`: nested lifecycle projection regression if
+  the real blank-canvas test localizes the stale pending label here.
+- `rust/tonk-worker/src/router/create_invite.rs`: complete user-facing refusal
+  detail when the worker owns the remedy.
+- `rust/tonk-worker/src/router/repository.rs`: share/refusal behavior and seeded
+  standard-library assertions.
+- `rust/tonk-worker/tests/standard_library.rs`: Hub markup and mobile CSS
+  contracts.
+- `rust/tonk-ui/assets/service_worker.js`: dynamic-viewport sizing for the
+  service-worker fatal-error document.
+- `rust/tonk-ui/README.md`: correct repository build and development commands.
+- `docs/storybook/bug-triage.md`: mark `B-05` fixed only after its duplicate
+  submission journey passes.
+
+### Task 1: Keep full-height surfaces and destructive controls inside the visible viewport
+
+**Files:**
+
+- Modify: `rust/tonk-ui/src/account.css:.account__dialog and mobile media rules`
+- Modify: `rust/tonk-ui/styles.css:.board-view`
+- Modify: `rust/tonk-core/assets/library/profile.yaml:join/route-view CSS`
+- Modify: `rust/tonk-ui/assets/service_worker.js:fatal error document CSS`
+- Modify: `rust/tonk-ui/src/account_flow.rs`
+- Test: `rust/tonk-ui/src/account_flow.rs`
+- Test: `rust/tonk-worker/tests/standard_library.rs`
+
+**Interfaces:**
+
+- Consumes: the existing fixed `.account__dialog`, its internal scrolling
+  surface, and the current `320x568` destructive confirmation markup.
+- Produces: a dialog whose top and bottom are bounded by `100dvh` plus safe-area
+  insets, and full-height surfaces that use `100vh` only as an older-browser
+  fallback immediately followed by `100dvh`.
+
+- [ ] Add
+  `it_keeps_destructive_dialog_controls_inside_a_short_mobile_viewport` to
+  `account_flow.rs`: open the account deletion confirmation at `320x568`,
+  expose its longest arming state, scroll `.account__dialog` to its maximum,
+  and assert `dialog.top >= 0`, `dialog.bottom <= innerHeight`, and both Cancel
+  and the destructive submit button are visible and focusable. Run
+  `nix develop path:. -c cargo test -p tonk-ui --features integration-tests it_keeps_destructive_dialog_controls_inside_a_short_mobile_viewport -- --test-threads=1 --nocapture`;
+  expect the current bottom near `604px` to exceed the `568px` viewport.
+- [ ] Restrict the current `top: max(12vh, safe-area + 48px)` phone placement
+  to viewports taller than `700px`. For `max-height:700px`, place the dialog at
+  `max(16px, env(safe-area-inset-top))`, calculate its maximum height from
+  `100dvh` minus that top inset and a `16px` bottom inset, and retain vertical
+  scrolling with horizontal clipping.
+- [ ] Replace the remaining product-owned `100vh` uses with an ordered fallback:
+  `100vh` first, `100dvh` second. Apply this to `.board-view`, `.join-view`, and
+  the service-worker fatal-error document; do not edit vendored Web Awesome
+  CSS.
+- [ ] Add a standard-library assertion that `.join-view` contains the dynamic
+  viewport declaration. Run
+  `cargo test -p tonk-worker --test standard_library`; expect success after the
+  CSS change.
+- [ ] Rerun the focused browser test at both `320x568` and `390x844`; expect all
+  controls inside the viewport with no horizontal overflow.
+
+### Task 2: Make registration a real modal with useful initial guidance
+
+**Files:**
+
+- Modify: `rust/tonk-ui/Cargo.toml:web-sys features`
+- Modify: `rust/tonk-ui/src/register_dialog.rs:DIALOG_HTML, open, open_when_upgraded, close`
+- Modify: `rust/tonk-ui/styles.css:.tonk-ceremony modal styles`
+- Modify: `rust/tonk-ui/src/account_flow.rs`
+- Test: `rust/tonk-ui/src/account_flow.rs`
+
+**Interfaces:**
+
+- Consumes: `register_dialog::open()`, `close()`, `describe()`, and the stable
+  `#tonk-register-*` selectors used by account/share flows.
+- Produces: a native `<dialog id="tonk-register">` shown with `showModal()`,
+  with the same inner selectors, native focus containment/background inertness,
+  Escape cleanup, and focus restoration to the element active before `open()`.
+
+- [ ] Add `it_scopes_registration_focus_and_restores_the_opener`: open the
+  registration ceremony from Settings, assert the initial status text is
+  non-empty, press Tab through more steps than the dialog has focusable
+  controls and assert focus never leaves `#tonk-register`, press Escape and
+  assert the dialog is removed, then assert focus returns to the original
+  opener. Also use a WebDriver pointer click to assert a background action is
+  not interactable while the modal is open. Run the focused integration test; expect failure
+  because the current fixed `<div role="dialog">` does not make the background
+  inert, trap focus, or close on Escape.
+- [ ] Add `HtmlDialogElement` to `rust/tonk-ui`'s `web-sys` features. Have
+  `open()` capture `document.active_element`, create the native dialog host,
+  append the existing ceremony contents, wire `cancel` to `preventDefault()`
+  plus `close()`, and call `show_modal()` after the current deferred layout
+  turn. Keep the stable descendant IDs so existing WebAuthn and account tests
+  do not need selector churn.
+- [ ] Replace `.tonk-dim` with `#tonk-register::backdrop`; remove the nested
+  `role="dialog"`/`aria-modal` duplication. Override Web Awesome's native
+  dialog defaults on this host so the current block-stack geometry and light/
+  dark tokens remain unchanged.
+- [ ] Initialize `#tonk-register-status` with: “Enter your email address. We’ll
+  tell you whether to create a passkey or sign in.” Add
+  `aria-describedby="tonk-register-status"` to the dialog, while retaining the
+  status element's `aria-live="polite"` updates.
+- [ ] In `close()`, close the native dialog before removing it, clear the
+  subscription/delegates as today, and focus the captured opener only if it is
+  still connected and enabled.
+- [ ] Rerun the focused test plus
+  `nix develop path:. -c cargo test -p tonk-ui --features integration-tests it_explains_email_verification_before_account_sync -- --test-threads=1 --nocapture`;
+  expect both to pass without changing the passkey flow.
+
+### Task 3: Make registration and activation submissions monotonic
+
+**Files:**
+
+- Modify: `rust/tonk-ui/src/register_dialog.rs:thread-local state, action_is_offered, submit, set_action, close`
+- Modify: `rust/tonk-ui/src/activate.rs:TonkActivate and bind`
+- Modify: `rust/tonk-ui/src/activate.html:#activate-accept`
+- Modify: `rust/tonk-ui/src/account_flow.rs`
+- Modify: `docs/storybook/bug-triage.md:B-05`
+- Test: `rust/tonk-ui/src/account_flow.rs`
+
+**Interfaces:**
+
+- Produces in `register_dialog.rs`:
+
+  ```rust
+  thread_local! {
+      static ACTION_PENDING: Cell<bool> = const { Cell::new(false) };
+  }
+
+  fn begin_action() -> bool;
+  fn finish_action();
+  ```
+
+- Produces in `activate.rs`: per-element `Rc<Cell<bool>>` submission state;
+  no global activation gate, so independent activation tabs remain independent.
+
+- [ ] Add a registration browser regression that resolves an actionable email,
+  dispatches click and Enter in the same JavaScript turn, and asserts only one
+  passkey ceremony/registration request begins. Add an activation regression
+  that replaces `window.fetch` for `/ucan/` with a held promise, double-clicks
+  `#activate-accept`, and asserts a request count of exactly one before settling
+  the response. Run each focused test; expect duplicate work on current code.
+- [ ] In registration, make `begin_action()` atomically reject a second action,
+  immediately set the real button's `disabled` property and `aria-busy=true`,
+  and make `action_is_offered()` require visible and not disabled. Make every
+  retryable error and every newly offered step call `set_action(label, true)`,
+  which clears the gate and attributes. `close()` also clears the gate. Audit
+  the early returns in signup, login, copy-link, and return-to-space paths so no
+  failed prerequisite leaves the singleton permanently busy.
+- [ ] In activation, check and set the per-element gate before `spawn_local`,
+  immediately disable `#activate-accept`, and set `aria-busy=true` on the
+  owning section. Successful activation is terminal: later responses cannot
+  replace the done panel. Re-enable only after a retryable network/service
+  failure; an expired/unauthorized one-use link stays disabled and points the
+  user back to the device for a fresh link.
+- [ ] Run both focused tests in both response orders (success then unauthorized,
+  unauthorized then success); expect one request and one final state.
+- [ ] After the runtime test passes, update `B-05` to `Fixed and verified` with
+  the current commit/test evidence. From `docs/storybook`, run
+  `python3 scripts/build.py --check` and `python3 scripts/check-links.py .`;
+  expect both to pass.
+
+### Task 4: Replace the Hub's radio-driven remove overlay with a native dialog
+
+**Files:**
+
+- Create: `rust/tonk-workspace/src/ui_space_remove.rs`
+- Modify: `rust/tonk-workspace/src/lib.rs`
+- Modify: `rust/tonk-core/assets/library/profile.yaml:Hub removal CSS and markup`
+- Modify: `rust/tonk-fab/src/dialog.rs:compact target geometry`
+- Modify: `rust/tonk-worker/tests/standard_library.rs`
+- Test: `rust/tonk-workspace/src/ui_space_remove.rs`
+- Test: `rust/tonk-ui/src/account_flow.rs`
+
+**Interfaces:**
+
+- Produces this seeded-view contract:
+
+  ```html
+  <ui-space-remove>
+    <button type="button" data-space-remove-open>remove</button>
+    <tonk-dialog data-space-remove-dialog heading="confirm space removal">
+      <form id="remove-{subject}" onsubmit="space/remove" data-remove="{subject}">
+        <!-- warning copy -->
+      </form>
+      <button slot="actions" type="button" data-dialog="close">cancel</button>
+      <button slot="actions" type="submit" form="remove-{subject}">remove space</button>
+    </tonk-dialog>
+  </ui-space-remove>
+  ```
+
+- `ui-space-remove` calls the existing `<tonk-dialog>.show()` property API; it
+  does not own removal, duplicate the `space/remove` command, or add storage.
+
+- [ ] Add a Wasm test that mounts `<ui-space-remove>` and a registered
+  `<tonk-dialog>`, activates the real button with Enter, and asserts the inner
+  native dialog is open; Escape and Cancel must close it and restore focus to
+  the remove button. Add a standard-library test rejecting `.rm-radio`,
+  label-based open/close controls, `.mscrim`, and the hand-authored
+  `role="alertdialog"`. Run the focused tests; expect failure on current markup.
+- [ ] Implement `ui_space_remove.rs` as a small custom element with one retained
+  click listener. On `[data-space-remove-open]`, call the descendant dialog's
+  `show()` function through `Reflect`; leave the existing form submit event to
+  `tonk-display` and `RemoveSpaceHandler`. Register the element in
+  `tonk-workspace::register()`.
+- [ ] Replace the hidden radios, labels, scrim, and modal markup with the
+  contract above. Keep the current warning text and destructive command data.
+  Do not close optimistically on submit: the repeated row disappearing after
+  successful removal should remove its dialog; a failed command must not look
+  successful.
+- [ ] Give `<tonk-dialog>` header close and slotted actions `44px` minimum
+  targets at `max-width:519px`, without changing its desktop `36px` block law.
+- [ ] Run `nix develop path:. -c test:web:debug -E 'package(tonk-workspace)'`
+  and `nix develop path:. -c test:web:debug -E 'package(tonk-fab)'`; expect the
+  modal, Escape, and focus tests to pass.
+
+### Task 5: Enforce a real 44-by-44 mobile action target floor
+
+**Files:**
+
+- Modify: `rust/tonk-core/assets/library/profile.yaml:Hub and join mobile CSS`
+- Modify: `rust/tonk-ui/src/account.css:phone action geometry`
+- Modify: `rust/tonk-ui/styles.css:registration phone geometry`
+- Modify: `rust/tonk-ui/src/account_flow.rs:mobile target assertions`
+- Modify: `rust/tonk-worker/tests/standard_library.rs`
+- Test: `rust/tonk-ui/src/account_flow.rs`
+
+**Interfaces:**
+
+- Produces a shared browser-test predicate:
+
+  ```javascript
+  const tooSmall = ({ width, height }) => width < 44 || height < 44;
+  ```
+
+- Checkbox/radio inputs are measured through their enclosing label; hidden
+  inputs and non-interactive status elements are excluded.
+
+- [ ] Replace both current `Math.max(rect.width, rect.height) < 44` checks in
+  `account_flow.rs` with the two-dimensional predicate. Add a route matrix for
+  Hub, Settings, activation, registration, and join at `320x568` and `390x844`.
+  Report selector, width, and height for every failure. Run the focused test;
+  expect the current `36px` rows/actions to be reported.
+- [ ] At `max-width:640px`, make Hub header cells, account-menu rows, space rows,
+  empty/create rows, and remove controls at least `44px` high. Keep visual glyphs
+  and text baselines optically seated with padding; do not scale icons to fill
+  the target.
+- [ ] At `max-width:680px`, make `.edge-field`, `.ebtn`, and the actual button
+  inside `.ebtn.solid` at least `44px` high. Preserve the existing stacked
+  mobile run.
+- [ ] At `max-width:463px`, give actionable Settings/activation rows, tabs,
+  buttons, links, inputs, and dialog actions a `44px` target. A `20px` checkbox
+  remains visually `20px`; its `.account__confirm-check` label owns the target.
+- [ ] At `max-width:519px`, make registration header, input row, action row,
+  and dismiss control at least `44px` high. Preserve the desktop `36px` rhythm.
+- [ ] Add standard-library assertions for the Hub/join mobile target contract,
+  then run `cargo test -p tonk-worker --test standard_library` and the focused
+  browser matrix; expect no undersized target and no horizontal overflow.
+
+### Task 6: Prevent iOS focus zoom without enlarging all mobile typography
+
+**Files:**
+
+- Modify: `rust/tonk-ui/src/account.css:mobile input rules`
+- Modify: `rust/tonk-ui/styles.css:.tonk-ceremony .ed mobile rule`
+- Modify: `rust/tonk-core/assets/library/profile.yaml:.edge-value mobile rule`
+- Modify: `rust/tonk-fab/src/field.rs:mobile .value rule`
+- Modify: `rust/tonk-ui/src/account_flow.rs`
+- Modify: `rust/tonk-fab/tests/edge_primitives.rs`
+- Test: `rust/tonk-ui/src/account_flow.rs`
+- Test: `rust/tonk-fab/tests/edge_primitives.rs`
+
+**Interfaces:**
+
+- Produces `font-size:16px` only on editable native inputs at phone widths or
+  coarse pointers; noun labels, settled values, and desktop inputs retain the
+  existing condensed scale.
+
+- [ ] Add computed-style assertions at `390px` for registration email/name,
+  account display-name and confirmation email, join URL, and `<tonk-field>`'s
+  shadow input. Assert each editable input is at least `16px`, then assert the
+  same controls keep their current desktop size at `1200px`. Run the focused
+  tests; expect mobile failures at `13px`/`13.5px`.
+- [ ] Add narrow/coarse media rules for only `.tonk-ceremony .ed`, account text
+  inputs, `.edge-input`, and `tonk-field .value`. Increase row padding/height as
+  needed to retain baseline alignment; do not use transforms or page-wide
+  `text-size-adjust` suppression as a substitute.
+- [ ] Run the focused browser and FABB Wasm tests; expect mobile computed input
+  sizes of `16px` and unchanged desktop typography.
+- [ ] Manually verify one real iOS Safari focus on registration, join, and
+  Settings. Record as unverified if no iOS device/simulator is available;
+  Chromium computed styles do not prove Safari will avoid visual-viewport zoom.
+
+### Task 7: Honor reduced motion in the registration ceremony
+
+**Files:**
+
+- Modify: `rust/tonk-ui/styles.css:registration reduced-motion rules`
+- Modify: `rust/tonk-ui/src/account_flow.rs`
+- Test: `rust/tonk-ui/src/account_flow.rs`
+
+**Interfaces:**
+
+- Consumes: `.tonk-cluster`, `.orow`, `.obtn`, `.cur`, `.obtn.wait`, and
+  `.flash` animation/transition declarations.
+- Produces: zero-duration disclosure/dim transitions and no cursor, wait, or
+  flash animation when `prefers-reduced-motion: reduce` is active.
+
+- [ ] Add a browser check that emulates `prefers-reduced-motion: reduce`, opens
+  registration, and reads computed animation/transition duration and name for
+  every selector above. Run it; expect current registration cursor/wait/flash
+  animation and `.orow` transition failures.
+- [ ] Add one registration-specific reduced-motion media block that sets
+  transitions to `none` on the modal/rows/actions and animations to `none` on
+  cursor, wait, and flash states. Keep existing account, join, Hub, and FABB
+  reduced-motion rules intact.
+- [ ] Rerun the focused test in normal and reduced modes; normal mode retains
+  the authored motion, reduced mode reports none.
+
+### Task 8: Make menu and disclosure semantics match their keyboard behavior
+
+**Files:**
+
+- Modify: `rust/tonk-fab/src/markup.rs:BAR_HTML and STACKS_HTML`
+- Modify: `rust/tonk-fab/src/menu.rs:connected_callback and semantics`
+- Modify: `rust/tonk-fab/src/mi.rs:observed attributes and sync`
+- Modify: `rust/tonk-fab/src/bar.rs:update overflow mode state`
+- Modify: `rust/tonk-fab/tests/responsive_overflow.rs`
+- Modify: `rust/tonk-workspace/src/ui_hub_account.html`
+- Modify: `rust/tonk-workspace/src/ui_hub_account.rs:open_menu and keydown`
+- Test: `rust/tonk-fab/tests/responsive_overflow.rs`
+- Test: `rust/tonk-workspace/src/ui_hub_account.rs`
+
+**Interfaces:**
+
+- FABB stacks become named disclosure groups: trigger buttons keep
+  `aria-expanded` and `aria-controls`, but remove `aria-haspopup`; each
+  `<tonk-menu>` host carries `role="group"` plus a concrete `aria-label`, and
+  its shadow rows remain ordinary Tab-reachable buttons.
+- `<tonk-mi pressed="true|false">` reflects `aria-pressed` onto its real shadow
+  `.row` button. The host itself does not claim `menuitemcheckbox`.
+- The Hub keeps its genuine `role="menu"` contract and gains ArrowDown,
+  ArrowUp, Home, End, Escape, initial-focus, and focus-restoration behavior.
+
+- [ ] Add FABB accessibility assertions that no trigger advertises a menu, each
+  controlled group has a name, all actions remain buttons in DOM/focus order,
+  and the appearance action exposes `aria-pressed` on its actual button. Add
+  Hub Wasm tests for initial focus, wrapping arrows, Home/End, Escape, and
+  focus restoration. Run the package Wasm tests; expect failures against the
+  mixed current semantics.
+- [ ] Remove FABB `aria-haspopup` and `menuitemcheckbox`, name every stack
+  (`space actions`, `spaces`, `share actions`, `more actions`), and set group
+  roles. Extend `TonkMi` to observe `pressed`, copy it to the shadow button's
+  `aria-pressed`, and have `bar.rs` update `pressed` with the resolved theme.
+- [ ] In `ui_hub_account.rs`, focus the first enabled menu item from
+  `open_menu()`. Implement a visible menuitem list and wrap ArrowDown/ArrowUp;
+  Home/End go to endpoints, Escape closes and restores trigger focus, and Tab
+  closes without preventing the browser's normal focus move. Do not add roving
+  semantics to FABB disclosures.
+- [ ] Run
+  `nix develop path:. -c test:web:debug -E 'package(tonk-fab)'` and
+  `nix develop path:. -c test:web:debug -E 'package(tonk-workspace)'`; expect
+  all keyboard and accessibility assertions to pass.
+
+### Task 9: Make blank-space share progress and refusal mutually exclusive
+
+**Files:**
+
+- Modify: `rust/tonk-core/assets/library/core.yaml:blank-canvas agent-link and share/blocked view`
+- Modify: `rust/tonk-worker/src/router/create_invite.rs:RemoteRefusal::detail if required by the failing copy cases`
+- Modify: `rust/tonk-worker/src/router/repository.rs:seeded-library tests`
+- Modify if localized here: `rust/tonk-display/src/state.rs:update_slot_children and nested state test`
+- Modify: `rust/tonk-ui/src/account_flow.rs`
+- Test: `rust/tonk-ui/src/account_flow.rs`
+- Test: `rust/tonk-display/src/state.rs`
+- Test: `rust/tonk-worker/src/router/repository.rs`
+
+**Interfaces:**
+
+- The blank canvas may show “Generating link…” only while no invite or refusal
+  result is available. A ready `tonk:share/blocked` view hides it in the same
+  frame.
+- The refusal view displays a neutral “sharing unavailable” label plus exactly
+  the worker-owned `{detail}` sentence. It does not append the unconditional
+  “Use connect in the condition banner” instruction.
+
+- [ ] Add `it_replaces_agent_link_progress_with_the_share_refusal`: create a
+  local-only fresh space without a registered provider, trigger sharing, wait
+  for `.local-invite-notice`, and assert the visible canvas contains exactly one
+  state—no “Generating link…” and no reference to a nonexistent condition
+  banner. Run the focused integration test; expect both current strings to be
+  visible.
+- [ ] Add a nested `tonk-display` lifecycle test that makes the inner display
+  move from `no-entity` to `ready` and asserts both the `hidden` attribute and
+  computed `display:none` on its pending slot. Use this result to localize the
+  fix: if it fails, correct direct-child projection in `state.rs`; if it passes,
+  keep `tonk-display` unchanged and repair the seeded blank-canvas markup/CSS.
+  Do not apply both fixes without evidence.
+- [ ] Remove the fixed banner instruction from the refusal view and use a
+  state-neutral label. Make every worker detail used here a complete sentence;
+  retain existing specific instructions such as confirming the email, and do
+  not tell suspended/unshareable accounts to connect.
+- [ ] Update `it_routes_refused_agent_links_to_the_local_only_notice` to require
+  mutual exclusion and reject the stale copy. Run
+  `cargo test -p tonk-worker it_routes_refused_agent_links_to_the_local_only_notice`
+  and `nix develop path:. -c test:web:debug -E 'package(tonk-display)'`; expect
+  success before rerunning the whole browser journey.
+
+## Decision gate: canonical terms content
+
+The repository contains no terms document, while `activate.html` says the user
+accepts one and `tonk-access-service` records version `2026-08`. Implementation
+must pause this finding until the product/legal owner supplies a canonical,
+stable terms document and confirms that its version is `2026-08` (or explicitly
+authorizes a coordinated version migration). Do not invent the document, link
+to a generic home page, or remove recorded acceptance as a UI cleanup.
+
+### Task 10: Link the activation decision to the approved terms version
+
+**Files:**
+
+- Modify after the decision gate is satisfied: `rust/tonk-ui/src/activate.html`
+- Modify if the approved version differs: `rust/tonk-access-service/src/registration.rs:SIGNUP_TERMS`
+- Modify if the approved version differs: `rust/tonk-access-service/tests/registration.rs`
+- Modify: `rust/tonk-ui/src/account_flow.rs`
+- Test: `rust/tonk-ui/src/account_flow.rs`
+- Test if the version changes: `rust/tonk-access-service/tests/registration.rs`
+
+**Interfaces:**
+
+- The exact linked document version and `SIGNUP_TERMS` value are one reviewed
+  release contract.
+- The activation action's accessible description contains the linked “terms
+  of service” phrase before a user can accept.
+
+- [ ] Once canonical content is supplied, add an activation browser test that
+  finds the terms link by accessible name, asserts a non-placeholder absolute
+  HTTPS URL or an existing same-origin document, opens it without losing the
+  activation URL, and confirms the served document identifies the same version
+  recorded by `SIGNUP_TERMS`. Run it; expect failure while no link/document
+  exists.
+- [ ] Link the existing phrase rather than adding a second legal sentence. Use
+  `target="_blank" rel="noopener"` for a cross-origin document; use ordinary
+  same-tab navigation only if the approved same-origin page preserves a safe
+  return to the one-use activation URL.
+- [ ] If and only if the approved version differs, update `SIGNUP_TERMS` and
+  its storage/registration assertions in the same change. Run
+  `cargo test -p tonk-access-service registration` and the focused browser
+  test; expect the visible document and stored version to agree.
+
+### Task 11: Correct the Tonk UI build instructions
+
+**Files:**
+
+- Modify: `rust/tonk-ui/README.md:Build and run`
+
+**Interfaces:**
+
+- Produces these repository-defined commands:
+
+  ```sh
+  nix develop . -c build:web
+  nix develop . -c dev:web
+  ```
+
+- [ ] Replace the two `nix run .#...` examples; retain the explanation that
+  `build:web` runs `nix build .#tonk-ui` and `dev:web` serves Trunk with the
+  access-service proxies.
+- [ ] Run `nix develop path:. -c build:web`; expect a successful production
+  artifact. Start `nix develop path:. -c dev:web`, wait for its printed local
+  URL, request the root and `/.well-known/tonk`, then stop it cleanly; expect
+  both endpoints to answer.
+
+### Task 12: Run the complete mobile regression matrix
+
+**Files:**
+
+- Modify only if a real product contract changed: relevant Storybook journey,
+  verification, screen, or triage Markdown under `docs/storybook/`
+- Test: all files above
+
+**Interfaces:**
+
+- Consumes: the production artifact after Tasks 1-11, including the approved
+  terms document if Task 10 is unblocked.
+- Produces: fresh evidence separated into rendering, interaction, accessibility,
+  console, and performance/runtime exclusions.
+
+- [ ] Run `cargo fmt --all -- --check`; expect no diff.
+- [ ] Run `cargo test -p tonk-worker --test standard_library`,
+  `cargo test -p tonk-workspace`, `cargo test -p tonk-fab`, and any changed
+  access-service package tests; expect success.
+- [ ] Run `nix develop path:. -c test:web:debug`; expect the changed UI,
+  workspace, FABB, and display Wasm tests to pass.
+- [ ] Run `nix develop path:. -c cargo test -p tonk-ui --features integration-tests -- --test-threads=1 --nocapture`;
+  expect the whole browser account suite to pass. If ChromeDriver does not
+  match Chrome, report that as an infrastructure block rather than product
+  evidence.
+- [ ] Run `nix develop path:. -c build:web`; serve the production artifact in
+  disposable profiles at `320x568x2` and `390x844x2`, mobile/touch. Exercise
+  Hub, create space, join, registration, activation, Settings, account delete,
+  and space remove in light/dark and reduced-motion modes.
+- [ ] For each journey, record: no horizontal overflow; all modal controls
+  reachable; focus contained/restored; all actionable targets at least
+  `44x44`; editable inputs at least `16px`; no duplicate request; no stale
+  progress/refusal copy; and no new console warning/error.
+- [ ] Keep the fresh-space recursive mutex panic in its separate incident
+  record if still present. It must not be waived as a mobile-plan failure or
+  suppressed to make this matrix green.
+- [ ] From `docs/storybook`, run `python3 scripts/build.py --check` and
+  `python3 scripts/check-links.py .`; expect both to pass after any product
+  behavior update.
+
+## Handoff order
+
+Tasks 1, 4, 5, 6, 7, 8, 9, and 11 are independently reviewable. Task 2 must
+land before Task 3 because the duplicate-submit tests address the final native
+registration host. Task 10 is blocked on canonical terms content and can land
+later without blocking the other mobile hardening work. Task 12 runs only after
+all unblocked tasks have their focused checks green.

--- a/plan/tonk-ui-mobile-runtime-failures.md
+++ b/plan/tonk-ui-mobile-runtime-failures.md
@@ -1,0 +1,380 @@
+# Tonk UI confirmed mobile runtime failures implementation plan
+
+**Goal:** Resolve the five failures reproduced on 2026-08-28 without widening
+the mobile-hardening scope or weakening the existing accessibility contracts.
+
+**Approach:** Preserve the current native-dialog, local-first, and compact FABB
+designs. Add or strengthen a real-browser regression for each observed failure,
+prove the current implementation fails at that boundary, then change the
+smallest owning module: portal/UI focus transport, registration ceremony state,
+the shared dialog primitive, Join CSS, or `tonk-display` lifecycle ordering.
+Keep compilation, Wasm execution, WebDriver execution, and production-artifact
+checks as separate evidence.
+
+**Plan basis:** `a8f849cf11` plus the uncommitted mobile-hardening worktree,
+inspected 2026-08-28.
+
+**Constraints:**
+
+- Preserve normal Tonk browser storage. Every browser run uses a disposable
+  profile; never clear a person's service-worker, IndexedDB, or local space
+  state.
+- Use native `<dialog>` for modality and Escape. The cross-frame fix may add a
+  composed-Tab guard, but must not replace the shared dialog or add a second
+  modal primitive.
+- A mobile actionable target must be at least `44px` in both dimensions. Keep
+  the Join wordmark and input typography at their current visual scale.
+- A registration retry reuses the already committed email receipt. It must not
+  rerun address discovery, make the settled row editable, or admit concurrent
+  WebAuthn ceremonies.
+- Keep fresh spaces local-only until the existing share flow attaches sync.
+  The share-state fix must not invent a remote or suppress the refusal.
+- Seeded-view browser verification must create a fresh space after the change;
+  an existing space can retain the prior seeded standard library.
+- Do not fold the canonical-terms decision, cold-boot/preload work, subscription
+  console cleanup, or the separate fresh-space runtime incident into these
+  fixes.
+- Before claiming browser completion, align the Nix ChromeDriver with installed
+  Chrome 152. A compiled test archive is not browser execution.
+
+## Failure coverage
+
+| Confirmed failure | Resolution task |
+| --- | --- |
+| Registration does not restore the Settings or Hub opener | Task 1 |
+| Registration cannot retry after WebAuthn rejects | Task 2 |
+| Space-removal Tab focus escapes the sealed guest | Task 3 |
+| Join wordmark and input are shorter than `44px` | Task 4 |
+| Fresh-space progress reappears beside a settled refusal | Task 5 |
+
+## File map
+
+- `rust/tonk-portal/src/bridge.rs`: carry a guest focus-return token with a
+  registration request and return focus through the same `MessagePort`.
+- `rust/tonk-portal/src/lib.rs`: re-export the registration focus-return handle.
+- `rust/tonk-ui/src/bin/ui.rs`: hand a portal-origin focus return to the
+  top-page registration dialog.
+- `rust/tonk-ui/src/register_dialog.rs`: own opener restoration, the committed
+  email receipt, and retry behavior.
+- `rust/tonk-ui/src/account.rs`: keep account-panel refresh event-driven rather
+  than repainting unconditionally during dialog dismissal.
+- `rust/tonk-ui/src/account_flow.rs`: real-browser regressions and an exact CDP
+  mobile viewport helper.
+- `rust/tonk-fab/src/dialog.rs`: keep Tab cycling inside the shared dialog's
+  composed shadow/light-DOM focus order.
+- `rust/tonk-workspace/src/ui_space_remove.rs`: exercise the real remove wrapper
+  against the shared dialog behavior.
+- `rust/tonk-core/assets/library/profile.yaml`: Join mobile hit geometry only.
+- `rust/tonk-worker/tests/standard_library.rs`: seeded Join CSS contracts.
+- `rust/tonk-display/src/element.rs`: prevent an obsolete async no-entity
+  diagnostic from overwriting a newer entity frame.
+- `plan/tonk-ui-mobile-hardening.md`: replace the five failure statuses only
+  after their runtime regressions pass.
+
+### Task 1: Restore registration focus across top-page and portal boundaries
+
+**Files:**
+
+- Modify: `rust/tonk-portal/src/bridge.rs:guest tonk.register, port dispatcher, on_register`
+- Modify: `rust/tonk-portal/src/lib.rs:bridge exports`
+- Modify: `rust/tonk-ui/src/bin/ui.rs:on_register installation`
+- Modify: `rust/tonk-ui/src/register_dialog.rs:RETURN_FOCUS, open, close`
+- Modify: `rust/tonk-ui/src/account.rs:registration close refresh path`
+- Test: `rust/tonk-ui/src/account_flow.rs`
+- Test: `rust/tonk-portal/src/bridge.rs`
+
+**Interfaces:**
+
+- Replace the portal callback with:
+
+  ```rust
+  pub struct RegisterFocusReturn {
+      port: web_sys::MessagePort,
+      token: String,
+      handled: bool,
+  }
+
+  impl RegisterFocusReturn {
+      pub fn restore(self);
+  }
+
+  pub fn on_register(
+      handler: impl Fn(&str, Option<RegisterFocusReturn>) + 'static,
+  );
+  ```
+
+- Add `register_dialog::open_with_return_focus(impl FnOnce() + 'static)` while
+  retaining `open()` for top-page/service-worker callers that can use the
+  current `document.activeElement`.
+- `RegisterFocusReturn` owns cleanup: restoring posts the token back to the
+  guest; dropping an unused handle removes the guest's stored token without
+  focusing it.
+
+- [x] Extend `it_scopes_registration_focus_and_restores_the_opener` to close
+  the Settings dialog with Escape and assert `#account-choose-link` remains the
+  active element after the account panel has had one asynchronous settle turn.
+  Add `it_restores_registration_focus_to_the_guest_opener`: open registration
+  from the provider-free Hub account trigger, close with Escape, return to the
+  sealed frame, and assert that exact trigger—not merely the iframe—has focus.
+- [x] Run
+  `nix develop path:. -c cargo test -p tonk-ui --features integration-tests it_scopes_registration_focus_and_restores_the_opener -- --test-threads=1 --nocapture`
+  and
+  `nix develop path:. -c cargo test -p tonk-ui --features integration-tests it_restores_registration_focus_to_the_guest_opener -- --test-threads=1 --nocapture`;
+  expect the current
+  Settings assertion to settle on `BODY` and the Hub assertion to stop at the
+  outer iframe.
+- [x] In the injected guest bridge, capture `document.activeElement`
+  synchronously when `tonk.register(reason)` is called, store it in a map under
+  a minted opaque token, and include the token in the `register` envelope. Do
+  not inspect or serialize guest selectors in the parent.
+- [x] Pass the dispatching `MessagePort` into `handle_register`. Construct
+  `RegisterFocusReturn` only when a non-empty token is present. Its `restore()`
+  posts a `register-focus` envelope; the guest consumes the token, verifies the
+  element is still connected and enabled, focuses it, and deletes the entry.
+  An unused handle posts a discard envelope so repeated register asks do not
+  leak element references.
+- [x] In `ui.rs`, pass the returned handle to
+  `open_with_return_focus`; registration requests without a guest token keep
+  using `open()`. Preserve `describe(reason)` ordering after the dialog opens.
+- [x] Remove `close()`'s unconditional `account::resettle()`. Account creation
+  already dispatches `ACCOUNT_CHANGED`, which the mounted account element
+  observes; a canceled ceremony changed no account state and must not repaint
+  the opener out from under focus restoration. Keep the direct active-element
+  restore for Settings and invoke the portal callback only after the native
+  dialog is closed and removed.
+- [x] Add bridge parser/round-trip tests rejecting empty tokens and proving a
+  focus-return envelope is sent through the request's own port. Run
+  `nix develop path:. -c test:web:debug -E 'package(tonk-portal)'`; expect the
+  bridge tests to pass. Rerun the two focused Tonk UI commands above; expect
+  both opener-restoration regressions to pass at runtime.
+- [x] Rerun
+  `nix develop path:. -c cargo test -p tonk-ui --features integration-tests it_explains_email_verification_before_account_sync -- --test-threads=1 --nocapture`;
+  expect a completed
+  account still refreshes the Settings panel through `ACCOUNT_CHANGED` without
+  the dismissal-time repaint.
+
+### Task 2: Retry WebAuthn with the committed registration address
+
+**Files:**
+
+- Modify: `rust/tonk-ui/src/register_dialog.rs:address, run_signup_ceremony, close`
+- Test: `rust/tonk-ui/src/account_flow.rs`
+
+**Interfaces:**
+
+- Add `const COMMITTED_EMAIL_ATTR: &str = "data-register-email"` on the dialog
+  host. `address()` reads the live input before commitment and this attribute
+  afterward.
+- The attribute lasts only for the dialog element's lifetime; closing/removing
+  the host clears it without another global cell.
+
+- [x] Add `it_retries_the_committed_address_after_a_failed_passkey_ceremony`.
+  Use a disposable provider-free profile, resolve an available email, and stub
+  `navigator.credentials.create` before the first action so each call rejects
+  with a controlled `NotAllowedError`. Click the re-enabled action twice in
+  sequence and assert: call count is two, the second click does not show “Enter
+  the address you want to use,” the settled email row still names the original
+  address, and each attempt is single-flight while pending.
+- [x] Run
+  `nix develop path:. -c cargo test -p tonk-ui --features integration-tests it_retries_the_committed_address_after_a_failed_passkey_ceremony -- --test-threads=1 --nocapture`;
+  expect the first rejection to re-enable
+  “create a passkey” and the second click to make no credential call because
+  `address()` can no longer find `#tonk-register-email`.
+- [x] After validating and trimming the address—but before
+  `settle_named_row(EMAIL_ROW, ...)` removes the input—write the committed value
+  to `COMMITTED_EMAIL_ATTR`. Make `address()` fall back to that attribute when
+  the live input is absent. Do not recreate the input or rerun the availability
+  lookup on retry.
+- [x] Keep the existing `ACTION_PENDING` sequence unchanged: `begin_action()`
+  claims the attempt; a retryable error calls `set_action(label, true)`; a
+  second click/Enter in the same pending turn is rejected.
+- [x] Rerun the retry command above, then run
+  `nix develop path:. -c cargo test -p tonk-ui --features integration-tests it_begins_only_one_registration_action_per_offered_step -- --test-threads=1 --nocapture`;
+  expect two
+  sequential rejected ceremonies in the former and exactly one concurrent
+  ceremony in the latter.
+
+### Task 3: Keep shared-dialog Tab focus inside the sealed guest
+
+**Files:**
+
+- Modify: `rust/tonk-fab/src/dialog.rs:TonkDialog listeners and focus helpers`
+- Modify test: `rust/tonk-workspace/src/ui_space_remove.rs:tests`
+- Test: `rust/tonk-ui/src/account_flow.rs`
+
+**Interfaces:**
+
+- `tonk-dialog` remains a native modal. Add only a boundary guard for joint
+  document focus navigation: forward Tab on the last composed focusable moves
+  to the first; Shift+Tab on the first moves to the last.
+- The ordered focusables are the shadow close button followed by visible,
+  enabled light-DOM controls in composed slot order. A custom-element control
+  focuses its internal `button`, `input`, or non-negative `tabindex` target.
+
+- [x] Add a FABB Wasm regression that opens a real `<tonk-dialog>` with a body
+  control and two slotted actions, focuses the final action, dispatches Tab,
+  and expects the shadow close button; reverse with Shift+Tab. Extend the
+  `ui-space-remove` test to use the same real close/cancel/remove sequence.
+- [x] Add `it_keeps_space_removal_focus_inside_the_sealed_guest`: create a
+  disposable local space, return to Hub, open its remove dialog, Tab for more
+  steps than the dialog contains, and after every step assert the top document's
+  active element remains the guest iframe and the guest active path belongs to
+  the open `tonk-dialog`. Escape must close and restore the remove opener.
+- [x] Run
+  `nix develop path:. -c cargo test -p tonk-ui --features integration-tests it_keeps_space_removal_focus_inside_the_sealed_guest -- --test-threads=1 --nocapture`;
+  expect current forward Tab from “remove
+  space” to reach a top-shell control while the guest dialog remains open.
+- [x] In `dialog.rs`, bind `keydown` on the native shadow dialog. Build the
+  candidate list on each Tab press so disabled/hidden slotted actions are not
+  cached. Filter `[hidden]`, disabled controls, negative `tabindex`, and nodes
+  with no rendered box. Use `KeyboardEvent.composed_path()` to recognize the
+  shadow close button and custom-element internals; prevent default only at the
+  two wrap boundaries.
+- [x] Preserve native Escape/cancel and ordinary Tab movement between interior
+  controls. Do not mark the parent document inert: the guard exists because a
+  native dialog cannot scope the joint tab order outside its iframe.
+- [x] Run
+  `nix develop path:. -c test:web:debug -E 'package(tonk-fab)'`,
+  `nix develop path:. -c test:web:debug -E 'package(tonk-workspace)'`, and
+  `nix develop path:. -c cargo test -p tonk-ui --features integration-tests it_keeps_space_removal_focus_inside_the_sealed_guest -- --test-threads=1 --nocapture`;
+  expect all focus-cycle and restoration assertions to pass.
+
+### Task 4: Give the Join wordmark and input real mobile targets
+
+**Files:**
+
+- Modify: `rust/tonk-core/assets/library/profile.yaml:join route compact CSS`
+- Modify: `rust/tonk-worker/tests/standard_library.rs:mobile Join contracts`
+- Modify test: `rust/tonk-ui/src/account_flow.rs:mobile viewport and target helpers`
+
+**Interfaces:**
+
+- Add a browser helper using CDP `Emulation.setDeviceMetricsOverride` with
+  `{width, height, deviceScaleFactor: 2, mobile: true}` plus touch emulation, so
+  Chrome's outer-window minimum cannot silently turn `320px` into `500px`.
+- The target scanner reports every visible `a`, `button`, and non-hidden `input`
+  whose width or height is below `44px`; it never uses the larger-dimension
+  predicate.
+
+- [x] Add `it_keeps_join_targets_accessible_at_phone_sizes`. Visit `/join` in a
+  clean profile at `320x568x2` and `390x844x2`, enter the sealed guest, and
+  assert exact `innerWidth`/`innerHeight`, no horizontal overflow, no undersized
+  targets, and a `16px` computed share-link input font. Run
+  `nix develop path:. -c cargo test -p tonk-ui --features integration-tests it_keeps_join_targets_accessible_at_phone_sizes -- --test-threads=1 --nocapture`;
+  expect
+  `.edge-mast` at about `98x32.8` and `.edge-input` at about `186x43` on the
+  short viewport.
+- [x] At `max-width:680px`, make `.edge-mast` a `44px`-minimum flex hit area
+  centered around the unchanged `98px` wordmark. Do not enlarge the image.
+- [x] Move the compact `.edge-field`'s 8px visual baseline inset from the field
+  container onto the noun/cursor presentation, then stretch `.edge-input` to a
+  `44px` minimum height inside the `44px` row. Preserve the right-aligned value,
+  `16px` input font, cursor position, and total row width; do not rely on the
+  enclosing label's rectangle as the input target.
+- [x] Strengthen `it_declares_mobile_target_and_input_floors_for_hub_and_join`
+  to require the wordmark and actual input floors, not only `.edge-field`.
+  Run `cargo test -p tonk-worker --test standard_library`; expect the current
+  seeded CSS to fail the two new contracts, then pass after the CSS change.
+- [x] Rerun
+  `nix develop path:. -c cargo test -p tonk-ui --features integration-tests it_keeps_join_targets_accessible_at_phone_sizes -- --test-threads=1 --nocapture`
+  in light and dark schemes at both viewports; expect
+  all targets at least `44x44`, no horizontal overflow, and unchanged wordmark
+  dimensions.
+
+### Task 5: Discard a stale no-entity diagnostic after a ready frame
+
+**Files:**
+
+- Modify: `rust/tonk-display/src/element.rs:handle_entity_frame, diagnose_no_entity`
+- Test: `rust/tonk-display/src/element.rs`
+- Test: `rust/tonk-ui/src/account_flow.rs:it_replaces_agent_link_progress_with_the_share_refusal`
+
+**Interfaces:**
+
+- Every entity frame already increments `Inner::entity_serial`. An async
+  no-entity diagnostic may mutate DOM only while its captured serial is still
+  current and the display is not disposed.
+- `rust/tonk-core/assets/library/core.yaml` remains unchanged unless the guarded
+  lifecycle test disproves this diagnosis; the current pending/refusal nesting
+  is valid when `data-state` ordering is monotonic.
+
+- [x] Add `it_discards_a_no_entity_diagnostic_superseded_by_a_ready_frame` in
+  `element.rs`. Start an empty single-entity frame, capture its diagnostic
+  serial, apply a non-empty frame that renders `ready`, then attempt to apply
+  the old diagnostic. Assert the host remains `data-state="ready"`, its direct
+  `slot="no-entity"` child stays hidden, and rendered content remains mounted.
+- [x] Run
+  `nix develop path:. -c test:web:debug -E 'test(it_discards_a_no_entity_diagnostic_superseded_by_a_ready_frame)'`;
+  expect the current diagnostic path to restore `no-entity` because it has no
+  generation check.
+- [x] In the empty-frame branch, capture `entity_serial` and clone the shared
+  `Inner` state before spawning `diagnose_no_entity`. Pass both into the async
+  function. Immediately before either `set_absence` or
+  `set_no_entity_diagnostic`, return without mutation when `disposed` is true
+  or `entity_serial` differs. Keep the per-attribute queries cancellable only
+  by this final generation check; they are reads and may finish harmlessly.
+- [x] Do not paper over the race with a `:has(.local-invite-notice)` CSS rule.
+  The observed DOM had a rendered refusal under a host reverted to
+  `data-state="no-entity"`; generation ordering is the owning invariant and
+  also protects every other display from stale diagnostics.
+- [x] Run the new Wasm command above,
+  `nix develop path:. -c test:web:debug -E 'test(it_keeps_nested_display_lifecycle_slots_scoped_to_their_owner)'`, and
+  `nix develop path:. -c cargo test -p tonk-ui --features integration-tests it_replaces_agent_link_progress_with_the_share_refusal -- --test-threads=1 --nocapture`.
+  The browser test must create a fresh space and see “sharing unavailable” with
+  no visible “Generating link…”.
+
+### Task 6: Close the five failures with fresh, separated evidence
+
+**Files:**
+
+- Modify after runtime success: `plan/tonk-ui-mobile-hardening.md:implementation status and evidence`
+- Test: all files above
+
+**Interfaces:**
+
+- Produces five runtime-green regressions and an evidence record that does not
+  equate compilation with browser execution.
+
+**Verification result (2026-08-28):** All five focused WebDriver regressions
+pass, as do the short destructive-dialog and exact-CDP Settings geometry
+regressions found while running the broad gate. The canonical serialized
+`test:e2e` run reached 51/57; its two UI failures were corrected afterward and
+pass exactly. The four remaining failures are native CLI-backed account tests
+whose `tonk.network` traffic resolves to public Cloudflare addresses instead
+of the loopback harness, so the full-suite item below remains unchecked.
+
+- [x] Run `cargo fmt --all -- --check` and `git diff --check`; expect no diff
+  or whitespace errors.
+- [x] Run `cargo test -p tonk-worker --test standard_library`,
+  `cargo test -p tonk-workspace`, `cargo test -p tonk-fab`,
+  `cargo test -p tonk-display`, and `cargo test -p tonk-portal`; expect all
+  native suites to pass.
+- [ ] With a ChromeDriver compatible with Chrome 152, run
+  `nix develop path:. -c test:web:debug`; expect all Wasm browser tests to
+  execute, not merely compile.
+- [ ] Run
+  `nix develop path:. -c cargo test -p tonk-ui --features integration-tests -- --test-threads=1 --nocapture`;
+  expect the whole serialized browser suite to pass, including the five focused
+  regressions.
+- [ ] Run `env -u NO_COLOR nix develop path:. -c build:web`; serve that exact
+  production artifact from a disposable profile and repeat the affected
+  journeys at `320x568x2` and `390x844x2`, light and dark. Also verify normal
+  and OS-level reduced motion if the automation environment can genuinely set
+  the media query.
+- [ ] Inspect the affected journeys' console and network output. Record
+  unrelated preload/subscription messages under their existing incident plans;
+  do not suppress them or misclassify them as one of these five fixes.
+- [x] Only after the runtime commands pass, update Tasks 2, 3, 4, 5, and 9 in
+  `plan/tonk-ui-mobile-hardening.md` from “Runtime defect found/failing” to
+  verified, with the exact commands and date. Leave iOS Safari, real passkey,
+  valid-invite, reduced-motion, terms, and production-device manual checks open
+  unless they were actually performed.
+
+## Handoff order
+
+Tasks 1-5 are independently reviewable and can be implemented as focused
+commits. Task 1 changes the portal callback interface and should be completed
+within one commit across `tonk-portal` and `tonk-ui`. Task 3 deliberately fixes
+the generic dialog primitive, so its FABB and workspace regressions must land
+together. Task 6 runs after every focused task is green; no status may be marked
+verified from compilation alone.

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -358,7 +358,7 @@ view!: &invitation/link
 # below derives it so the agent-prompt view can template the repo name and
 # the invite URL from one model. It resolves only once the invitation's
 # both halves (durable authorization + overlay credential) exist, so the
-# canvas shows "Generating link…" until the mint lands.
+# canvas shows "Generating link…" until the mint lands or a refusal replaces it.
 concept!: &tonk/agent-invite
   this: tonk:agent-invite
   description: A live invite joined with the repo's display name, for the agent prompt.
@@ -392,8 +392,8 @@ concept!: &tonk/agent-invite
 # A refused invite mint, asserted into the session overlay by the worker.
 # The empty-canvas and empty-sheet agent-link panels use it as the fallback
 # behind `tonk:agent-invite`: while neither exists they show a short pending
-# label; if minting is refused they replace that label with the reason and the
-# action that makes a link possible.
+# label; if minting is refused they replace that label with the worker-owned
+# reason sentence.
 concept!: &share/blocked
   this: tonk:share/blocked
   description: Why the latest invite request could not produce a shareable link.
@@ -460,8 +460,8 @@ view!:
           text-wrap: pretty;
         }
       </style>
-      <span class="local-invite-notice__label">local spot &middot; no sync remote</span>
-      <p>{detail} Use connect in the condition banner, then create the agent link again.</p>
+      <span class="local-invite-notice__label">sharing unavailable</span>
+      <p>{detail}</p>
     </div>
 
 # Derive `tonk:agent-invite` by joining the repo's `tonk:repository` name

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -343,6 +343,7 @@ view/directory!:
         .verbs { position:absolute; left:16px; bottom:9px; display:flex; gap:22px;
           opacity:0; transition:opacity .15s var(--ease); color:var(--soft); }
         .srow-wrap:hover .verbs, .srow-wrap:focus-within .verbs { opacity:1; }
+        ui-space-remove { display:contents; }
         .verbs button, .verbs .verb-remove { display:inline-flex; align-items:center;
           color:inherit; font:inherit; letter-spacing:inherit;
           text-transform:lowercase; cursor:pointer; }
@@ -354,36 +355,15 @@ view/directory!:
           width:100%; height:36px; padding:0 10px 9px 16px; background:var(--ink);
           color:var(--on-ink); box-shadow:0 0 0 1px var(--ink); cursor:pointer; }
         .snew:hover { background:linear-gradient(var(--wash-p),var(--wash-p)), var(--ink); }
-        /* ── the remove cluster — the page dims, the surface never ──
-           Driven by the same native radios the rest of the view uses: no
-           script runs in a seeded view, so the open state has to be
-           something CSS can hold. */
-        .rm-radio { position:absolute; opacity:0; pointer-events:none; }
-        .mscrim { display:none; position:fixed; inset:0; z-index:30; background:var(--dim); }
-        .modal { display:none; position:fixed; left:50%; top:34vh;
-          transform:translateX(-50%); width:432px; z-index:31; }
-        .srow-wrap > .rm-radio:checked ~ .mscrim,
-        .srow-wrap > .rm-radio:checked ~ .modal { display:block; }
-        /* solid cards — no filter behind opaque paint */
-        .modal .blk { background:var(--card);
-          -webkit-backdrop-filter:none; backdrop-filter:none; }
-        .m-hrow { display:flex; margin-right:-36px; margin-bottom:7px; }
-        .m-head { flex:1; display:flex; align-items:flex-end; justify-content:flex-start;
-          padding:0 16px 9px; font-size:13px; }
-        .m-x { width:36px; flex:none; display:grid; place-items:center;
-          border-radius:0 18px 18px 0; font-size:15px; cursor:pointer; }
-        .m-x:hover { background:linear-gradient(var(--wash),var(--wash)), var(--card); }
-        .m-body { height:auto; min-height:110px; padding:16px;
-          font-family:var(--sans); font-weight:600; font-size:13.5px;
-          line-height:1.6; color:var(--ink); text-transform:none; }
-        .m-name { text-transform:none; }
-        .m-foot { display:flex; justify-content:flex-end; margin-top:7px; }
-        /* the run fuses flush — the fill boundary is the divider */
+        .remove-form { margin:0; font-family:var(--sans); font-weight:600;
+          font-size:13.5px; line-height:1.6; text-transform:none; }
         .m-cancel { display:flex; align-items:flex-end; justify-content:flex-end;
-          min-width:144px; padding:0 10px 9px 24px; font-size:13px; cursor:pointer; }
+          min-width:144px; height:36px; padding:0 10px 9px 24px; border:0;
+          background:var(--card); color:var(--ink); font:inherit; font-size:13px;
+          cursor:pointer; }
         .m-cancel:hover { background:linear-gradient(var(--wash),var(--wash)), var(--card); }
         .m-go { height:36px; display:flex; align-items:flex-end; justify-content:flex-end;
-          min-width:144px; padding:0 10px 9px 24px; background:var(--ink);
+          min-width:144px; padding:0 10px 9px 24px; border:0; background:var(--ink);
           color:var(--on-ink); box-shadow:0 0 0 1px var(--ink); font-size:13px;
           cursor:pointer; white-space:nowrap; }
         /* brightness on near-black reads as nothing — wash it instead */
@@ -403,15 +383,16 @@ view/directory!:
           .srow .n { max-width:calc(100% - 150px); }
         }
         @media (max-width:640px) {
-          .modal { width:min(432px, calc(100vw - 84px));
-            top:max(20vh, calc(env(safe-area-inset-top) + 90px)); }
+          .hubbar, .hcell, .hub-page .mode-cap { height:44px; min-height:44px; }
+          .account-menu__row, .sempty, .srow, .snew { min-height:44px; }
+          .m-cancel, .m-go { min-height:44px; }
         }
         @media (max-width:607px) {
           .hubcol { width:min(432px, calc(100vw - 32px)); }
           .hc-acct { width:168px; }
           .hc-view { width:144px; }
-          .hc-cfg { width:84px; }
-          .hub-page .mode-cap { width:36px; }
+          .hc-cfg { width:76px; }
+          .hub-page .mode-cap { width:44px; flex:0 0 44px; }
         }
         @media (max-width:519px) {
           .hub-logo { top:62px; }
@@ -442,40 +423,27 @@ view/directory!:
              Each per-space consumer carries its OWN subject; the routing
              helpers read an element's own attribute and never walk ancestors. -->
         <div class="srow-wrap" data-status={status} data-local={local} data-id={this}>
-          <!-- The confirm's open state, held by a native radio because no
-               script runs in a seeded view. `tabindex=-1`: this is invisible
-               chrome, and Tab landing on it would silently arm a destructive
-               overlay. The named group means opening one confirm closes any
-               other. -->
-          <input class="rm-radio" type="radio" name="__rm" id="rm-{subject}" tabindex="-1">
           <a class="srow blk" href="/space/{subject}"><span class="n">{name}</span></a>
           <!-- Both verbs sit outside the anchor and are laid over it: a
                <button> inside an <a> is invalid markup the parser reshapes,
                and a <label for> inside one navigates rather than opening the
                confirm. Hovering the row reveals them (`.srow-wrap:hover`),
                so the reveal still follows the row and not just the verbs. -->
-          <span class="verbs">
-            <ui-copy-link url="/space/{subject}" label="copy link"></ui-copy-link>
-            <label class="verb-remove" for="rm-{subject}">remove</label>
-          </span>
-          <div class="mscrim"></div>
-          <div class="modal chrome" role="alertdialog" aria-modal="true">
-            <form onsubmit=space/remove data-remove={subject} data-close-radio="rm-closed">
-              <div class="m-hrow">
-                <div class="m-head blk">confirm space removal</div>
-                <label class="m-x blk" for="rm-closed" aria-label="close">&#215;</label>
-              </div>
-              <div class="m-body blk">
+          <ui-space-remove>
+            <span class="verbs">
+              <ui-copy-link url="/space/{subject}" label="copy link"></ui-copy-link>
+              <button class="verb-remove" type="button" data-space-remove-open>remove</button>
+            </span>
+            <tonk-dialog data-space-remove-dialog heading="confirm space removal">
+              <form id="remove-{subject}" class="remove-form" onsubmit=space/remove data-remove={subject}>
                 Remove {name} from this device? A synced space can be rejoined with
                 a share link; a local-only space is gone for good. Removing it
                 does not delete other members' copies.
-              </div>
-              <div class="m-foot">
-                <label class="m-cancel blk" for="rm-closed">cancel</label>
-                <button class="m-go" type="submit">remove space</button>
-              </div>
-            </form>
-          </div>
+              </form>
+              <button class="m-cancel" slot="actions" type="button" data-dialog="close">cancel</button>
+              <button class="m-go" slot="actions" type="submit" form="remove-{subject}">remove space</button>
+            </tonk-dialog>
+          </ui-space-remove>
         </div>
         <!-- Creating asks nothing up front: the space starts "Untitled" (the
              worker uniquifies the sentinel) and is renamed in place with the
@@ -489,9 +457,6 @@ view/directory!:
         </form>
       </div>
 
-      <!-- The shared "everything closed" state for the confirm radios. Last,
-           so a row's own radio can never be un-checked by it accidentally. -->
-      <input class="rm-radio" type="radio" name="__rm" id="rm-closed" checked tabindex="-1">
       </main>
     </div>
 
@@ -867,7 +832,7 @@ view!: &join/route-view
             --edge-page:#e8e6e4; --edge-ink:#38182a; --edge-on:#f7f6f5;
             --edge-soft:#5b4953; --edge-card:#f7f6f5;
             --edge-ring:rgba(56,24,42,.85); --edge-wash:rgba(56,24,42,.12);
-            min-height:100vh; padding:1px; color:var(--edge-ink);
+            min-height:100vh; min-height:100dvh; padding:1px; color:var(--edge-ink);
             background:var(--edge-page); font-family:'IBM Plex Sans Condensed',
               'Bahnschrift','Arial Narrow',system-ui,sans-serif;
             font-weight:600; letter-spacing:.02em; -webkit-font-smoothing:antialiased;
@@ -935,10 +900,14 @@ view!: &join/route-view
             background:var(--edge-card); box-shadow:0 0 0 1px var(--edge-ring); }
           .join-status:has(tonk-display[data-state="ready"]) .join-opening { display:none; }
           @media (max-width:680px) {
-            .edge-mast { left:16px; top:24px; width:98px; }
+            .edge-mast { left:16px; top:18px; width:98px; min-height:44px;
+              display:flex; align-items:center; }
             .edge-wall, .join-opening { margin-left:16px; margin-top:132px; }
             .edge-run { flex-direction:column; }
-            .ebtn { min-height:44px; }
+            .edge-field, .ebtn, .ebtn.solid button { min-height:44px; }
+            .edge-field { height:44px; padding-bottom:0; align-items:stretch; }
+            .edge-input { min-height:44px; font-size:16px; }
+            .edge-noun, .edge-cur { align-self:flex-end; margin-bottom:8px; }
           }
           @media (prefers-reduced-motion:reduce) {
             .edge-cur, .edge-wall:has(tonk-invite-link[data-state="invalid"])

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -1780,6 +1780,8 @@ fn handle_entity_frame(
         // no-entity diagnostic can name the concept's required attributes
         // and probe which ones the entity is actually missing.
         let descriptor = s.resolved_model.as_ref().map(|(_, value)| value.clone());
+        let diagnostic_serial = s.entity_serial;
+        let diagnostic_state = state.clone();
         // A directory view with zero instances still renders chrome that may
         // read {dom.host/*} (the FAB reads {dom.host/data-space}); feed a
         // synthetic host-only conclusion so those resolve. Single mode keeps
@@ -1801,7 +1803,7 @@ fn handle_entity_frame(
             // report which are missing — then show that as the notation.
             let host = host.clone();
             spawn_local(async move {
-                diagnose_no_entity(&host, descriptor).await;
+                diagnose_no_entity(&host, descriptor, &diagnostic_state, diagnostic_serial).await;
             });
         }
         return;
@@ -1852,7 +1854,12 @@ fn handle_entity_frame(
 /// on top, the raw present facts as notation below. A descriptor that
 /// isn't available (or has no `with:` map) falls back to the bare
 /// `model: / this:` notation — there is nothing to diff against.
-async fn diagnose_no_entity(host: &Element, descriptor: Option<serde_json::Value>) {
+async fn diagnose_no_entity(
+    host: &Element,
+    descriptor: Option<serde_json::Value>,
+    state: &Rc<RefCell<Inner>>,
+    entity_serial: u64,
+) {
     let model = host.get_attribute("model").unwrap_or_default();
     let entity = host.get_attribute("entity").unwrap_or_default();
 
@@ -1863,6 +1870,9 @@ async fn diagnose_no_entity(host: &Element, descriptor: Option<serde_json::Value
         .and_then(|d| d.get("with"))
         .and_then(|w| w.as_object());
     let Some(with) = with else {
+        if diagnostic_was_superseded(state, entity_serial) {
+            return;
+        }
         state::set_absence(
             host,
             State::NoEntity,
@@ -1913,7 +1923,15 @@ async fn diagnose_no_entity(host: &Element, descriptor: Option<serde_json::Value
         }
     }
 
+    if diagnostic_was_superseded(state, entity_serial) {
+        return;
+    }
     state::set_no_entity_diagnostic(host, &model, &entity, &present, &missing);
+}
+
+fn diagnostic_was_superseded(state: &Rc<RefCell<Inner>>, entity_serial: u64) -> bool {
+    let state = state.borrow();
+    state.disposed || state.entity_serial != entity_serial
 }
 
 /// Refresh the trailing notation slide's source `<script>` with
@@ -2648,6 +2666,45 @@ mod tests {
             state.borrow().last_frame.is_empty(),
             "a plain empty frame clears as before"
         );
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[dialog_common::test]
+    async fn it_discards_a_no_entity_diagnostic_superseded_by_a_ready_frame() {
+        let (host, state, content) = rendered_display();
+        let no_entity = web_sys::window()
+            .unwrap()
+            .document()
+            .unwrap()
+            .create_element("span")
+            .unwrap();
+        no_entity.set_attribute("slot", "no-entity").unwrap();
+        no_entity.set_attribute("hidden", "").unwrap();
+        host.append_child(&no_entity).unwrap();
+
+        handle_entity_frame(&host, &state, Vec::new(), false);
+        let stale_serial = state.borrow().entity_serial;
+        handle_entity_frame(
+            &host,
+            &state,
+            vec![Conclusion {
+                this: "e:ready".to_owned(),
+                fields: BTreeMap::new(),
+            }],
+            false,
+        );
+        diagnose_no_entity(&host, None, &state, stale_serial).await;
+
+        assert_eq!(host.get_attribute("data-state").as_deref(), Some("ready"));
+        assert!(
+            no_entity.has_attribute("hidden"),
+            "a stale diagnostic must not reveal the no-entity slot"
+        );
+        assert!(
+            content.is_connected(),
+            "the ready frame must remain mounted"
+        );
+        host.remove();
     }
 
     /// An authorization refusal is a real failure: the loud path replaces

--- a/rust/tonk-display/src/state.rs
+++ b/rust/tonk-display/src/state.rs
@@ -904,6 +904,44 @@ mod tests {
 
     #[cfg(target_arch = "wasm32")]
     #[dialog_common::test]
+    fn it_keeps_nested_display_lifecycle_slots_scoped_to_their_owner() {
+        let document = web_sys::window().unwrap().document().unwrap();
+        let outer = host();
+        let inner = host();
+        inner.set_attribute("slot", "no-entity").unwrap();
+        let pending = document.create_element("span").unwrap();
+        pending.set_attribute("slot", "no-entity").unwrap();
+        pending.set_text_content(Some("Generating link…"));
+        inner.append_child(&pending).unwrap();
+        outer.append_child(&inner).unwrap();
+        document.body().unwrap().append_child(&outer).unwrap();
+
+        set(&outer, State::NoEntity);
+        set(&inner, State::NoEntity);
+        assert!(!pending.has_attribute("hidden"));
+        set(&inner, State::Ready);
+
+        assert!(
+            pending.has_attribute("hidden"),
+            "the inner ready state hides its own pending slot"
+        );
+        let display = web_sys::window()
+            .unwrap()
+            .get_computed_style(&pending)
+            .unwrap()
+            .unwrap()
+            .get_property_value("display")
+            .unwrap();
+        assert_eq!(display, "none", "hidden pending content is not rendered");
+        assert!(
+            !inner.has_attribute("hidden"),
+            "the outer display does not hide its active nested display"
+        );
+        outer.remove();
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[dialog_common::test]
     fn it_renders_the_danger_callout_on_set_error() {
         let host = host();
         set_error(&host, State::Malformed, "Not found", "no entity matched");

--- a/rust/tonk-fab/Cargo.toml
+++ b/rust/tonk-fab/Cargo.toml
@@ -43,6 +43,7 @@ web-sys = { workspace = true, features = [
     "HtmlHeadElement",
     "HtmlInputElement",
     "KeyboardEvent",
+    "KeyboardEventInit",
     "Location",
     "MediaQueryList",
     "MessageEvent",

--- a/rust/tonk-fab/src/bar.rs
+++ b/rust/tonk-fab/src/bar.rs
@@ -816,7 +816,7 @@ pub(crate) fn update(this: &HtmlElement) {
         }));
     }
     if let Ok(Some(mode)) = this.query_selector("[data-overflow-mode]") {
-        let _ = mode.set_attribute("aria-checked", &shadow::is_dark(this).to_string());
+        let _ = mode.set_attribute("pressed", &shadow::is_dark(this).to_string());
     }
     update_more_glyph(this);
     update_sync_condition(this);

--- a/rust/tonk-fab/src/dialog.rs
+++ b/rust/tonk-fab/src/dialog.rs
@@ -19,7 +19,7 @@ use js_sys::Object;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::*;
-use web_sys::{Element, HtmlDialogElement, HtmlElement, window};
+use web_sys::{Element, HtmlDialogElement, HtmlElement, KeyboardEvent, window};
 
 use crate::shadow::{self, Bound};
 
@@ -44,6 +44,11 @@ dialog::backdrop{ background:rgba(16,16,12,.32); }
   max-height:min(60vh, 420px); overflow:auto; }
 .frow{ display:none; gap:0; justify-content:flex-end; margin-right:43px; }
 .w.has-acts .frow{ display:flex; }
+@media(max-width:519px){
+  .t,.x{ height:44px; }
+  .x{ width:44px; border-radius:0 22px 22px 0; }
+  ::slotted([slot=actions]){ min-height:44px !important; }
+}
 "#;
 
 const HTML: &str = r#"<dialog>
@@ -117,6 +122,15 @@ impl CustomElement for TonkDialog {
                     {
                         close_dialog(&host);
                     }
+                }));
+
+            let host = this.clone();
+            self.listeners
+                .push(shadow::bind(&dialog, "keydown", move |event| {
+                    let Ok(event) = event.dyn_into::<KeyboardEvent>() else {
+                        return;
+                    };
+                    guard_tab_boundary(&host, &event);
                 }));
         }
 
@@ -230,6 +244,131 @@ fn native_dialog(this: &HtmlElement) -> Option<HtmlDialogElement> {
         .and_then(|d| d.dyn_into::<HtmlDialogElement>().ok())
 }
 
+fn guard_tab_boundary(this: &HtmlElement, event: &KeyboardEvent) {
+    if event.key() != "Tab" {
+        return;
+    }
+    let focusables = composed_focusables(this);
+    let Some(first) = focusables.first() else {
+        return;
+    };
+    let Some(last) = focusables.last() else {
+        return;
+    };
+    let path = event.composed_path();
+    let at_first = path
+        .iter()
+        .any(|node| first.is_same_node(node.dyn_ref::<web_sys::Node>()));
+    let at_last = path
+        .iter()
+        .any(|node| last.is_same_node(node.dyn_ref::<web_sys::Node>()));
+
+    let target = if event.shift_key() && at_first {
+        Some(last)
+    } else if !event.shift_key() && at_last {
+        Some(first)
+    } else {
+        None
+    };
+    if let Some(target) = target {
+        event.prevent_default();
+        let _ = target.focus();
+    }
+}
+
+fn composed_focusables(this: &HtmlElement) -> Vec<HtmlElement> {
+    let mut focusables = Vec::new();
+    if let Some(close) = this
+        .shadow_root()
+        .and_then(|root| root.query_selector(".x").ok().flatten())
+        .and_then(focus_target)
+    {
+        focusables.push(close);
+    }
+    let Ok(elements) = this.query_selector_all("*") else {
+        return focusables;
+    };
+    for index in 0..elements.length() {
+        let Some(element) = elements
+            .item(index)
+            .and_then(|node| node.dyn_into::<Element>().ok())
+        else {
+            continue;
+        };
+        if let Some(target) = focus_target(element) {
+            if !focusables
+                .iter()
+                .any(|known| known.is_same_node(Some(target.as_ref())))
+            {
+                focusables.push(target);
+            }
+        }
+    }
+    focusables
+}
+
+fn focus_target(element: Element) -> Option<HtmlElement> {
+    if element.has_attribute("hidden")
+        || element.has_attribute("disabled")
+        || element
+            .closest("[hidden]")
+            .ok()
+            .flatten()
+            .is_some_and(|hidden| hidden != element)
+        || element
+            .get_attribute("tabindex")
+            .and_then(|value| value.parse::<i32>().ok())
+            .is_some_and(|tabindex| tabindex < 0)
+    {
+        return None;
+    }
+
+    if element.tag_name().contains('-')
+        && let Some(shadow) = element.shadow_root()
+        && let Ok(candidates) =
+            shadow.query_selector_all("button,input,select,textarea,a[href],[tabindex]")
+    {
+        for index in 0..candidates.length() {
+            let Some(candidate) = candidates
+                .item(index)
+                .and_then(|node| node.dyn_into::<Element>().ok())
+            else {
+                continue;
+            };
+            if let Some(target) = ordinary_focus_target(candidate) {
+                return Some(target);
+            }
+        }
+    }
+    ordinary_focus_target(element)
+}
+
+fn ordinary_focus_target(element: Element) -> Option<HtmlElement> {
+    if element.has_attribute("hidden")
+        || element.has_attribute("disabled")
+        || element
+            .get_attribute("tabindex")
+            .and_then(|value| value.parse::<i32>().ok())
+            .is_some_and(|tabindex| tabindex < 0)
+        || (element.tag_name() == "INPUT"
+            && element.get_attribute("type").as_deref() == Some("hidden"))
+    {
+        return None;
+    }
+    let naturally_focusable = matches!(
+        element.tag_name().as_str(),
+        "BUTTON" | "INPUT" | "SELECT" | "TEXTAREA"
+    ) || (element.tag_name() == "A" && element.has_attribute("href"));
+    if !naturally_focusable && !element.has_attribute("tabindex") {
+        return None;
+    }
+    let rect = element.get_bounding_client_rect();
+    if rect.width() <= 0.0 || rect.height() <= 0.0 {
+        return None;
+    }
+    element.dyn_into::<HtmlElement>().ok()
+}
+
 /// Open the cluster modally.
 pub(crate) fn show_dialog(this: &HtmlElement) {
     shadow::apply_mode(this);
@@ -294,5 +433,84 @@ pub(crate) fn register() {
     let Some(win) = window() else { return };
     if win.custom_elements().get("tonk-dialog").is_undefined() {
         TonkDialog::define("tonk-dialog");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use wasm_bindgen::JsCast as _;
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+    use web_sys::{HtmlElement, KeyboardEvent, KeyboardEventInit, window};
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn presses_tab(target: &HtmlElement, shift: bool) {
+        let init = KeyboardEventInit::new();
+        init.set_key("Tab");
+        init.set_bubbles(true);
+        init.set_composed(true);
+        init.set_cancelable(true);
+        init.set_shift_key(shift);
+        let event =
+            KeyboardEvent::new_with_keyboard_event_init_dict("keydown", &init).expect("Tab event");
+        target.dispatch_event(&event).expect("dispatch Tab");
+    }
+
+    #[wasm_bindgen_test]
+    fn it_cycles_tab_across_shadow_and_slotted_dialog_controls() {
+        super::register();
+        let document = window().expect("window").document().expect("document");
+        let host: HtmlElement = document
+            .create_element("tonk-dialog")
+            .expect("dialog host")
+            .dyn_into()
+            .expect("HtmlElement");
+        host.set_inner_html(
+            r#"<button type="button">body control</button>
+               <button slot="actions" type="button">cancel</button>
+               <button slot="actions" type="button">remove space</button>"#,
+        );
+        document
+            .body()
+            .expect("body")
+            .append_child(&host)
+            .expect("append dialog");
+        super::show_dialog(&host);
+
+        let close: HtmlElement = host
+            .shadow_root()
+            .expect("shadow root")
+            .query_selector(".x")
+            .unwrap()
+            .unwrap()
+            .dyn_into()
+            .unwrap();
+        let actions = host.query_selector_all("[slot=actions]").unwrap();
+        let last: HtmlElement = actions.item(1).unwrap().dyn_into().unwrap();
+
+        last.focus().unwrap();
+        presses_tab(&last, false);
+        assert!(
+            document
+                .active_element()
+                .is_some_and(|active| active.is_same_node(Some(&host))),
+            "the document focus path must remain rooted at the dialog host"
+        );
+        assert!(
+            host.shadow_root()
+                .and_then(|root| root.active_element())
+                .is_some_and(|active| active.is_same_node(Some(&close))),
+            "forward Tab on the last action must wrap to the shadow close button"
+        );
+
+        presses_tab(&close, true);
+        assert!(
+            document
+                .active_element()
+                .is_some_and(|active| active.is_same_node(Some(&last))),
+            "Shift+Tab on the close button must wrap to the final action"
+        );
+        super::close_dialog(&host);
+        host.remove();
     }
 }

--- a/rust/tonk-fab/src/field.rs
+++ b/rust/tonk-fab/src/field.rs
@@ -37,6 +37,10 @@ const CSS: &str = r#"
   :host([changeable]) .noun-current{ display:none; }
   :host([changeable]) .noun-change{ display:inline-flex; align-items:flex-end; }
 }
+@media (max-width:519px), (pointer:coarse){
+  .row{ height:44px; }
+  .value{ font-size:16px; }
+}
 @media (prefers-reduced-motion:reduce){
   .row.rejecting{ animation:none; }
   .cur{ animation:none; }
@@ -306,6 +310,9 @@ mod tests {
         assert!(CSS.contains("height:36px"));
         assert!(CSS.contains(":host([settled])"));
         assert!(CSS.contains(":host([filter=digits])"));
+        assert!(CSS.contains("@media (max-width:519px), (pointer:coarse)"));
+        assert!(CSS.contains(".row{ height:44px; }"));
+        assert!(CSS.contains(".value{ font-size:16px; }"));
     }
 
     #[test]

--- a/rust/tonk-fab/src/markup.rs
+++ b/rust/tonk-fab/src/markup.rs
@@ -96,9 +96,9 @@ pub const BAR_HTML: &str = r#"<div class="w">
   <div class="bar" part="bar">
     <button class="cell fab" data-cell="sync" part="fab" title="sync status · drag to move"><span class="disc st"></span></button>
     <div class="run">
-      <button class="cell space" data-cell="space" title="space name" aria-haspopup="true" aria-expanded="false" aria-controls="fabb-space-menu"><span class="n"></span></button>
-      <button class="cell share chrome" data-cell="share" title="share with others" aria-haspopup="true" aria-expanded="false" aria-controls="fabb-share-menu">share</button>
-      <button class="cell more chrome" data-cell="more" title="more actions" aria-label="more actions" aria-haspopup="true" aria-expanded="false" aria-controls="fabb-overflow-menu"><span class="more-glyph" aria-hidden="true">&#9652;</span></button>
+      <button class="cell space" data-cell="space" title="space name" aria-expanded="false" aria-controls="fabb-space-menu"><span class="n"></span></button>
+      <button class="cell share chrome" data-cell="share" title="share with others" aria-expanded="false" aria-controls="fabb-share-menu">share</button>
+      <button class="cell more chrome" data-cell="more" title="more actions" aria-label="more actions" aria-expanded="false" aria-controls="fabb-overflow-menu"><span class="more-glyph" aria-hidden="true">&#9652;</span></button>
       <button class="cell toggle" data-cell="toggle" role="switch" title="dark / light" aria-label="dark mode"></button>
     </div>
   </div>
@@ -136,10 +136,10 @@ pub const STACK_GAP_PX: i32 = 7;
 /// library.
 pub const STACKS_HTML: &str = r#"<ui-sync-status headless with="main@{space}"></ui-sync-status>
 <ui-space-name headless space="{space}"></ui-space-name>
-<tonk-menu id="fabb-space-menu" slot="menu" data-for="space" hidden>
+<tonk-menu id="fabb-space-menu" slot="menu" data-for="space" role="group" aria-label="space actions" hidden>
   <tonk-mi chrome data-mi-new>new<span class="g">+</span></tonk-mi>
   <tonk-mi chrome data-mi-open>open<span class="g">&#9656;</span>
-    <tonk-menu slot="sub">
+    <tonk-menu slot="sub" role="group" aria-label="spaces">
       <ui-space-switcher exclude="{space}"></ui-space-switcher>
       <tonk-mi muted chrome data-mi-home title="back to the directory at home">more<span class="g">&#8598;</span></tonk-mi>
     </tonk-menu>
@@ -147,7 +147,7 @@ pub const STACKS_HTML: &str = r#"<ui-sync-status headless with="main@{space}"></
   <tonk-mi chrome data-mi-rename>rename<span class="g rename-mark" aria-hidden="true"></span></tonk-mi>
 </tonk-menu>
 <tonk-share headless space="{space}"></tonk-share>
-<tonk-menu id="fabb-share-menu" slot="menu" data-for="share" hidden>
+<tonk-menu id="fabb-share-menu" slot="menu" data-for="share" role="group" aria-label="share actions" hidden>
   <tonk-mi chrome data-mi-back hidden>back<span class="g">&#9666;</span></tonk-mi>
   <tonk-mi chrome data-share-account>log in to share<span class="g">&#8598;</span></tonk-mi>
   <tonk-mi chrome data-share-link hidden>
@@ -159,9 +159,9 @@ pub const STACKS_HTML: &str = r#"<ui-sync-status headless with="main@{space}"></
   </tonk-mi>
   <ui-member-roster space="{space}"></ui-member-roster>
 </tonk-menu>
-<tonk-menu id="fabb-overflow-menu" slot="menu" data-for="overflow" hidden>
+<tonk-menu id="fabb-overflow-menu" slot="menu" data-for="overflow" role="group" aria-label="more actions" hidden>
   <tonk-mi chrome data-overflow-share>share<span class="g">&#9656;</span></tonk-mi>
-  <tonk-mi chrome data-overflow-mode role="menuitemcheckbox" aria-checked="false"><span data-mode-label>dark mode</span></tonk-mi>
+  <tonk-mi chrome data-overflow-mode pressed="false"><span data-mode-label>dark mode</span></tonk-mi>
 </tonk-menu>"#;
 
 /// Styles for the slotted stack content.
@@ -395,6 +395,24 @@ mod tests {
         assert!(share < mode);
         assert!(!html.contains("data-overflow-collapse"));
         assert_eq!(html.matches(r#"data-for="share""#).count(), 1);
+    }
+
+    #[test]
+    fn it_describes_stacks_as_named_disclosure_groups() {
+        assert!(
+            !BAR_HTML.contains("aria-haspopup"),
+            "disclosure triggers must not claim menu behavior"
+        );
+        let html = stacks_html("did:key:z6Mk");
+        for label in ["space actions", "spaces", "share actions", "more actions"] {
+            assert!(
+                html.contains(&format!(r#"role="group" aria-label="{label}""#)),
+                "the {label} stack must be a named group"
+            );
+        }
+        assert!(!html.contains("menuitemcheckbox"));
+        assert!(!html.contains("aria-checked"));
+        assert!(html.contains(r#"data-overflow-mode pressed="false""#));
     }
 
     #[test]

--- a/rust/tonk-fab/src/menu.rs
+++ b/rust/tonk-fab/src/menu.rs
@@ -87,6 +87,9 @@ impl CustomElement for TonkMenu {
             return;
         }
         *self.wired.borrow_mut() = true;
+        if !this.has_attribute("role") {
+            let _ = this.set_attribute("role", "group");
+        }
 
         let root = shadow::build(this, CSS, HTML);
 

--- a/rust/tonk-fab/src/mi.rs
+++ b/rust/tonk-fab/src/mi.rs
@@ -106,7 +106,9 @@ impl CustomElement for TonkMi {
     }
 
     fn observed_attributes() -> &'static [&'static str] {
-        &["mode", "muted", "chrome", "tall", "current", "cap"]
+        &[
+            "mode", "muted", "chrome", "tall", "current", "cap", "pressed",
+        ]
     }
 
     fn inject_children(&mut self, _this: &HtmlElement) {}
@@ -133,6 +135,7 @@ impl CustomElement for TonkMi {
                 shadow::emit(&host, "fabb-pick", &detail);
             }));
         }
+        sync_pressed(this);
 
         // `.fly.sub` only applies when something is actually slotted —
         // without the check the bridge would paint across an empty gap on
@@ -179,6 +182,28 @@ impl CustomElement for TonkMi {
         if name == "mode" {
             shadow::apply_mode(this);
             propagate(this);
+        } else if name == "pressed" {
+            sync_pressed(this);
+        }
+    }
+}
+
+fn sync_pressed(this: &HtmlElement) {
+    let Some(root) = this.shadow_root() else {
+        return;
+    };
+    let Ok(Some(row)) = root.query_selector(".row") else {
+        return;
+    };
+    match this.get_attribute("pressed") {
+        Some(value) => {
+            let _ = row.set_attribute(
+                "aria-pressed",
+                if value == "true" { "true" } else { "false" },
+            );
+        }
+        None => {
+            let _ = row.remove_attribute("aria-pressed");
         }
     }
 }

--- a/rust/tonk-fab/tests/responsive_overflow.rs
+++ b/rust/tonk-fab/tests/responsive_overflow.rs
@@ -146,6 +146,33 @@ async fn the_stack_uses_one_visible_gap_and_the_disc_collapses_it() {
         .expect("mount parent");
 
     set_parent_width(&parent, &fab, 375, true, false).await;
+    for selector in ["[data-cell=space]", "[data-cell=share]", "[data-cell=more]"] {
+        let trigger = shadow_element(&fab, selector);
+        assert!(
+            !trigger.has_attribute("aria-haspopup"),
+            "{selector} is a disclosure trigger, not a menu button"
+        );
+    }
+    for (selector, label) in [
+        ("tonk-menu[data-for=space]", "space actions"),
+        ("tonk-menu[slot=sub]", "spaces"),
+        ("tonk-menu[data-for=share]", "share actions"),
+        ("tonk-menu[data-for=overflow]", "more actions"),
+    ] {
+        let group = light_element(&fab, selector);
+        assert_eq!(group.get_attribute("role").as_deref(), Some("group"));
+        assert_eq!(group.get_attribute("aria-label").as_deref(), Some(label));
+    }
+    let actions = fab.query_selector_all("tonk-mi").expect("action selector");
+    for index in 0..actions.length() {
+        let action = actions
+            .item(index)
+            .expect("action")
+            .dyn_into::<Element>()
+            .expect("action element");
+        let row = menu_row(&action);
+        assert_eq!(row.tag_name(), "BUTTON", "stack actions stay real buttons");
+    }
     fab.set_attribute("up", "").expect("open upward");
     shadow_element(&fab, "[data-cell=more]")
         .unchecked_into::<HtmlElement>()
@@ -297,7 +324,11 @@ async fn the_action_partition_follows_usable_width_without_a_fold() {
         light_element(&fab, "[data-overflow-mode]")
             .get_attribute("role")
             .as_deref(),
-        Some("menuitemcheckbox")
+        None
+    );
+    assert_eq!(
+        mode_row.get_attribute("aria-pressed").as_deref(),
+        Some("false")
     );
     shadow_element(&fab, "[data-cell=share]")
         .unchecked_into::<HtmlElement>()
@@ -357,8 +388,9 @@ async fn the_action_partition_follows_usable_width_without_a_fold() {
             .as_deref()
             .is_some_and(|mode| mode == "dark" || mode == "light")
     );
+    let mode_button = menu_row(&light_element(&fab, "[data-overflow-mode]"));
     assert_eq!(
-        light_element(&fab, "[data-overflow-mode]").get_attribute("aria-checked"),
+        mode_button.get_attribute("aria-pressed"),
         Some((mode_after.as_deref() == Some("dark")).to_string())
     );
     assert!(overflow.has_attribute("hidden"));

--- a/rust/tonk-fab/tests/responsive_overflow.rs
+++ b/rust/tonk-fab/tests/responsive_overflow.rs
@@ -326,9 +326,10 @@ async fn the_action_partition_follows_usable_width_without_a_fold() {
             .as_deref(),
         None
     );
+    let mode_is_dark = (fab.get_attribute("mode").as_deref() == Some("dark")).to_string();
     assert_eq!(
         mode_row.get_attribute("aria-pressed").as_deref(),
-        Some("false")
+        Some(mode_is_dark.as_str())
     );
     shadow_element(&fab, "[data-cell=share]")
         .unchecked_into::<HtmlElement>()

--- a/rust/tonk-portal/src/bridge.rs
+++ b/rust/tonk-portal/src/bridge.rs
@@ -179,7 +179,7 @@ impl PortalState {
 /// Posting to `"*"` is unavoidable from a null origin; the parent
 /// authenticates by `event.source`, not `event.origin`.
 const BOOTSTRAP_JS: &str = r#"(function(){
-  var nextId=0, pending=new Map(), streams=new Map(), subRows=new Map();
+  var nextId=0, pending=new Map(), streams=new Map(), subRows=new Map(), registerFocus=new Map();
   var resolveReady; var ready=new Promise(function(r){resolveReady=r;});
   var ch=new MessageChannel(), port=ch.port1;
   function mint(){return "r"+(++nextId);}
@@ -280,7 +280,10 @@ const BOOTSTRAP_JS: &str = r#"(function(){
     // the service worker both lack. The guest posts the refusal class so
     // the host can word the prompt. Fire-and-forget (no response).
     register:function(reason){
-      ready.then(function(){port.postMessage({v:1,type:"register",reason:reason});});
+      var opener=document.activeElement;
+      var token=(opener&&opener!==document.body)?mint():"";
+      if(token){ registerFocus.set(token,opener); }
+      ready.then(function(){port.postMessage({v:1,type:"register",reason:reason,focusToken:token});});
     },
     // Same-origin request performed by the HOST: the opaque guest can't reach a
     // same-origin, SW-routed `/api/...` endpoint itself. The host issues the
@@ -328,6 +331,18 @@ const BOOTSTRAP_JS: &str = r#"(function(){
       case "delegate-result": {
         var h=pending.get(env.id); if(!h) return; pending.delete(env.id);
         h.resolve(env.delegation); return;
+      }
+      case "register-focus": {
+        var opener=registerFocus.get(env.focusToken);
+        registerFocus.delete(env.focusToken);
+        if(opener&&opener.isConnected&&!opener.matches(":disabled")){
+          window.focus();
+          opener.focus({preventScroll:true});
+        }
+        return;
+      }
+      case "register-focus-discard": {
+        registerFocus.delete(env.focusToken); return;
       }
       case "fetch-result": {
         var h=pending.get(env.id); if(!h) return; pending.delete(env.id);
@@ -1608,7 +1623,7 @@ fn make_dispatcher(
             "reload" => tonk_host::reload_page(),
             "title" => handle_title(&data),
             "open" => handle_open(&state, &data),
-            "register" => handle_register(&data),
+            "register" => handle_register(&state, &port, &data),
             "fetch" => handle_host_fetch(&state, &port, &data),
             "delegate" => handle_delegate(&port, &data),
             _ => {}
@@ -1911,19 +1926,66 @@ fn is_top_level_route(rest: &str) -> bool {
 /// handler at boot instead — the same shape as the other page effects,
 /// where this crate carries the transport and the shell supplies the
 /// behaviour.
-fn handle_register(data: &JsValue) {
-    let Some(reason) = register_reason(data) else {
+fn handle_register(state: &Rc<RefCell<PortalState>>, port: &MessagePort, data: &JsValue) {
+    let Some((reason, token)) = register_request(data) else {
         return;
     };
+    let focus_return = token.map(|token| RegisterFocusReturn {
+        port: port.clone(),
+        frame: state.borrow().iframe.clone(),
+        token,
+        handled: false,
+    });
     REGISTER_HANDLER.with(|handler| {
         if let Some(handler) = handler.borrow().as_ref() {
-            handler(&reason);
+            handler(&reason, focus_return);
         }
     });
 }
 
+/// A one-shot return path to the exact control in a sealed guest that asked
+/// the top page to open registration.
+pub struct RegisterFocusReturn {
+    port: MessagePort,
+    frame: Option<HtmlIFrameElement>,
+    token: String,
+    handled: bool,
+}
+
+impl RegisterFocusReturn {
+    /// Return focus to the still-connected guest opener and consume its token.
+    pub fn restore(mut self) {
+        if let Some(frame) = self.frame.as_ref()
+            && frame.is_connected()
+        {
+            let _ = frame.focus();
+        }
+        self.post("register-focus");
+        self.handled = true;
+    }
+
+    fn post(&self, kind: &str) {
+        let envelope = Object::new();
+        set_v1(&envelope, kind);
+        let _ = Reflect::set(
+            &envelope,
+            &"focusToken".into(),
+            &JsValue::from_str(&self.token),
+        );
+        let _ = self.port.post_message(&envelope);
+    }
+}
+
+impl Drop for RegisterFocusReturn {
+    fn drop(&mut self) {
+        if !self.handled {
+            self.post("register-focus-discard");
+        }
+    }
+}
+
 /// What a page does when a guest asks it to raise registration.
-type RegisterHandler = Box<dyn Fn(&str)>;
+type RegisterHandler = Box<dyn Fn(&str, Option<RegisterFocusReturn>)>;
 
 thread_local! {
     /// What to do when a guest asks for registration. `None` until the
@@ -1937,7 +1999,7 @@ thread_local! {
 ///
 /// Called once by the shell at boot. Later calls replace the handler,
 /// which keeps a hot reload from stacking dialogs.
-pub fn on_register(handler: impl Fn(&str) + 'static) {
+pub fn on_register(handler: impl Fn(&str, Option<RegisterFocusReturn>) + 'static) {
     REGISTER_HANDLER.with(|slot| {
         *slot.borrow_mut() = Some(Box::new(handler));
     });
@@ -1946,11 +2008,13 @@ pub fn on_register(handler: impl Fn(&str) + 'static) {
 /// Read `reason` out of a `{ type: "register", reason }` message, or
 /// `None` when the message is not one. Split out so the parse is
 /// testable on its own, the way [`title_text`] is.
-fn register_reason(data: &JsValue) -> Option<String> {
+fn register_request(data: &JsValue) -> Option<(String, Option<String>)> {
     if get_str(data, "type")? != "register" {
         return None;
     }
-    get_str(data, "reason").filter(|reason| !reason.is_empty())
+    let reason = get_str(data, "reason").filter(|reason| !reason.is_empty())?;
+    let token = get_str(data, "focusToken").filter(|token| !token.is_empty());
+    Some((reason, token))
 }
 
 fn handle_title(data: &JsValue) {
@@ -4125,6 +4189,53 @@ mod tests {
             None,
             "a non-object payload should yield None"
         );
+    }
+
+    #[dialog_common::test]
+    async fn it_parses_only_non_empty_registration_focus_tokens() {
+        let message = Object::new();
+        let _ = Reflect::set(&message, &"type".into(), &"register".into());
+        let _ = Reflect::set(&message, &"reason".into(), &"needs-account".into());
+        let _ = Reflect::set(&message, &"focusToken".into(), &"focus-1".into());
+        assert_eq!(
+            register_request(&message.clone().into()),
+            Some(("needs-account".into(), Some("focus-1".into())))
+        );
+
+        let _ = Reflect::set(&message, &"focusToken".into(), &"".into());
+        assert_eq!(
+            register_request(&message.clone().into()),
+            Some(("needs-account".into(), None)),
+            "an empty token must never create a guest focus handle"
+        );
+        let _ = Reflect::set(&message, &"reason".into(), &"".into());
+        assert_eq!(register_request(&message.into()), None);
+    }
+
+    #[dialog_common::test]
+    async fn it_returns_registration_focus_through_the_request_port() {
+        let state = Rc::new(RefCell::new(PortalState::new()));
+        let channel = MessageChannel::new().expect("message channel");
+        let listener = PortListener::attach(&channel.port2());
+        let held = Rc::new(RefCell::new(None));
+        let captured = held.clone();
+        on_register(move |reason, focus_return| {
+            assert_eq!(reason, "needs-account");
+            *captured.borrow_mut() = focus_return;
+        });
+
+        let request = Object::new();
+        let _ = Reflect::set(&request, &"type".into(), &"register".into());
+        let _ = Reflect::set(&request, &"reason".into(), &"needs-account".into());
+        let _ = Reflect::set(&request, &"focusToken".into(), &"focus-2".into());
+        handle_register(&state, &channel.port1(), &request.into());
+        held.borrow_mut()
+            .take()
+            .expect("focus return handle")
+            .restore();
+
+        let returned = listener.wait_for("register-focus").await;
+        assert_eq!(get_str(&returned, "focusToken").as_deref(), Some("focus-2"));
     }
 
     /// `open_href` accepts only a well-formed `{type:"open", href}`. The

--- a/rust/tonk-portal/src/lib.rs
+++ b/rust/tonk-portal/src/lib.rs
@@ -29,7 +29,7 @@ mod bridge;
 /// The dialog lives in the shell, which depends on this crate, so the
 /// behaviour is supplied rather than named here.
 #[cfg(target_arch = "wasm32")]
-pub use bridge::on_register;
+pub use bridge::{RegisterFocusReturn, on_register};
 #[cfg(target_arch = "wasm32")]
 mod element;
 #[cfg(target_arch = "wasm32")]

--- a/rust/tonk-ui/Cargo.toml
+++ b/rust/tonk-ui/Cargo.toml
@@ -92,6 +92,7 @@ features = [
     "Event",
     "HtmlButtonElement",
     "HtmlCollection",
+    "HtmlDialogElement",
     "HtmlFormElement",
     "HtmlHeadElement",
     "HtmlInputElement",

--- a/rust/tonk-ui/README.md
+++ b/rust/tonk-ui/README.md
@@ -99,8 +99,8 @@ routes because the router matches in definition order.
 Build the app with Trunk (driven through the flake):
 
 ```sh
-nix run .#build:web     # nix build .#tonk-ui
-nix run .#dev:web       # trunk serve, proxying /ucan/ to the access service
+nix develop . -c build:web     # nix build .#tonk-ui
+nix develop . -c dev:web       # trunk serve, proxying /ucan/ to the access service
 ```
 
 `Trunk.toml` disables Trunk's autoreload (the dev-only `hot-swap.js` taps Trunk's

--- a/rust/tonk-ui/assets/service_worker.js
+++ b/rust/tonk-ui/assets/service_worker.js
@@ -403,7 +403,8 @@ function failurePage() {
 <title>Tonk failed to start</title>
 <style>
   body { font: 16px/1.5 system-ui, sans-serif; margin: 0; display: grid;
-         place-items: center; min-height: 100vh; background: #111; color: #eee; }
+         place-items: center; min-height: 100vh; min-height: 100dvh;
+         background: #111; color: #eee; }
   main { max-width: 42rem; padding: 2rem; }
   h1 { font-size: 1.3rem; }
   pre { background: #1d1d1f; border: 1px solid #333; border-radius: 8px;

--- a/rust/tonk-ui/src/account.css
+++ b/rust/tonk-ui/src/account.css
@@ -464,6 +464,7 @@ tonk-account[data-mode="success"] .account__working {
 }
 
 .account__link {
+    min-width: 44px;
     min-height: 44px;
     color: var(--ink);
     font-family: var(--cond);
@@ -602,10 +603,11 @@ tonk-account[data-mode="success"] .account__working {
    cancel and confirm unreachable there. The head gives up its close-
    button overhang in this mode — the overhang is horizontal overflow,
    and a scroll container would answer it with a second scrollbar. */
-@media (max-height: 700px) {
+@media (max-height: 720px) {
     .account__dialog {
-        top: 16px;
-        max-height: calc(100vh - 32px);
+        top: max(16px, env(safe-area-inset-top));
+        max-height: calc(100vh - max(16px, env(safe-area-inset-top)) - 16px);
+        max-height: calc(100dvh - max(16px, env(safe-area-inset-top)) - 16px);
         overflow-y: auto;
         overflow-x: hidden;
     }
@@ -834,6 +836,30 @@ tonk-account[data-busy="true"] .account__run[data-initiating="true"] {
         height: min(408px, 60vh);
     }
 
+    .account__ceremony-head,
+    .account__run,
+    .account__editor-row,
+    .account__row,
+    .account__rail button,
+    .account__details summary,
+    .account__ghost,
+    .account__dialog-foot button,
+    .account__dialog-go {
+        min-height: 44px;
+    }
+
+    .account__ceremony-head,
+    .account__rail button {
+        height: 44px;
+    }
+
+    .account__editor-row input,
+    .account__row--field input,
+    .account__confirm-field input {
+        min-height: 44px;
+        font-size: 16px;
+    }
+
     .account__profile-row,
     .account__device-row {
         grid-template-columns: 1fr;
@@ -866,6 +892,9 @@ tonk-account[data-busy="true"] .account__run[data-initiating="true"] {
         margin-bottom: 32px;
     }
 
+}
+
+@media (max-width: 463px) and (min-height: 701px) {
     .account__dialog {
         top: max(12vh, calc(env(safe-area-inset-top) + 48px));
     }

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -166,6 +166,14 @@ mod tests {
         Ok(())
     }
 
+    /// Enter the seeded view inside the space shell's own sealed frame.
+    async fn enter_space_view(driver: &WebDriver) -> Result<()> {
+        enter_guest(driver).await?;
+        let frame = element(driver, "tonk-site > iframe").await?;
+        frame.enter_frame().await?;
+        Ok(())
+    }
+
     async fn wait_for_displayed(driver: &WebDriver, selector: &str) -> Result<WebElement> {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
         loop {
@@ -181,6 +189,31 @@ mod tests {
             }
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
+    }
+
+    async fn registration_motion_styles(driver: &WebDriver) -> Result<serde_json::Value> {
+        driver
+            .execute(
+                r#"const action = document.querySelector('.obtn');
+                   action.classList.add('wait', 'flash');
+                   const read = selector => {
+                     const style = getComputedStyle(document.querySelector(selector));
+                     return {
+                       animation: style.animationName,
+                       transition: style.transitionDuration
+                     };
+                   };
+                   return {
+                     cluster: read('.tonk-cluster'),
+                     row: read('.orow'),
+                     action: read('.obtn'),
+                     cursor: read('.cur')
+                   };"#,
+                Vec::new(),
+            )
+            .await
+            .map(|value| value.json().clone())
+            .map_err(Into::into)
     }
 
     /// The latest activation link the access service captured for `email`.
@@ -289,6 +322,30 @@ mod tests {
             .as_array()
             .map(Vec::len)
             .ok_or_else(|| anyhow!("Chrome omitted the virtual authenticator credentials"))
+    }
+
+    async fn emulate_phone(driver: &WebDriver, width: u32, height: u32) -> Result<()> {
+        let devtools = ChromeDevTools::new(driver.handle.clone());
+        devtools
+            .execute_cdp_with_params(
+                "Emulation.setDeviceMetricsOverride",
+                serde_json::json!({
+                    "width": width,
+                    "height": height,
+                    "deviceScaleFactor": 2,
+                    "mobile": true,
+                    "screenWidth": width,
+                    "screenHeight": height
+                }),
+            )
+            .await?;
+        devtools
+            .execute_cdp_with_params(
+                "Emulation.setTouchEmulationEnabled",
+                serde_json::json!({ "enabled": true, "maxTouchPoints": 5 }),
+            )
+            .await?;
+        Ok(())
     }
 
     /// Create an account and confirm its email, leaving it able to host
@@ -750,7 +807,7 @@ mod tests {
             assert_eq!(geometry["logoVisible"], true);
         }
 
-        driver.set_window_rect(0, 0, 390, 844).await?;
+        emulate_phone(&driver, 390, 844).await?;
         let compact = driver
             .execute(
                 r#"const settings = document.querySelector('.account__settings');
@@ -764,10 +821,15 @@ mod tests {
                       body: Math.round(body.getBoundingClientRect().width),
                       viewport: innerWidth,
                       overflow: document.documentElement.scrollWidth > innerWidth,
-                      undersized: visible.filter(el => {
+                      undersized: visible.flatMap(el => {
                         const rect = el.getBoundingClientRect();
-                        return Math.max(rect.width, rect.height) < 44;
-                      }).map(el => el.id || el.textContent.trim())
+                        if (rect.width >= 44 && rect.height >= 44) return [];
+                        return [{
+                          selector: el.id ? `#${el.id}` : el.tagName.toLowerCase(),
+                          width: rect.width,
+                          height: rect.height
+                        }];
+                      })
                     };"#,
                 Vec::new(),
             )
@@ -850,6 +912,237 @@ mod tests {
             );
         }
 
+        driver.quit().await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_scopes_registration_focus_and_restores_the_opener(
+        env: TestEnvironment,
+    ) -> Result<()> {
+        let driver = driver_with_prf(&env).await?;
+        wait_for_service_worker(&driver).await?;
+        goto(&driver, env.tonk_web.join("settings")?.as_str()).await?;
+        element(&driver, "tonk-account[data-mode=\"choice\"]").await?;
+
+        let opener = element(&driver, "#account-choose-link").await?;
+        opener.click().await?;
+        await_register_dialog(&driver).await?;
+
+        let focus_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        let state = loop {
+            let state = driver
+                .execute(
+                    r#"const dialog = document.querySelector('#tonk-register');
+                       return {
+                         tag: dialog?.tagName,
+                         open: dialog?.open,
+                         status: (document.querySelector('#tonk-register-status')?.textContent || '').trim(),
+                         focusedInside: dialog?.contains(document.activeElement)
+                       };"#,
+                    Vec::new(),
+                )
+                .await?;
+            if state.json()["focusedInside"] == true {
+                break state;
+            }
+            anyhow::ensure!(
+                tokio::time::Instant::now() < focus_deadline,
+                "registration did not move initial focus inside the dialog: {}",
+                state.json()
+            );
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        };
+        let state = state.json();
+        assert_eq!(state["tag"], "DIALOG");
+        assert_eq!(state["open"], true);
+        assert_eq!(state["focusedInside"], true);
+        assert!(
+            state["status"]
+                .as_str()
+                .is_some_and(|status| !status.is_empty()),
+            "registration must narrate its initial step: {state}"
+        );
+
+        assert!(
+            opener.click().await.is_err(),
+            "the modal top layer must make background actions non-interactable"
+        );
+        for _ in 0..8 {
+            driver.action_chain().send_keys(Key::Tab).perform().await?;
+            let focus = driver
+                .execute(
+                    r#"const dialog = document.querySelector('#tonk-register');
+                       return {
+                         inside: dialog.contains(document.activeElement),
+                         active: document.activeElement?.id || document.activeElement?.tagName
+                       };"#,
+                    Vec::new(),
+                )
+                .await?;
+            assert_eq!(
+                focus.json()["inside"],
+                true,
+                "Tab escaped the registration dialog: {}",
+                focus.json()
+            );
+        }
+
+        driver
+            .action_chain()
+            .send_keys(Key::Escape)
+            .perform()
+            .await?;
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let closed = driver
+                .execute(
+                    r#"return {
+                         gone: !document.querySelector('#tonk-register'),
+                         active: document.activeElement?.id || ''
+                       };"#,
+                    Vec::new(),
+                )
+                .await?;
+            if closed.json()["gone"] == true {
+                let focus_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+                loop {
+                    let active = driver
+                        .execute(r#"return document.activeElement?.id || '';"#, Vec::new())
+                        .await?;
+                    if active.json() == "account-choose-link" {
+                        break;
+                    }
+                    anyhow::ensure!(
+                        tokio::time::Instant::now() < focus_deadline,
+                        "closing registration did not restore the Settings opener: {}",
+                        active.json()
+                    );
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                }
+                break;
+            }
+            anyhow::ensure!(
+                tokio::time::Instant::now() < deadline,
+                "registration remained after Escape"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        driver.quit().await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_restores_registration_focus_to_the_guest_opener(
+        env: TestEnvironment,
+    ) -> Result<()> {
+        let driver = driver_with_prf(&env).await?;
+        wait_for_service_worker(&driver).await?;
+        goto(&driver, env.tonk_web.as_str()).await?;
+
+        enter_hub(&driver).await?;
+        let opener = wait_for_displayed(&driver, "[data-account-trigger]").await?;
+        opener.click().await?;
+        await_register_dialog(&driver).await?;
+
+        driver.enter_default_frame().await?;
+        driver
+            .action_chain()
+            .send_keys(Key::Escape)
+            .perform()
+            .await?;
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            if driver.find(By::Css("#tonk-register")).await.is_err() {
+                break;
+            }
+            anyhow::ensure!(
+                tokio::time::Instant::now() < deadline,
+                "registration remained after Escape"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        let focus_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let outer = driver
+                .execute(
+                    r#"return document.activeElement?.matches('tonk-site > iframe') || false;"#,
+                    Vec::new(),
+                )
+                .await?;
+            if outer.json() == true {
+                break;
+            }
+            anyhow::ensure!(
+                tokio::time::Instant::now() < focus_deadline,
+                "focus did not return through the sealed Hub frame"
+            );
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        enter_hub(&driver).await?;
+        loop {
+            let guest = driver
+                .execute(
+                    r#"return document.activeElement?.matches('[data-account-trigger]') || false;"#,
+                    Vec::new(),
+                )
+                .await?;
+            if guest.json() == true {
+                break;
+            }
+            anyhow::ensure!(
+                tokio::time::Instant::now() < focus_deadline,
+                "focus did not return to the exact Hub account trigger"
+            );
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+
+        driver.quit().await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_removes_registration_motion_when_reduced_motion_is_requested(
+        env: TestEnvironment,
+    ) -> Result<()> {
+        let driver = driver_with_prf(&env).await?;
+        wait_for_service_worker(&driver).await?;
+        goto(&driver, env.tonk_web.join("settings")?.as_str()).await?;
+        element(&driver, "tonk-account[data-mode=\"choice\"]").await?;
+        click(&driver, "#account-choose-link").await?;
+        await_register_dialog(&driver).await?;
+
+        let normal = registration_motion_styles(&driver).await?;
+        assert!(
+            normal["row"]["transition"]
+                .as_str()
+                .is_some_and(|duration| duration != "0s"),
+            "normal mode retains the authored row transition: {normal}"
+        );
+
+        ChromeDevTools::new(driver.handle.clone())
+            .execute_cdp_with_params(
+                "Emulation.setEmulatedMedia",
+                serde_json::json!({
+                    "features": [{ "name": "prefers-reduced-motion", "value": "reduce" }]
+                }),
+            )
+            .await?;
+        let reduced = registration_motion_styles(&driver).await?;
+        for selector in ["cluster", "row", "action"] {
+            assert_eq!(
+                reduced[selector]["transition"], "0s",
+                "{selector} transition must stop in reduced motion: {reduced}"
+            );
+        }
+        for selector in ["action", "cursor"] {
+            assert_eq!(
+                reduced[selector]["animation"], "none",
+                "{selector} animation must stop in reduced motion: {reduced}"
+            );
+        }
         driver.quit().await?;
         Ok(())
     }
@@ -942,10 +1235,15 @@ mod tests {
                       ceremonyWidth: Math.round(ceremony.width),
                       logoWidth: Math.round(document.querySelector('.account__logo').getBoundingClientRect().width),
                       overflow: document.documentElement.scrollWidth > innerWidth,
-                      undersized: visible.filter(el => {
+                      undersized: visible.flatMap(el => {
                         const rect = el.getBoundingClientRect();
-                        return Math.max(rect.width, rect.height) < 44;
-                      }).map(el => el.id || el.textContent.trim())
+                        if (rect.width >= 44 && rect.height >= 44) return [];
+                        return [{
+                          selector: el.id ? `#${el.id}` : el.tagName.toLowerCase(),
+                          width: rect.width,
+                          height: rect.height
+                        }];
+                      })
                     };"#,
                 Vec::new(),
             )
@@ -968,6 +1266,74 @@ mod tests {
         assert_eq!(compact["logoWidth"], 98);
         assert_eq!(compact["overflow"], false);
         assert_eq!(compact["undersized"], serde_json::json!([]));
+
+        driver.quit().await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_keeps_join_targets_accessible_at_phone_sizes(env: TestEnvironment) -> Result<()> {
+        let driver = driver_with_prf(&env).await?;
+        wait_for_service_worker(&driver).await?;
+
+        for (width, height) in [(320_u32, 568_u32), (390, 844)] {
+            emulate_phone(&driver, width, height).await?;
+            goto(&driver, env.tonk_web.join("join")?.as_str()).await?;
+            enter_guest(&driver).await?;
+            element(&driver, ".join-view").await?;
+
+            for dark in [false, true] {
+                let geometry = driver
+                    .execute(
+                        r#"const dark = arguments[0];
+                           document.documentElement.classList.toggle('wa-dark', dark);
+                           document.documentElement.classList.toggle('wa-light', !dark);
+                           const visible = [...document.querySelectorAll('a,button,input:not([type=hidden])')]
+                             .filter(el => el.getClientRects().length > 0);
+                           const mast = document.querySelector('.edge-mast').getBoundingClientRect();
+                           const wordmark = document.querySelector('.edge-mast img').getBoundingClientRect();
+                           const input = document.querySelector('.edge-input');
+                           return {
+                             width: innerWidth,
+                             height: innerHeight,
+                             overflow: document.documentElement.scrollWidth > innerWidth,
+                             mast: { width: mast.width, height: mast.height },
+                             wordmark: { width: wordmark.width, height: wordmark.height },
+                             inputFont: getComputedStyle(input).fontSize,
+                             undersized: visible.flatMap(el => {
+                               const rect = el.getBoundingClientRect();
+                               if (rect.width >= 44 && rect.height >= 44) return [];
+                               return [{
+                                 selector: el.className || el.id || el.tagName.toLowerCase(),
+                                 width: rect.width,
+                                 height: rect.height
+                               }];
+                             })
+                           };"#,
+                        vec![serde_json::json!(dark)],
+                    )
+                    .await?;
+                let geometry = geometry.json();
+                assert_eq!(geometry["width"], width);
+                assert_eq!(geometry["height"], height);
+                assert_eq!(geometry["overflow"], false);
+                assert_eq!(geometry["undersized"], serde_json::json!([]));
+                assert_eq!(geometry["inputFont"], "16px");
+                assert_eq!(geometry["mast"]["width"], 98.0);
+                assert!(
+                    geometry["mast"]["height"].as_f64().unwrap_or_default() >= 44.0,
+                    "the wordmark link needs a 44px hit area: {geometry}"
+                );
+                assert_eq!(geometry["wordmark"]["width"], 98.0);
+                assert!(
+                    geometry["wordmark"]["height"]
+                        .as_f64()
+                        .is_some_and(|height| height < 44.0),
+                    "the visual wordmark must keep its existing scale: {geometry}"
+                );
+            }
+            driver.enter_default_frame().await?;
+        }
 
         driver.quit().await?;
         Ok(())
@@ -1062,6 +1428,177 @@ mod tests {
             0,
             "changing the address must not have minted anything either",
         );
+
+        driver.quit().await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_begins_only_one_registration_action_per_offered_step(
+        env: TestEnvironment,
+    ) -> Result<()> {
+        let (driver, authenticator) = driver_with_prf_authenticator(&env).await?;
+        wait_for_service_worker(&driver).await?;
+        goto(&driver, env.tonk_web.join("settings")?.as_str()).await?;
+        element(&driver, "tonk-account[data-mode=\"choice\"]").await?;
+        click(&driver, "#account-choose-link").await?;
+        await_register_dialog(&driver).await?;
+        type_into_register_dialog(&driver, "one-action@example.com").await?;
+        await_register_action(&driver, "create a passkey").await?;
+
+        driver
+            .execute(
+                r#"const action = document.querySelector('#tonk-register-action');
+                   const email = document.querySelector('#tonk-register-email');
+                   action.click();
+                   email.dispatchEvent(new KeyboardEvent('keydown', {
+                     key: 'Enter', bubbles: true, cancelable: true
+                   }));"#,
+                Vec::new(),
+            )
+            .await?;
+        await_credential_count(&driver, &authenticator, 1).await?;
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        assert_eq!(
+            credential_count(&driver, &authenticator).await?,
+            1,
+            "click and Enter in one turn must begin one passkey ceremony"
+        );
+
+        driver.quit().await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_retries_the_committed_address_after_a_failed_passkey_ceremony(
+        env: TestEnvironment,
+    ) -> Result<()> {
+        let driver = driver_with_prf(&env).await?;
+        wait_for_service_worker(&driver).await?;
+        goto(&driver, env.tonk_web.join("settings")?.as_str()).await?;
+        element(&driver, "tonk-account[data-mode=\"choice\"]").await?;
+        click(&driver, "#account-choose-link").await?;
+        await_register_dialog(&driver).await?;
+
+        driver
+            .execute(
+                r#"window.__registerCreateCalls = 0;
+                   Object.defineProperty(navigator.credentials, 'create', {
+                     configurable: true,
+                     value: () => {
+                       window.__registerCreateCalls += 1;
+                       return Promise.reject(new DOMException(
+                         'controlled passkey rejection', 'NotAllowedError'
+                       ));
+                     }
+                   });"#,
+                Vec::new(),
+            )
+            .await?;
+
+        let email = "retry-committed@example.com";
+        type_into_register_dialog(&driver, email).await?;
+        await_register_action(&driver, "create a passkey").await?;
+        click(&driver, "#tonk-register-action").await?;
+        await_register_action(&driver, "create a passkey").await?;
+
+        let first = driver
+            .execute(
+                r#"return {
+                     calls: window.__registerCreateCalls,
+                     row: (document.querySelector('#tonk-register-email-row')?.textContent || '').trim(),
+                     status: (document.querySelector('#tonk-register-status')?.textContent || '').trim()
+                   };"#,
+                Vec::new(),
+            )
+            .await?;
+        assert_eq!(first.json()["calls"], 1);
+        assert!(
+            first.json()["row"]
+                .as_str()
+                .is_some_and(|row| row.contains(email)),
+            "the committed email receipt must remain visible: {}",
+            first.json()
+        );
+
+        driver
+            .execute(
+                r#"const action = document.querySelector('#tonk-register-action');
+                   action.click();
+                   action.click();"#,
+                Vec::new(),
+            )
+            .await?;
+        await_register_action(&driver, "create a passkey").await?;
+        let retried = driver
+            .execute(
+                r#"return {
+                     calls: window.__registerCreateCalls,
+                     row: (document.querySelector('#tonk-register-email-row')?.textContent || '').trim(),
+                     status: (document.querySelector('#tonk-register-status')?.textContent || '').trim()
+                   };"#,
+                Vec::new(),
+            )
+            .await?;
+        assert_eq!(
+            retried.json()["calls"],
+            2,
+            "a sequential retry must run once, while its duplicate pending click is ignored"
+        );
+        assert!(
+            retried.json()["row"]
+                .as_str()
+                .is_some_and(|row| row.contains(email)),
+            "the retry must retain the original address receipt: {}",
+            retried.json()
+        );
+        assert_ne!(
+            retried.json()["status"],
+            "Enter the address you want to use.",
+            "retry must read the committed address after the live input is gone"
+        );
+
+        driver.quit().await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_submits_activation_once_while_the_request_is_pending(
+        env: TestEnvironment,
+    ) -> Result<()> {
+        let driver = driver_with_prf(&env).await?;
+        let mut activation = env.tonk_web.join("activate")?;
+        activation.set_query(Some("ucan=AA"));
+        goto(&driver, activation.as_str()).await?;
+        element(&driver, "#activate-accept").await?;
+
+        let count = driver
+            .execute_async(
+                r#"const done = arguments[arguments.length - 1];
+                   const original = window.fetch;
+                   let requests = 0;
+                   window.fetch = (...args) => {
+                     const url = String(args[0]?.url || args[0]);
+                     if (url.includes('/ucan/')) {
+                       requests += 1;
+                       return new Promise(() => {});
+                     }
+                     return original(...args);
+                   };
+                   const accept = document.querySelector('#activate-accept');
+                   accept.click();
+                   accept.click();
+                   queueMicrotask(() => done({
+                     requests,
+                     disabled: accept.disabled,
+                     busy: document.querySelector('#activate-confirm')?.getAttribute('aria-busy')
+                   }));"#,
+                Vec::new(),
+            )
+            .await?;
+        assert_eq!(count.json()["requests"], 1, "activation must post once");
+        assert_eq!(count.json()["disabled"], true);
+        assert_eq!(count.json()["busy"], "true");
 
         driver.quit().await?;
         Ok(())
@@ -1756,6 +2293,123 @@ mod tests {
         // feature: the spot gains the remote it refused to share
         // without, and the invite link arrives.
         await_share_link(&driver, &key).await?;
+
+        driver.quit().await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_replaces_agent_link_progress_with_the_share_refusal(
+        env: TestEnvironment,
+    ) -> Result<()> {
+        let driver = driver_with_prf(&env).await?;
+        driver.goto(env.tonk_web.as_str()).await?;
+        let before = space_keys(&driver).await?;
+        submit_hub_wizard(&driver).await?;
+        let key = await_new_space(&driver, &before).await?;
+        await_url_containing(&driver, &format!("/space/{key}")).await?;
+        enter_space_view(&driver).await?;
+
+        wait_for_displayed(&driver, ".local-invite-notice").await?;
+        let canvas = element(&driver, ".blank-canvas__deeplink")
+            .await?
+            .text()
+            .await?;
+        assert!(
+            canvas.contains("sharing unavailable"),
+            "the settled refusal needs a neutral label: {canvas:?}"
+        );
+        assert!(
+            !canvas.contains("Generating link"),
+            "pending progress must disappear when refusal settles: {canvas:?}"
+        );
+        assert!(
+            !canvas.contains("condition banner"),
+            "the refusal must not point to absent UI: {canvas:?}"
+        );
+
+        driver.quit().await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
+    async fn it_keeps_space_removal_focus_inside_the_sealed_guest(
+        env: TestEnvironment,
+    ) -> Result<()> {
+        let driver = driver_with_prf(&env).await?;
+        driver.goto(env.tonk_web.as_str()).await?;
+        let before = space_keys(&driver).await?;
+        submit_hub_wizard(&driver).await?;
+        let _ = await_new_space(&driver, &before).await?;
+
+        goto(&driver, env.tonk_web.as_str()).await?;
+        enter_hub(&driver).await?;
+        let row = wait_for_displayed(&driver, ".srow-wrap").await?;
+        driver
+            .action_chain()
+            .move_to_element_center(&row)
+            .perform()
+            .await?;
+        let opener = wait_for_displayed(&driver, "[data-space-remove-open]").await?;
+        opener.click().await?;
+        wait_for_displayed(&driver, "tonk-dialog[data-space-remove-dialog]").await?;
+
+        for _ in 0..8 {
+            driver.action_chain().send_keys(Key::Tab).perform().await?;
+            driver.enter_default_frame().await?;
+            let outer = driver
+                .execute(
+                    r#"return document.activeElement?.matches('tonk-site > iframe') || false;"#,
+                    Vec::new(),
+                )
+                .await?;
+            assert_eq!(
+                outer.json(),
+                true,
+                "Tab must not escape the sealed Hub while removal stays open"
+            );
+
+            enter_hub(&driver).await?;
+            let guest = driver
+                .execute(
+                    r#"const dialog = document.querySelector('tonk-dialog[data-space-remove-dialog]');
+                       const active = document.activeElement;
+                       return {
+                         open: dialog?.open || false,
+                         inside: !!dialog && (active === dialog || dialog.contains(active))
+                       };"#,
+                    Vec::new(),
+                )
+                .await?;
+            assert_eq!(guest.json()["open"], true);
+            assert_eq!(
+                guest.json()["inside"],
+                true,
+                "Tab focus left the open removal dialog: {}",
+                guest.json()
+            );
+        }
+
+        driver
+            .action_chain()
+            .send_keys(Key::Escape)
+            .perform()
+            .await?;
+        let restored = driver
+            .execute(
+                r#"return {
+                     open: document.querySelector('tonk-dialog[data-space-remove-dialog]')?.open || false,
+                     opener: document.activeElement?.matches('[data-space-remove-open]') || false
+                   };"#,
+                Vec::new(),
+            )
+            .await?;
+        assert_eq!(restored.json()["open"], false);
+        assert_eq!(
+            restored.json()["opener"],
+            true,
+            "Escape must restore the remove opener"
+        );
 
         driver.quit().await?;
         Ok(())
@@ -3444,6 +4098,104 @@ mod tests {
     /// hosted space, and both account-level finalizations. Only the
     /// passkey user-verification gesture is UI-side and out of scope;
     /// everything destructive runs here exactly as in production.
+    #[dialog_common::test]
+    async fn it_keeps_destructive_dialog_controls_inside_a_short_mobile_viewport(
+        env: TestEnvironment,
+    ) -> Result<()> {
+        let driver = driver_with_prf(&env).await?;
+        let email = "short-mobile@example.com";
+        sign_up(&driver, &env, email).await?;
+
+        goto(&driver, env.tonk_web.join("settings")?.as_str()).await?;
+        element(&driver, "tonk-account[data-mode=\"success\"]").await?;
+        driver.set_window_rect(0, 0, 320, 568).await?;
+        click(&driver, "#account-delete-review").await?;
+        wait_for_displayed(&driver, "#account-delete-arming").await?;
+
+        // The number of owned spaces varies by account. Fill the real plan list
+        // to its maximum-height state so this remains a geometry regression,
+        // rather than depending on a costly remote-space fixture.
+        driver
+            .execute(
+                r#"const list = document.querySelector('#account-delete-spaces');
+                   for (let index = list.children.length; index < 8; index += 1) {
+                     const item = document.createElement('li');
+                     item.textContent = `owned space ${index + 1} with a deliberately long name`;
+                     list.append(item);
+                   }"#,
+                Vec::new(),
+            )
+            .await?;
+        element(&driver, "#account-delete-email")
+            .await?
+            .send_keys(email)
+            .await?;
+        element(&driver, "#account-delete-understood")
+            .await?
+            .click()
+            .await?;
+
+        for (width, height) in [(320, 568), (390, 844)] {
+            driver.set_window_rect(0, 0, width, height).await?;
+            let geometry = driver
+                .execute(
+                    r#"const dialog = document.querySelector('.account__dialog');
+                   dialog.scrollTop = dialog.scrollHeight;
+                   const bounds = dialog.getBoundingClientRect();
+                   const inspect = selector => {
+                     const element = document.querySelector(selector);
+                     const rect = element.getBoundingClientRect();
+                     element.focus();
+                     return {
+                       top: rect.top,
+                       bottom: rect.bottom,
+                       visible: rect.top >= 0 && rect.bottom <= innerHeight,
+                       focused: document.activeElement === element,
+                       disabled: element.disabled
+                     };
+                   };
+                   return {
+                     top: bounds.top,
+                     bottom: bounds.bottom,
+                     viewport: innerHeight,
+                     cancel: inspect('#account-confirm-cancel'),
+                     submit: inspect('#account-delete-submit')
+                   };"#,
+                    Vec::new(),
+                )
+                .await?;
+            let geometry = geometry.json();
+            let top = geometry["top"].as_f64().unwrap_or(f64::NEG_INFINITY);
+            let bottom = geometry["bottom"].as_f64().unwrap_or(f64::INFINITY);
+            let viewport = geometry["viewport"].as_f64().unwrap_or_default();
+            assert!(
+                top >= 0.0,
+                "dialog starts above the {width}x{height} viewport: {geometry}"
+            );
+            assert!(
+                bottom <= viewport,
+                "dialog ends below the {width}x{height} viewport: {geometry}"
+            );
+            for action in ["cancel", "submit"] {
+                assert_eq!(
+                    geometry[action]["visible"], true,
+                    "{action} must remain visible at {width}x{height}: {geometry}"
+                );
+                assert_eq!(
+                    geometry[action]["focused"], true,
+                    "{action} must remain focusable at {width}x{height}: {geometry}"
+                );
+                assert_eq!(
+                    geometry[action]["disabled"], false,
+                    "{action} must be enabled in the armed state: {geometry}"
+                );
+            }
+        }
+
+        driver.quit().await?;
+        Ok(())
+    }
+
     #[dialog_common::test]
     async fn it_deletes_the_account_and_releases_its_email_and_profile(
         env: TestEnvironment,

--- a/rust/tonk-ui/src/activate.html
+++ b/rust/tonk-ui/src/activate.html
@@ -5,7 +5,7 @@
     <section id="activate-confirm" class="account__activation-state" aria-labelledby="activate-confirm-title" hidden>
       <div class="account__stack">
         <h1 id="activate-confirm-title" class="account__ceremony-head">activate your account</h1>
-        <button id="activate-accept" class="account__run" type="button">accept and activate</button>
+        <button id="activate-accept" class="account__run" type="button" aria-describedby="activate-working activate-error">accept and activate</button>
       </div>
       <div class="account__narrator">
         <p>Confirm your email address to activate syncing for your Tonk account. By selecting accept and activate, you agree to the terms of service.</p>

--- a/rust/tonk-ui/src/activate.rs
+++ b/rust/tonk-ui/src/activate.rs
@@ -6,19 +6,25 @@
 //! accept button posts the decoded bytes to the same-origin `/ucan/`
 //! endpoint and reports the outcome.
 
+use std::cell::Cell;
+use std::rc::Rc;
+
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use custom_elements::CustomElement;
 use js_sys::Reflect;
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::spawn_local;
-use web_sys::{HtmlElement, window};
+use web_sys::{HtmlButtonElement, HtmlElement, window};
 
 const STYLE_ID: &str = "tonk-activate-styles";
 
 /// The top-document activation element.
 #[derive(Default)]
-struct TonkActivate;
+struct TonkActivate {
+    pending: Rc<Cell<bool>>,
+    terminal: Rc<Cell<bool>>,
+}
 
 impl CustomElement for TonkActivate {
     fn shadow() -> bool {
@@ -42,7 +48,7 @@ impl CustomElement for TonkActivate {
             return;
         }
         let _ = Reflect::set(this.as_ref(), &"__tonkActivateBound".into(), &JsValue::TRUE);
-        bind(this);
+        bind(this, self.pending.clone(), self.terminal.clone());
     }
 
     fn disconnected_callback(&mut self, _this: &HtmlElement) {}
@@ -111,6 +117,28 @@ fn show_error(host: &HtmlElement, message: &str) {
     set_status(host, "");
 }
 
+fn clear_error(host: &HtmlElement) {
+    if let Ok(Some(error)) = host.query_selector("#activate-error") {
+        error.set_text_content(None);
+        let _ = error.set_attribute("hidden", "");
+    }
+}
+
+fn set_busy(host: &HtmlElement, busy: bool, keep_disabled: bool) {
+    if let Ok(Some(section)) = host.query_selector("#activate-confirm") {
+        if busy {
+            let _ = section.set_attribute("aria-busy", "true");
+        } else {
+            let _ = section.remove_attribute("aria-busy");
+        }
+    }
+    if let Ok(Some(button)) = host.query_selector("#activate-accept")
+        && let Ok(button) = button.dyn_into::<HtmlButtonElement>()
+    {
+        button.set_disabled(busy || keep_disabled);
+    }
+}
+
 fn show_panel(host: &HtmlElement, selector: &str) {
     for panel in ["#activate-confirm", "#activate-done"] {
         if let Ok(Some(element)) = host.query_selector(panel) {
@@ -124,7 +152,7 @@ fn show_panel(host: &HtmlElement, selector: &str) {
     }
 }
 
-fn bind(host: &HtmlElement) {
+fn bind(host: &HtmlElement, pending: Rc<Cell<bool>>, terminal: Rc<Cell<bool>>) {
     // A damaged link is visible before the button is pressed rather than
     // after: the page's one job is presenting the invocation it carries.
     if let Err(error) = link_invocation() {
@@ -134,12 +162,25 @@ fn bind(host: &HtmlElement) {
     show_panel(host, "#activate-confirm");
 
     let target = host.clone();
+    let action_pending = pending.clone();
+    let action_terminal = terminal.clone();
     let onclick = wasm_bindgen::closure::Closure::<dyn FnMut()>::new(move || {
+        if action_terminal.get() || action_pending.replace(true) {
+            return;
+        }
         let host = target.clone();
+        let pending = action_pending.clone();
+        let terminal = action_terminal.clone();
+        clear_error(&host);
+        set_busy(&host, true, false);
         spawn_local(async move {
             let invocation = match link_invocation() {
                 Ok(bytes) => bytes,
-                Err(error) => return show_error(&host, &error),
+                Err(error) => {
+                    pending.set(false);
+                    set_busy(&host, false, false);
+                    return show_error(&host, &error);
+                }
             };
             set_status(&host, "Activating…");
             let response = reqwest::Client::new()
@@ -151,12 +192,22 @@ fn bind(host: &HtmlElement) {
             let response = match response {
                 Ok(response) => response,
                 Err(_) => {
+                    pending.set(false);
+                    set_busy(&host, false, false);
                     return show_error(&host, "The service could not be reached. Try again.");
                 }
             };
             let status = response.status();
             let body: serde_json::Value = response.json().await.unwrap_or_default();
+            if terminal.get() {
+                return;
+            }
             if status.is_success() {
+                // The service has consumed the one-use link. Claim the
+                // terminal outcome before recording the receipt can yield,
+                // so no later completion can replace success with an error.
+                terminal.set(true);
+                pending.set(false);
                 // Hand the receipt to the worker before declaring
                 // success. The service names the provider serving this
                 // account here, and this page is the only place that
@@ -169,14 +220,21 @@ fn bind(host: &HtmlElement) {
                         &format!("activation receipt not recorded: {error}").into(),
                     );
                 }
+                set_busy(&host, false, true);
+                clear_error(&host);
                 set_status(&host, "");
                 show_panel(&host, "#activate-done");
             } else if body["error"]["code"].as_str() == Some("Unauthorized") {
+                terminal.set(true);
+                pending.set(false);
+                set_busy(&host, false, true);
                 show_error(
                     &host,
                     "This activation link has expired. Sign in on your device to get a fresh one.",
                 );
             } else {
+                pending.set(false);
+                set_busy(&host, false, false);
                 let message = body["error"]["message"]
                     .as_str()
                     .unwrap_or("Activation failed. Try again.")

--- a/rust/tonk-ui/src/bin/ui.rs
+++ b/rust/tonk-ui/src/bin/ui.rs
@@ -54,8 +54,13 @@ async fn main() {
     tonk_ui::custody_relay::install();
     // A guest asking to register raises the dialog here, in the only
     // document that can run the ceremony.
-    tonk_portal::on_register(|reason| {
-        tonk_ui::register_dialog::open();
+    tonk_portal::on_register(|reason, return_focus| {
+        match return_focus {
+            Some(return_focus) => tonk_ui::register_dialog::open_with_return_focus(move || {
+                return_focus.restore();
+            }),
+            None => tonk_ui::register_dialog::open(),
+        }
         tonk_ui::register_dialog::describe(reason);
     });
     tonk_ui::account::register();

--- a/rust/tonk-ui/src/helpers.rs
+++ b/rust/tonk-ui/src/helpers.rs
@@ -268,11 +268,16 @@ mod native {
                 .ok_or_else(|| anyhow!("Access service URL has no port"))?;
             let caddy_data = std::env::temp_dir().join(format!("tonk-e2e-caddy-{web_port}"));
             std::fs::create_dir_all(&caddy_data)?;
+            let workspace = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .and_then(std::path::Path::parent)
+                .ok_or_else(|| anyhow!("tonk-ui manifest has no workspace root"))?;
+            let test_server = format!("path:{}#tonk-ui-test-server", workspace.display());
             let mut web_server = ManagedChild::new(
                 std::process::Command::new("nix")
                     .args([
                         "run",
-                        ".#tonk-ui-test-server",
+                        &test_server,
                         "--",
                         &format!("{web_port}"),
                         &format!("{access_service_port}"),

--- a/rust/tonk-ui/src/register_dialog.rs
+++ b/rust/tonk-ui/src/register_dialog.rs
@@ -19,15 +19,15 @@
 //! neither is on offer. The answer is a fact, arrived at by a command,
 //! and this only draws it.
 
-use std::cell::Cell;
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 
 use wasm_bindgen::JsCast;
 use wasm_bindgen::closure::Closure;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen::prelude::*;
-use web_sys::{Element, HtmlElement};
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use web_sys::HtmlButtonElement;
+use web_sys::{Element, HtmlDialogElement, HtmlElement};
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tonk_host::consumer::{self, Subscription};
@@ -36,6 +36,12 @@ thread_local! {
     /// The dialog is a singleton: a second refusal while it is up is
     /// already answered by the registration in progress.
     static OPEN: Cell<bool> = const { Cell::new(false) };
+    /// The control that raised the singleton. Native modal focus is restored
+    /// explicitly because the host is removed, rather than merely closed.
+    static RETURN_FOCUS: RefCell<Option<ReturnFocus>> = const { RefCell::new(None) };
+    /// Set synchronously at the event boundary, before any WebAuthn or network
+    /// future can yield and admit a second click/Enter activation.
+    static ACTION_PENDING: Cell<bool> = const { Cell::new(false) };
     /// The live subscription to the answer row, held for as long as the
     /// dialog is up so the frames keep arriving, and dropped on close.
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -61,8 +67,14 @@ thread_local! {
     static ANSWER: RefCell<Option<Answer>> = const { RefCell::new(None) };
 }
 
+enum ReturnFocus {
+    Direct(HtmlElement),
+    Guest(Option<Box<dyn FnOnce()>>),
+}
+
 /// The dialog's host id, and the parts the handlers address.
 const DIALOG_ID: &str = "tonk-register";
+const COMMITTED_EMAIL_ATTR: &str = "data-register-email";
 const EMAIL_INPUT: &str = "#tonk-register-email";
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 const ACTION: &str = "#tonk-register-action";
@@ -88,36 +100,42 @@ const CONFIRM_ROW: &str = "#tonk-register-confirm-row";
 /// input's autofill. `wa-input` forwards the attribute to the inner
 /// native input, which is where it has to land.
 const DIALOG_HTML: &str = r##"
-<div id="tonk-register-dim" class="tonk-dim"></div>
-<div id="tonk-register-cluster" class="tonk-cluster" role="dialog" aria-modal="true"
-     aria-labelledby="tonk-register-head">
-  <div class="ocol">
-    <div class="ostack" id="tonk-register-stack">
-      <div class="m-head mblk" id="tonk-register-head">link an account</div>
-      <div class="orow mblk" id="tonk-register-email-row">
-        <span class="k">email</span>
-        <span class="v"><input class="ed" id="tonk-register-email" type="email"
-              inputmode="email" enterkeyhint="go" autocomplete="username webauthn"
-              aria-label="email" placeholder="you@example.com"><i class="cur"
-              aria-hidden="true"></i></span>
-      </div>
-      <!-- Unfolds once the address is committed and the lookup answers:
-           "create a passkey" for an address nobody has, "log in with your
-           passkey" for one that is taken. Which of the two is the whole
-           reason the address is checked before any ceremony runs. -->
-      <button class="obtn pre" id="tonk-register-action" hidden></button>
+<div class="ocol">
+  <div class="ostack" id="tonk-register-stack">
+    <div class="m-head mblk" id="tonk-register-head">link an account</div>
+    <div class="orow mblk" id="tonk-register-email-row">
+      <span class="k">email</span>
+      <span class="v"><input class="ed" id="tonk-register-email" type="email"
+            inputmode="email" enterkeyhint="go" autocomplete="username webauthn"
+            aria-label="email" placeholder="you@example.com"><i class="cur"
+            aria-hidden="true"></i></span>
     </div>
-    <div class="oexp mblk">
-      <p id="tonk-register-status" aria-live="polite"></p>
-    </div>
-    <button class="ghost" id="tonk-register-dismiss">
-      <span aria-hidden="true">&#9666;</span> back to space</button>
+    <!-- Unfolds once the address is committed and the lookup answers:
+         "create a passkey" for an address nobody has, "log in with your
+         passkey" for one that is taken. Which of the two is the whole
+         reason the address is checked before any ceremony runs. -->
+    <button class="obtn pre" id="tonk-register-action" hidden></button>
   </div>
+  <div class="oexp mblk">
+    <p id="tonk-register-status" aria-live="polite">Enter your email address. We’ll tell you whether to create a passkey or sign in.</p>
+  </div>
+  <button class="ghost" id="tonk-register-dismiss">
+    <span aria-hidden="true">&#9666;</span> back to space</button>
 </div>
 "##;
 
 /// Raise the dialog. A no-op while one is already up.
 pub fn open() {
+    open_with_return(None);
+}
+
+/// Raise the dialog for a sealed-guest request and invoke `restore` only after
+/// the native modal has closed and its top-page host has been removed.
+pub fn open_with_return_focus(restore: impl FnOnce() + 'static) {
+    open_with_return(Some(Box::new(restore)));
+}
+
+fn open_with_return(guest_restore: Option<Box<dyn FnOnce()>>) {
     if OPEN.with(|open| open.replace(true)) {
         return;
     }
@@ -125,16 +143,34 @@ pub fn open() {
         OPEN.with(|open| open.set(false));
         return;
     };
-    let (Some(body), Ok(host)) = (document.body(), document.create_element("div")) else {
+    let return_focus = match guest_restore {
+        Some(restore) => Some(ReturnFocus::Guest(Some(restore))),
+        None => document
+            .active_element()
+            .and_then(|element| element.dyn_into::<HtmlElement>().ok())
+            .map(ReturnFocus::Direct),
+    };
+    RETURN_FOCUS.with(|held| *held.borrow_mut() = return_focus);
+    let (Some(body), Ok(host)) = (document.body(), document.create_element("dialog")) else {
         OPEN.with(|open| open.set(false));
+        RETURN_FOCUS.with(|held| *held.borrow_mut() = None);
         return;
     };
     host.set_id(DIALOG_ID);
-    host.set_class_name("tonk-ceremony");
+    host.set_class_name("tonk-ceremony tonk-cluster");
+    let _ = host.set_attribute("aria-labelledby", "tonk-register-head");
+    let _ = host.set_attribute("aria-describedby", "tonk-register-status");
     host.set_inner_html(DIALOG_HTML);
     let _ = body.append_child(&host);
 
     on_click(&host, DISMISS, close);
+    let cancel = Closure::<dyn FnMut(web_sys::Event)>::new(move |event: web_sys::Event| {
+        event.prevent_default();
+        close();
+    });
+    let _ = host.add_event_listener_with_callback("cancel", cancel.as_ref().unchecked_ref());
+    cancel.forget();
+    contain_tab_focus(&host);
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     on_click(&host, ACTION, submit);
     watch_address(&host);
@@ -160,10 +196,10 @@ fn open_when_upgraded(host: &Element) {
     };
     let host = host.clone();
     let raise = Closure::<dyn FnMut()>::new(move || {
-        if let Ok(Some(dim)) = host.query_selector("#tonk-register-dim") {
-            // `add_1`, not `set_class_name`: the element already
-            // carries `tonk-dim`, which is what styles it at all.
-            let _ = dim.class_list().add_1("on");
+        if let Some(dialog) = host.dyn_ref::<HtmlDialogElement>()
+            && !dialog.open()
+        {
+            let _ = dialog.show_modal();
         }
         focus_address(&host);
     });
@@ -258,7 +294,8 @@ fn action_is_offered() -> bool {
     web_sys::window()
         .and_then(|window| window.document())
         .and_then(|document| document.query_selector(ACTION).ok().flatten())
-        .is_some_and(|action| !action.has_attribute("hidden"))
+        .and_then(|action| action.dyn_into::<HtmlButtonElement>().ok())
+        .is_some_and(|action| !action.has_attribute("hidden") && !action.disabled())
 }
 
 /// Clicking anywhere in a row seats the cursor in its editor.
@@ -370,6 +407,7 @@ pub fn close() {
     OPEN.with(|open| open.set(false));
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     {
+        finish_action();
         ANSWERS.with(|held| {
             if let Some(mut subscription) = held.borrow_mut().take() {
                 subscription.cancel();
@@ -384,14 +422,111 @@ pub fn close() {
         .and_then(|window| window.document())
         .and_then(|document| document.get_element_by_id(DIALOG_ID))
     {
+        if let Some(dialog) = host.dyn_ref::<HtmlDialogElement>()
+            && dialog.open()
+        {
+            dialog.close();
+        }
         host.remove();
     }
-    // Whatever was under it may now be about a different account than
-    // when it was raised. The settings panel decides which face to show
-    // from a read it does at boot, and nothing else asks it to look
-    // again.
-    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-    crate::account::resettle();
+    let Some(return_focus) = RETURN_FOCUS.with(|held| held.borrow_mut().take()) else {
+        return;
+    };
+    let Some(window) = web_sys::window() else {
+        restore_focus(return_focus);
+        return;
+    };
+    // The native dialog performs its own close-focus settlement after the
+    // `cancel` listener returns. Restore on the next task so that settlement
+    // cannot overwrite either a top-page opener or a sealed guest's iframe.
+    let restore = Closure::once(move || restore_focus(return_focus));
+    let _ = window
+        .set_timeout_with_callback_and_timeout_and_arguments_0(restore.as_ref().unchecked_ref(), 0);
+    restore.forget();
+}
+
+fn restore_focus(return_focus: ReturnFocus) {
+    match return_focus {
+        ReturnFocus::Direct(opener)
+            if opener.is_connected() && !opener.matches(":disabled").unwrap_or(false) =>
+        {
+            let _ = opener.focus();
+        }
+        ReturnFocus::Guest(Some(restore)) => restore(),
+        _ => {}
+    }
+}
+
+/// Chrome can move focus to `BODY` when Tab crosses the end of a native
+/// modal. Guard only the two boundaries; ordinary movement and Escape stay
+/// under the platform dialog.
+fn contain_tab_focus(host: &Element) {
+    let dialog = host.clone();
+    let listener =
+        Closure::<dyn FnMut(web_sys::KeyboardEvent)>::new(move |event: web_sys::KeyboardEvent| {
+            if event.key() != "Tab" {
+                return;
+            }
+            let focusables = registration_focusables(&dialog);
+            let (Some(first), Some(last)) = (focusables.first(), focusables.last()) else {
+                return;
+            };
+            let active = web_sys::window()
+                .and_then(|window| window.document())
+                .and_then(|document| document.active_element());
+            let target = if event.shift_key()
+                && active
+                    .as_ref()
+                    .is_some_and(|active| first.is_same_node(Some(active.as_ref())))
+            {
+                Some(last)
+            } else if !event.shift_key()
+                && active
+                    .as_ref()
+                    .is_some_and(|active| last.is_same_node(Some(active.as_ref())))
+            {
+                Some(first)
+            } else {
+                None
+            };
+            if let Some(target) = target {
+                event.prevent_default();
+                let _ = target.focus();
+            }
+        });
+    let _ = host.add_event_listener_with_callback("keydown", listener.as_ref().unchecked_ref());
+    listener.forget();
+}
+
+fn registration_focusables(host: &Element) -> Vec<HtmlElement> {
+    let Ok(candidates) = host.query_selector_all("button,input,select,textarea,a[href],[tabindex]")
+    else {
+        return Vec::new();
+    };
+    let mut focusables = Vec::new();
+    for index in 0..candidates.length() {
+        let Some(element) = candidates
+            .item(index)
+            .and_then(|node| node.dyn_into::<Element>().ok())
+        else {
+            continue;
+        };
+        if element.closest("[hidden]").ok().flatten().is_some()
+            || element.matches(":disabled").unwrap_or(false)
+            || element
+                .get_attribute("tabindex")
+                .and_then(|value| value.parse::<i32>().ok())
+                .is_some_and(|tabindex| tabindex < 0)
+            || (element.tag_name() == "INPUT"
+                && element.get_attribute("type").as_deref() == Some("hidden"))
+        {
+            continue;
+        }
+        if let Ok(element) = element.dyn_into::<HtmlElement>() {
+            focusables.push(element);
+        }
+    }
+    focusables
 }
 
 /// Ask about the address as it is typed, so the dialog can offer
@@ -753,22 +888,24 @@ fn show_answer(answer: &Answer) {
         finish_ceremony();
         return;
     }
+    // A lookup replay can land while WebAuthn or the share handoff is still
+    // pending. It may refresh the host's state, but it must not re-enable the
+    // action the user already accepted.
+    if ACTION_PENDING.with(Cell::get) {
+        return;
+    }
     set_status(status_for(&answer.state));
 
     // The action row unfolds only once the lookup has named a step, and
     // says which one. Before that there is nothing to offer: an address
     // nobody has asked about could be either branch, and guessing wrong
     // runs a creation ceremony against an account that already exists.
-    let Some(action) = host.query_selector(ACTION).ok().flatten() else {
-        return;
-    };
     match action_label(&answer.state) {
-        Some(label) => {
-            action.set_text_content(Some(label));
-            unfold(&action);
-        }
+        Some(label) => set_action(label, true),
         None => {
-            let _ = action.set_attribute("hidden", "");
+            if let Ok(Some(action)) = host.query_selector(ACTION) {
+                let _ = action.set_attribute("hidden", "");
+            }
         }
     }
 }
@@ -883,6 +1020,9 @@ fn claim(description: &str, email: &str) -> serde_json::Value {
 /// interrupted.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 fn submit() {
+    if !begin_action() {
+        return;
+    }
     // The action row means different things at different steps, and its
     // label is which one — the same word the person just read.
     let label = web_sys::window()
@@ -893,6 +1033,7 @@ fn submit() {
     match label.trim() {
         COPY_LINK => copy_the_share_link(),
         RETURN_TO_SPACE => close(),
+        "" => finish_action(),
         _ => run_signup_ceremony(),
     }
 }
@@ -912,6 +1053,7 @@ const RETURN_TO_SPACE: &str = "return to space";
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 fn copy_the_share_link() {
     let Some(space) = pending_share() else {
+        finish_action();
         return;
     };
     set_action("copying link…", false);
@@ -1023,6 +1165,7 @@ async fn write_to_clipboard(text: &str) {
 pub(crate) fn run_signup_ceremony() {
     let Some(email) = address().filter(|email| is_plausible(email)) else {
         set_status("Enter the address you want to use.");
+        finish_action();
         return;
     };
     // Which ceremony is the answer's to choose, not this function's.
@@ -1042,6 +1185,9 @@ pub(crate) fn run_signup_ceremony() {
 
     // The address is answered; settle its row so it reads as a record
     // and the step in front of you is the only one taking input.
+    if let Some(host) = host_element() {
+        let _ = host.set_attribute(COMMITTED_EMAIL_ATTR, &email);
+    }
     settle_named_row(EMAIL_ROW, "email", &email);
     // While the platform holds the ceremony, the action row says so
     // rather than looking clickable. It blinks rather than spinning:
@@ -1198,10 +1344,47 @@ fn set_action(label: &str, ready: bool) {
     action.set_text_content(Some(label));
     if ready {
         let _ = action.class_list().remove_1("wait");
+        finish_action();
     } else {
         let _ = action.class_list().add_1("wait");
+        ACTION_PENDING.with(|pending| pending.set(true));
+        if let Some(button) = action.dyn_ref::<HtmlButtonElement>() {
+            button.set_disabled(true);
+            let _ = button.set_attribute("aria-busy", "true");
+        }
     }
     unfold(&action);
+}
+
+/// Claim the currently offered action before its handler can yield.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+fn begin_action() -> bool {
+    if ACTION_PENDING.with(|pending| pending.replace(true)) {
+        return false;
+    }
+    let Some(action) = host_element()
+        .and_then(|host| host.query_selector(ACTION).ok().flatten())
+        .and_then(|action| action.dyn_into::<HtmlButtonElement>().ok())
+    else {
+        ACTION_PENDING.with(|pending| pending.set(false));
+        return false;
+    };
+    action.set_disabled(true);
+    let _ = action.set_attribute("aria-busy", "true");
+    true
+}
+
+/// Offer the next attempt after a retryable outcome.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+fn finish_action() {
+    ACTION_PENDING.with(|pending| pending.set(false));
+    if let Some(action) = host_element()
+        .and_then(|host| host.query_selector(ACTION).ok().flatten())
+        .and_then(|action| action.dyn_into::<HtmlButtonElement>().ok())
+    {
+        action.set_disabled(false);
+        let _ = action.remove_attribute("aria-busy");
+    }
 }
 
 /// Put the cursor on the offered step.
@@ -1424,13 +1607,16 @@ pub(crate) fn enable_sync_claim(space: &str, time: f64) -> serde_json::Value {
 
 /// What is typed in the address field.
 fn address() -> Option<String> {
-    let input = web_sys::window()?
-        .document()?
-        .query_selector(EMAIL_INPUT)
-        .ok()??;
-    js_sys::Reflect::get(input.as_ref(), &"value".into())
-        .ok()?
-        .as_string()
+    let document = web_sys::window()?.document()?;
+    let value = match document.query_selector(EMAIL_INPUT).ok().flatten() {
+        Some(input) => js_sys::Reflect::get(input.as_ref(), &"value".into())
+            .ok()?
+            .as_string(),
+        None => document
+            .get_element_by_id(DIALOG_ID)
+            .and_then(|host| host.get_attribute(COMMITTED_EMAIL_ATTR)),
+    };
+    value
         .map(|value| value.trim().to_owned())
         .filter(|value| !value.is_empty())
 }

--- a/rust/tonk-ui/styles.css
+++ b/rust/tonk-ui/styles.css
@@ -2750,6 +2750,7 @@ tonk-code:focus-within {
     padding: 0;
     margin: 0;
     block-size: 100vh;
+    block-size: 100dvh;
     inline-size: 100%;
 }
 
@@ -2791,19 +2792,18 @@ tonk-code:focus-within {
      it has to actually hide what is behind it. A light-theme value
      hardcoded here read as nearly transparent against the dark theme,
      and the page showed through and collided with the rows. */
-  .tonk-dim {
-    position: fixed; inset: 0; z-index: 20;
-    background: var(--dim);
-    opacity: 0; transition: opacity .4s var(--ease);
-    pointer-events: none;
+  #tonk-register {
+    position: fixed; inset: 0; z-index: 21;
+    box-sizing: border-box;
+    inline-size: auto; max-inline-size: none;
+    block-size: auto; max-block-size: none;
+    margin: 0; padding: 0; overflow: auto;
+    border: 0; border-radius: 0;
+    background: transparent; box-shadow: none;
+    color: inherit;
   }
-  .tonk-dim.on { opacity: 1; pointer-events: auto; }
-
-  .tonk-cluster {
-    position: fixed; inset: 0; z-index: 21; overflow: auto;
-    transition: opacity .4s var(--ease);
-  }
-  .tonk-cluster[hidden] { display: none; }
+  #tonk-register[open] { display: block; }
+  #tonk-register::backdrop { background: var(--dim); }
 
   /* The study's chrome type: condensed, 600, 13px, slightly tracked and
      lowercased. Inheriting the page's body font instead made everything
@@ -2954,4 +2954,47 @@ tonk-code:focus-within {
     font-size: 13px; cursor: pointer;
     color: var(--ink);
     text-decoration: underline; text-underline-offset: 3px;
+  }
+
+  @media (max-width: 519px) {
+    .tonk-ceremony .m-head,
+    .tonk-ceremony .orow,
+    .tonk-ceremony .obtn {
+      min-height: 44px;
+      height: 44px;
+    }
+    .tonk-ceremony .orow {
+      align-items: center;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    .tonk-ceremony .orow .v,
+    .tonk-ceremony .orow .k {
+      align-items: center;
+      padding-bottom: 0;
+      margin-bottom: 0;
+    }
+    .tonk-ceremony .ed {
+      height: 44px;
+      font-size: 16px;
+      line-height: 44px;
+    }
+    .tonk-ceremony .ghost {
+      min-height: 44px;
+      display: flex;
+      align-items: center;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    #tonk-register,
+    .tonk-ceremony .orow,
+    .tonk-ceremony .obtn {
+      transition: none;
+    }
+    .tonk-ceremony .cur,
+    .tonk-ceremony .obtn.wait,
+    .tonk-ceremony .flash {
+      animation: none;
+    }
   }

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -5661,9 +5661,14 @@ mod tests {
             CORE.contains("tonk-display > [slot][hidden]"),
             "inactive pending and refusal slots should not survive a ready result",
         );
-        assert!(CORE.contains("local spot &middot; no sync remote"));
+        assert!(CORE.contains("sharing unavailable"));
         assert!(
-            CORE.contains("Use connect in the condition banner, then create the agent link again.")
+            !CORE.contains("Use connect in the condition banner"),
+            "the refusal must not prescribe a repair that is absent or inappropriate"
+        );
+        assert!(
+            CORE.contains("<p>{detail}</p>"),
+            "the worker-owned complete sentence is the only refusal body"
         );
     }
 

--- a/rust/tonk-worker/tests/standard_library.rs
+++ b/rust/tonk-worker/tests/standard_library.rs
@@ -183,6 +183,34 @@ fn it_describes_space_removal_as_device_local() {
 }
 
 #[test]
+fn it_uses_the_shared_native_dialog_for_hub_space_removal() {
+    for contract in [
+        "<ui-space-remove>",
+        "data-space-remove-open",
+        "<tonk-dialog data-space-remove-dialog",
+        "data-dialog=\"close\"",
+        "type=\"submit\" form=\"remove-{subject}\"",
+    ] {
+        assert!(
+            PROFILE_LIBRARY.contains(contract),
+            "Hub removal must preserve the shared dialog contract `{contract}`"
+        );
+    }
+    for rejected in [
+        ".rm-radio",
+        "class=\"rm-radio\"",
+        "class=\"mscrim\"",
+        "role=\"alertdialog\"",
+        "for=\"rm-",
+    ] {
+        assert!(
+            !PROFILE_LIBRARY.contains(rejected),
+            "Hub removal must not retain `{rejected}`"
+        );
+    }
+}
+
+#[test]
 fn it_keeps_keyboard_focus_visible_on_inverted_hub_controls() {
     assert!(
         PROFILE_LIBRARY
@@ -342,5 +370,43 @@ fn it_renders_join_refusals_as_neutral_edge_walls() {
         );
         assert!(wall.1.contains("start a new space"));
         assert!(wall.1.contains("join this space"));
+    }
+}
+
+#[test]
+fn it_sizes_the_join_route_to_the_dynamic_mobile_viewport() {
+    let route = PROFILE_LIBRARY
+        .split("view!: &join/route-view")
+        .nth(1)
+        .and_then(|tail| tail.split("# The /inspector and /diagnose routes").next())
+        .expect("join route view");
+    let join_view = css_rule(route, ".join-view {");
+    let fallback = join_view
+        .find("min-height:100vh")
+        .expect("join route must retain the legacy viewport fallback");
+    let dynamic = join_view
+        .find("min-height:100dvh")
+        .expect("join route must use the dynamic mobile viewport");
+    assert!(
+        fallback < dynamic,
+        "the dynamic viewport declaration must follow and override the fallback"
+    );
+}
+
+#[test]
+fn it_declares_mobile_target_and_input_floors_for_hub_and_join() {
+    for contract in [
+        ".hubbar, .hcell, .hub-page .mode-cap { height:44px; min-height:44px; }",
+        ".account-menu__row, .sempty, .srow, .snew { min-height:44px; }",
+        ".edge-mast { left:16px; top:18px; width:98px; min-height:44px;",
+        ".edge-field, .ebtn, .ebtn.solid button { min-height:44px; }",
+        ".edge-field { height:44px; padding-bottom:0; align-items:stretch; }",
+        ".edge-input { min-height:44px; font-size:16px; }",
+        ".edge-noun, .edge-cur { align-self:flex-end; margin-bottom:8px; }",
+    ] {
+        assert!(
+            PROFILE_LIBRARY.contains(contract),
+            "mobile Hub/join CSS must contain `{contract}`"
+        );
     }
 }

--- a/rust/tonk-workspace/Cargo.toml
+++ b/rust/tonk-workspace/Cargo.toml
@@ -70,6 +70,7 @@ web-sys = { workspace = true, features = [
 dialog-common = { workspace = true, features = ["helpers"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
+tonk-fab = { workspace = true }
 wasm-bindgen-test = { workspace = true }
 
 [lints.rust]

--- a/rust/tonk-workspace/src/lib.rs
+++ b/rust/tonk-workspace/src/lib.rs
@@ -45,6 +45,8 @@ mod ui_hub_account;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 mod ui_mode_switch;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+mod ui_space_remove;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 mod ui_sync_status;
 
 /// `<tonk-sheet-binder>`, `<tonk-page>`, `<tonk-origin>`,
@@ -63,6 +65,7 @@ pub fn register() {
     ui_mode_switch::register();
     ui_copy_link::register();
     ui_hub_account::register();
+    ui_space_remove::register();
     default_remote::register();
     editable::register();
     join_retry::register();

--- a/rust/tonk-workspace/src/ui_hub_account.rs
+++ b/rust/tonk-workspace/src/ui_hub_account.rs
@@ -89,6 +89,7 @@ fn render_profiles(this: &HtmlElement, response: &ProfilesResponse) {
         let _ = row.set_attribute("role", "menuitem");
         if is_active {
             let _ = row.set_attribute("aria-current", "true");
+            let _ = row.set_attribute("aria-disabled", "true");
             let _ = row.set_attribute("tabindex", "-1");
         } else {
             let _ = row.set_attribute("type", "button");
@@ -239,8 +240,36 @@ impl CustomElement for UiHubAccount {
 
         let host = this.clone();
         let keydown: KeyClosure = Closure::wrap(Box::new(move |event: KeyboardEvent| {
-            if event.key() == "Escape" {
-                close_menu(&host, true);
+            let open = account_trigger(&host)
+                .and_then(|trigger| trigger.get_attribute("aria-expanded"))
+                .as_deref()
+                == Some("true");
+            if !open {
+                return;
+            }
+            match event.key().as_str() {
+                "ArrowDown" => {
+                    event.prevent_default();
+                    move_menu_focus(&host, 1, false);
+                }
+                "ArrowUp" => {
+                    event.prevent_default();
+                    move_menu_focus(&host, -1, false);
+                }
+                "Home" => {
+                    event.prevent_default();
+                    move_menu_focus(&host, 1, true);
+                }
+                "End" => {
+                    event.prevent_default();
+                    move_menu_focus(&host, -1, true);
+                }
+                "Escape" => {
+                    event.prevent_default();
+                    close_menu(&host, true);
+                }
+                "Tab" => close_menu(&host, false),
+                _ => {}
             }
         }));
         let _ = this.add_event_listener_with_callback("keydown", keydown.as_ref().unchecked_ref());
@@ -412,6 +441,47 @@ fn open_menu(this: &HtmlElement) {
     {
         menu.set_hidden(false);
     }
+    if let Some(first) = menu_items(this).first() {
+        let _ = first.focus();
+    }
+}
+
+fn menu_items(this: &HtmlElement) -> Vec<HtmlElement> {
+    let Ok(nodes) = this.query_selector_all("[data-account-menu] [role=menuitem]") else {
+        return Vec::new();
+    };
+    (0..nodes.length())
+        .filter_map(|index| nodes.item(index))
+        .filter_map(|node| node.dyn_into::<HtmlElement>().ok())
+        .filter(|item| {
+            item.get_attribute("aria-disabled").as_deref() != Some("true")
+                && !item.matches(":disabled").unwrap_or(false)
+                && !item.hidden()
+        })
+        .collect()
+}
+
+fn move_menu_focus(this: &HtmlElement, direction: i32, endpoint: bool) {
+    let items = menu_items(this);
+    if items.is_empty() {
+        return;
+    }
+    let next = if endpoint {
+        if direction > 0 { 0 } else { items.len() - 1 }
+    } else {
+        let active = window()
+            .and_then(|window| window.document())
+            .and_then(|document| document.active_element());
+        let current = active
+            .and_then(|active| {
+                items
+                    .iter()
+                    .position(|item| active.is_same_node(Some(item)))
+            })
+            .unwrap_or_else(|| if direction > 0 { items.len() - 1 } else { 0 });
+        (current as i32 + direction).rem_euclid(items.len() as i32) as usize
+    };
+    let _ = items[next].focus();
 }
 
 fn close_menu(this: &HtmlElement, restore_focus: bool) {
@@ -670,6 +740,97 @@ mod tests {
             document
                 .active_element()
                 .is_some_and(|active| active.is_same_node(Some(&trigger)))
+        );
+        host.remove();
+    }
+
+    #[wasm_bindgen_test]
+    fn it_moves_focus_through_the_account_menu_with_the_keyboard() {
+        let host = account_element();
+        super::render_profiles(
+            &host,
+            &ProfilesResponse {
+                active: "primary".into(),
+                profiles: vec![
+                    profile("primary", Some("Ada"), None, Some("remote"), true),
+                    profile("second", Some("Grace"), None, Some("remote"), false),
+                    profile("third", Some("Katherine"), None, Some("remote"), false),
+                ],
+            },
+        );
+        let document = window().unwrap().document().unwrap();
+        let trigger: HtmlElement = host
+            .query_selector("[data-account-trigger]")
+            .unwrap()
+            .unwrap()
+            .dyn_into()
+            .unwrap();
+        trigger.click();
+
+        let active_profile = || {
+            document
+                .active_element()
+                .and_then(|element| element.get_attribute("data-profile"))
+        };
+        assert_eq!(active_profile().as_deref(), Some("second"));
+
+        let key = |value: &str| {
+            let init = KeyboardEventInit::new();
+            init.set_key(value);
+            init.set_bubbles(true);
+            document
+                .active_element()
+                .unwrap()
+                .dispatch_event(
+                    &KeyboardEvent::new_with_keyboard_event_init_dict("keydown", &init).unwrap(),
+                )
+                .unwrap();
+        };
+        key("ArrowUp");
+        assert!(
+            document
+                .active_element()
+                .unwrap()
+                .has_attribute("data-add-profile"),
+            "ArrowUp wraps to the last enabled item"
+        );
+        key("ArrowDown");
+        assert_eq!(active_profile().as_deref(), Some("second"));
+        key("End");
+        assert!(
+            document
+                .active_element()
+                .unwrap()
+                .has_attribute("data-add-profile")
+        );
+        key("Home");
+        assert_eq!(active_profile().as_deref(), Some("second"));
+        key("Escape");
+        assert!(
+            document
+                .active_element()
+                .unwrap()
+                .is_same_node(Some(&trigger))
+        );
+        assert_eq!(
+            trigger.get_attribute("aria-expanded").as_deref(),
+            Some("false")
+        );
+
+        trigger.click();
+        let focused = document.active_element().unwrap();
+        let init = KeyboardEventInit::new();
+        init.set_key("Tab");
+        init.set_bubbles(true);
+        let tab = KeyboardEvent::new_with_keyboard_event_init_dict("keydown", &init).unwrap();
+        focused.dispatch_event(&tab).unwrap();
+        assert!(
+            !tab.default_prevented(),
+            "Tab keeps its browser-default move"
+        );
+        assert_eq!(
+            trigger.get_attribute("aria-expanded").as_deref(),
+            Some("false")
         );
         host.remove();
     }

--- a/rust/tonk-workspace/src/ui_space_remove.rs
+++ b/rust/tonk-workspace/src/ui_space_remove.rs
@@ -1,0 +1,190 @@
+//! `<ui-space-remove>` — opens the shared modal around a seeded remove form.
+
+use custom_elements::CustomElement;
+use js_sys::{Function, Reflect};
+use wasm_bindgen::JsCast as _;
+use wasm_bindgen::closure::Closure;
+use web_sys::{Element, Event, HtmlElement, window};
+
+type EventClosure = Closure<dyn FnMut(Event)>;
+
+#[derive(Default)]
+struct UiSpaceRemove {
+    click: Option<EventClosure>,
+}
+
+impl CustomElement for UiSpaceRemove {
+    fn shadow() -> bool {
+        false
+    }
+
+    fn observed_attributes() -> &'static [&'static str] {
+        &[]
+    }
+
+    fn inject_children(&mut self, _this: &HtmlElement) {}
+
+    fn connected_callback(&mut self, this: &HtmlElement) {
+        if self.click.is_some() {
+            return;
+        }
+        let host = this.clone();
+        let click: EventClosure = Closure::wrap(Box::new(move |event: Event| {
+            let opens = event
+                .target()
+                .and_then(|target| target.dyn_into::<Element>().ok())
+                .and_then(|target| target.closest("[data-space-remove-open]").ok().flatten())
+                .is_some();
+            if !opens {
+                return;
+            }
+            let Some(dialog) = host
+                .query_selector("[data-space-remove-dialog]")
+                .ok()
+                .flatten()
+            else {
+                return;
+            };
+            let Some(show) = Reflect::get(dialog.as_ref(), &"show".into())
+                .ok()
+                .and_then(|show| show.dyn_into::<Function>().ok())
+            else {
+                return;
+            };
+            let _ = show.call0(dialog.as_ref());
+        }));
+        let _ = this.add_event_listener_with_callback("click", click.as_ref().unchecked_ref());
+        self.click = Some(click);
+    }
+
+    fn disconnected_callback(&mut self, this: &HtmlElement) {
+        if let Some(click) = self.click.take() {
+            let _ =
+                this.remove_event_listener_with_callback("click", click.as_ref().unchecked_ref());
+        }
+    }
+
+    fn attribute_changed_callback(
+        &mut self,
+        _this: &HtmlElement,
+        _name: String,
+        _old: Option<String>,
+        _new: Option<String>,
+    ) {
+    }
+}
+
+/// Register `<ui-space-remove>`. Idempotent.
+pub(crate) fn register() {
+    let Some(win) = window() else { return };
+    if win.custom_elements().get("ui-space-remove").is_undefined() {
+        UiSpaceRemove::define("ui-space-remove");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    use wasm_bindgen::JsCast as _;
+    use wasm_bindgen::closure::Closure;
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+    use web_sys::{Event, HtmlDialogElement, HtmlElement, window};
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[wasm_bindgen_test]
+    fn it_opens_the_shared_dialog_and_restores_the_remove_button() {
+        tonk_fab::register();
+        super::register();
+        let document = window().expect("window").document().expect("document");
+        let host: HtmlElement = document
+            .create_element("ui-space-remove")
+            .expect("create remove element")
+            .dyn_into()
+            .expect("HtmlElement");
+        host.set_inner_html(
+            r#"<button type="button" data-space-remove-open>remove</button>
+               <tonk-dialog data-space-remove-dialog heading="confirm space removal">
+                 <form id="remove-test"></form>
+                 <button slot="actions" type="button" data-dialog="close">cancel</button>
+                 <button slot="actions" type="submit" form="remove-test" data-remove>remove space</button>
+               </tonk-dialog>"#,
+        );
+        document
+            .body()
+            .expect("body")
+            .append_child(&host)
+            .expect("append remove element");
+
+        let opener: HtmlElement = host
+            .query_selector("[data-space-remove-open]")
+            .unwrap()
+            .unwrap()
+            .dyn_into()
+            .unwrap();
+        opener.focus().unwrap();
+        opener.click();
+
+        let dialog_host: HtmlElement = host
+            .query_selector("tonk-dialog")
+            .unwrap()
+            .unwrap()
+            .dyn_into()
+            .unwrap();
+        let native: HtmlDialogElement = dialog_host
+            .shadow_root()
+            .expect("dialog shadow root")
+            .query_selector("dialog")
+            .unwrap()
+            .unwrap()
+            .dyn_into()
+            .unwrap();
+        assert!(native.open(), "the opener must call tonk-dialog.show()");
+
+        host.query_selector("[data-dialog=close]")
+            .unwrap()
+            .unwrap()
+            .dyn_into::<HtmlElement>()
+            .unwrap()
+            .click();
+        assert!(!native.open(), "Cancel must close the native dialog");
+        assert!(
+            document
+                .active_element()
+                .is_some_and(|active| active.is_same_node(Some(&opener))),
+            "native dialog close must restore the remove button"
+        );
+
+        let submitted = Rc::new(Cell::new(false));
+        let saw_submit = submitted.clone();
+        let on_submit = Closure::<dyn FnMut(Event)>::new(move |event: Event| {
+            event.prevent_default();
+            saw_submit.set(true);
+        });
+        host.query_selector("form")
+            .unwrap()
+            .unwrap()
+            .add_event_listener_with_callback("submit", on_submit.as_ref().unchecked_ref())
+            .unwrap();
+        opener.click();
+        host.query_selector("[data-remove]")
+            .unwrap()
+            .unwrap()
+            .dyn_into::<HtmlElement>()
+            .unwrap()
+            .click();
+        assert!(
+            submitted.get(),
+            "the real remove action must submit its form"
+        );
+        host.query_selector("[data-dialog=close]")
+            .unwrap()
+            .unwrap()
+            .dyn_into::<HtmlElement>()
+            .unwrap()
+            .click();
+        host.remove();
+    }
+}


### PR DESCRIPTION
## Summary

- keep account, activation, Join, Hub, registration, and fatal-error surfaces usable at 320px and 390px phone viewports with 44px targets and iOS-safe inputs
- move registration and space removal onto native dialog semantics, contain composed focus, and restore exact openers across the sealed portal boundary
- make registration retries reuse the committed email while preserving single-flight actions
- prevent stale display diagnostics and share progress from overwriting settled fresh-space refusal state
- add native, Wasm, contract, and real-browser regression coverage; align the Nix ChromeDriver with Chrome 152

## Validation

- cargo fmt --all -- --check
- git diff --check origin/staging...HEAD
- cargo test -q -p tonk-ui -p tonk-workspace -p tonk-fab -p tonk-display -p tonk-portal
- cargo test -q -p tonk-worker --test standard_library
- focused WebDriver regressions for Settings and guest registration focus, committed-email retry, sealed removal focus, exact Join geometry, settled share refusal, short destructive-dialog geometry, and exact Settings geometry
- direct production build: nix build path:.#tonk-ui --no-link --print-out-paths
- the committed-snapshot test:web:debug archive built successfully and 1,066 of 1,437 browser tests passed before the broad run was manually interrupted; no full-suite pass is claimed

## Known limits

- the serialized full E2E run reached 51/57 before the two UI failures were fixed and rerun exactly; the four remaining failures are CLI-backed account cases whose native CLI process resolves tonk.network publicly instead of to the loopback harness
- real iOS Safari, genuine reduced-motion OS state, real passkey account lifecycle, and the production device matrix remain manual coverage
- the canonical terms/version decision and Storybook B-05 verification remain pending and are not invented by this change

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces several enhancements and fixes across multiple modules, focusing on improving accessibility, refining UI components, and enhancing functionality related to dialog handling and user interactions.

### Detailed summary
- Added `KeyboardEventInit` to support keyboard events.
- Introduced `ui-space-remove` for space removal functionality.
- Enhanced accessibility attributes like `role`, `aria-pressed`, and `aria-disabled`.
- Improved focus management for dialogs and menus.
- Updated CSS for better responsiveness and usability.
- Refined event handling for keyboard navigation in menus.
- Adjusted error handling and user feedback in activation flows.

> The following files were skipped due to too many changes: `rust/tonk-ui/src/register_dialog.rs`, `plan/tonk-ui-mobile-runtime-failures.md`, `rust/tonk-ui/src/account_flow.rs`, `plan/tonk-ui-mobile-hardening.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->