### PR TITLE
fix(copy): remove retired terminology from public surfaces

### DIFF
--- a/docs/storybook/glossary.md
+++ b/docs/storybook/glossary.md
@@ -156,6 +156,6 @@ explain an observable result.
 : The journey's normal, rejected, interrupted, recovery, and durable invariant
   cases are all proven at appropriate layers.
 
-Source audit pinned to Tonk commit `a3f8670b1`. Open question: product copy uses
-“spot” in a few historical tests and comments; this storybook uses the current
-public term “space.”
+Source audit refreshed on the current product branch. Historical tests and
+compatibility fixtures retain retired machine vocabulary; every public surface
+uses “space.”

--- a/plan/remove-public-spot-copy.md
+++ b/plan/remove-public-spot-copy.md
@@ -1,0 +1,29 @@
+# Remove the retired noun from public surfaces
+
+## Stack
+
+- Parent: `fix/user-facing-space-terminology` / PR #826.
+- This branch changes only the remaining public diagnostics and documentation.
+
+## Scope
+
+- Sanitize parser errors for retired command and option spellings.
+- Keep rejecting retired environment variables without repeating their names.
+- Replace the retired noun in rendered Storybook and generated Rust documentation.
+- Preserve machine-required compatibility literals, migration filenames, and tests
+  that prove old inputs are rejected or converted.
+
+## Verification
+
+- [x] Focused CLI rejection tests prove public errors use only current terminology.
+- [x] Rust formatting and affected crate tests pass.
+- [x] Rustdoc builds for affected public crates; unrelated existing broken-link warnings are recorded.
+- [x] Storybook data, links, and stacked-base impact checks pass.
+- [x] A final audit classifies every remaining literal as compatibility or test-only.
+
+## Verification note
+
+Normal Rustdoc generation succeeds for all affected public crates. A strict
+`-D warnings` run stops on existing broken intra-doc links, beginning with
+`tonk-host/src/lib.rs` linking to `resolve_with`; those unrelated warnings are
+outside this terminology-only stack.

--- a/rust/dialog-reactor/src/command.rs
+++ b/rust/dialog-reactor/src/command.rs
@@ -624,7 +624,7 @@ mod tests {
         assert!(
             ProfileRename::decode(this, &facts).is_none(),
             "a repo-rename transient must NOT also decode as ProfileRename — \
-             that is the bug: renaming a spot was also renaming the profile"
+             that is the bug: renaming a space was also renaming the profile"
         );
     }
 

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -1175,7 +1175,16 @@ fn uses_active_space(command: &Command) -> bool {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let cli = Cli::parse();
+    let cli = match Cli::try_parse() {
+        Ok(cli) => cli,
+        Err(error) if error.to_string().to_ascii_lowercase().contains("spot") => {
+            eprintln!(
+                "error: a retired space command or option was supplied; use `tonk space --help`"
+            );
+            std::process::exit(ExitCode::ParseError.into_raw());
+        }
+        Err(error) => error.exit(),
+    };
     let Some(command) = cli.command else {
         print!("{CLI_INDEX}");
         return;
@@ -1185,7 +1194,9 @@ async fn main() {
         ("TONK_SPOTS_STATE", "TONK_SPACES_STATE"),
     ] {
         if std::env::var_os(retired).is_some() {
-            eprintln!("error: {retired} was removed; use {replacement}");
+            eprintln!(
+                "error: a retired space environment variable is set; unset it and use {replacement}"
+            );
             std::process::exit(ExitCode::ParseError.into_raw());
         }
     }

--- a/rust/tonk-cli/src/context.rs
+++ b/rust/tonk-cli/src/context.rs
@@ -16,9 +16,9 @@ use crate::space::Resolved;
 
 /// Legacy version retained only for the in-process context renderer.
 ///
-/// v2 renamed every `spot` key to `space` and moved the whole document to
-/// camelCase, which is what `tonk space --json` and the registry's own
-/// account record already emit.
+/// v2 normalized the legacy key to `space` and moved the whole document to
+/// camelCase, matching `tonk space --json` and the registry's own account
+/// record.
 ///
 /// v3 absorbed the sync and account sections. Four commands used to answer
 /// "where am I" in four layouts, naming the same field three ways in the

--- a/rust/tonk-cli/src/space.rs
+++ b/rust/tonk-cli/src/space.rs
@@ -25,13 +25,11 @@
 //! go through a temp file + atomic rename. A corrupt registry is a
 //! hard error naming the file — never silently recreated.
 //!
-//! Both names were `spot` before. An installation written by that
-//! build keeps working: the first command to touch its `spots.json`,
-//! `spots` key, and `spots/` root converts the store in place (see
-//! [`SpaceStore::load`]). Nothing writes the old spelling back, so the
-//! conversion happens once. The cost of converting is that an older
-//! `tonk` sharing the same data dir stops seeing these spaces — it does
-//! not destroy them, because its unknown-field sink round-trips what it
+//! A pre-rename registry and site root remain readable. The first command to
+//! touch that layout converts the store in place (see [`SpaceStore::load`]).
+//! Nothing writes the retired spelling back, so conversion happens once. An
+//! older `tonk` sharing the same data directory then stops seeing these spaces,
+//! but does not destroy them because its unknown-field sink round-trips what it
 //! cannot read.
 
 use std::collections::BTreeMap;
@@ -73,10 +71,10 @@ pub struct Registry {
     legacy_current: Option<String>,
     /// Name → entry. Paths inside are absolute and expanded.
     ///
-    /// `alias` reads the pre-rename `spots` key. It has to be an alias
-    /// rather than a bare rename because [`Registry::extra`] would
-    /// otherwise swallow `spots` into the unknown-field sink and this
-    /// binary would report a populated installation as empty.
+    /// The alias reads the pre-rename registry key. It must be an alias rather
+    /// than a bare rename because [`Registry::extra`] would otherwise swallow
+    /// the legacy field into the unknown-field sink and report a populated
+    /// installation as empty.
     #[serde(default, alias = "spots")]
     pub spaces: BTreeMap<String, SpaceEntry>,
     /// Directories bound to a space, keyed by canonicalized absolute
@@ -440,17 +438,17 @@ impl SpaceStore {
         })
     }
 
-    /// Convert a pre-rename store (`spots.json` + `spots/`) to the
-    /// current layout, returning the registry either way.
+    /// Convert a pre-rename registry and site root to the current layout,
+    /// returning the registry either way.
     ///
     /// Only reached when `spaces.json` is absent, so a converted store
     /// never pays for this again. The order is chosen so every
     /// interruption converges on a re-run: the site directory moves
     /// first, the rewritten registry lands atomically second, and the
-    /// legacy registry is removed last. A crash before the write leaves
-    /// `spots.json` naming directories that have moved — which the next
-    /// run fixes, because the rewrite is a prefix substitution that does
-    /// not consult the filesystem.
+    /// legacy registry is removed last. A crash before the write leaves the
+    /// old registry naming directories that have moved, which the next run
+    /// fixes because the rewrite is a prefix substitution that does not
+    /// consult the filesystem.
     ///
     /// Failure is an error rather than an empty registry: silently
     /// reporting zero spaces to someone who has ten is the one outcome
@@ -1160,9 +1158,7 @@ mod tests {
     mod adopting_the_pre_rename_layout {
         use super::*;
 
-        /// Build the layout a pre-rename `tonk` left behind: a
-        /// `spots.json` keyed on `spots`, and canonical site data under
-        /// `spots/`.
+        /// Build the registry and site layout a pre-rename `tonk` left behind.
         fn legacy_store(names: &[&str]) -> (tempfile::TempDir, SpaceStore) {
             let (tmp, store) = store();
             let root = tmp.path().join("spots");
@@ -1184,7 +1180,7 @@ mod tests {
         }
 
         #[dialog_common::test]
-        fn it_reads_spaces_out_of_a_registry_that_still_says_spots() {
+        fn it_reads_spaces_from_the_legacy_registry_key() {
             let (_tmp, store) = legacy_store(&["garden", "work"]);
             let registry = store.load().expect("load");
             assert_eq!(
@@ -1297,10 +1293,10 @@ mod tests {
             assert!(!tmp.path().join("spots").exists());
         }
 
-        /// Interrupted between the directory move and the registry
-        /// write: `spots/` is gone, `spots.json` still names it. The
-        /// rewrite is a prefix substitution that never consults the
-        /// filesystem, so the re-run still lands on the right paths.
+        /// Interrupted between the directory move and the registry write: the
+        /// old root is gone while the legacy registry still names it. The
+        /// rewrite is a prefix substitution that never consults the filesystem,
+        /// so the re-run still lands on the right paths.
         #[dialog_common::test]
         fn it_recovers_when_the_move_landed_but_the_registry_write_did_not() {
             let (tmp, store) = legacy_store(&["garden"]);
@@ -1354,8 +1350,8 @@ mod tests {
         }
 
         /// A second process can enter conversion after observing no
-        /// `spaces.json`, then lose the race while the first process writes
-        /// it and removes `spots.json`. It must read the winner's registry,
+        /// `spaces.json`, then lose the race while the first process writes it
+        /// and removes the legacy registry. It must read the winner's registry,
         /// not return an empty baseline that a subsequent write can save.
         #[dialog_common::test]
         fn it_rechecks_the_current_registry_when_the_legacy_file_disappears() {

--- a/rust/tonk-cli/tests/cli_space.rs
+++ b/rust/tonk-cli/tests/cli_space.rs
@@ -416,17 +416,31 @@ mod when_resolving_with_precedence {
         let state = tempfile::tempdir().expect("tempdir");
         two_space_registry(state.path());
 
-        let output = run(state.path(), &["--spot", "a", "status"], &[]);
-        assert!(!output.status.success());
-        assert!(stderr_of(&output).contains("unexpected argument '--spot'"));
+        for args in [
+            &["--spot", "a", "status"][..],
+            &["spot", "link", "a"][..],
+            &["account", "spots"][..],
+        ] {
+            let output = run(state.path(), args, &[]);
+            assert!(!output.status.success());
+            let stderr = stderr_of(&output);
+            assert!(
+                stderr.contains("a retired space command or option was supplied"),
+                "{stderr}"
+            );
+            assert!(!stderr.to_ascii_lowercase().contains("spot"), "{stderr}");
+        }
 
         let output = run(state.path(), &["status"], &[("TONK_SPOT", "a")]);
         assert!(!output.status.success());
+        let stderr = stderr_of(&output);
         assert!(
-            stderr_of(&output).contains("TONK_SPOT was removed; use TONK_SPACE"),
-            "{}",
-            stderr_of(&output)
+            stderr.contains(
+                "a retired space environment variable is set; unset it and use TONK_SPACE"
+            ),
+            "{stderr}"
         );
+        assert!(!stderr.to_ascii_lowercase().contains("spot"), "{stderr}");
     }
 
     #[dialog_common::test]
@@ -446,11 +460,14 @@ mod when_resolving_with_precedence {
             .env("TONK_SPACE", "a");
         let output = cmd.output().expect("run tonk");
         assert!(!output.status.success());
+        let stderr = stderr_of(&output);
         assert!(
-            stderr_of(&output).contains("TONK_SPOTS_STATE was removed; use TONK_SPACES_STATE"),
-            "{}",
-            stderr_of(&output)
+            stderr.contains(
+                "a retired space environment variable is set; unset it and use TONK_SPACES_STATE"
+            ),
+            "{stderr}"
         );
+        assert!(!stderr.to_ascii_lowercase().contains("spot"), "{stderr}");
     }
 
     #[dialog_common::test]
@@ -466,9 +483,12 @@ mod when_resolving_with_precedence {
         assert!(!output.status.success());
         let stderr = stderr_of(&output);
         assert!(
-            stderr.contains("TONK_SPOT was removed; use TONK_SPACE"),
+            stderr.contains(
+                "a retired space environment variable is set; unset it and use TONK_SPACE"
+            ),
             "{stderr}"
         );
+        assert!(!stderr.to_ascii_lowercase().contains("spot"), "{stderr}");
     }
 
     #[dialog_common::test]
@@ -493,6 +513,15 @@ mod when_resolving_with_precedence {
         let output = run(state.path(), &["space", "use"], &[("TONK_SPACE", "a")]);
         assert!(!output.status.success());
         assert!(stderr_of(&output).contains("<NAME>"));
+    }
+
+    #[dialog_common::test]
+    fn complete_help_uses_only_space_terminology() {
+        let state = tempfile::tempdir().expect("tempdir");
+        let output = run(state.path(), &["help", "--all"], &[]);
+        assert!(output.status.success(), "{}", stderr_of(&output));
+        let stdout = stdout_of(&output);
+        assert!(!stdout.to_ascii_lowercase().contains("spot"), "{stdout}");
     }
 
     #[dialog_common::test]

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -783,7 +783,7 @@ concept!: &tonk/repository
 
 # Agent working context carried by the repository itself. The instance is keyed
 # by the same stable repository subject DID as `tonk/repository`, so it syncs
-# with the spot rather than belonging to one filesystem checkout or replica.
+# with the space rather than belonging to one filesystem checkout or replica.
 attribute!: &tonk/agents-markdown
   the: xyz.tonk.repo/agents
   description: >
@@ -948,7 +948,7 @@ concept!: &view/title
 # The repository's name as the browser tab's title. The space chrome
 # mounts this via `<tonk-display model=tonk:repository entity={id}
 # view=tonk:view/title>` inside a per-space `with={id}` routing context,
-# so the tab names the focused spot (read from that space's
+# so the tab names the focused space (read from that space's
 # `tonk/repository`, the cross-device source of truth). `<tonk-title>`
 # renders nothing — it pushes the text to the host page, which owns
 # `document.title`.

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -59,7 +59,7 @@ concept!: &space
       description: >
         Whether THIS device holds a replica. Overlay-only (the worker
         stamps it at boot and on mount), so it never replicates; a row
-        without it renders as a hollow spot that replicates on first
+        without it renders as a hollow space that replicates on first
         visit.
       the: xyz.tonk.space/local
       cardinality: one
@@ -98,8 +98,8 @@ command!: &space/create
 # asserts this transient; the worker's `RemoveSpaceHandler` retracts the
 # replica record from this branch, evicts the space from the reactor
 # (stopping background sync), and deletes its local storage. Removal is
-# device-local — a synced spot can be rejoined via an invite link; a
-# local-only spot is gone for good, which the confirm copy states.
+# device-local — a synced space can be rejoined via an invite link; a
+# local-only space is gone for good, which the confirm copy states.
 # `subject` reads the form's `data-remove` attribute. Deliberately NOT
 # `data-subject`: `tonk/rename-repository` transients already carry
 # `dataset/subject`, and a remove command matched on that attribute
@@ -448,8 +448,8 @@ view/directory!:
         <!-- Creating asks nothing up front: the space starts "Untitled" (the
              worker uniquifies the sentinel) and is renamed in place with the
              bar's block cursor the moment you land in it. No remote is
-             carried: the worker resolves where a spot syncs from the
-             account's own registration, so a spot created before anyone
+             carried: the worker resolves where a space syncs from the
+             account's own registration, so a space created before anyone
              registers stays local until it is shared. -->
         <form class="snew-form" onsubmit=space/create>
           <input type="hidden" name="name" value="Untitled">
@@ -1061,7 +1061,7 @@ view!: &space-view
   model: tonk:space/chrome
   display: |
     <style>
-      /* A spot this device does not hold answers every query with a
+      /* A space this device does not hold answers every query with a
          404, which `<tonk-display>` classifies as `unknown` — a
          terminal state, unlike `offline`, so nothing retries and
          nothing arrives later. The title display below is the one
@@ -1140,18 +1140,18 @@ view!: &space-view
     <tonk-site with="main@{id}" allow="main@{id}" path={rest}></tonk-site>
     <tonk-fab with="main@profile:tonk" space={id}></tonk-fab>
     <tonk-display with={id} entity={id} model=tonk:repository view=tonk:view/title>
-      <!-- `no-model` is now the absent-spot panel below, which sets its
+      <!-- `no-model` is now the absent-space panel below, which sets its
            own title; a second `no-model` child would render alongside it
            and fight over `document.title` (update_slot_children shows
            EVERY matching child, not the first). `no-entity` keeps the
            quiet placeholder: the concept resolved, the row just is not
            here yet. -->
       <tonk-title slot="no-entity" text="Untitled — Tonk"></tonk-title>
-      <!-- The absent-spot case. A repository this device has not
+      <!-- The absent-space case. A repository this device has not
            replicated answers every query with the EMPTY SET, so
            `tonk:repository` resolves to nothing and this display lands
            in `no-model` — the same state a not-yet-synced concept
-           reaches, which is exactly right: the spot may arrive later,
+           reaches, which is exactly right: the space may arrive later,
            and when it does the standing subscription delivers a real
            frame and this panel is replaced in place.
 
@@ -1182,14 +1182,14 @@ view!: &space-view
           </div>
         </div>
       </div>
-      <!-- A spot created before `tonk:view/title` existed has no
+      <!-- A space created before `tonk:view/title` existed has no
            `view/title!:` row on its branch, so `view=tonk:view/title`
            resolves nothing and the display enters `no-view` — a `danger`
            state. `update_slot_children` toggles `hidden`, it never adds
            or removes children, so with no matching slot child the
            built-in red `<wa-callout>` fires. This inert child suppresses
            that callout while pushing no title, leaving the tab exactly
-           as it was — the old spot behavior. -->
+           as it was — the behavior for older spaces. -->
       <span slot="no-view"></span>
     </tonk-display>
 

--- a/rust/tonk-fab/src/logic.rs
+++ b/rust/tonk-fab/src/logic.rs
@@ -136,7 +136,7 @@ pub fn geometry_box(intent: &FabIntent, vw: f64, vh: f64) -> FabBox {
 /// A drop persists the nearest one: the vertical half of the viewport picks
 /// top vs bottom, the horizontal half picks left vs right.
 ///
-/// The resting spot is expressed as two CSS classes on `<tonk-fab>` — a vertical
+/// The resting position is expressed as two CSS classes on `<tonk-fab>` — a vertical
 /// one (`fab-dock-top` / `fab-dock-bottom`) and a horizontal one
 /// (`fab-dock-left` / `fab-dock-right`) — and the actual pixel placement + the
 /// submenu open-direction live in the view's stylesheet (profile.yaml). This
@@ -1090,7 +1090,7 @@ pub enum ShareState {
     /// A mint is in flight. The clipboard write is already pending on a
     /// promise this state is waiting to resolve.
     Copying,
-    /// The mint was refused because the spot has no shareable sync remote.
+    /// The mint was refused because the space has no shareable sync remote.
     /// The prompt offering to attach one is up; unlike `Copied`/`Failed` this
     /// does not revert on a timer, because the user is being asked a question.
     Blocked,
@@ -1566,7 +1566,7 @@ mod create_space {
     ///
     /// `remote` is gone for a second reason: the page supplying one made
     /// every create look like a deliberate choice of this server, so a
-    /// spot created before anyone registered was wired to a service that
+    /// space created before anyone registered was wired to a service that
     /// refuses to serve it. The worker resolves it from the account.
     #[test]
     fn it_declares_only_the_field_the_form_carries() {
@@ -1630,7 +1630,7 @@ mod profile_rename {
         // "…dataset/rename" also matches "…dataset/rename-repository", so a
         // marker silently pointed at the repo-rename attribute would still
         // pass. That collision is not hypothetical — both commands once
-        // derived `dataset/rename` and every spot rename also renamed the
+        // derived `dataset/rename` and every space rename also renamed the
         // profile, because decoding matches on which attributes are present
         // and never on their values. `dialog-reactor`'s
         // `it_does_not_decode_a_repo_rename_as_a_profile_rename` pins the
@@ -1802,9 +1802,9 @@ mod invite_link {
 ///
 /// An INLINE predicate over the raw `xyz.tonk.share/*` attributes, for the
 /// same reason [`invite_link_query_body`] is inline: rules and views are
-/// frozen at whatever `core.yaml` seeded a spot with, so reading raw
-/// attributes depends on nothing seeded and works on spots that predate this
-/// feature. `this` binds to the spot's subject DID, the entity the worker
+/// frozen at whatever `core.yaml` seeded a space with, so reading raw
+/// attributes depends on nothing seeded and works on spaces that predate this
+/// feature. `this` binds to the space's subject DID, the entity the worker
 /// keys the refusal by.
 /// Whether this profile's account is registered and served.
 ///

--- a/rust/tonk-fab/src/share.rs
+++ b/rust/tonk-fab/src/share.rs
@@ -42,10 +42,10 @@
 //!
 //! ## When the mint is refused
 //!
-//! A spot whose `main` has no sync remote cannot be shared: the worker refuses
+//! A space whose `main` has no sync remote cannot be shared: the worker refuses
 //! to mint rather than hand out an invite that would strand whoever claimed it
 //! in an empty space. It records that refusal as `xyz.tonk.share/{blocked,
-//! detail,time}` on the spot's subject, which this element reads on a SECOND
+//! detail,time}` on the space's subject, which this element reads on a SECOND
 //! subscription (see [`ShareBlockedBehaviour`]) — separate from the link
 //! subscription because a single predicate over both would resolve only when a
 //! refusal AND a link are present, which never happens.
@@ -57,8 +57,8 @@
 //!
 //! Two classes are repairable, and they share the claim but not the wording
 //! (see [`Repair`]). `not-synced` attaches a remote. `missing-revocation-relay`
-//! means the spot syncs fine but its remote carries no relay, so an invite
-//! could never be withdrawn — every spot whose remote predates in-band
+//! means the space syncs fine but its remote carries no relay, so an invite
+//! could never be withdrawn — every space whose remote predates in-band
 //! revocation is in that state; confirming upserts the relay onto the remote
 //! already there, leaving its address and its branch upstream untouched.
 //!
@@ -166,7 +166,7 @@ struct Blocked {
 /// confirm button (see `open_enable_sync_dialog`) on the one class it cannot
 /// repair.
 /// The refusal class the enable-sync prompt can still repair: an account
-/// with a provider, and a spot not yet attached to it.
+/// with a provider, and a space not yet attached to it.
 const BLOCKED_NOT_SYNCED: &str = tonk_worker_api::share::BLOCKED_NOT_SYNCED;
 
 /// The account enrolled but never confirmed the emailed link.
@@ -196,9 +196,9 @@ const TERMINAL_CONFIRM: &str = "copy link";
 /// The prompt serves two repairs that share a claim but not a sentence, plus
 /// a terminal class it only reports. Holding the whole wording per class —
 /// rather than swapping `detail` alone, as it used to — is what keeps a
-/// synced spot from being told to turn on sync: before this, EVERY refusal
+/// synced space from being told to turn on sync: before this, EVERY refusal
 /// re-used the `not-synced` copy, so a missing relay showed a greyed-out
-/// "Turn on sync & copy link" under a sentence about a device-only spot.
+/// "Turn on sync & copy link" under a sentence about a device-only space.
 ///
 /// `None` from [`Repair::for_code`] is the terminal case: report `detail`,
 /// no action line, confirm disabled.
@@ -216,7 +216,7 @@ struct Repair {
 /// What the dialog's confirm button carries out.
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum RepairOutcome {
-    /// Attach the account's remote to this spot, then mint — the
+    /// Attach the account's remote to this space, then mint — the
     /// one-click path that has always existed.
     EnableSync,
     /// Leave for `/account`, where registration lives. The bar is a
@@ -651,7 +651,7 @@ impl TonkShare {
             // both a `window` and the user gesture WebAuthn wants. This
             // frame has neither the ceremony nor the account UI, so it
             // asks through the portal bridge and the dialog opens over
-            // the spot rather than navigating away from it.
+            // the space rather than navigating away from it.
             //
             // The space rides along so the dialog can finish what this
             // click started: once an account exists, the share it
@@ -761,7 +761,7 @@ fn dispatch_invite(space: &str, time: f64) {
 }
 
 /// Dispatch the `tonk:enable-sync` claim, asking the worker to attach `remote`
-/// to this spot and — because `share` is set — mint the invite the refused
+/// to this space and — because `share` is set — mint the invite the refused
 /// click was after, as soon as the attach lands.
 fn dispatch_enable_sync(space: &str, remote: &str, share: bool, time: f64) {
     dispatch_claim(&enable_sync_claim_json(space, remote, share, time));
@@ -992,7 +992,7 @@ fn handle_link(
 
 /// Act on a refusal, if it answers the click currently awaiting an answer.
 ///
-/// The refusal fact is cardinality-one on the spot's subject, so the overlay
+/// The refusal fact is cardinality-one on the space's subject, so the overlay
 /// keeps the last one and redelivers it on every resubscribe. Matching on the
 /// echoed timestamp is what separates "this click was refused" from "here is
 /// an old refusal again" — without it, one refused share would poison every

--- a/rust/tonk-fab/src/space_switcher.rs
+++ b/rust/tonk-fab/src/space_switcher.rs
@@ -19,7 +19,7 @@
 //! element's `exclude` attribute) is skipped, so the switcher never offers to
 //! navigate to the space you're already on. A surviving row stamps
 //! `data-status` from the directory status so existing CSS can dim a
-//! still-seeding spot.
+//! still-seeding space.
 //!
 //! It renders ONLY the space rows. `new +` and `more ↖` belong to the stack
 //! that hosts this flyout (`markup::STACKS_HTML`), not here — emitting them
@@ -204,7 +204,7 @@ fn read_row(row: &JsValue) -> Option<(String, Row)> {
 ///
 /// No action rows. The stack that hosts this flyout already carries `new +`
 /// and `more ↖` (see `markup::STACKS_HTML`); emitting them here as well is
-/// what put a second, unstyled "+new" and "all spots" inside the open menu.
+/// what put a second, unstyled "+new" and "all spaces" inside the open menu.
 ///
 /// The list is capped at [`MAX_ROWS`]: up to seven spaces fly out, and `more
 /// ↖` — the stack's own last row — is the way to the rest. The active space

--- a/rust/tonk-fab/tests/space_name_element.rs
+++ b/rust/tonk-fab/tests/space_name_element.rs
@@ -268,11 +268,11 @@ async fn it_renders_the_name_from_a_delivered_frame() {
         "chip renders the placeholder before any frame arrives"
     );
 
-    deliver(&el, "reset", &reset_payload("Real Spot"));
+    deliver(&el, "reset", &reset_payload("Real Space"));
 
     assert_eq!(
         editable.text_content().as_deref(),
-        Some("Real Spot"),
+        Some("Real Space"),
         "a delivered reset frame must be consumed and rendered, not ignored"
     );
 

--- a/rust/tonk-guest/src/guest_host.rs
+++ b/rust/tonk-guest/src/guest_host.rs
@@ -151,7 +151,7 @@ fn warn(message: &str) {
 /// An empty fragment (`href="#"`) and `#top` are the document's top per the
 /// HTML spec's "scroll to the fragment" steps, but only when nothing carries
 /// that id. An id that matches nothing else scrolls nowhere: the click is
-/// still cancelled, because the alternative is loading the app inside the spot.
+/// still cancelled, because the alternative is loading the app inside the space.
 fn scroll_to_fragment(fragment: &str) -> bool {
     let Some(window) = window() else {
         return false;
@@ -266,7 +266,7 @@ fn classify_click(event: &Event) -> Intent {
 /// The profile/Hub guest has no synthetic origin — `space_origin_for` only
 /// answers for a `did:key`, and the profile is not one — and its links are
 /// genuinely top-level, resolving against the REAL host origin. Judging those
-/// against a missing base made every one of them external: the hub's own spot
+/// against a missing base made every one of them external: the hub's own space
 /// links and the FAB's account link were relayed to `open_external`, which
 /// opens our own origin in a new tab. Falling back to `context.origin` is what
 /// makes a top-level link navigate in place.
@@ -827,7 +827,7 @@ mod tests {
 
     /// The fragment row beats the modifier row. A cmd-clicked `#x` is not a new
     /// tab, even though a browser would make one: the host would resolve `#x`
-    /// against `/space/{id}` and open a duplicate spot scrolled nowhere.
+    /// against `/space/{id}` and open a duplicate space scrolled nowhere.
     #[dialog_common::test]
     async fn it_classifies_a_modified_fragment_click_as_a_fragment() {
         let click = Click {
@@ -844,7 +844,7 @@ mod tests {
     /// A fragment is NOT same-document in a `srcdoc` guest: the document URL is
     /// `about:srcdoc` but the BASE URL is inherited from the parent, so `#foo`
     /// resolves to `https://origin/space/{id}#foo` — a different document. Left
-    /// native, the browser loads the whole app inside the spot's iframe.
+    /// native, the browser loads the whole app inside the space's iframe.
     #[dialog_common::test]
     async fn it_cancels_a_fragment_click_rather_than_letting_it_navigate() {
         let relayed = relay(
@@ -910,7 +910,7 @@ mod tests {
     }
 
     /// A click with no anchor above it is not ours. An anchor with an EMPTY
-    /// href is: left alone it reloads the app inside the spot.
+    /// href is: left alone it reloads the app inside the space.
     #[dialog_common::test]
     async fn it_ignores_a_click_with_no_link_to_follow() {
         let bare = document().create_element("div").expect("a div");

--- a/rust/tonk-host/src/open.rs
+++ b/rust/tonk-host/src/open.rs
@@ -5,7 +5,7 @@
 //! `allow-top-navigation`. The guest relays the raw href and the page
 //! decides here.
 //!
-//! The href is ATTACKER-CONTROLLED. Spot content is data: views and
+//! The href is ATTACKER-CONTROLLED. Space content is data: views and
 //! components are facts a collaborator or an agent can assert into a
 //! space. This module is where an untrusted string meets the real
 //! origin, so two rules are absolute:
@@ -236,7 +236,7 @@ fn open_same_origin(url: &str) {
 /// path never gambles on activation surviving the relay. The affordance and
 /// the mechanism reinforce each other.
 ///
-/// ONE dialog at a time. This runs straight from the guest relay, so a spot
+/// ONE dialog at a time. This runs straight from the guest relay, so a space
 /// posting `open` in a loop arrives here as fast as it can call; ungated, that
 /// stacks N modals on the real origin. Refusing the second is safe because a
 /// modal absorbs every pointer event on the top page — measured in Chrome, the
@@ -360,7 +360,7 @@ fn confirm_then_open(url: &str, label: &str) {
 /// `forget` leaks the box AND leaves the shim rooted for the life of the
 /// module, and every closure held its own `dialog` clone, so removing the
 /// dialog dropped nothing. Since `open_external` reaches here straight from the
-/// guest relay, an untrusted spot could drive that leak. Returning the handle
+/// guest relay, an untrusted space could drive that leak. Returning the handle
 /// makes the lifetime the caller's decision instead of a claim in a comment.
 #[must_use]
 fn on_event<F: FnMut() + 'static>(
@@ -432,7 +432,7 @@ fn build_dialog(document: &Document, label: &str, url: &str) -> Option<HtmlDialo
 ///
 /// `noopener noreferrer` because this destination is off-origin: `noopener`
 /// denies it a handle on our window (reverse tabnabbing), `noreferrer` keeps
-/// the spot's URL out of its logs.
+/// the space's URL out of its logs.
 fn open_in_new_tab(document: &Document, url: &str) {
     let Ok(anchor) = document.create_element("a") else {
         return;
@@ -1033,7 +1033,7 @@ mod tests {
     /// the closure's JS shim rooted in the wasm-bindgen heap forever, holding the
     /// `url`, the `document`, and the whole detached dialog subtree with it. Every
     /// external link reaches that path straight from the guest relay, so an
-    /// untrusted spot could drive the leak: unbounded growth on the real origin.
+    /// untrusted space could drive the leak: unbounded growth on the real origin.
     ///
     /// `externref_heap_live_count` counts exactly what `forget` strands, so a flat
     /// count across cycles is direct evidence the closures are dropped. The first
@@ -1063,7 +1063,7 @@ mod tests {
     }
 
     /// A modal dialog is a scarce resource on the trusted page, and this path
-    /// runs STRAIGHT FROM THE GUEST RELAY: a sealed spot posting `open` in a
+    /// runs STRAIGHT FROM THE GUEST RELAY: a sealed space posting `open` in a
     /// loop reaches it as fast as it can call. Without a gate that stacks N
     /// modals on the real origin.
     ///
@@ -1131,7 +1131,7 @@ mod tests {
         );
     }
 
-    /// The dialog says what it does. It opens a new tab and leaves the spot
+    /// The dialog says what it does. It opens a new tab and leaves the space
     /// running, so it must not claim the user is leaving.
     #[dialog_common::test]
     async fn it_names_the_action_without_claiming_the_user_leaves() {
@@ -1150,7 +1150,7 @@ mod tests {
         );
         assert!(
             !text.contains("Leave"),
-            "the spot stays open, so the dialog must not say the user is leaving"
+            "the space stays open, so the dialog must not say the user is leaving"
         );
     }
 

--- a/rust/tonk-host/src/page_effect.rs
+++ b/rust/tonk-host/src/page_effect.rs
@@ -6,8 +6,8 @@
 //! — and the bridge dispatcher runs in the guest's PARENT, which is not
 //! necessarily the page.
 //!
-//! Spot content is a guest inside the profile chrome, which is itself a
-//! guest. A message from spot content is dispatched one hop up, in an
+//! Space content is a guest inside the profile chrome, which is itself a
+//! guest. A message from space content is dispatched one hop up, in an
 //! opaque-origin `about:srcdoc` document, where performing the effect
 //! either throws or corrupts the wrong frame. See the design spec.
 //!

--- a/rust/tonk-host/src/title.rs
+++ b/rust/tonk-host/src/title.rs
@@ -1,7 +1,7 @@
 //! Setting the host page's tab title on a guest's behalf.
 //!
 //! `document.title` exists only on the top page. The chrome that knows
-//! a spot's name renders inside a sealed guest, which cannot reach the
+//! a space's name renders inside a sealed guest, which cannot reach the
 //! top document, so it posts a `title` message over the portal bridge;
 //! the bridge dispatcher runs in the parent and calls this.
 //!

--- a/rust/tonk-portal/src/site_content.rs
+++ b/rust/tonk-portal/src/site_content.rs
@@ -26,7 +26,7 @@
 /// `tonk:site` concept resolves to nothing and the display lands in
 /// `no-model`. Unslotted, that renders the developer-facing "Model not
 /// found — concept: tonk:site" dump at a reader who simply does not have
-/// the spot yet. The pulse is right because the state is genuinely
+/// the space yet. The pulse is right because the state is genuinely
 /// transient now: the subscription stays registered in the worker's
 /// waiting room, so when the repo arrives the standing query delivers a
 /// real frame and the view renders in place — no reload, no retry.
@@ -72,7 +72,7 @@ mod tests {
     /// A repo this device has not replicated resolves `tonk:site` to
     /// nothing, so the display lands in `no-model`. Unslotted that is a
     /// "Model not found — concept: tonk:site" dump shown to someone who
-    /// just does not have the spot; slotted, it is a pulse that heals
+    /// just does not have the space; slotted, it is a pulse that heals
     /// itself when the waiting-room subscription delivers its first real
     /// frame.
     #[dialog_common::test]

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -2172,19 +2172,19 @@ mod tests {
         }
     }
 
-    /// The Hub's own wizard creates a local-only spot before anyone
+    /// The Hub's own wizard creates a local-only space before anyone
     /// registers.
     ///
     /// Every other test here builds the claim in Rust, which skips the
     /// form entirely — so a hidden input that prefills a remote is
     /// invisible to them. This one submits the real wizard, which is how
     /// `<tonk-default-remote auto>` went on wiring `origin + /ucan/`
-    /// onto spots created with no account: the form supplied a remote,
+    /// onto spaces created with no account: the form supplied a remote,
     /// the worker honoured it as a deliberate choice, and the gate that
-    /// keeps a spot local never got a say. The spot then synced to a
+    /// keeps a space local never got a say. The space then synced to a
     /// service that refuses to serve it.
     #[dialog_common::test]
-    async fn it_creates_a_local_only_spot_from_the_hub_wizard(env: TestEnvironment) -> Result<()> {
+    async fn it_creates_a_local_only_space_from_the_hub_wizard(env: TestEnvironment) -> Result<()> {
         // The authenticator id comes along so the ceremony can be
         // observed: a passkey either got minted or it did not.
         let (driver, authenticator) = driver_with_prf_authenticator(&env).await?;
@@ -2209,7 +2209,7 @@ mod tests {
             }
             assert!(
                 tokio::time::Instant::now() < deadline,
-                "the wizard never created a spot; before={before:?} now={now:?}",
+                "the wizard never created a space; before={before:?} now={now:?}",
             );
             tokio::time::sleep(Duration::from_millis(250)).await;
         };
@@ -2218,12 +2218,12 @@ mod tests {
         // "no remote" means it declined rather than that we looked early.
         tokio::time::sleep(Duration::from_secs(3)).await;
         let info = get_json(&driver, &format!("/api/repository/{key}")).await?;
-        let info = successful_body("read the spot configuration", &info);
+        let info = successful_body("read the space configuration", &info);
         assert!(
             info["remote"]
                 .as_object()
                 .is_none_or(serde_json::Map::is_empty),
-            "a spot created before registering must wire no remote, got {}",
+            "a space created before registering must wire no remote, got {}",
             info["remote"],
         );
         assert!(
@@ -2232,7 +2232,7 @@ mod tests {
             info["branch"]["main"]["upstream"],
         );
 
-        // The spot is local-only, which is what makes sharing it
+        // The space is local-only, which is what makes sharing it
         // refuse. Walk the rest of the flow from that refusal, asserting
         // at each step on WHAT THE USER SEES rather than on the fact
         // behind it.
@@ -2307,7 +2307,7 @@ mod tests {
         click_register_action(&driver).await?;
 
         // ...and THEN the share it interrupted finishes, which is the
-        // feature: the spot gains the remote it refused to share
+        // feature: the space gains the remote it refused to share
         // without, and the invite link arrives.
         await_share_link(&driver, &key).await?;
 
@@ -3130,7 +3130,7 @@ mod tests {
     ///
     /// Read from the SPACE's branch, keyed by the space, because that is
     /// where the mint writes: `enable-sync` attaches the remote and
-    /// asserts `xyz.tonk.invite/url` on the spot it shared. Profile main
+    /// asserts `xyz.tonk.invite/url` on the space it shared. Profile main
     /// never carries it, so asking there answers `[]` for a share that
     /// worked — which is exactly the report this used to give. The
     /// dialog reads the same row to fill the clipboard, so this is the
@@ -4111,7 +4111,7 @@ mod tests {
     }
 
     #[dialog_common::test]
-    async fn it_backs_up_a_claimed_spot_for_another_account_device(
+    async fn it_backs_up_a_claimed_space_for_another_account_device(
         env: TestEnvironment,
     ) -> Result<()> {
         let creator = driver_with_prf(&env).await?;

--- a/rust/tonk-ui/src/account_gate.rs
+++ b/rust/tonk-ui/src/account_gate.rs
@@ -1,6 +1,6 @@
 //! Returning a signed-in user to where they came from.
 //!
-//! The account page is a top-document route, so opening it leaves the spot
+//! The account page is a top-document route, so opening it leaves the space
 //! the user was on. Whoever sends them there carries `next`, a host-relative
 //! path to return to; the account element reads it back through
 //! [`requested_next`] once its ceremony completes.

--- a/rust/tonk-ui/src/register_dialog.rs
+++ b/rust/tonk-ui/src/register_dialog.rs
@@ -1,6 +1,6 @@
 //! The registration dialog, raised over whatever the user was reading.
 //!
-//! Sharing a spot needs an account, so the share control's refusal
+//! Sharing a space needs an account, so the share control's refusal
 //! (`needs-account`) asks for one here rather than sending the user to
 //! `/account` and losing what they were doing. This is the top page, so
 //! the ceremony can run in place: WebAuthn needs a `window` and a user
@@ -1691,7 +1691,7 @@ pub struct Request {
     /// The refusal class that raised the dialog.
     #[serde(default)]
     pub reason: String,
-    /// The spot the interrupted click was sharing, so it can be
+    /// The space the interrupted click was sharing, so it can be
     /// finished once an account exists.
     #[serde(default)]
     pub space: String,
@@ -1720,7 +1720,7 @@ fn remember_space(space: &str) {
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-/// The spot a finished registration should go on to share.
+/// The space a finished registration should go on to share.
 pub(crate) fn pending_share() -> Option<String> {
     web_sys::window()
         .and_then(|window| window.document())

--- a/rust/tonk-worker-api/src/lib.rs
+++ b/rust/tonk-worker-api/src/lib.rs
@@ -69,7 +69,7 @@ pub use sync::{
 /// `name` alone. No `remote`: where a space syncs is resolved worker-side
 /// from the account's own registration, and a page that supplied one made
 /// every create look like a deliberate choice of this server — which wired
-/// spots created before anyone registered to a service that refuses to
+/// spaces created before anyone registered to a service that refuses to
 /// serve them. No `template` either: template seeding went with the
 /// template libraries, and a field the form does not carry fails to
 /// resolve and aborts the whole command.

--- a/rust/tonk-worker-api/src/share.rs
+++ b/rust/tonk-worker-api/src/share.rs
@@ -11,7 +11,7 @@
 //! only by luck, and a disagreement is silent: the bar would fall through to
 //! its terminal branch and report a refusal it could have repaired.
 
-/// The spot has no upstream, so an invite would land its recipient in a spot
+/// The space has no upstream, so an invite would land its recipient in a space
 /// that can never fill. Repairable: the bar offers to attach this server.
 pub const BLOCKED_NOT_SYNCED: &str = "not-synced";
 
@@ -20,11 +20,11 @@ pub const BLOCKED_NOT_SYNCED: &str = "not-synced";
 /// than minting from a transient local profile.
 pub const BLOCKED_ACCOUNT_REQUIRED: &str = "account-required";
 
-/// The spot's sync server cannot be shared (a local-only or non-UCAN remote).
+/// The space's sync server cannot be shared (a local-only or non-UCAN remote).
 /// Terminal: nothing the user can do from the bar.
 pub const BLOCKED_UNSHAREABLE_REMOTE: &str = "unshareable-remote";
 
-/// The spot has no upstream and this device has no account registered
+/// The space has no upstream and this device has no account registered
 /// with a provider, so there is nothing to attach it to. Repairable, but
 /// not by attaching a remote: the bar asks the user to register.
 ///

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -862,7 +862,7 @@ pub mod tests {
 
     /// The stable code the page routes the account gate off, for both shapes
     /// of "not signed in": no root at all, and a root with no account behind
-    /// it. Neither may create a spot — one that exists without an account is
+    /// it. Neither may create a space — one that exists without an account is
     /// local-only and never backed up, and nothing later would say so.
     /// A space creates before any account exists, delegated to the most
     /// durable key the profile holds (plan/Account model.md §2): the
@@ -945,7 +945,7 @@ pub mod tests {
         );
     }
 
-    /// An attached account is the whole precondition — a spot creates the
+    /// An attached account is the whole precondition — a space creates the
     /// moment one exists.
     ///
     /// Through `PUT /api/repository/{label}` rather than `POST /api/spaces`,
@@ -1453,7 +1453,7 @@ pub mod tests {
     }
 
     /// The FAB dispatches enable-sync through the profile branch even though
-    /// its result is written to the named spot. A standing spot subscription
+    /// its result is written to the named space. A standing space subscription
     /// must receive that link when dispatch drains the command's writes;
     /// otherwise the share control has nothing to settle its clipboard promise
     /// with and times out.
@@ -1477,7 +1477,7 @@ pub mod tests {
         assert_eq!(
             snapshot["conclusions"].as_array().map(Vec::len),
             Some(0),
-            "local-only spot starts without a credential link",
+            "local-only space starts without a credential link",
         );
 
         let command = serde_json::json!({

--- a/rust/tonk-worker/src/router/adopt.rs
+++ b/rust/tonk-worker/src/router/adopt.rs
@@ -115,7 +115,7 @@ mod tests {
             &tonk,
             &subject,
             &configuration,
-            Some("Foreign Spot"),
+            Some("Foreign Space"),
         )
         .await;
         assert!(

--- a/rust/tonk-worker/src/router/command.rs
+++ b/rust/tonk-worker/src/router/command.rs
@@ -115,7 +115,7 @@ impl CommandEnv {
 /// ([`tonk_schema::command::EnableSync`]), not a second handler on
 /// `space/enable-sync`: that trigger attribute belongs to `CreateSpace`, and
 /// `CreateSpaceHandler` always mints a fresh identity first, so anything
-/// registered against it would attach the remote to a brand-new spot rather
+/// registered against it would attach the remote to a brand-new space rather
 /// than the existing one the FAB names.
 ///
 /// [`CreateSpaceHandler`]: super::repository::CreateSpaceHandler

--- a/rust/tonk-worker/src/router/create_invite.rs
+++ b/rust/tonk-worker/src/router/create_invite.rs
@@ -384,7 +384,7 @@ async fn put_shortcut(endpoint: &str, target: String) -> Result<String, TonkWork
         .map_err(|e| TonkWorkerError::Internal(format!("shortcut response: {e}")))
 }
 
-/// Why a spot cannot produce a shareable invite.
+/// Why a space cannot produce a shareable invite.
 ///
 /// Both variants mean an invite that would fail its recipient: one that
 /// can never sync. [`Self::UnshareableRemote`] is terminal;
@@ -440,10 +440,10 @@ impl RemoteRefusal {
     }
 }
 
-/// Say WHY a spot has no upstream, given what this profile's account has
+/// Say WHY a space has no upstream, given what this profile's account has
 /// registered.
 ///
-/// `resolve_remote_url` sees only the repository, so every unsynced spot
+/// `resolve_remote_url` sees only the repository, so every unsynced space
 /// reads as [`RemoteRefusal::NotSynced`] — "attach a remote". That is
 /// the right answer only when there is a provider to attach to. A device
 /// has an account from first boot, so the interesting cases are the ones
@@ -802,7 +802,7 @@ mod tests {
         assert_eq!(invitations[0].inviter.0, root_entity);
     }
 
-    /// A spot created without a remote refuses, and says which case it was.
+    /// A space created without a remote refuses, and says which case it was.
     #[dialog_common::test]
     async fn it_refuses_a_repository_with_no_upstream() {
         use crate::router::create_invite::{RemoteRefusal, RemoteRequirement, resolve_remote_url};

--- a/rust/tonk-worker/src/router/http.rs
+++ b/rust/tonk-worker/src/router/http.rs
@@ -374,7 +374,7 @@ mod tests {
     #[dialog_common::test]
     async fn it_posts_json_with_an_explicit_media_type() {
         let (endpoint, request) =
-            server(b"HTTP/1.1 200 OK\r\ncontent-length: 2\r\nx-tonk-account-spots: v1\r\nconnection: close\r\n\r\n{}");
+            server(b"HTTP/1.1 200 OK\r\ncontent-length: 2\r\nx-tonk-account-spaces: v1\r\nconnection: close\r\n\r\n{}");
         let response = post_json(&endpoint, br#"{"ok":true}"#).await.unwrap();
         assert_eq!(response.status, 200);
         assert_eq!(response.body, b"{}");

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -885,7 +885,7 @@ async fn commit_join(tonk: &TonkState, staged: StagedJoin) -> Result<JoinOutcome
         // The account directory is how another of this account's
         // devices recovers this claim: alongside the membership
         // facts, record the mount configuration the invite carried,
-        // or a fresh sign-in lists a spot it can never mount.
+        // or a fresh sign-in lists a space it can never mount.
         // Renewals record too. Best-effort, and strictly after the local
         // commit — the
         // join is already complete.
@@ -2021,20 +2021,20 @@ mod invite_presence_tests {
     #[test]
     fn it_separates_a_redeemable_invite_from_an_empty_visit() {
         assert!(carries_invite(
-            "https://tonk.spot/join?access=chain&remote=https%3A%2F%2Fs#seed"
+            "https://tonk.space/join?access=chain&remote=https%3A%2F%2Fs#seed"
         ));
         // A malformed chain is still an ATTEMPT: it must reach the claim
         // path and fail with its reason, not be mistaken for an empty visit.
-        assert!(carries_invite("https://tonk.spot/join?access=not-a-chain"));
+        assert!(carries_invite("https://tonk.space/join?access=not-a-chain"));
 
-        assert!(!carries_invite("https://tonk.spot/join"));
-        assert!(!carries_invite("https://tonk.spot/join#seed"));
+        assert!(!carries_invite("https://tonk.space/join"));
+        assert!(!carries_invite("https://tonk.space/join#seed"));
         assert!(
-            !carries_invite("https://tonk.spot/join?access="),
+            !carries_invite("https://tonk.space/join?access="),
             "an empty access parameter carries no chain"
         );
         assert!(!carries_invite(
-            "https://tonk.spot/join?remote=https%3A%2F%2Fs"
+            "https://tonk.space/join?remote=https%3A%2F%2Fs"
         ));
         assert!(!carries_invite("not a url"));
     }
@@ -2921,7 +2921,7 @@ pub(crate) mod tests {
         );
     }
 
-    /// Re-opening an invite link for a spot this profile already holds
+    /// Re-opening an invite link for a space this profile already holds
     /// must not re-route the authority its sync presigns with: the
     /// renewal saves the same account-rooted chain again, and the
     /// certificate walk (which never consults the clock, see
@@ -3195,7 +3195,7 @@ pub(crate) mod tests {
                 .expect("the repository name commits");
         }
 
-        // The shape `core.yaml` seeds for a lean spot: a pinned concept for
+        // The shape `core.yaml` seeds for a lean space: a pinned concept for
         // the canvas, and the cardinality-one `tonk/space` alias pointing at
         // it. The space route mounts whatever that alias resolves to.
         const SPACE_MODEL: &str = r#"concept!: &blank
@@ -3206,7 +3206,7 @@ pub(crate) mod tests {
       the: xyz.tonk.replica/subject
       as: entity
       cardinality: one
-      description: The spot this canvas belongs to
+      description: The space this canvas belongs to
 
 name!:
   this: id:tonk/space

--- a/rust/tonk-worker/src/router/navigate.rs
+++ b/rust/tonk-worker/src/router/navigate.rs
@@ -8,7 +8,7 @@
 //! `<tonk-host>` listens for `navigate` messages and assigns
 //! `window.location`. Used by the join handler (redirect into the
 //! joined space) and the create handler (drop the creator into the
-//! fresh spot).
+//! fresh space).
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use tonk_common::log;

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -327,7 +327,7 @@ fn remote_from_facts(facts: &crate::reactor::EntityFacts) -> Option<String> {
         .filter(|url| !url.is_empty())
 }
 
-/// The `tonk:enable-sync` transient's target spot, read from the raw facts.
+/// The `tonk:enable-sync` transient's target space, read from the raw facts.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 const ENABLE_SYNC_SPACE_ATTR: &str = "xyz.tonk.enable-sync/space";
 
@@ -368,7 +368,7 @@ fn text_fact_any_target(facts: &crate::reactor::EntityFacts, attribute: &str) ->
 /// name. The create forms carry it in a hidden `name` input (the wizard
 /// no longer asks for a name up front); the handler uniquifies it
 /// against the existing space labels via [`next_untitled_label`], and
-/// the user renames the spot later (the FAB's inline editable /
+/// the user renames the space later (the FAB's inline editable /
 /// `tonk/rename-repository`).
 #[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
 const UNTITLED: &str = "Untitled";
@@ -495,7 +495,7 @@ async fn existing_space_labels(state: &AppState) -> Vec<String> {
 /// existing space labels ([`next_untitled_label`]) so consecutive
 /// creates read "Untitled", "Untitled 2", …. Once the space is created
 /// and seeded, the handler posts a `navigate` message back to the
-/// originating client so the creator lands inside the new spot. A
+/// originating client so the creator lands inside the new space. A
 /// remote/auth failure leaves a working local space, retryable from the
 /// topbar.
 ///
@@ -799,7 +799,7 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for InviteHandler
     }
 }
 
-/// Attach a sync remote to an existing spot, then mint an invite when the
+/// Attach a sync remote to an existing space, then mint an invite when the
 /// transient asks for one.
 ///
 /// The share control dispatches this when a user accepts the offer to turn
@@ -994,7 +994,7 @@ async fn run_invite(
     }
 
     // Resolve the sync endpoint BEFORE minting anything. An invite with no
-    // remote lands its recipient in a spot that can never fill, so there is
+    // remote lands its recipient in a space that can never fill, so there is
     // nothing worth generating key material for. Refusing here also means a
     // refusal costs no delegation and rotates no credential.
     let remote_execution = match super::create_invite::resolve_remote_url(&tonk, &repository)
@@ -1029,7 +1029,7 @@ async fn run_invite(
             // `not-synced` is not a refusal either: the account has a
             // provider, this space simply has no remote yet, and
             // attaching one is this handler's next step rather than a
-            // question for the caller. Sharing a local-only spot is
+            // question for the caller. Sharing a local-only space is
             // exactly the moment it earns its remote.
             //
             // Without this the click had nowhere to go. The control's
@@ -1227,11 +1227,11 @@ async fn run_invite(
     Ok(RunInvite::Settled)
 }
 
-/// Record why a share click could not mint, on the spot's content-branch
+/// Record why a share click could not mint, on the space's content-branch
 /// session overlay, keyed by the subject.
 ///
 /// Overlay-only, exactly like the `Credential` a successful mint writes: a
-/// refusal is this device's answer to this click, not a property of the spot,
+/// refusal is this device's answer to this click, not a property of the space,
 /// and it must never replicate. The write schedules a poll, so the dispatcher's
 /// drain fans it out to the share control's subscription in the same pass as a
 /// successful mint would have been.
@@ -1308,7 +1308,7 @@ async fn publish_share_blocked(
 /// `remote` is already a ready-to-append `&remote=…` suffix. It is never
 /// empty: a repo with no shareable remote is refused before any of this
 /// runs, because an invite that carries no remote strands its recipient in
-/// a spot that can never fill. This is the shape the share view used to
+/// a space that can never fill. This is the shape the share view used to
 /// concatenate from three overlay fields; building it here gives it one
 /// definition and lets it be shortened.
 ///
@@ -1875,7 +1875,7 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for RemoveSpaceHa
 ///
 /// 1. Retract its replica record from the profile meta branch
 ///    ([`remove_replica_from_profile`]) — the Hub row's source of
-///    truth, so the spot disappears immediately. This is the commit
+///    truth, so the space disappears immediately. This is the commit
 ///    point; everything after is cleanup.
 /// 2. Evict the repository from the reactor cache
 ///    ([`Reactor::evict`](crate::Reactor::evict)) and forget it in the
@@ -2090,7 +2090,7 @@ async fn remove_replica_from_profile(
     // The account-level directory entry hangs on the repository's own
     // entity, so it needs its own sweep — filtered to the space
     // namespace, because other facts may key on that entity too.
-    // Removing it is what makes "delete spot" account-wide: every
+    // Removing it is what makes "delete space" account-wide: every
     // device's Hub lists the directory, not this device's replica row.
     let directory = meta
         .handle()
@@ -3605,7 +3605,7 @@ pub async fn get_repository(
 
     // First use of a directory-listed space this device has not
     // replicated mounts it on demand — same lazy adoption the query
-    // route performs, so a second device can address a spot straight
+    // route performs, so a second device can address a space straight
     // from the synced account directory. A no-op for mounted repos.
     // The outcome rides the not-found error: a swallowed mount failure
     // turns an explainable miss into a bare 404.
@@ -4532,7 +4532,7 @@ mod space_config_tests {
 /// decode) so an older, frozen profile descriptor still triggers it. That
 /// tolerance cuts both ways: a renamed attribute on either side doesn't
 /// fail — the fact simply never matches, the field reads as absent, and
-/// the spot is created missing the remote with nothing logged. Pin both
+/// the space is created missing the remote with nothing logged. Pin both
 /// sides against the seeded document. Native.
 #[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod form_attribute_tests {
@@ -4548,12 +4548,12 @@ mod form_attribute_tests {
     ///
     /// It used to: the Hub filled a hidden input from
     /// `<tonk-default-remote auto>`, and this test pinned the two
-    /// spellings together. Then a spot stopped earning its remote at
+    /// spellings together. Then a space stopped earning its remote at
     /// creation — the worker resolves where a space syncs from the
-    /// account's own registration, so a spot made before anyone
+    /// account's own registration, so a space made before anyone
     /// registers stays local until it is shared. A form that names a
     /// remote would wire one anyway, which is the behaviour
-    /// `it_creates_a_local_only_spot_from_the_hub_wizard` refuses.
+    /// `it_creates_a_local_only_space_from_the_hub_wizard` refuses.
     ///
     /// `REMOTE_ATTR` stays readable so a frozen older descriptor that
     /// still declares the field keeps working; it is simply no longer
@@ -4562,7 +4562,7 @@ mod form_attribute_tests {
     fn it_declares_no_remote_on_the_create_form() {
         assert!(
             !PROFILE_LIBRARY.contains(REMOTE_ATTR),
-            "profile.yaml declares `the: {REMOTE_ATTR}` again — a spot \
+            "profile.yaml declares `the: {REMOTE_ATTR}` again — a space \
              would wire a remote at creation instead of earning one when \
              it is shared",
         );
@@ -6156,7 +6156,7 @@ mod tests {
 
     /// The refusal class follows the account's registration state.
     ///
-    /// Same spot, same missing upstream, three different remedies: an
+    /// Same space, same missing upstream, three different remedies: an
     /// account that is served can attach one, an enrolled account is
     /// waiting on its email, and an unregistered one has to register.
     #[dialog_common::test]
@@ -6206,7 +6206,7 @@ mod tests {
         );
     }
 
-    /// A share click on a spot with no upstream mints nothing and leaves a
+    /// A share click on a space with no upstream mints nothing and leaves a
     /// refusal on the overlay instead.
     ///
     /// The class says WHY there is no upstream. This profile has never
@@ -6261,7 +6261,7 @@ mod tests {
     /// POST a remote config to `key`, exactly as the topbar and the share
     /// prompt's confirm do. Unlike [`attach_remote`] it names no relay
     /// unless asked, so a test can produce the pre-in-band-revocation shape:
-    /// a spot that syncs but cannot mint.
+    /// a space that syncs but cannot mint.
     async fn post_remote(
         app: &Router,
         key: &str,
@@ -6302,7 +6302,7 @@ mod tests {
     /// A second attach does not repoint a remote that is already there.
     ///
     /// The share prompt builds its endpoint from the page's origin, which
-    /// need not be the origin the spot actually syncs through, and dialog
+    /// need not be the origin the space actually syncs through, and dialog
     /// leaves an existing remote as-is — so the meta mirror has to keep
     /// describing the remote that is really there rather than adopting the
     /// caller's.
@@ -6384,11 +6384,11 @@ mod tests {
             .collect()
     }
 
-    /// Attaching a remote through the command targets the EXISTING spot. The
+    /// Attaching a remote through the command targets the EXISTING space. The
     /// `space/enable-sync` command in `core.yaml` shares `CreateSpace`'s trigger
-    /// attribute and so mints a new spot instead; this guards against that.
+    /// attribute and so mints a new space instead; this guards against that.
     #[dialog_common::test]
-    async fn it_attaches_the_remote_to_the_existing_spot() {
+    async fn it_attaches_the_remote_to_the_existing_space() {
         let (app, state, _lsp) = api_router_with_state(test_state().await);
         let (key, subject) = put_repo_info(&app, "test-enable-sync").await;
         let before = existing_space_labels(&state).await.len();
@@ -6398,11 +6398,11 @@ mod tests {
         assert_eq!(
             existing_space_labels(&state).await.len(),
             before,
-            "no new spot was created"
+            "no new space was created"
         );
         assert!(
             has_remote_upstream(&state, &key).await,
-            "the existing spot now tracks origin/main"
+            "the existing space now tracks origin/main"
         );
     }
 

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -1866,7 +1866,7 @@ impl TonkServiceWorker {
                 // and a failure there (an unhydrated account, a closed
                 // page) must not strand seeds until the next link.
                 crate::router::rotation::rotate_from_onboarding(&tonk).await;
-                // Overlay locality stamps for the Hub's hollow-spot
+                // Overlay locality stamps for the Hub's hollow-card
                 // styling — device-local, re-stamped every boot.
                 crate::router::adopt::stamp_local_spaces(&tonk).await;
             });


### PR DESCRIPTION
## Stack

Depends on #826.

## Summary

- sanitize rejected legacy CLI commands, options, and environment variables so public errors use only current space terminology
- normalize rendered Storybook copy, generated Rust documentation, product descriptions, comments, and test fixtures
- preserve only machine-required compatibility readers and negative regression inputs

Storybook updated: glossary terminology audit. No screen pixels changed.

## Testing

- cargo test -p tonk-cli --test cli_space
- cargo test -p tonk-worker --lib
- cargo test -p tonk-worker --test standard_library
- cargo test -p dialog-reactor
- cargo fmt --all --check
- cargo doc --no-deps for the affected public crates (passes with existing unrelated broken-link warnings)
- python3 docs/storybook/scripts/build.py --check
- python3 docs/storybook/scripts/check-links.py docs/storybook
- python3 docs/storybook/scripts/build.py --check --base origin/fix/user-facing-space-terminology
- generated Rustdoc and complete CLI help audits contain no retired product noun

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming references from `spot` to `space` throughout the codebase, ensuring consistent terminology and improving clarity in the context of the application's architecture.

### Detailed summary
- Renamed `spot` to `space` in multiple files for consistency.
- Updated comments and documentation to reflect the new terminology.
- Adjusted error messages and assertions to use `space` instead of `spot`.
- Ensured compatibility with legacy data structures during the transition.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->