### PR TITLE
Make account setup recoverable after response loss

### DIFF
--- a/plan/audit-account-setup-provider.md
+++ b/plan/audit-account-setup-provider.md
@@ -10,7 +10,9 @@
 - The shared `tonk-account::creation` input and algorithm are the single source of truth for provider and client fingerprints. Its wire form is exactly 64 lowercase hexadecimal characters; its version-1 test vector is pinned.
 - The random attachment ID and server-selected account/device creation time are excluded from equality and the fingerprint.
 - Every non-exact conflict retains the current conflict classification and must not expose SQLite/D1 driver text.
-- Setup status is signed by the device through one command-open, subject-open, unexpired `root -> device` proof. It may query only the invocation subject root, never a caller-supplied email or root.
+- Account creation, device registration, and setup status share one canonical stable-grant validator: exactly one valid `root -> device` proof, expected issuer/audience, subject-open, command-open, and no not-before or expiration.
+- Setup status additionally requires the invocation audience to equal its root subject. It may query only that subject root, never a caller-supplied email or root.
+- Missing/deleted accounts, missing or inactive first devices, and nonmatching device DIDs or delegation CIDs are deliberately indistinguishable as `Absent`; only the exact active first-device proof may receive `Accepted` or `Mismatch`.
 - Do not add a database migration or new dependency. If the live schema cannot support the contract, stop before changing it.
 - This provider-only PR changes no rendered UI or copy, so it does not add Storybook journeys; API documentation and executable HTTP coverage record the contract.
 
@@ -56,14 +58,21 @@
 
 **Interfaces:**
 - Consumes: command `['account', 'setup', 'status']` with required `createFingerprint` and exactly one attached root-to-device delegation.
-- Produces: `SetupCaller { root_did, device_did, delegation_cid, arguments }` only after invocation/delegation signatures, five-minute expiry, issuer/audience alignment, root issuer, subject-open shape, and command-open shape verify.
+- Produces: `SetupCaller { root_did, device_did, delegation_cid, arguments }` only after the invocation signature and five-minute expiry, audience/root-subject equality, and the shared stable-grant validator all succeed.
 - Produces: `{ "status": "absent" }`, `{ "status": "accepted", "accountId", "descriptorHex", "createFingerprint" }`, or `{ "status": "mismatch" }`.
 
 - [x] Add auth tests proving a valid root-to-device invocation succeeds without a store/account row, while missing proof, a proof from the wrong root, a proof delegated to a different device, subject-specific proof, and command-scoped proof fail. The focused positive test failed to compile before the helper existed.
 - [x] Implement the narrow verifier by extending the already verified invocation chain; it accepts no root/email argument and calls no `Store` method.
-- [x] Add setup-status core tests: valid unknown root returns `Absent`; exact persisted state and matching first-device proof returns `Accepted`; a wrong 32-byte fingerprint returns `Mismatch`; mismatched device DID/CID and inactive first device are rejected; malformed legacy descriptor/delegation state cannot be reported as accepted.
+- [x] Add setup-status core tests: valid unknown root returns `Absent`; exact persisted state and matching first-device proof returns `Accepted`; a wrong 32-byte fingerprint returns `Mismatch`; mismatched device DID/CID and inactive or missing first-device state return `Absent`; malformed legacy descriptor/delegation state cannot be reported as accepted.
 - [x] Implement status lookup by verified root, require the proof to name the stored earliest active device and delegation CID, reconstruct the same fingerprint, and return only the typed outcome.
 - [x] Run focused auth/status tests and adjacent auth/core suites; all focused filters pass.
+
+### Independent review follow-up
+
+- [x] RED/GREEN: reject command-scoped, expiring, and not-before first-device grants that account creation previously accepted, using the same validator for creation/device registration and setup authentication.
+- [x] RED/GREEN: collapse missing account/first-device, inactive first-device, wrong device DID, and wrong delegation CID to the exact `Absent` result while retaining `Mismatch` for an exact active first device with different creation facts.
+- [x] RED/GREEN: reject a setup invocation whose audience differs from its root subject.
+- [x] Re-run both affected packages, warning-denied all-target clippy, rustfmt/diff checks, and the account-service-only Cloudflare build; all pass before the follow-up commit.
 
 ### Task 3: Keep Cloudflare and native HTTP contracts identical
 
@@ -79,7 +88,7 @@
 - `OPTIONS /accounts/setup-status`: returns the service's existing CORS headers.
 
 - [x] Add an HTTP response-loss test that discards the first 201 body, replays the exact bytes, and requires 200 plus `reused: true`, the original ID/descriptor/fingerprint, and no duplicate device.
-- [x] Add HTTP tests for accepted, mismatch, and valid-proof absent status; unknown/missing proof, wrong device/delegation, wrong command, and malformed fingerprint produce structured 4xx errors without raw DB text or account details.
+- [x] Add HTTP tests for accepted, mismatch, and valid-proof absent status; wrong device/delegation and deleted accounts receive the same `200 Absent` body, while missing proof, wrong command, and malformed fingerprint produce structured 4xx errors without raw DB text or account details.
 - [x] Run the status HTTP test before routing; it failed with the expected 404. Exact replay had already failed at the core conflict boundary in the first RED run.
 - [x] Implement the Worker handler/routes, native helper route, response status selection, JSON serialization, and preflight registration from the same core/auth seams.
 - [x] Run the focused response-loss, privacy, and CORS HTTP filters; each passes. Native HTTP filters required loopback permission after the sandbox rejected binding before behavior ran.
@@ -95,9 +104,9 @@
 
 - [x] Update the README with exact request commands, response status codes/fields, proof requirements, and the no-account-existence-leak boundary.
 - [x] Run `cargo fmt --all -- --check` and `git diff --check`; both pass after rustfmt's mechanical layout changes.
-- [x] Run `cargo test -p tonk-account` (35 unit plus 1 integration test) and `cargo test -p tonk-account-service --features helpers` (49 unit plus 9 native HTTP integration tests); all pass. The service package ran with loopback permission because the restricted sandbox had already denied native listener binding before behavior.
+- [x] Run `cargo test -p tonk-account` (35 unit plus 1 integration test) and `cargo test -p tonk-account-service --features helpers` (52 unit plus 9 native HTTP integration tests); all pass. The service package ran with loopback permission because the restricted sandbox had already denied native listener binding before behavior.
 - [x] Run all-target warning-denied clippy for both `tonk-account` and `tonk-account-service --features helpers`; both pass.
-- [x] Run the repository-defined account-service-only Cloudflare build, `nix build path:.#tonk-account-service --no-link`; the final source passes at `/nix/store/f89778xgprap6jl7qgmbqkm2rmh0r8hv-tonk-account-service-0.6.9` without building `tonk-ui`.
+- [x] Run the repository-defined account-service-only Cloudflare build, `nix build path:.#tonk-account-service --no-link`; the final follow-up source passes at `/nix/store/xhi7wq04sghi5mcg23xnynbwfghjypna-tonk-account-service-0.6.9` without building `tonk-ui`.
 - [x] Re-read the final diff against every mismatch and privacy requirement, update this plan with fresh green evidence, and confirm no migration, lock-file change, UI source, or unrelated work entered the branch. That review found and fixed one malformed stored-delegation acceptance gap before commit.
 
 ## Focused TDD evidence
@@ -108,4 +117,7 @@
 - Auth helper RED: the positive setup-proof test did not compile before `authorize_setup_device` existed. GREEN proof-shape matrix passed 1 / 1 with 46 filtered.
 - Status core RED: the absent-status test did not compile before the status contract existed, and the accepted-status test initially returned `Mismatch`. A final mutation proved that merely decoding malformed stored delegation bytes could incorrectly return `Accepted`; that focused run failed 0 / 1 with 48 filtered, then passed unchanged after the stored bytes were revalidated to the authenticated root, device, and CID. The full negative matrix is green.
 - HTTP RED: the response-loss/status test reached the native route and received 404 before registration. GREEN response-loss, privacy/error, and CORS filters each passed 1 / 1. The final response-loss form computes the shared fingerprint before `POST /accounts`, discards the `201` body, and obtains `Accepted` before receiving any replay response.
+- Stable-grant review RED/GREEN: `it_rejects_first_device_grants_that_cannot_survive_response_loss` first accepted and inserted a command-scoped grant (0 passed / 1 failed / 49 filtered), then passed unchanged (1 / 1) after creation, device registration, and setup auth shared the exact-one-proof, valid-signature, issuer/audience, subject-open, command-open, unbounded validator. The same test covers expiring and not-before grants.
+- Status-privacy review RED/GREEN: `it_hides_every_nonmatching_first_device_state_as_absent` first returned `Mismatch` for a missing first device (0 passed / 1 failed / 50 filtered), then passed unchanged (1 / 1) after missing/inactive/wrong-device/wrong-CID states collapsed to `Absent`.
+- Audience review RED/GREEN: `it_rejects_setup_invocations_for_an_unrelated_audience` failed before the binding existed (0 passed / 1 failed / 51 filtered), then passed unchanged (1 / 1) once invocation audience had to equal root subject.
 - The first native HTTP attempt in the restricted sandbox failed to bind loopback with `PermissionDenied` before behavior; every unchanged HTTP filter passed with loopback permission.

--- a/plan/audit-account-setup-provider.md
+++ b/plan/audit-account-setup-provider.md
@@ -1,0 +1,111 @@
+# Account-setup provider recovery implementation plan
+
+**Goal:** Make account creation safe to retry after a lost response and expose a proof-bound setup-status check without revealing whether an arbitrary root or email has an account.
+**Approach:** Validate every creation ceremony before the existing atomic account/device insert, then treat an insert conflict as a successful replay only when the persisted account and its earliest active device reproduce every caller-controlled semantic input. The shared `tonk-account` contract derives a domain-separated, length-framed BLAKE3 fingerprint from those inputs, allowing the caller to retain it before sending the request. A device-signed setup-status invocation can then distinguish absent, accepted, and mismatched provider state without adding mutable setup rows or a schema migration.
+**Constraints:**
+- Base this work only on live `origin/staging` commit `605ab21f548e2404db18d4800afbf67631ea9b94`; do not copy or depend on the dirty browser-account audit worktree.
+- Keep the initial `POST /accounts` response at HTTP 201. An exact replay returns HTTP 200 with `reused: true`; both outcomes carry the same stable account ID, canonical descriptor, and creation fingerprint.
+- Continue attempting the atomic account/device insert first. Recovery is allowed only after its conflict and only after the descriptor and delegation have passed full cryptographic validation.
+- The normalized email is the service's existing lowercase form, and the optional passkey `createdOn` label is trimmed. Credential ID, optional passkey presence/creation time, canonical descriptor bytes, first-device DID/name, and delegation CID plus decoded bytes must otherwise match exactly.
+- The shared `tonk-account::creation` input and algorithm are the single source of truth for provider and client fingerprints. Its wire form is exactly 64 lowercase hexadecimal characters; its version-1 test vector is pinned.
+- The random attachment ID and server-selected account/device creation time are excluded from equality and the fingerprint.
+- Every non-exact conflict retains the current conflict classification and must not expose SQLite/D1 driver text.
+- Setup status is signed by the device through one command-open, subject-open, unexpired `root -> device` proof. It may query only the invocation subject root, never a caller-supplied email or root.
+- Do not add a database migration or new dependency. If the live schema cannot support the contract, stop before changing it.
+- This provider-only PR changes no rendered UI or copy, so it does not add Storybook journeys; API documentation and executable HTTP coverage record the contract.
+
+## File map
+
+- `plan/audit-account-setup-provider.md`: durable scope, invariants, TDD sequence, and verification evidence.
+- `rust/tonk-account/src/creation.rs`: caller-visible canonical fingerprint input, versioned algorithm, strict wire parser, and fixed test vector.
+- `rust/tonk-account/src/lib.rs`: exports the shared creation-recovery contract.
+- `rust/tonk-account-service/src/core/accounts.rs`: canonical stored creation facts, shared fingerprint adapter, exact-conflict recovery, and typed setup-status policy.
+- `rust/tonk-account-service/src/auth.rs`: narrow root-to-device setup proof verifier that does not consult account storage.
+- `rust/tonk-account-service/src/handlers/accounts.rs`: Cloudflare create replay response and setup-status handler.
+- `rust/tonk-account-service/src/helpers/server.rs`: native route parity for status codes, JSON, CORS, and integration tests.
+- `rust/tonk-account-service/src/lib.rs`: Worker route and preflight registration.
+- `rust/tonk-account-service/tests/service.rs`: response-loss replay, status outcomes, proof rejection, and wire-error regressions.
+- `rust/tonk-account-service/README.md`: public request/response, authentication, fingerprint, and deployment-order contract.
+
+### Task 1: Recover only an exact account-creation replay
+
+**Files:**
+- Create: `rust/tonk-account/src/creation.rs`
+- Modify: `rust/tonk-account/src/lib.rs`
+- Modify: `rust/tonk-account-service/src/core/accounts.rs:CreateAccount, create_account, tests`
+- Test: `rust/tonk-account-service/src/core/accounts.rs:tests`
+
+**Interfaces:**
+- Produces: `CreateAccountOutcome { account_id: i64, descriptor: Vec<u8>, create_fingerprint: String, reused: bool }`.
+- Produces: shared `AccountCreationFingerprintInput` and strict `AccountCreationFingerprint` types so a caller can calculate and retain the fingerprint before `POST /accounts`.
+- Produces: lowercase 64-hex `createFingerprint`, BLAKE3 domain `tonk-account-create-v1`, over explicit length-framed semantic fields in the order email, root DID, credential ID, passkey option/value, descriptor bytes, device DID, device name, delegation CID, delegation bytes. The pinned version-1 vector is `35cda4b0895490a01c4307584da2fe045c568b53d9817b3f38c97309a07dbb52`.
+- Consumes: the current `Store::create_account_with_device`, `Store::account_by_root`, and `Store::devices` methods; no store or schema extension is required.
+
+- [x] Add `it_reuses_only_an_exact_account_creation` with normalized-equivalent email, passkey label, descriptor hex, delegation hex, and a second random attachment candidate; require the same account ID/descriptor/fingerprint, `reused: true`, and exactly one unchanged device row. Its first focused run failed through the existing `CeremonyError::Conflict` path before implementation.
+- [x] Add the shared caller-visible fingerprint contract, fixed vector, and strict parse/format test, then adapt immutable service creation facts to that contract.
+- [x] Implement post-conflict comparison against the account plus earliest device row. Require the earliest row to remain active; compare decoded delegation bytes and exclude attachment ID and provider timestamps.
+- [x] Add a semantic mismatch regression covering normalized email, root DID through a separately valid ceremony, credential ID, absent/present passkey metadata, each passkey field, a different valid descriptor for the same root, a different delegated device DID, device name, and a newly minted delegation. Every case retains `EMAIL_TAKEN` or `ROOT_TAKEN` and never returns an account outcome.
+- [x] Convert the existing database-text regression into a non-exact replay so it still proves raw SQLite/D1 details cannot cross the boundary.
+- [x] Run the exact replay and mismatch filters plus adjacent `core::accounts::tests`; all focused filters pass.
+
+### Task 2: Authenticate and answer setup status without arbitrary lookup
+
+**Files:**
+- Modify: `rust/tonk-account-service/src/auth.rs:verified_chain, setup-proof helper, tests`
+- Modify: `rust/tonk-account-service/src/core/accounts.rs:AccountSetupStatus, account_setup_status, tests`
+
+**Interfaces:**
+- Consumes: command `['account', 'setup', 'status']` with required `createFingerprint` and exactly one attached root-to-device delegation.
+- Produces: `SetupCaller { root_did, device_did, delegation_cid, arguments }` only after invocation/delegation signatures, five-minute expiry, issuer/audience alignment, root issuer, subject-open shape, and command-open shape verify.
+- Produces: `{ "status": "absent" }`, `{ "status": "accepted", "accountId", "descriptorHex", "createFingerprint" }`, or `{ "status": "mismatch" }`.
+
+- [x] Add auth tests proving a valid root-to-device invocation succeeds without a store/account row, while missing proof, a proof from the wrong root, a proof delegated to a different device, subject-specific proof, and command-scoped proof fail. The focused positive test failed to compile before the helper existed.
+- [x] Implement the narrow verifier by extending the already verified invocation chain; it accepts no root/email argument and calls no `Store` method.
+- [x] Add setup-status core tests: valid unknown root returns `Absent`; exact persisted state and matching first-device proof returns `Accepted`; a wrong 32-byte fingerprint returns `Mismatch`; mismatched device DID/CID and inactive first device are rejected; malformed legacy descriptor/delegation state cannot be reported as accepted.
+- [x] Implement status lookup by verified root, require the proof to name the stored earliest active device and delegation CID, reconstruct the same fingerprint, and return only the typed outcome.
+- [x] Run focused auth/status tests and adjacent auth/core suites; all focused filters pass.
+
+### Task 3: Keep Cloudflare and native HTTP contracts identical
+
+**Files:**
+- Modify: `rust/tonk-account-service/src/handlers/accounts.rs:handle_inner, setup status handler`
+- Modify: `rust/tonk-account-service/src/helpers/server.rs:dispatch, accounts_route, setup-status route`
+- Modify: `rust/tonk-account-service/src/lib.rs:Worker routes`
+- Test: `rust/tonk-account-service/tests/service.rs`
+
+**Interfaces:**
+- `POST /accounts`: initial create returns 201; exact replay returns 200. Both return `{ accountId, descriptorHex, createFingerprint, reused }`.
+- `POST /accounts/setup-status`: accepts the CBOR invocation above and returns one typed JSON status with HTTP 200. Authentication/argument failures retain structured 4xx responses; storage failures retain generic 500 responses.
+- `OPTIONS /accounts/setup-status`: returns the service's existing CORS headers.
+
+- [x] Add an HTTP response-loss test that discards the first 201 body, replays the exact bytes, and requires 200 plus `reused: true`, the original ID/descriptor/fingerprint, and no duplicate device.
+- [x] Add HTTP tests for accepted, mismatch, and valid-proof absent status; unknown/missing proof, wrong device/delegation, wrong command, and malformed fingerprint produce structured 4xx errors without raw DB text or account details.
+- [x] Run the status HTTP test before routing; it failed with the expected 404. Exact replay had already failed at the core conflict boundary in the first RED run.
+- [x] Implement the Worker handler/routes, native helper route, response status selection, JSON serialization, and preflight registration from the same core/auth seams.
+- [x] Run the focused response-loss, privacy, and CORS HTTP filters; each passes. Native HTTP filters required loopback permission after the sandbox rejected binding before behavior ran.
+
+### Task 4: Document and verify the provider slice
+
+**Files:**
+- Modify: `rust/tonk-account-service/README.md:API and deployment order`
+- Modify: `plan/audit-account-setup-provider.md:verification evidence`
+
+**Interfaces:**
+- Documents: retry semantics, exact fingerprint inputs/exclusions, setup-status proof requirements, response shapes, mismatch privacy, and deployment order before a browser client begins recovery calls.
+
+- [x] Update the README with exact request commands, response status codes/fields, proof requirements, and the no-account-existence-leak boundary.
+- [x] Run `cargo fmt --all -- --check` and `git diff --check`; both pass after rustfmt's mechanical layout changes.
+- [x] Run `cargo test -p tonk-account` (35 unit plus 1 integration test) and `cargo test -p tonk-account-service --features helpers` (49 unit plus 9 native HTTP integration tests); all pass. The service package ran with loopback permission because the restricted sandbox had already denied native listener binding before behavior.
+- [x] Run all-target warning-denied clippy for both `tonk-account` and `tonk-account-service --features helpers`; both pass.
+- [x] Run the repository-defined account-service-only Cloudflare build, `nix build path:.#tonk-account-service --no-link`; the final source passes at `/nix/store/f89778xgprap6jl7qgmbqkm2rmh0r8hv-tonk-account-service-0.6.9` without building `tonk-ui`.
+- [x] Re-read the final diff against every mismatch and privacy requirement, update this plan with fresh green evidence, and confirm no migration, lock-file change, UI source, or unrelated work entered the branch. That review found and fixed one malformed stored-delegation acceptance gap before commit.
+
+## Focused TDD evidence
+
+- Exact replay RED: `it_reuses_only_an_exact_account_creation` ran 0 passed / 1 failed / 42 filtered; SQLite's root uniqueness conflict was safely classified as `an account already exists for this passkey`.
+- Exact replay GREEN, including every normalization-equivalent form: 1 passed / 0 failed / 47 filtered.
+- Shared fingerprint contract RED: the fixed-vector test did not compile before the shared types existed. GREEN fixed-vector and strict parse/format filters each passed 1 / 1 with 34 filtered.
+- Auth helper RED: the positive setup-proof test did not compile before `authorize_setup_device` existed. GREEN proof-shape matrix passed 1 / 1 with 46 filtered.
+- Status core RED: the absent-status test did not compile before the status contract existed, and the accepted-status test initially returned `Mismatch`. A final mutation proved that merely decoding malformed stored delegation bytes could incorrectly return `Accepted`; that focused run failed 0 / 1 with 48 filtered, then passed unchanged after the stored bytes were revalidated to the authenticated root, device, and CID. The full negative matrix is green.
+- HTTP RED: the response-loss/status test reached the native route and received 404 before registration. GREEN response-loss, privacy/error, and CORS filters each passed 1 / 1. The final response-loss form computes the shared fingerprint before `POST /accounts`, discards the `201` body, and obtains `Accepted` before receiving any replay response.
+- The first native HTTP attempt in the restricted sandbox failed to bind loopback with `PermissionDenied` before behavior; every unchanged HTTP filter passed with loopback permission.

--- a/plan/audit-account-setup-provider.md
+++ b/plan/audit-account-setup-provider.md
@@ -1,7 +1,7 @@
 # Account-setup provider recovery implementation plan
 
 **Goal:** Make account creation safe to retry after a lost response and expose a proof-bound setup-status check without revealing whether an arbitrary root or email has an account.
-**Approach:** Validate every creation ceremony before the existing atomic account/device insert, then treat an insert conflict as a successful replay only when the persisted account and its earliest active device reproduce every caller-controlled semantic input. The shared `tonk-account` contract derives a domain-separated, length-framed BLAKE3 fingerprint from those inputs, allowing the caller to retain it before sending the request. A device-signed setup-status invocation can then distinguish absent, accepted, and mismatched provider state without adding mutable setup rows or a schema migration.
+**Approach:** Validate every creation ceremony before the existing atomic account/device insert, then treat an insert conflict as a successful replay only when the persisted account and its earliest active device reproduce every caller-controlled semantic input. The shared `tonk-account` contract derives a domain-separated, length-framed BLAKE3 fingerprint from those inputs, allowing the caller to retain it before sending the request. A device-signed setup-status invocation can then distinguish absent, accepted, and mismatched provider state without adding mutable setup rows or a schema migration. A privacy-neutral, CORS-readable capability marker lets clients confirm that full contract before creating a credential.
 **Constraints:**
 - Base this work only on live `origin/staging` commit `605ab21f548e2404db18d4800afbf67631ea9b94`; do not copy or depend on the dirty browser-account audit worktree.
 - Keep the initial `POST /accounts` response at HTTP 201. An exact replay returns HTTP 200 with `reused: true`; both outcomes carry the same stable account ID, canonical descriptor, and creation fingerprint.
@@ -13,6 +13,7 @@
 - Account creation, device registration, and setup status share one canonical stable-grant validator: exactly one valid `root -> device` proof, expected issuer/audience, subject-open, command-open, policy-free (an empty predicate list), and no not-before or expiration.
 - Setup status additionally requires the invocation audience to equal its root subject. It may query only that subject root, never a caller-supplied email or root.
 - Missing/deleted accounts, missing or inactive first devices, and nonmatching device DIDs or delegation CIDs are deliberately indistinguishable as `Absent`; only the exact active first-device proof may receive `Accepted` or `Mismatch`.
+- `GET /capabilities` returns only the service name and numeric `accountSetupRecovery: 1`; it performs no account lookup and exposes no identity-specific state.
 - Do not add a database migration or new dependency. If the live schema cannot support the contract, stop before changing it.
 - This provider-only PR changes no rendered UI or copy, so it does not add Storybook journeys; API documentation and executable HTTP coverage record the contract.
 
@@ -23,6 +24,7 @@
 - `rust/tonk-account/src/lib.rs`: exports the shared creation-recovery contract.
 - `rust/tonk-account-service/src/core/accounts.rs`: canonical stored creation facts, shared fingerprint adapter, exact-conflict recovery, and typed setup-status policy.
 - `rust/tonk-account-service/src/auth.rs`: narrow root-to-device setup proof verifier that does not consult account storage.
+- `rust/tonk-account-service/src/handlers/capabilities.rs`: shared exact capability payload plus the CORS-wrapped Worker handler.
 - `rust/tonk-account-service/src/handlers/accounts.rs`: Cloudflare create replay response and setup-status handler.
 - `rust/tonk-account-service/src/helpers/server.rs`: native route parity for status codes, JSON, CORS, and integration tests.
 - `rust/tonk-account-service/src/lib.rs`: Worker route and preflight registration.
@@ -79,6 +81,12 @@
 - [x] RED/GREEN: reject a non-empty predicate policy at the shared durable-grant boundary, so account creation/device registration cannot persist a grant that setup-status chain verification will later refuse after a lost response.
 - [x] Re-run both affected packages, warning-denied all-target clippy, rustfmt/diff checks, and the account-service-only Cloudflare build before the third commit; 35 unit plus 1 integration `tonk-account` tests, 53 unit plus 9 native HTTP account-service tests, both Clippy gates, and `/nix/store/4wdc713zip5rxyjg05cwsi7bwc8blsam-tonk-account-service-0.6.9` all pass.
 
+### Final capability follow-up
+
+- [x] RED/GREEN: require `GET /capabilities` to return HTTP 200, the exact numeric account-setup recovery marker, and CORS headers; the focused native HTTP test first received the existing 404, then passed unchanged after Worker/native route registration.
+- [x] Pin one deterministically serialized payload shared by the Worker handler and native helper, advertise `GET, POST, OPTIONS`, and register an exact Worker `OPTIONS /capabilities` route.
+- [x] Re-run the account-service package, warning-denied all-target Clippy, rustfmt/diff checks, and the account-service-only Cloudflare build before the fourth commit; 54 unit plus 10 native HTTP tests, Clippy, and `/nix/store/f85nyy0sdbsyyk8qmk1bmvr1mb7gzqay-tonk-account-service-0.6.9` all pass.
+
 ### Task 3: Keep Cloudflare and native HTTP contracts identical
 
 **Files:**
@@ -88,6 +96,8 @@
 - Test: `rust/tonk-account-service/tests/service.rs`
 
 **Interfaces:**
+- `GET /capabilities`: returns exactly `{ "service": "tonk-account-service", "capabilities": { "accountSetupRecovery": 1 } }` with HTTP 200 and CORS headers; no account state is read.
+- `OPTIONS /capabilities`: returns 204 with `GET, POST, OPTIONS` allowed.
 - `POST /accounts`: initial create returns 201; exact replay returns 200. Both return `{ accountId, descriptorHex, createFingerprint, reused }`.
 - `POST /accounts/setup-status`: accepts the CBOR invocation above and returns one typed JSON status with HTTP 200. Authentication/argument failures retain structured 4xx responses; storage failures retain generic 500 responses.
 - `OPTIONS /accounts/setup-status`: returns the service's existing CORS headers.
@@ -97,6 +107,7 @@
 - [x] Run the status HTTP test before routing; it failed with the expected 404. Exact replay had already failed at the core conflict boundary in the first RED run.
 - [x] Implement the Worker handler/routes, native helper route, response status selection, JSON serialization, and preflight registration from the same core/auth seams.
 - [x] Run the focused response-loss, privacy, and CORS HTTP filters; each passes. Native HTTP filters required loopback permission after the sandbox rejected binding before behavior ran.
+- [x] Add native HTTP and shared handler-payload tests for the capability marker, exact response, GET-enabled CORS, and preflight parity.
 
 ### Task 4: Document and verify the provider slice
 
@@ -105,13 +116,13 @@
 - Modify: `plan/audit-account-setup-provider.md:verification evidence`
 
 **Interfaces:**
-- Documents: retry semantics, exact fingerprint inputs/exclusions, setup-status proof requirements, response shapes, mismatch privacy, and deployment order before a browser client begins recovery calls.
+- Documents: retry semantics, exact fingerprint inputs/exclusions, setup-status proof requirements, response shapes, mismatch privacy, the capability marker, and deployment order before a browser client begins recovery calls.
 
 - [x] Update the README with exact request commands, response status codes/fields, proof requirements, and the no-account-existence-leak boundary.
 - [x] Run `cargo fmt --all -- --check` and `git diff --check`; both pass after rustfmt's mechanical layout changes.
-- [x] Run `cargo test -p tonk-account` (35 unit plus 1 integration test) and `cargo test -p tonk-account-service --features helpers` (53 unit plus 9 native HTTP integration tests); all pass. The service package ran with loopback permission because the restricted sandbox had already denied native listener binding before behavior.
+- [x] Run `cargo test -p tonk-account` (35 unit plus 1 integration test) and `cargo test -p tonk-account-service --features helpers` (54 unit plus 10 native HTTP integration tests); all pass. The service package ran with loopback permission because the restricted sandbox had already denied native listener binding before behavior.
 - [x] Run all-target warning-denied clippy for both `tonk-account` and `tonk-account-service --features helpers`; both pass.
-- [x] Run the repository-defined account-service-only Cloudflare build, `nix build path:.#tonk-account-service --no-link`; the final follow-up source passes at `/nix/store/4wdc713zip5rxyjg05cwsi7bwc8blsam-tonk-account-service-0.6.9` without building `tonk-ui`.
+- [x] Run the repository-defined account-service-only Cloudflare build, `nix build path:.#tonk-account-service --no-link`; the final follow-up source passes at `/nix/store/f85nyy0sdbsyyk8qmk1bmvr1mb7gzqay-tonk-account-service-0.6.9` without building `tonk-ui`.
 - [x] Re-read the final diff against every mismatch and privacy requirement, update this plan with fresh green evidence, and confirm no migration, lock-file change, UI source, or unrelated work entered the branch. That review found and fixed one malformed stored-delegation acceptance gap before commit.
 
 ## Focused TDD evidence
@@ -126,4 +137,5 @@
 - Status-privacy review RED/GREEN: `it_hides_every_nonmatching_first_device_state_as_absent` first returned `Mismatch` for a missing first device (0 passed / 1 failed / 50 filtered), then passed unchanged (1 / 1) after missing/inactive/wrong-device/wrong-CID states collapsed to `Absent`.
 - Audience review RED/GREEN: `it_rejects_setup_invocations_for_an_unrelated_audience` failed before the binding existed (0 passed / 1 failed / 51 filtered), then passed unchanged (1 / 1) once invocation audience had to equal root subject.
 - Predicate-policy review RED/GREEN: `it_never_persists_a_policy_scoped_grant_setup_status_would_reject` first proved setup authentication refused an impossible `createFingerprint` predicate while account creation still accepted and inserted that grant (0 passed / 1 failed / 52 filtered), then passed unchanged (1 / 1) after the shared validator required an empty predicate list and returned an actionable `PolicyScoped` error.
+- Capability-route RED/GREEN: `it_advertises_account_setup_recovery_with_cors` first received HTTP 404 from the native helper (0 passed / 1 failed / 9 filtered), then passed unchanged (1 / 1) with the exact shared JSON marker and `GET, POST, OPTIONS` CORS contract. The handler payload unit filter also passes 1 / 1.
 - The first native HTTP attempt in the restricted sandbox failed to bind loopback with `PermissionDenied` before behavior; every unchanged HTTP filter passed with loopback permission.

--- a/plan/audit-account-setup-provider.md
+++ b/plan/audit-account-setup-provider.md
@@ -10,7 +10,7 @@
 - The shared `tonk-account::creation` input and algorithm are the single source of truth for provider and client fingerprints. Its wire form is exactly 64 lowercase hexadecimal characters; its version-1 test vector is pinned.
 - The random attachment ID and server-selected account/device creation time are excluded from equality and the fingerprint.
 - Every non-exact conflict retains the current conflict classification and must not expose SQLite/D1 driver text.
-- Account creation, device registration, and setup status share one canonical stable-grant validator: exactly one valid `root -> device` proof, expected issuer/audience, subject-open, command-open, and no not-before or expiration.
+- Account creation, device registration, and setup status share one canonical stable-grant validator: exactly one valid `root -> device` proof, expected issuer/audience, subject-open, command-open, policy-free (an empty predicate list), and no not-before or expiration.
 - Setup status additionally requires the invocation audience to equal its root subject. It may query only that subject root, never a caller-supplied email or root.
 - Missing/deleted accounts, missing or inactive first devices, and nonmatching device DIDs or delegation CIDs are deliberately indistinguishable as `Absent`; only the exact active first-device proof may receive `Accepted` or `Mismatch`.
 - Do not add a database migration or new dependency. If the live schema cannot support the contract, stop before changing it.
@@ -74,6 +74,11 @@
 - [x] RED/GREEN: reject a setup invocation whose audience differs from its root subject.
 - [x] Re-run both affected packages, warning-denied all-target clippy, rustfmt/diff checks, and the account-service-only Cloudflare build; all pass before the follow-up commit.
 
+### Second independent review follow-up
+
+- [x] RED/GREEN: reject a non-empty predicate policy at the shared durable-grant boundary, so account creation/device registration cannot persist a grant that setup-status chain verification will later refuse after a lost response.
+- [x] Re-run both affected packages, warning-denied all-target clippy, rustfmt/diff checks, and the account-service-only Cloudflare build before the third commit; 35 unit plus 1 integration `tonk-account` tests, 53 unit plus 9 native HTTP account-service tests, both Clippy gates, and `/nix/store/4wdc713zip5rxyjg05cwsi7bwc8blsam-tonk-account-service-0.6.9` all pass.
+
 ### Task 3: Keep Cloudflare and native HTTP contracts identical
 
 **Files:**
@@ -104,9 +109,9 @@
 
 - [x] Update the README with exact request commands, response status codes/fields, proof requirements, and the no-account-existence-leak boundary.
 - [x] Run `cargo fmt --all -- --check` and `git diff --check`; both pass after rustfmt's mechanical layout changes.
-- [x] Run `cargo test -p tonk-account` (35 unit plus 1 integration test) and `cargo test -p tonk-account-service --features helpers` (52 unit plus 9 native HTTP integration tests); all pass. The service package ran with loopback permission because the restricted sandbox had already denied native listener binding before behavior.
+- [x] Run `cargo test -p tonk-account` (35 unit plus 1 integration test) and `cargo test -p tonk-account-service --features helpers` (53 unit plus 9 native HTTP integration tests); all pass. The service package ran with loopback permission because the restricted sandbox had already denied native listener binding before behavior.
 - [x] Run all-target warning-denied clippy for both `tonk-account` and `tonk-account-service --features helpers`; both pass.
-- [x] Run the repository-defined account-service-only Cloudflare build, `nix build path:.#tonk-account-service --no-link`; the final follow-up source passes at `/nix/store/xhi7wq04sghi5mcg23xnynbwfghjypna-tonk-account-service-0.6.9` without building `tonk-ui`.
+- [x] Run the repository-defined account-service-only Cloudflare build, `nix build path:.#tonk-account-service --no-link`; the final follow-up source passes at `/nix/store/4wdc713zip5rxyjg05cwsi7bwc8blsam-tonk-account-service-0.6.9` without building `tonk-ui`.
 - [x] Re-read the final diff against every mismatch and privacy requirement, update this plan with fresh green evidence, and confirm no migration, lock-file change, UI source, or unrelated work entered the branch. That review found and fixed one malformed stored-delegation acceptance gap before commit.
 
 ## Focused TDD evidence
@@ -120,4 +125,5 @@
 - Stable-grant review RED/GREEN: `it_rejects_first_device_grants_that_cannot_survive_response_loss` first accepted and inserted a command-scoped grant (0 passed / 1 failed / 49 filtered), then passed unchanged (1 / 1) after creation, device registration, and setup auth shared the exact-one-proof, valid-signature, issuer/audience, subject-open, command-open, unbounded validator. The same test covers expiring and not-before grants.
 - Status-privacy review RED/GREEN: `it_hides_every_nonmatching_first_device_state_as_absent` first returned `Mismatch` for a missing first device (0 passed / 1 failed / 50 filtered), then passed unchanged (1 / 1) after missing/inactive/wrong-device/wrong-CID states collapsed to `Absent`.
 - Audience review RED/GREEN: `it_rejects_setup_invocations_for_an_unrelated_audience` failed before the binding existed (0 passed / 1 failed / 51 filtered), then passed unchanged (1 / 1) once invocation audience had to equal root subject.
+- Predicate-policy review RED/GREEN: `it_never_persists_a_policy_scoped_grant_setup_status_would_reject` first proved setup authentication refused an impossible `createFingerprint` predicate while account creation still accepted and inserted that grant (0 passed / 1 failed / 52 filtered), then passed unchanged (1 / 1) after the shared validator required an empty predicate list and returned an actionable `PolicyScoped` error.
 - The first native HTTP attempt in the restricted sandbox failed to bind loopback with `PermissionDenied` before behavior; every unchanged HTTP filter passed with loopback permission.

--- a/rust/tonk-account-service/README.md
+++ b/rust/tonk-account-service/README.md
@@ -63,7 +63,9 @@ permissive CORS headers).
   root-signed UCAN invocation container with command `["account", "create"]`
   and arguments `email`,
   `credentialId`, `deviceDid`, `deviceName`, `delegation` (the hex-encoded
-  `root → device` delegation), and `repositoryDescriptor`.
+  `root → device` delegation), and `repositoryDescriptor`. The durable device
+  grant must contain exactly one valid proof and be subject-open, command-open,
+  and unbounded (no not-before or expiration).
   A new account returns `201`; an exact retry of an already-committed creation
   returns `200`. Both return `{ "accountId": number, "descriptorHex": string,
   "createFingerprint": string, "reused": boolean }`, with `reused: false` for
@@ -72,13 +74,16 @@ permissive CORS headers).
 - `POST /accounts/setup-status`: recover after losing an account-creation
   response. Body: a device-signed UCAN invocation container with command
   `["account", "setup", "status"]`, argument `createFingerprint`, subject and
-  audience equal to the account root, and exactly one unexpired, subject-open,
-  command-open `root → device` proof. Returns one of
+  audience equal to the account root, and exactly one valid, subject-open,
+  command-open, unbounded `root → device` proof. Returns one of
   `{ "status": "absent" }`, `{ "status": "accepted", "accountId": number,
   "descriptorHex": string, "createFingerprint": string }`, or
   `{ "status": "mismatch" }`. The verified invocation root is the only root
   queried: the endpoint accepts no email or arbitrary root argument, and
-  `absent` is never available to an unauthenticated caller.
+  `absent` is never available to an unauthenticated caller. Unknown/deleted
+  accounts, missing or inactive first devices, and nonmatching device DIDs or
+  delegation CIDs all return that exact `absent` body; only the exact active
+  first-device proof may receive `accepted` or `mismatch`.
 - `POST /account/repository/establish`: root-authorized set-if-absent
   descriptor establishment for an existing account. Returns the exact stored
   winner as `{ "descriptorHex": string, "created": boolean }`.

--- a/rust/tonk-account-service/README.md
+++ b/rust/tonk-account-service/README.md
@@ -22,11 +22,12 @@ CID equals the active attachment's grant, then resolves its subject and issuer
 to that account and device. Account creation and browser self-link are
 instead signed directly by the passkey-derived root: successful verification,
 with issuer equal to subject, proves root-key control before the service writes
-the first account or another device. Account creation additionally consumes an
-email verification code. `POST /codes` and creation of a pending CLI handoff
-are unauthenticated and edge-rate-limited. Account preflight is authenticated
-by the submitted email code and edge-rate-limited; resolving and consuming a
-handoff requires its 256-bit bearer secret.
+the first account or another device. Account creation records the submitted
+address but does not itself prove address control; the access-service
+activation flow confirms it afterwards. `POST /codes` and creation of a
+pending CLI handoff are unauthenticated and edge-rate-limited. Account
+preflight is authenticated by the submitted email code and edge-rate-limited;
+resolving and consuming a handoff requires its 256-bit bearer secret.
 
 ## RP ID invariants
 
@@ -58,12 +59,26 @@ permissive CORS headers).
 - `POST /accounts/preflight`: verify a submitted `{ "email", "code" }` and
   reject an already-registered address before WebAuthn. A successful check
   does not consume the code; `POST /accounts` remains authoritative.
-- `POST /accounts`: create an account and register its first device, consuming
-  a verification code. Body: a root-signed UCAN invocation container with
-  command `["account", "create"]` and arguments `email`, `code`,
+- `POST /accounts`: create an account and register its first device. Body: a
+  root-signed UCAN invocation container with command `["account", "create"]`
+  and arguments `email`,
   `credentialId`, `deviceDid`, `deviceName`, `delegation` (the hex-encoded
   `root → device` delegation), and `repositoryDescriptor`.
-  Returns `201` with `{ "accountId": number, "descriptorHex": string }`.
+  A new account returns `201`; an exact retry of an already-committed creation
+  returns `200`. Both return `{ "accountId": number, "descriptorHex": string,
+  "createFingerprint": string, "reused": boolean }`, with `reused: false` for
+  the initial insert and `true` only for an exact retry. Any semantic mismatch
+  remains a conflict.
+- `POST /accounts/setup-status`: recover after losing an account-creation
+  response. Body: a device-signed UCAN invocation container with command
+  `["account", "setup", "status"]`, argument `createFingerprint`, subject and
+  audience equal to the account root, and exactly one unexpired, subject-open,
+  command-open `root → device` proof. Returns one of
+  `{ "status": "absent" }`, `{ "status": "accepted", "accountId": number,
+  "descriptorHex": string, "createFingerprint": string }`, or
+  `{ "status": "mismatch" }`. The verified invocation root is the only root
+  queried: the endpoint accepts no email or arbitrary root argument, and
+  `absent` is never available to an unauthenticated caller.
 - `POST /account/repository/establish`: root-authorized set-if-absent
   descriptor establishment for an existing account. Returns the exact stored
   winner as `{ "descriptorHex": string, "created": boolean }`.
@@ -115,6 +130,23 @@ UCAN invocation containers and raw signed revocation artifacts are posted as
 `application/cbor`. JSON is reserved for the unauthenticated code/link request
 envelopes and JSON responses.
 
+### Account-creation recovery fingerprint
+
+Clients compute and retain `createFingerprint` before sending `POST /accounts`
+using `tonk_account::creation::AccountCreationFingerprintInput`. The version-1
+algorithm uses a domain-separated BLAKE3 digest with an explicit length frame
+around each semantic field: normalized lowercase email, root DID, credential
+ID, optional passkey `createdAt` and trimmed `createdOn`, canonical descriptor
+bytes, first-device DID and name, and the first delegation's CID and decoded
+bytes. Provider-selected attachment IDs and provider timestamps are excluded.
+The wire form is exactly 64 lowercase hexadecimal characters.
+
+The account provider revalidates the descriptor and delegation before its
+atomic insert. Only after a uniqueness conflict does it compare the persisted
+account and earliest active device against all of those normalized facts. This
+makes a lost response recoverable without treating a different ceremony as an
+idempotent retry.
+
 ## Deploying
 
 Config lives in `wrangler.account.toml` at the repo root, alongside the
@@ -131,6 +163,12 @@ The preflight route is a hard dependency of this account UI: deploy the account
 worker containing `/accounts/preflight` before the UI that calls it. The UI
 fails closed if the route is absent rather than creating a passkey before email
 availability has been verified.
+
+Account-setup recovery has the same provider-first rollout requirement: deploy
+the account worker containing `/accounts/setup-status` and exact-retry support
+before a UI or CLI starts the recovery saga. Older clients can ignore the new
+fields on the initial `201`; recovery-aware clients must not assume the status
+route exists until that provider deployment is complete.
 
 Releases are not manual. `.github/workflows/publish.yml` applies this
 crate's migrations and deploys the worker on every push to `staging` and

--- a/rust/tonk-account-service/README.md
+++ b/rust/tonk-account-service/README.md
@@ -65,7 +65,8 @@ permissive CORS headers).
   `credentialId`, `deviceDid`, `deviceName`, `delegation` (the hex-encoded
   `root → device` delegation), and `repositoryDescriptor`. The durable device
   grant must contain exactly one valid proof and be subject-open, command-open,
-  and unbounded (no not-before or expiration).
+  policy-free (no predicate policy), and unbounded (no not-before or
+  expiration).
   A new account returns `201`; an exact retry of an already-committed creation
   returns `200`. Both return `{ "accountId": number, "descriptorHex": string,
   "createFingerprint": string, "reused": boolean }`, with `reused: false` for
@@ -75,7 +76,7 @@ permissive CORS headers).
   response. Body: a device-signed UCAN invocation container with command
   `["account", "setup", "status"]`, argument `createFingerprint`, subject and
   audience equal to the account root, and exactly one valid, subject-open,
-  command-open, unbounded `root → device` proof. Returns one of
+  command-open, policy-free, unbounded `root → device` proof. Returns one of
   `{ "status": "absent" }`, `{ "status": "accepted", "accountId": number,
   "descriptorHex": string, "createFingerprint": string }`, or
   `{ "status": "mismatch" }`. The verified invocation root is the only root

--- a/rust/tonk-account-service/README.md
+++ b/rust/tonk-account-service/README.md
@@ -9,9 +9,9 @@ This crate is a Cloudflare Worker. It stores account and device rows in
 Cloudflare D1 (`migrations/` is the schema's single source of truth) and backs
 up chain bytes, keyed by content address, in an R2 bucket. It also relays self-certifying revocation artifacts into a separate immutable R2 bucket; the D1 device status is only an account UI projection.
 Email codes are sent through Resend. Natively (off wasm32), only the
-binding-free routes (`GET /`, `GET /health`) are registered; the D1/R2/Resend
-routes are wasm-only adapters (see `src/store/d1.rs`, `src/chains/r2.rs`,
-`src/email/resend.rs`).
+binding-free routes (`GET /`, `GET /health`, `GET /capabilities`) are
+registered; the D1/R2/Resend routes are wasm-only adapters (see
+`src/store/d1.rs`, `src/chains/r2.rs`, `src/email/resend.rs`).
 
 ## Auth model
 
@@ -49,12 +49,18 @@ is not: it orphans every credential minted under the wider boundary.
 
 ## Endpoints
 
-The Worker (`src/lib.rs`) routes, all under `accounts.tonk.xyz`. Every
-`POST` route also has a matching `OPTIONS` route for CORS preflight (204,
-permissive CORS headers).
+The Worker (`src/lib.rs`) routes, all under `accounts.tonk.xyz`. Every `POST`
+route and the CORS-readable capability route have a matching `OPTIONS` route
+for CORS preflight (204, permissive CORS headers).
 
 - `GET /`: service info as JSON (`service`, `version`).
 - `GET /health`: liveness check (`OK`).
+- `GET /capabilities`: privacy-neutral feature discovery with CORS headers.
+  Returns exactly `{ "service": "tonk-account-service", "capabilities": {
+  "accountSetupRecovery": 1 } }`. The numeric `1` is the only marker for the
+  response-loss recovery contract described below; a missing route, malformed
+  response, or different value is unsupported and must be rejected by the
+  calling UI before it creates a credential.
 - `POST /codes`: request an email verification code. Body: `{ "email": string }`.
 - `POST /accounts/preflight`: verify a submitted `{ "email", "code" }` and
   reject an already-registered address before WebAuthn. A successful check
@@ -171,10 +177,12 @@ fails closed if the route is absent rather than creating a passkey before email
 availability has been verified.
 
 Account-setup recovery has the same provider-first rollout requirement: deploy
-the account worker containing `/accounts/setup-status` and exact-retry support
-before a UI or CLI starts the recovery saga. Older clients can ignore the new
-fields on the initial `201`; recovery-aware clients must not assume the status
-route exists until that provider deployment is complete.
+the account worker containing `/capabilities`, `/accounts/setup-status`, and
+exact-retry support before a UI or CLI starts the recovery saga. A
+recovery-aware client must fetch `/capabilities` and require the numeric
+`accountSetupRecovery: 1` marker before credential creation; a missing, wrong,
+or unreadable marker fails closed without querying account state. Older clients
+can ignore the new fields on the initial `201`.
 
 Releases are not manual. `.github/workflows/publish.yml` applies this
 crate's migrations and deploys the worker on every push to `staging` and

--- a/rust/tonk-account-service/src/auth.rs
+++ b/rust/tonk-account-service/src/auth.rs
@@ -13,6 +13,7 @@ use dialog_credentials::DidKeyResolver;
 use dialog_ucan_core::InvocationChain;
 use dialog_ucan_core::promise::Promised;
 use dialog_ucan_core::revocation::UnverifiedRevocations;
+use dialog_ucan_core::subject::Subject;
 use dialog_ucan_core::time::timestamp::{Duration, SystemTime, Timestamp};
 use dialog_ucan_core::verification::{Environment, VerificationContext};
 use dialog_varsig::AnySignature;
@@ -36,6 +37,23 @@ pub struct RootCaller {
     /// The root DID that signed and subjects the invocation.
     pub root_did: String,
     /// The invocation's signed arguments.
+    pub arguments: BTreeMap<String, Promised>,
+}
+
+/// A device whose attached one-hop proof cryptographically binds it to a root.
+///
+/// Unlike [`Caller`], this does not imply the root or device is registered.
+/// It exists only for account-setup recovery, where an absent account is a
+/// legitimate result and the service must not accept an arbitrary root query.
+pub struct SetupCaller {
+    /// Root DID issued by the attached delegation and named as the invocation
+    /// subject.
+    pub root_did: String,
+    /// Device DID that signed the invocation and received the delegation.
+    pub device_did: String,
+    /// CID of the exact root-to-device proof carried by the invocation.
+    pub delegation_cid: String,
+    /// Signed invocation arguments.
     pub arguments: BTreeMap<String, Promised>,
 }
 
@@ -171,6 +189,57 @@ pub async fn authorize_root(
     })
 }
 
+/// Verify a narrowly scoped setup request through a root-to-device proof,
+/// without consulting account storage.
+///
+/// This requires the same one-hop, subject-open, command-open delegation Tonk
+/// persists for a device. The verified invocation subject is the only root a
+/// caller can subsequently look up, so this helper cannot become an arbitrary
+/// root or email existence oracle.
+pub async fn authorize_setup_device(
+    body: &[u8],
+    expected_command: &[&str],
+) -> Result<SetupCaller, CeremonyError> {
+    let chain = verified_chain(body, expected_command).await?;
+    require_ceremony_expiration(&chain)?;
+
+    let [proof_cid] = chain.proofs().as_slice() else {
+        return Err(CeremonyError::Unauthorized(
+            "setup invocation must carry exactly one root to device proof".to_string(),
+        ));
+    };
+    let delegation = chain.delegation(proof_cid).ok_or_else(|| {
+        CeremonyError::Unauthorized("setup invocation proof is missing".to_string())
+    })?;
+    if delegation.issuer() != chain.subject() {
+        return Err(CeremonyError::Forbidden(
+            "setup proof issuer does not match the invocation root".to_string(),
+        ));
+    }
+    if delegation.audience() != chain.issuer() {
+        return Err(CeremonyError::Forbidden(
+            "setup proof audience does not match the invoking device".to_string(),
+        ));
+    }
+    if delegation.subject() != &Subject::Any {
+        return Err(CeremonyError::Forbidden(
+            "setup proof must be subject-open".to_string(),
+        ));
+    }
+    if !delegation.command().0.is_empty() {
+        return Err(CeremonyError::Forbidden(
+            "setup proof must be command-open".to_string(),
+        ));
+    }
+
+    Ok(SetupCaller {
+        root_did: chain.subject().to_string(),
+        device_did: chain.issuer().to_string(),
+        delegation_cid: proof_cid.to_string(),
+        arguments: chain.arguments().clone(),
+    })
+}
+
 /// Extract a required string from an invocation argument map.
 pub fn required_string(
     arguments: &BTreeMap<String, Promised>,
@@ -253,7 +322,7 @@ mod tests {
     use crate::store::DeviceStatus;
     use crate::store::sqlite::SqliteStore;
     use dialog_credentials::Ed25519Signer;
-    use dialog_ucan_core::InvocationBuilder;
+    use dialog_ucan_core::{Delegation, DelegationBuilder, InvocationBuilder};
     use dialog_varsig::Principal;
 
     #[dialog_common::test]
@@ -337,6 +406,33 @@ mod tests {
         container_with_expiration(command, args, Some(Timestamp::five_minutes_from_now())).await
     }
 
+    async fn setup_container_with_delegation(
+        root_did: &dialog_varsig::Did,
+        device: Ed25519Signer,
+        delegation: Delegation<AnySignature>,
+    ) -> Vec<u8> {
+        let cid = delegation.to_cid();
+        let invocation = InvocationBuilder::new()
+            .issuer(dialog_credentials::Signer::from(device))
+            .audience(root_did)
+            .subject(root_did)
+            .command(vec!["account".into(), "setup".into(), "status".into()])
+            .arguments(BTreeMap::new())
+            .proofs(vec![cid])
+            .expiration(Timestamp::five_minutes_from_now())
+            .try_build()
+            .await
+            .unwrap();
+        InvocationChain::new(
+            invocation,
+            [(cid, std::sync::Arc::new(delegation))]
+                .into_iter()
+                .collect(),
+        )
+        .to_bytes()
+        .unwrap()
+    }
+
     async fn seed_device_with_cid(
         store: &SqliteStore,
         root_did: &str,
@@ -400,6 +496,111 @@ mod tests {
             .unwrap()
             .proofs()[0]
             .to_string()
+    }
+
+    #[dialog_common::test]
+    async fn it_authorizes_setup_status_without_an_account_lookup() {
+        let arguments = BTreeMap::from([(
+            "createFingerprint".to_string(),
+            Promised::String("ab".repeat(32)),
+        )]);
+        let (root_did, device_did, bytes) = container(
+            vec!["account".into(), "setup".into(), "status".into()],
+            arguments,
+        )
+        .await;
+
+        let caller = authorize_setup_device(&bytes, &["account", "setup", "status"])
+            .await
+            .expect("a valid root to device proof does not need an account row");
+        assert_eq!(caller.root_did, root_did);
+        assert_eq!(caller.device_did, device_did);
+        assert_eq!(caller.delegation_cid, invocation_proof_cid(&bytes));
+        assert_eq!(
+            required_string(&caller.arguments, "createFingerprint").unwrap(),
+            "ab".repeat(32)
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_noncanonical_setup_device_proofs() {
+        let command = vec!["account".into(), "setup".into(), "status".into()];
+        let root = dialog_credentials::Ed25519Signer::import(&ROOT_PRF)
+            .await
+            .unwrap();
+        let root_did = root.did();
+        let device = Ed25519Signer::import(&DEVICE_SEED).await.unwrap();
+
+        // A root-signed invocation proves the root but is not the required
+        // device-authenticated request with a root-to-device proof.
+        let no_proof = InvocationBuilder::new()
+            .issuer(dialog_credentials::Signer::from(root.clone()))
+            .audience(&root_did)
+            .subject(&root_did)
+            .command(command.clone())
+            .arguments(BTreeMap::new())
+            .proofs(vec![])
+            .expiration(Timestamp::five_minutes_from_now())
+            .try_build()
+            .await
+            .unwrap();
+        let no_proof = InvocationChain::new(no_proof, std::collections::HashMap::new())
+            .to_bytes()
+            .unwrap();
+        assert!(matches!(
+            authorize_setup_device(&no_proof, &["account", "setup", "status"]).await,
+            Err(CeremonyError::Unauthorized(message))
+                if message.contains("exactly one root to device proof")
+        ));
+
+        // A valid grant addressed to one device cannot authenticate a
+        // different device's invocation.
+        let grant = tonk_identity::delegation::mint_device_delegation(root.clone(), &device.did())
+            .await
+            .unwrap();
+        let other_device = Ed25519Signer::import(&[10u8; 32]).await.unwrap();
+        let wrong_device = setup_container_with_delegation(
+            &root_did,
+            other_device,
+            grant.proofs().next().unwrap().clone(),
+        )
+        .await;
+        assert!(matches!(
+            authorize_setup_device(&wrong_device, &["account", "setup", "status"]).await,
+            Err(CeremonyError::Unauthorized(_))
+        ));
+
+        // Even cryptographically valid attenuated delegations are rejected:
+        // the durable device grant is specifically subject- and command-open.
+        let subject_specific = DelegationBuilder::new()
+            .issuer(dialog_credentials::Signer::from(root.clone()))
+            .audience(&device.did())
+            .subject(Subject::Specific(root_did.clone()))
+            .command(vec![])
+            .try_build()
+            .await
+            .unwrap();
+        let subject_specific =
+            setup_container_with_delegation(&root_did, device.clone(), subject_specific).await;
+        assert!(matches!(
+            authorize_setup_device(&subject_specific, &["account", "setup", "status"]).await,
+            Err(CeremonyError::Forbidden(message)) if message.contains("subject-open")
+        ));
+
+        let command_scoped = DelegationBuilder::new()
+            .issuer(dialog_credentials::Signer::from(root))
+            .audience(&device.did())
+            .subject(Subject::Any)
+            .command(command)
+            .try_build()
+            .await
+            .unwrap();
+        let command_scoped =
+            setup_container_with_delegation(&root_did, device, command_scoped).await;
+        assert!(matches!(
+            authorize_setup_device(&command_scoped, &["account", "setup", "status"]).await,
+            Err(CeremonyError::Forbidden(message)) if message.contains("command-open")
+        ));
     }
 
     #[dialog_common::test]

--- a/rust/tonk-account-service/src/auth.rs
+++ b/rust/tonk-account-service/src/auth.rs
@@ -13,12 +13,12 @@ use dialog_credentials::DidKeyResolver;
 use dialog_ucan_core::InvocationChain;
 use dialog_ucan_core::promise::Promised;
 use dialog_ucan_core::revocation::UnverifiedRevocations;
-use dialog_ucan_core::subject::Subject;
 use dialog_ucan_core::time::timestamp::{Duration, SystemTime, Timestamp};
 use dialog_ucan_core::verification::{Environment, VerificationContext};
 use dialog_varsig::AnySignature;
 
 use crate::core::CeremonyError;
+use crate::core::delegation::{DeviceGrantError, validate_root_device_grant};
 use crate::store::{Account, Device, PasskeyMetadata, Store};
 
 /// An authenticated caller: the account and device bound by a verified
@@ -192,52 +192,69 @@ pub async fn authorize_root(
 /// Verify a narrowly scoped setup request through a root-to-device proof,
 /// without consulting account storage.
 ///
-/// This requires the same one-hop, subject-open, command-open delegation Tonk
-/// persists for a device. The verified invocation subject is the only root a
-/// caller can subsequently look up, so this helper cannot become an arbitrary
-/// root or email existence oracle.
+/// This requires the same one-hop, subject-open, command-open, unbounded
+/// delegation Tonk persists for a device, and binds the invocation audience to
+/// its root subject. The verified invocation subject is the only root a caller
+/// can subsequently look up, so this helper cannot become an arbitrary root or
+/// email existence oracle.
 pub async fn authorize_setup_device(
     body: &[u8],
     expected_command: &[&str],
 ) -> Result<SetupCaller, CeremonyError> {
     let chain = verified_chain(body, expected_command).await?;
     require_ceremony_expiration(&chain)?;
+    if chain.invocation.audience() != chain.subject() {
+        return Err(CeremonyError::Forbidden(
+            "setup invocation audience must equal its root subject".to_string(),
+        ));
+    }
 
-    let [proof_cid] = chain.proofs().as_slice() else {
-        return Err(CeremonyError::Unauthorized(
-            "setup invocation must carry exactly one root to device proof".to_string(),
-        ));
+    let proof_cids = chain.proofs();
+    let proof = match proof_cids.as_slice() {
+        [proof_cid] => chain.delegation(proof_cid),
+        _ => None,
     };
-    let delegation = chain.delegation(proof_cid).ok_or_else(|| {
-        CeremonyError::Unauthorized("setup invocation proof is missing".to_string())
-    })?;
-    if delegation.issuer() != chain.subject() {
-        return Err(CeremonyError::Forbidden(
-            "setup proof issuer does not match the invocation root".to_string(),
-        ));
-    }
-    if delegation.audience() != chain.issuer() {
-        return Err(CeremonyError::Forbidden(
-            "setup proof audience does not match the invoking device".to_string(),
-        ));
-    }
-    if delegation.subject() != &Subject::Any {
-        return Err(CeremonyError::Forbidden(
-            "setup proof must be subject-open".to_string(),
-        ));
-    }
-    if !delegation.command().0.is_empty() {
-        return Err(CeremonyError::Forbidden(
-            "setup proof must be command-open".to_string(),
-        ));
-    }
+    let delegation_cid = validate_root_device_grant(
+        proof_cids.len(),
+        proof.map(AsRef::as_ref),
+        chain.subject().as_ref(),
+        chain.issuer().as_ref(),
+    )
+    .await
+    .map_err(setup_grant_error)?;
 
     Ok(SetupCaller {
         root_did: chain.subject().to_string(),
         device_did: chain.issuer().to_string(),
-        delegation_cid: proof_cid.to_string(),
+        delegation_cid,
         arguments: chain.arguments().clone(),
     })
+}
+
+fn setup_grant_error(error: DeviceGrantError) -> CeremonyError {
+    match error {
+        DeviceGrantError::ProofCount => CeremonyError::Unauthorized(
+            "setup invocation must carry exactly one root to device proof".to_string(),
+        ),
+        DeviceGrantError::InvalidSignature(detail) => {
+            CeremonyError::Unauthorized(format!("setup proof failed to verify: {detail}"))
+        }
+        DeviceGrantError::WrongIssuer => CeremonyError::Forbidden(
+            "setup proof issuer does not match the invocation root".to_string(),
+        ),
+        DeviceGrantError::WrongAudience => CeremonyError::Forbidden(
+            "setup proof audience does not match the invoking device".to_string(),
+        ),
+        DeviceGrantError::SubjectScoped => {
+            CeremonyError::Forbidden("setup proof must be subject-open".to_string())
+        }
+        DeviceGrantError::CommandScoped => {
+            CeremonyError::Forbidden("setup proof must be command-open".to_string())
+        }
+        DeviceGrantError::TimeBounded => {
+            CeremonyError::Forbidden("setup proof must be unbounded".to_string())
+        }
+    }
 }
 
 /// Extract a required string from an invocation argument map.
@@ -322,6 +339,7 @@ mod tests {
     use crate::store::DeviceStatus;
     use crate::store::sqlite::SqliteStore;
     use dialog_credentials::Ed25519Signer;
+    use dialog_ucan_core::subject::Subject;
     use dialog_ucan_core::{Delegation, DelegationBuilder, InvocationBuilder};
     use dialog_varsig::Principal;
 
@@ -520,6 +538,48 @@ mod tests {
             required_string(&caller.arguments, "createFingerprint").unwrap(),
             "ab".repeat(32)
         );
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_setup_invocations_for_an_unrelated_audience() {
+        let root = dialog_credentials::Ed25519Signer::import(&ROOT_PRF)
+            .await
+            .unwrap();
+        let root_did = root.did();
+        let device = Ed25519Signer::import(&DEVICE_SEED).await.unwrap();
+        let grant = tonk_identity::delegation::mint_device_delegation(root, &device.did())
+            .await
+            .unwrap();
+        let delegation = grant.proofs().next().unwrap().clone();
+        let cid = delegation.to_cid();
+        let unrelated = Ed25519Signer::import(&[23u8; 32]).await.unwrap();
+        let invocation = InvocationBuilder::new()
+            .issuer(dialog_credentials::Signer::from(device))
+            .audience(&unrelated.did())
+            .subject(&root_did)
+            .command(vec!["account".into(), "setup".into(), "status".into()])
+            .arguments(BTreeMap::from([(
+                "createFingerprint".to_string(),
+                Promised::String("ab".repeat(32)),
+            )]))
+            .proofs(vec![cid])
+            .expiration(Timestamp::five_minutes_from_now())
+            .try_build()
+            .await
+            .unwrap();
+        let bytes = InvocationChain::new(
+            invocation,
+            [(cid, std::sync::Arc::new(delegation))]
+                .into_iter()
+                .collect(),
+        )
+        .to_bytes()
+        .unwrap();
+
+        assert!(matches!(
+            authorize_setup_device(&bytes, &["account", "setup", "status"]).await,
+            Err(CeremonyError::Forbidden(message)) if message.contains("audience")
+        ));
     }
 
     #[dialog_common::test]

--- a/rust/tonk-account-service/src/auth.rs
+++ b/rust/tonk-account-service/src/auth.rs
@@ -192,11 +192,11 @@ pub async fn authorize_root(
 /// Verify a narrowly scoped setup request through a root-to-device proof,
 /// without consulting account storage.
 ///
-/// This requires the same one-hop, subject-open, command-open, unbounded
-/// delegation Tonk persists for a device, and binds the invocation audience to
-/// its root subject. The verified invocation subject is the only root a caller
-/// can subsequently look up, so this helper cannot become an arbitrary root or
-/// email existence oracle.
+/// This requires the same one-hop, subject-open, command-open, policy-free,
+/// unbounded delegation Tonk persists for a device, and binds the invocation
+/// audience to its root subject. The verified invocation subject is the only
+/// root a caller can subsequently look up, so this helper cannot become an
+/// arbitrary root or email existence oracle.
 pub async fn authorize_setup_device(
     body: &[u8],
     expected_command: &[&str],
@@ -250,6 +250,9 @@ fn setup_grant_error(error: DeviceGrantError) -> CeremonyError {
         }
         DeviceGrantError::CommandScoped => {
             CeremonyError::Forbidden("setup proof must be command-open".to_string())
+        }
+        DeviceGrantError::PolicyScoped => {
+            CeremonyError::Forbidden("setup proof must not contain policy predicates".to_string())
         }
         DeviceGrantError::TimeBounded => {
             CeremonyError::Forbidden("setup proof must be unbounded".to_string())

--- a/rust/tonk-account-service/src/core/accounts.rs
+++ b/rust/tonk-account-service/src/core/accounts.rs
@@ -559,6 +559,109 @@ mod tests {
     }
 
     #[dialog_common::test]
+    async fn it_never_persists_a_policy_scoped_grant_setup_status_would_reject() {
+        use std::collections::BTreeMap;
+        use std::str::FromStr as _;
+        use std::sync::Arc;
+
+        use dialog_ucan_core::delegation::policy::predicate::Predicate;
+        use dialog_ucan_core::delegation::policy::selector::select::Select;
+        use dialog_ucan_core::promise::Promised;
+        use dialog_ucan_core::subject::Subject;
+        use dialog_ucan_core::time::timestamp::Timestamp;
+        use dialog_ucan_core::{
+            DelegationBuilder, DelegationChain, InvocationBuilder, InvocationChain,
+        };
+        use dialog_varsig::Principal as _;
+
+        let root = dialog_credentials::Ed25519Signer::import(&ROOT_PRF)
+            .await
+            .unwrap();
+        let device = dialog_credentials::Ed25519Signer::import(&DEVICE_SEED)
+            .await
+            .unwrap();
+        let root_did = root.did();
+        let device_did = device.did();
+        let descriptor = tonk_account::AccountRepositoryDescriptorV1::sign(
+            &root,
+            "https://accounts.example/ucan/",
+        )
+        .await
+        .unwrap();
+        let policy_scoped = DelegationBuilder::new()
+            .issuer(dialog_credentials::Signer::from(root))
+            .audience(&device_did)
+            .subject(Subject::Any)
+            .command(vec![])
+            .policy(vec![Predicate::Like(
+                Select::from_str(".createFingerprint").unwrap(),
+                "impossible".into(),
+            )])
+            .try_build()
+            .await
+            .unwrap();
+
+        let proof_cid = policy_scoped.to_cid();
+        let setup_invocation = InvocationBuilder::new()
+            .issuer(dialog_credentials::Signer::from(device))
+            .audience(&root_did)
+            .subject(&root_did)
+            .command(vec!["account".into(), "setup".into(), "status".into()])
+            .arguments(BTreeMap::from([(
+                "createFingerprint".into(),
+                Promised::String("ab".repeat(32)),
+            )]))
+            .proofs(vec![proof_cid])
+            .expiration(Timestamp::five_minutes_from_now())
+            .try_build()
+            .await
+            .unwrap();
+        let setup_container = InvocationChain::new(
+            setup_invocation,
+            [(proof_cid, Arc::new(policy_scoped.clone()))]
+                .into_iter()
+                .collect(),
+        )
+        .to_bytes()
+        .unwrap();
+        assert!(matches!(
+            crate::auth::authorize_setup_device(
+                &setup_container,
+                &["account", "setup", "status"]
+            )
+            .await,
+            Err(CeremonyError::Unauthorized(message)) if message.contains("policy")
+        ));
+
+        let store = SqliteStore::in_memory().unwrap();
+        let request = CreateAccount {
+            email: "policy-scoped@example.com".into(),
+            root_did: root_did.to_string(),
+            credential_id: "credential-policy-scoped".into(),
+            device_did: device_did.to_string(),
+            device_name: "laptop".into(),
+            delegation_hex: hex::encode(DelegationChain::new(policy_scoped).to_bytes().unwrap()),
+            repository_descriptor_hex: hex::encode(descriptor.bytes()),
+            passkey: None,
+        };
+        let result = create_account(&store, &request, 1).await;
+        let Err(CeremonyError::Invalid(message)) = result else {
+            panic!("policy-scoped first-device grant was accepted: {result:?}");
+        };
+        assert!(
+            message.contains("policy predicates"),
+            "wrong refusal: {message}"
+        );
+        assert!(
+            store
+                .account_by_root(root_did.as_ref())
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[dialog_common::test]
     async fn it_reuses_only_an_exact_account_creation() {
         let store = SqliteStore::in_memory().unwrap();
         let (root_did, device_did, delegation_hex, repository_descriptor_hex) = fixture().await;

--- a/rust/tonk-account-service/src/core/accounts.rs
+++ b/rust/tonk-account-service/src/core/accounts.rs
@@ -10,7 +10,12 @@
 use crate::core::CeremonyError;
 use crate::core::delegation::check_device_delegation;
 use crate::core::descriptor::validate_descriptor;
-use crate::store::{NewAccount, NewDevice, PasskeyMetadata, Store, StoreError};
+use crate::store::{
+    Account, Device, DeviceStatus, NewAccount, NewDevice, PasskeyMetadata, Store, StoreError,
+};
+use tonk_account::creation::{
+    AccountCreationFingerprint, AccountCreationFingerprintInput, AccountCreationPasskey,
+};
 
 /// Returned when the verified email address already belongs to an
 /// account under a different root DID.
@@ -20,6 +25,7 @@ pub const EMAIL_TAKEN: &str = "an account already exists for this email address"
 pub const ROOT_TAKEN: &str = "an account already exists for this passkey";
 
 /// A request to create a new account and register its first device.
+#[derive(Debug, Clone)]
 pub struct CreateAccount {
     /// The account's verified email address.
     pub email: String,
@@ -39,6 +45,103 @@ pub struct CreateAccount {
     pub passkey: Option<PasskeyMetadata>,
 }
 
+/// Stable result of creating an account or recovering its exact winner.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateAccountOutcome {
+    /// Provider account row ID.
+    pub account_id: i64,
+    /// Exact canonical root-signed repository descriptor bytes.
+    pub descriptor: Vec<u8>,
+    /// Versioned fingerprint of every caller-controlled creation fact.
+    pub create_fingerprint: String,
+    /// Whether an earlier atomic insert had already committed this winner.
+    pub reused: bool,
+}
+
+/// Provider state for one proof-bound account-setup operation.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(tag = "status", rename_all = "camelCase")]
+pub enum AccountSetupStatus {
+    /// The verified root has no provider account row.
+    Absent,
+    /// The persisted account is the exact operation the caller fingerprinted.
+    Accepted {
+        /// Provider account row ID.
+        #[serde(rename = "accountId")]
+        account_id: i64,
+        /// Canonical root-signed repository descriptor, hex encoded.
+        #[serde(rename = "descriptorHex")]
+        descriptor_hex: String,
+        /// Server-reconstructed canonical creation fingerprint.
+        #[serde(rename = "createFingerprint")]
+        create_fingerprint: String,
+    },
+    /// The root exists, but its durable creation facts differ.
+    Mismatch,
+}
+
+/// Canonical caller-controlled facts that make one account creation unique.
+///
+/// Provider-generated attachment IDs and timestamps are deliberately absent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CreationFacts {
+    email: String,
+    root_did: String,
+    credential_id: String,
+    passkey: Option<PasskeyMetadata>,
+    descriptor: Vec<u8>,
+    device_did: String,
+    device_name: String,
+    delegation_cid: String,
+    delegation: Vec<u8>,
+}
+
+impl CreationFacts {
+    fn fingerprint(&self) -> String {
+        AccountCreationFingerprintInput {
+            email: &self.email,
+            root_did: &self.root_did,
+            credential_id: &self.credential_id,
+            passkey: self.passkey.as_ref().map(|passkey| AccountCreationPasskey {
+                created_at: passkey.created_at,
+                created_on: &passkey.created_on,
+            }),
+            descriptor: &self.descriptor,
+            device_did: &self.device_did,
+            device_name: &self.device_name,
+            delegation_cid: &self.delegation_cid,
+            delegation: &self.delegation,
+        }
+        .fingerprint()
+        .to_hex()
+    }
+
+    fn from_stored(account: &Account, first_device: &Device) -> Option<Self> {
+        let passkey = match (
+            account.passkey_created_at,
+            account.passkey_created_on.as_ref(),
+        ) {
+            (None, None) => None,
+            (Some(created_at), Some(created_on)) => Some(PasskeyMetadata {
+                created_at,
+                created_on: created_on.trim().to_string(),
+            }),
+            _ => return None,
+        };
+        Some(Self {
+            email: account.email.to_lowercase(),
+            root_did: account.root_did.clone(),
+            credential_id: account.credential_id.clone(),
+            passkey,
+            descriptor: account.repository_descriptor.clone()?,
+            device_did: first_device.device_did.clone(),
+            device_name: first_device.name.clone(),
+            delegation_cid: first_device.delegation_cid.clone(),
+            delegation: hex::decode(&first_device.delegation_hex).ok()?,
+        })
+    }
+}
+
 /// Create a new account and register its first device.
 ///
 /// Checks the presented descriptor and delegation, both purely local,
@@ -53,7 +156,7 @@ pub async fn create_account<S: Store>(
     store: &S,
     request: &CreateAccount,
     now: u64,
-) -> Result<i64, CeremonyError> {
+) -> Result<CreateAccountOutcome, CeremonyError> {
     let repository_descriptor =
         validate_descriptor(&request.repository_descriptor_hex, &request.root_did).await?;
     let delegation_cid = check_device_delegation(
@@ -63,12 +166,29 @@ pub async fn create_account<S: Store>(
     )
     .await?;
     let email = request.email.to_lowercase();
+    let passkey = request.passkey.as_ref().map(|passkey| PasskeyMetadata {
+        created_at: passkey.created_at,
+        created_on: passkey.created_on.trim().to_string(),
+    });
+    let facts = CreationFacts {
+        email: email.clone(),
+        root_did: request.root_did.clone(),
+        credential_id: request.credential_id.clone(),
+        passkey: passkey.clone(),
+        descriptor: repository_descriptor.clone(),
+        device_did: request.device_did.clone(),
+        device_name: request.device_name.clone(),
+        delegation_cid: delegation_cid.clone(),
+        delegation: hex::decode(&request.delegation_hex).map_err(|error| {
+            CeremonyError::Invalid(format!("bad delegation hex after validation: {error}"))
+        })?,
+    };
     let account = NewAccount {
         email: &email,
         root_did: &request.root_did,
         credential_id: &request.credential_id,
         repository_descriptor: &repository_descriptor,
-        passkey: request.passkey.as_ref(),
+        passkey: passkey.as_ref(),
         created_at: now,
     };
     let device = NewDevice {
@@ -81,12 +201,137 @@ pub async fn create_account<S: Store>(
     let created = store.create_account_with_device(&account, &device).await;
 
     match created {
-        Ok(account_id) => Ok(account_id),
+        Ok(account_id) => Ok(CreateAccountOutcome {
+            account_id,
+            descriptor: facts.descriptor.clone(),
+            create_fingerprint: facts.fingerprint(),
+            reused: false,
+        }),
         Err(StoreError::Conflict(detail)) => {
+            if let Some(outcome) = recover_exact_replay(store, &facts).await {
+                return Ok(outcome);
+            }
             Err(explain_conflict(store, request, &email, detail).await)
         }
         Err(err) => Err(err.into()),
     }
+}
+
+/// Recover the winner only when the account and its earliest device reproduce
+/// the complete validated operation. A lookup failure leaves the original
+/// conflict authoritative and is logged without exposing driver detail.
+async fn recover_exact_replay<S: Store>(
+    store: &S,
+    expected: &CreationFacts,
+) -> Option<CreateAccountOutcome> {
+    let account = match store.account_by_root(&expected.root_did).await {
+        Ok(Some(account)) => account,
+        Ok(None) => return None,
+        Err(error) => {
+            crate::core::log_detail(&format!(
+                "account replay lookup failed after conflict: {error:?}"
+            ));
+            return None;
+        }
+    };
+    let devices = match store.devices(account.id).await {
+        Ok(devices) => devices,
+        Err(error) => {
+            crate::core::log_detail(&format!(
+                "account replay device lookup failed after conflict: {error:?}"
+            ));
+            return None;
+        }
+    };
+    let first_device = devices.into_iter().min_by_key(|device| device.id)?;
+    if first_device.status != DeviceStatus::Active {
+        return None;
+    }
+    let stored = CreationFacts::from_stored(&account, &first_device)?;
+    if &stored != expected {
+        return None;
+    }
+    let create_fingerprint = stored.fingerprint();
+    Some(CreateAccountOutcome {
+        account_id: account.id,
+        descriptor: stored.descriptor,
+        create_fingerprint,
+        reused: true,
+    })
+}
+
+/// Check provider setup state for the root cryptographically bound by a
+/// device invocation.
+///
+/// Authentication happens before this function. Its root argument must come
+/// from the verified invocation subject, never from a request field.
+pub async fn account_setup_status<S: Store>(
+    store: &S,
+    root_did: &str,
+    device_did: &str,
+    delegation_cid: &str,
+    expected_fingerprint: &str,
+) -> Result<AccountSetupStatus, CeremonyError> {
+    let expected_fingerprint = canonical_create_fingerprint(expected_fingerprint)?;
+    let Some(account) = store.account_by_root(root_did).await? else {
+        return Ok(AccountSetupStatus::Absent);
+    };
+    let Some(first_device) = store
+        .devices(account.id)
+        .await?
+        .into_iter()
+        .min_by_key(|device| device.id)
+    else {
+        return Ok(AccountSetupStatus::Mismatch);
+    };
+    if first_device.status != DeviceStatus::Active {
+        return Err(CeremonyError::Forbidden(
+            "setup status requires the active first account device".to_string(),
+        ));
+    }
+    if first_device.device_did != device_did || first_device.delegation_cid != delegation_cid {
+        return Err(CeremonyError::Forbidden(
+            "setup proof does not match the first account device".to_string(),
+        ));
+    }
+    let Ok(stored_delegation_cid) = check_device_delegation(
+        &first_device.delegation_hex,
+        root_did,
+        &first_device.device_did,
+    )
+    .await
+    else {
+        return Ok(AccountSetupStatus::Mismatch);
+    };
+    if stored_delegation_cid != first_device.delegation_cid {
+        return Ok(AccountSetupStatus::Mismatch);
+    }
+    let Some(stored) = CreationFacts::from_stored(&account, &first_device) else {
+        return Ok(AccountSetupStatus::Mismatch);
+    };
+    let descriptor_hex = hex::encode(&stored.descriptor);
+    let Ok(canonical_descriptor) = validate_descriptor(&descriptor_hex, root_did).await else {
+        return Ok(AccountSetupStatus::Mismatch);
+    };
+    if canonical_descriptor != stored.descriptor {
+        return Ok(AccountSetupStatus::Mismatch);
+    }
+    let create_fingerprint = stored.fingerprint();
+    if create_fingerprint != expected_fingerprint {
+        return Ok(AccountSetupStatus::Mismatch);
+    }
+    Ok(AccountSetupStatus::Accepted {
+        account_id: account.id,
+        descriptor_hex,
+        create_fingerprint,
+    })
+}
+
+/// Parse a 32-byte BLAKE3 fingerprint and return its lowercase wire form.
+fn canonical_create_fingerprint(value: &str) -> Result<String, CeremonyError> {
+    AccountCreationFingerprint::from_hex(value)
+        .map(AccountCreationFingerprint::to_hex)
+        .map_err(|error| CeremonyError::Invalid(error.to_string()))
 }
 
 /// Turn a uniqueness conflict from
@@ -132,12 +377,16 @@ mod tests {
     const ROOT_PRF: [u8; 32] = [7u8; 32];
     const DEVICE_SEED: [u8; 32] = [8u8; 32];
 
-    async fn fixture() -> (String, String, String, String) {
+    async fn fixture_for(
+        root_seed: [u8; 32],
+        device_seed: [u8; 32],
+        remote: &str,
+    ) -> (String, String, String, String) {
         // (root_did, device_did, delegation_hex, descriptor_hex)
-        let root = dialog_credentials::Ed25519Signer::import(&ROOT_PRF)
+        let root = dialog_credentials::Ed25519Signer::import(&root_seed)
             .await
             .unwrap();
-        let device = dialog_credentials::Ed25519Signer::import(&DEVICE_SEED)
+        let device = dialog_credentials::Ed25519Signer::import(&device_seed)
             .await
             .unwrap();
         let root_did = {
@@ -148,12 +397,9 @@ mod tests {
             use dialog_varsig::Principal;
             device.did().to_string()
         };
-        let descriptor = tonk_account::AccountRepositoryDescriptorV1::sign(
-            &root,
-            "https://accounts.example/ucan/",
-        )
-        .await
-        .unwrap();
+        let descriptor = tonk_account::AccountRepositoryDescriptorV1::sign(&root, remote)
+            .await
+            .unwrap();
         let descriptor_hex = hex::encode(descriptor.bytes());
         let chain = tonk_identity::delegation::mint_device_delegation(root, &{
             use dialog_varsig::Principal;
@@ -167,6 +413,38 @@ mod tests {
             hex::encode(chain.to_bytes().unwrap()),
             descriptor_hex,
         )
+    }
+
+    async fn fixture() -> (String, String, String, String) {
+        fixture_for(ROOT_PRF, DEVICE_SEED, "https://accounts.example/ucan/").await
+    }
+
+    async fn assert_replay_conflict(
+        store: &SqliteStore,
+        request: &CreateAccount,
+        expected_message: &str,
+        label: &str,
+    ) {
+        let error = create_account(store, request, 500).await;
+        let Err(CeremonyError::Conflict(message)) = error else {
+            panic!("{label} unexpectedly recovered as an exact replay: {error:?}");
+        };
+        assert_eq!(message, expected_message, "wrong conflict for {label}");
+        for leak in [
+            "UNIQUE constraint",
+            "constraint failed",
+            "accounts.",
+            "devices.",
+            "SQLITE_",
+            "D1Error",
+            "person@example.com",
+            "did:key:",
+        ] {
+            assert!(
+                !message.contains(leak),
+                "{label} leaked {leak:?} in its conflict: {message}"
+            );
+        }
     }
 
     #[dialog_common::test]
@@ -186,7 +464,10 @@ mod tests {
                 created_on: "Chrome on macOS".into(),
             }),
         };
-        let id = create_account(&store, &request, 200).await.unwrap();
+        let outcome = create_account(&store, &request, 200).await.unwrap();
+        assert!(!outcome.reused);
+        assert_eq!(outcome.create_fingerprint.len(), 64);
+        let id = outcome.account_id;
         let account = store.account_by_root(&root_did).await.unwrap().unwrap();
         assert_eq!((account.id, account.email.as_str()), (id, "a@x.com"));
         assert_eq!(account.passkey_created_at, Some(150));
@@ -195,6 +476,400 @@ mod tests {
             Some("Chrome on macOS")
         );
         assert_eq!(store.devices(id).await.unwrap().len(), 1);
+    }
+
+    #[dialog_common::test]
+    async fn it_reuses_only_an_exact_account_creation() {
+        let store = SqliteStore::in_memory().unwrap();
+        let (root_did, device_did, delegation_hex, repository_descriptor_hex) = fixture().await;
+        let passkey = Some(PasskeyMetadata {
+            created_at: 150,
+            created_on: "Chrome on macOS".into(),
+        });
+        let first = create_account(
+            &store,
+            &CreateAccount {
+                email: "person@example.com".into(),
+                root_did: root_did.clone(),
+                credential_id: "credential".into(),
+                device_did: device_did.clone(),
+                device_name: "laptop".into(),
+                delegation_hex: delegation_hex.clone(),
+                repository_descriptor_hex: repository_descriptor_hex.clone(),
+                passkey: passkey.clone(),
+            },
+            200,
+        )
+        .await
+        .unwrap();
+        assert!(!first.reused);
+        let first_id = first.account_id;
+        let first_device = store.devices(first_id).await.unwrap().remove(0);
+
+        // This is the same signed semantic operation after the caller lost
+        // the first response. Email case is normalized, while the server's
+        // random attachment candidate and timestamps are deliberately not
+        // part of replay identity.
+        let replayed = create_account(
+            &store,
+            &CreateAccount {
+                email: "PERSON@EXAMPLE.COM".into(),
+                root_did,
+                credential_id: "credential".into(),
+                device_did,
+                device_name: "laptop".into(),
+                delegation_hex: delegation_hex.to_uppercase(),
+                repository_descriptor_hex: repository_descriptor_hex.to_uppercase(),
+                passkey: passkey.map(|passkey| PasskeyMetadata {
+                    created_at: passkey.created_at,
+                    created_on: format!("  {}  ", passkey.created_on),
+                }),
+            },
+            500,
+        )
+        .await
+        .expect("an exact account creation replay should recover its winner");
+
+        assert!(replayed.reused);
+        assert_eq!(replayed.account_id, first_id);
+        assert_eq!(replayed.descriptor, first.descriptor);
+        assert_eq!(replayed.create_fingerprint, first.create_fingerprint);
+        let devices = store.devices(first_id).await.unwrap();
+        assert_eq!(devices.len(), 1, "replay must not add another device");
+        assert_eq!(devices[0].attachment_id, first_device.attachment_id);
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_every_nonexact_creation_replay() {
+        use dialog_ucan_core::subject::Subject;
+        use dialog_ucan_core::time::timestamp::Timestamp;
+        use dialog_ucan_core::{DelegationBuilder, DelegationChain};
+        use dialog_varsig::Principal as _;
+
+        let store = SqliteStore::in_memory().unwrap();
+        let (root_did, device_did, delegation_hex, repository_descriptor_hex) = fixture().await;
+        let base = CreateAccount {
+            email: "person@example.com".into(),
+            root_did: root_did.clone(),
+            credential_id: "credential".into(),
+            device_did: device_did.clone(),
+            device_name: "laptop".into(),
+            delegation_hex: delegation_hex.clone(),
+            repository_descriptor_hex: repository_descriptor_hex.clone(),
+            passkey: Some(PasskeyMetadata {
+                created_at: 150,
+                created_on: "Chrome on macOS".into(),
+            }),
+        };
+        create_account(&store, &base, 200).await.unwrap();
+
+        let mut changed = base.clone();
+        changed.email = "other@example.com".into();
+        assert_replay_conflict(&store, &changed, ROOT_TAKEN, "normalized email").await;
+
+        // A root change must carry its own valid descriptor and delegation;
+        // it then collides on the original normalized email.
+        let (other_root, other_device, other_delegation, other_descriptor) =
+            fixture_for([10u8; 32], [11u8; 32], "https://accounts.example/ucan/").await;
+        changed = base.clone();
+        changed.root_did = other_root;
+        changed.device_did = other_device;
+        changed.delegation_hex = other_delegation;
+        changed.repository_descriptor_hex = other_descriptor;
+        assert_replay_conflict(&store, &changed, EMAIL_TAKEN, "root DID").await;
+
+        changed = base.clone();
+        changed.credential_id = "other-credential".into();
+        assert_replay_conflict(&store, &changed, ROOT_TAKEN, "credential ID").await;
+
+        changed = base.clone();
+        changed.passkey = None;
+        assert_replay_conflict(&store, &changed, ROOT_TAKEN, "passkey presence").await;
+
+        changed = base.clone();
+        changed.passkey.as_mut().unwrap().created_at += 1;
+        assert_replay_conflict(&store, &changed, ROOT_TAKEN, "passkey createdAt").await;
+
+        changed = base.clone();
+        changed.passkey.as_mut().unwrap().created_on = "Firefox on Linux".into();
+        assert_replay_conflict(&store, &changed, ROOT_TAKEN, "passkey createdOn").await;
+
+        let root = dialog_credentials::Ed25519Signer::import(&ROOT_PRF)
+            .await
+            .unwrap();
+        let other_descriptor =
+            tonk_account::AccountRepositoryDescriptorV1::sign(&root, "https://other.example/ucan/")
+                .await
+                .unwrap();
+        changed = base.clone();
+        changed.repository_descriptor_hex = hex::encode(other_descriptor.bytes());
+        assert_replay_conflict(&store, &changed, ROOT_TAKEN, "repository descriptor bytes").await;
+
+        let other_device = dialog_credentials::Ed25519Signer::import(&[12u8; 32])
+            .await
+            .unwrap();
+        let other_device_delegation =
+            tonk_identity::delegation::mint_device_delegation(root.clone(), &other_device.did())
+                .await
+                .unwrap();
+        changed = base.clone();
+        changed.device_did = other_device.did().to_string();
+        changed.delegation_hex = hex::encode(other_device_delegation.to_bytes().unwrap());
+        assert_replay_conflict(&store, &changed, ROOT_TAKEN, "first-device DID").await;
+
+        changed = base.clone();
+        changed.device_name = "phone".into();
+        assert_replay_conflict(&store, &changed, ROOT_TAKEN, "first-device name").await;
+
+        // Keep the same root and device while changing the signed delegation
+        // bytes and therefore its content CID.
+        let device = dialog_credentials::Ed25519Signer::import(&DEVICE_SEED)
+            .await
+            .unwrap();
+        let alternate_delegation = DelegationBuilder::new()
+            .issuer(dialog_credentials::Signer::from(root))
+            .audience(&device.did())
+            .subject(Subject::Any)
+            .command(vec![])
+            .expiration(Timestamp::five_minutes_from_now())
+            .try_build()
+            .await
+            .unwrap();
+        changed = base;
+        changed.delegation_hex = hex::encode(
+            DelegationChain::new(alternate_delegation)
+                .to_bytes()
+                .unwrap(),
+        );
+        assert_replay_conflict(&store, &changed, ROOT_TAKEN, "delegation CID and bytes").await;
+    }
+
+    #[dialog_common::test]
+    async fn it_reports_absent_for_a_verified_root_without_an_account() {
+        let store = SqliteStore::in_memory().unwrap();
+        let status = account_setup_status(
+            &store,
+            "did:key:zAbsentRoot",
+            "did:key:zAbsentDevice",
+            "bafyAbsentDelegation",
+            &"ab".repeat(32),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(status, AccountSetupStatus::Absent);
+    }
+
+    #[dialog_common::test]
+    async fn it_accepts_the_exact_persisted_setup_fingerprint() {
+        let store = SqliteStore::in_memory().unwrap();
+        let (root_did, device_did, delegation_hex, repository_descriptor_hex) = fixture().await;
+        let created = create_account(
+            &store,
+            &CreateAccount {
+                email: "person@example.com".into(),
+                root_did: root_did.clone(),
+                credential_id: "credential".into(),
+                device_did: device_did.clone(),
+                device_name: "laptop".into(),
+                delegation_hex,
+                repository_descriptor_hex,
+                passkey: Some(PasskeyMetadata {
+                    created_at: 150,
+                    created_on: "Chrome on macOS".into(),
+                }),
+            },
+            200,
+        )
+        .await
+        .unwrap();
+        let first_device = store.devices(created.account_id).await.unwrap().remove(0);
+
+        let status = account_setup_status(
+            &store,
+            &root_did,
+            &device_did,
+            &first_device.delegation_cid,
+            &created.create_fingerprint,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            status,
+            AccountSetupStatus::Accepted {
+                account_id: created.account_id,
+                descriptor_hex: hex::encode(created.descriptor),
+                create_fingerprint: created.create_fingerprint,
+            }
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_distinguishes_mismatched_setup_and_rejects_wrong_first_device() {
+        let store = SqliteStore::in_memory().unwrap();
+        let (root_did, device_did, delegation_hex, repository_descriptor_hex) = fixture().await;
+        let created = create_account(
+            &store,
+            &CreateAccount {
+                email: "person@example.com".into(),
+                root_did: root_did.clone(),
+                credential_id: "credential".into(),
+                device_did: device_did.clone(),
+                device_name: "laptop".into(),
+                delegation_hex,
+                repository_descriptor_hex,
+                passkey: None,
+            },
+            200,
+        )
+        .await
+        .unwrap();
+        let first_device = store.devices(created.account_id).await.unwrap().remove(0);
+
+        assert_eq!(
+            account_setup_status(
+                &store,
+                &root_did,
+                &device_did,
+                &first_device.delegation_cid,
+                &"cd".repeat(32),
+            )
+            .await
+            .unwrap(),
+            AccountSetupStatus::Mismatch
+        );
+        assert!(matches!(
+            account_setup_status(
+                &store,
+                &root_did,
+                "did:key:zWrongDevice",
+                &first_device.delegation_cid,
+                &created.create_fingerprint,
+            )
+            .await,
+            Err(CeremonyError::Forbidden(_))
+        ));
+        assert!(matches!(
+            account_setup_status(
+                &store,
+                &root_did,
+                &device_did,
+                "bafyWrongDelegation",
+                &created.create_fingerprint,
+            )
+            .await,
+            Err(CeremonyError::Forbidden(_))
+        ));
+        assert!(matches!(
+            account_setup_status(
+                &store,
+                &root_did,
+                &device_did,
+                &first_device.delegation_cid,
+                &created.create_fingerprint.to_uppercase(),
+            )
+            .await,
+            Err(CeremonyError::Invalid(_))
+        ));
+
+        store
+            .revoke_device(created.account_id, &device_did)
+            .await
+            .unwrap();
+        assert!(matches!(
+            account_setup_status(
+                &store,
+                &root_did,
+                &device_did,
+                &first_device.delegation_cid,
+                &created.create_fingerprint,
+            )
+            .await,
+            Err(CeremonyError::Forbidden(_))
+        ));
+
+        // A legacy/incomplete account row cannot be called accepted merely
+        // because the cryptographic proof and a caller-provided hash exist.
+        let incomplete = SqliteStore::in_memory().unwrap();
+        let account_id = incomplete
+            .create_account("legacy@example.com", &root_did, "credential", 1)
+            .await
+            .unwrap();
+        incomplete
+            .insert_device(&Device {
+                id: 0,
+                account_id,
+                device_did: device_did.clone(),
+                attachment_id: "01".repeat(32),
+                delegation_cid: first_device.delegation_cid.clone(),
+                delegation_hex: first_device.delegation_hex,
+                name: "laptop".into(),
+                status: DeviceStatus::Active,
+                created_at: 1,
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            account_setup_status(
+                &incomplete,
+                &root_did,
+                &device_did,
+                &first_device.delegation_cid,
+                &"ab".repeat(32),
+            )
+            .await
+            .unwrap(),
+            AccountSetupStatus::Mismatch
+        );
+
+        // The stored delegation bytes must still validate to the proof-bound
+        // root, device, and CID. Decoding alone would let a legacy empty value
+        // be fingerprinted and incorrectly called accepted.
+        let malformed = SqliteStore::in_memory().unwrap();
+        let malformed_account = NewAccount {
+            email: "malformed@example.com",
+            root_did: &root_did,
+            credential_id: "credential",
+            repository_descriptor: &created.descriptor,
+            passkey: None,
+            created_at: 1,
+        };
+        let malformed_device = NewDevice {
+            device_did: device_did.clone(),
+            attachment_id: "02".repeat(32),
+            delegation_cid: first_device.delegation_cid.clone(),
+            delegation_hex: String::new(),
+            name: "laptop".into(),
+        };
+        malformed
+            .create_account_with_device(&malformed_account, &malformed_device)
+            .await
+            .unwrap();
+        let malformed_fingerprint = AccountCreationFingerprintInput {
+            email: malformed_account.email,
+            root_did: &root_did,
+            credential_id: malformed_account.credential_id,
+            passkey: None,
+            descriptor: &created.descriptor,
+            device_did: &device_did,
+            device_name: &malformed_device.name,
+            delegation_cid: &first_device.delegation_cid,
+            delegation: &[],
+        }
+        .fingerprint()
+        .to_hex();
+        assert_eq!(
+            account_setup_status(
+                &malformed,
+                &root_did,
+                &device_did,
+                &first_device.delegation_cid,
+                &malformed_fingerprint,
+            )
+            .await
+            .unwrap(),
+            AccountSetupStatus::Mismatch
+        );
     }
 
     #[dialog_common::test]
@@ -341,7 +1016,10 @@ mod tests {
         };
         create_account(&store, &request, 200).await.unwrap();
 
-        let request = CreateAccount { ..request };
+        let request = CreateAccount {
+            device_name: "different laptop".into(),
+            ..request
+        };
         let Err(CeremonyError::Conflict(message)) = create_account(&store, &request, 500).await
         else {
             panic!("expected a conflict");

--- a/rust/tonk-account-service/src/core/accounts.rs
+++ b/rust/tonk-account-service/src/core/accounts.rs
@@ -62,7 +62,10 @@ pub struct CreateAccountOutcome {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 #[serde(tag = "status", rename_all = "camelCase")]
 pub enum AccountSetupStatus {
-    /// The verified root has no provider account row.
+    /// No exact active first-device setup is visible to this proof.
+    ///
+    /// This deliberately covers an unknown/deleted account, a missing or
+    /// inactive first device, and a nonmatching device DID or delegation CID.
     Absent,
     /// The persisted account is the exact operation the caller fingerprinted.
     Accepted {
@@ -76,7 +79,8 @@ pub enum AccountSetupStatus {
         #[serde(rename = "createFingerprint")]
         create_fingerprint: String,
     },
-    /// The root exists, but its durable creation facts differ.
+    /// The exact active first device exists, but its durable creation facts
+    /// differ from the caller's fingerprint.
     Mismatch,
 }
 
@@ -264,7 +268,9 @@ async fn recover_exact_replay<S: Store>(
 /// device invocation.
 ///
 /// Authentication happens before this function. Its root argument must come
-/// from the verified invocation subject, never from a request field.
+/// from the verified invocation subject, never from a request field. Provider
+/// state is disclosed only to the exact active first-device grant; every other
+/// authenticated root-to-device proof receives [`AccountSetupStatus::Absent`].
 pub async fn account_setup_status<S: Store>(
     store: &S,
     root_did: &str,
@@ -282,17 +288,13 @@ pub async fn account_setup_status<S: Store>(
         .into_iter()
         .min_by_key(|device| device.id)
     else {
-        return Ok(AccountSetupStatus::Mismatch);
+        return Ok(AccountSetupStatus::Absent);
     };
     if first_device.status != DeviceStatus::Active {
-        return Err(CeremonyError::Forbidden(
-            "setup status requires the active first account device".to_string(),
-        ));
+        return Ok(AccountSetupStatus::Absent);
     }
     if first_device.device_did != device_did || first_device.delegation_cid != delegation_cid {
-        return Err(CeremonyError::Forbidden(
-            "setup proof does not match the first account device".to_string(),
-        ));
+        return Ok(AccountSetupStatus::Absent);
     }
     let Ok(stored_delegation_cid) = check_device_delegation(
         &first_device.delegation_hex,
@@ -479,6 +481,84 @@ mod tests {
     }
 
     #[dialog_common::test]
+    async fn it_rejects_first_device_grants_that_cannot_survive_response_loss() {
+        use dialog_ucan_core::subject::Subject;
+        use dialog_ucan_core::time::timestamp::Timestamp;
+        use dialog_ucan_core::{DelegationBuilder, DelegationChain};
+        use dialog_varsig::Principal as _;
+
+        let root = dialog_credentials::Ed25519Signer::import(&ROOT_PRF)
+            .await
+            .unwrap();
+        let device = dialog_credentials::Ed25519Signer::import(&DEVICE_SEED)
+            .await
+            .unwrap();
+        let root_did = root.did().to_string();
+        let device_did = device.did().to_string();
+        let descriptor = tonk_account::AccountRepositoryDescriptorV1::sign(
+            &root,
+            "https://accounts.example/ucan/",
+        )
+        .await
+        .unwrap();
+        let descriptor_hex = hex::encode(descriptor.bytes());
+
+        let command_scoped = DelegationBuilder::new()
+            .issuer(dialog_credentials::Signer::from(root.clone()))
+            .audience(&device.did())
+            .subject(Subject::Any)
+            .command(vec!["account".into(), "setup".into(), "status".into()])
+            .try_build()
+            .await
+            .unwrap();
+        let expiring = DelegationBuilder::new()
+            .issuer(dialog_credentials::Signer::from(root.clone()))
+            .audience(&device.did())
+            .subject(Subject::Any)
+            .command(vec![])
+            .expiration(Timestamp::five_minutes_from_now())
+            .try_build()
+            .await
+            .unwrap();
+        let not_before = DelegationBuilder::new()
+            .issuer(dialog_credentials::Signer::from(root))
+            .audience(&device.did())
+            .subject(Subject::Any)
+            .command(vec![])
+            .not_before(Timestamp::now())
+            .try_build()
+            .await
+            .unwrap();
+
+        for (label, grant, expected_message) in [
+            ("command-scoped", command_scoped, "command-open"),
+            ("expiring", expiring, "unbounded"),
+            ("not-before", not_before, "unbounded"),
+        ] {
+            let store = SqliteStore::in_memory().unwrap();
+            let request = CreateAccount {
+                email: format!("{label}@example.com"),
+                root_did: root_did.clone(),
+                credential_id: format!("credential-{label}"),
+                device_did: device_did.clone(),
+                device_name: "laptop".into(),
+                delegation_hex: hex::encode(DelegationChain::new(grant).to_bytes().unwrap()),
+                repository_descriptor_hex: descriptor_hex.clone(),
+                passkey: None,
+            };
+            let result = create_account(&store, &request, 1).await;
+            let Err(CeremonyError::Invalid(message)) = result else {
+                panic!("{label} first-device grant was accepted: {result:?}");
+            };
+            assert!(
+                message.contains(expected_message),
+                "wrong {label} refusal: {message}"
+            );
+            assert!(store.account_by_root(&root_did).await.unwrap().is_none());
+        }
+    }
+
+    #[dialog_common::test]
     async fn it_reuses_only_an_exact_account_creation() {
         let store = SqliteStore::in_memory().unwrap();
         let (root_did, device_did, delegation_hex, repository_descriptor_hex) = fixture().await;
@@ -542,7 +622,6 @@ mod tests {
     #[dialog_common::test]
     async fn it_rejects_every_nonexact_creation_replay() {
         use dialog_ucan_core::subject::Subject;
-        use dialog_ucan_core::time::timestamp::Timestamp;
         use dialog_ucan_core::{DelegationBuilder, DelegationChain};
         use dialog_varsig::Principal as _;
 
@@ -631,7 +710,6 @@ mod tests {
             .audience(&device.did())
             .subject(Subject::Any)
             .command(vec![])
-            .expiration(Timestamp::five_minutes_from_now())
             .try_build()
             .await
             .unwrap();
@@ -658,6 +736,102 @@ mod tests {
         .unwrap();
 
         assert_eq!(status, AccountSetupStatus::Absent);
+    }
+
+    #[dialog_common::test]
+    async fn it_hides_every_nonmatching_first_device_state_as_absent() {
+        let (root_did, device_did, delegation_hex, repository_descriptor_hex) = fixture().await;
+
+        let no_device = SqliteStore::in_memory().unwrap();
+        no_device
+            .create_account("no-device@example.com", &root_did, "credential", 1)
+            .await
+            .unwrap();
+        assert_eq!(
+            account_setup_status(
+                &no_device,
+                &root_did,
+                &device_did,
+                "bafyMissingDelegation",
+                &"ab".repeat(32),
+            )
+            .await
+            .unwrap(),
+            AccountSetupStatus::Absent
+        );
+
+        let store = SqliteStore::in_memory().unwrap();
+        let created = create_account(
+            &store,
+            &CreateAccount {
+                email: "person@example.com".into(),
+                root_did: root_did.clone(),
+                credential_id: "credential".into(),
+                device_did: device_did.clone(),
+                device_name: "laptop".into(),
+                delegation_hex,
+                repository_descriptor_hex,
+                passkey: None,
+            },
+            1,
+        )
+        .await
+        .unwrap();
+        let first_device = store.devices(created.account_id).await.unwrap().remove(0);
+
+        for (label, presented_device, presented_cid) in [
+            (
+                "wrong DID",
+                "did:key:zWrongDevice",
+                first_device.delegation_cid.as_str(),
+            ),
+            ("wrong CID", device_did.as_str(), "bafyWrongDelegation"),
+        ] {
+            assert_eq!(
+                account_setup_status(
+                    &store,
+                    &root_did,
+                    presented_device,
+                    presented_cid,
+                    &created.create_fingerprint,
+                )
+                .await
+                .unwrap(),
+                AccountSetupStatus::Absent,
+                "{label} disclosed that the account exists"
+            );
+        }
+
+        assert_eq!(
+            account_setup_status(
+                &store,
+                &root_did,
+                &device_did,
+                &first_device.delegation_cid,
+                &"cd".repeat(32),
+            )
+            .await
+            .unwrap(),
+            AccountSetupStatus::Mismatch,
+            "only the exact active first device may learn mismatch"
+        );
+
+        store
+            .revoke_device(created.account_id, &device_did)
+            .await
+            .unwrap();
+        assert_eq!(
+            account_setup_status(
+                &store,
+                &root_did,
+                &device_did,
+                &first_device.delegation_cid,
+                &created.create_fingerprint,
+            )
+            .await
+            .unwrap(),
+            AccountSetupStatus::Absent
+        );
     }
 
     #[dialog_common::test]
@@ -705,7 +879,7 @@ mod tests {
     }
 
     #[dialog_common::test]
-    async fn it_distinguishes_mismatched_setup_and_rejects_wrong_first_device() {
+    async fn it_distinguishes_mismatched_setup_and_hides_wrong_first_device() {
         let store = SqliteStore::in_memory().unwrap();
         let (root_did, device_did, delegation_hex, repository_descriptor_hex) = fixture().await;
         let created = create_account(
@@ -738,7 +912,7 @@ mod tests {
             .unwrap(),
             AccountSetupStatus::Mismatch
         );
-        assert!(matches!(
+        assert_eq!(
             account_setup_status(
                 &store,
                 &root_did,
@@ -746,10 +920,11 @@ mod tests {
                 &first_device.delegation_cid,
                 &created.create_fingerprint,
             )
-            .await,
-            Err(CeremonyError::Forbidden(_))
-        ));
-        assert!(matches!(
+            .await
+            .unwrap(),
+            AccountSetupStatus::Absent
+        );
+        assert_eq!(
             account_setup_status(
                 &store,
                 &root_did,
@@ -757,9 +932,10 @@ mod tests {
                 "bafyWrongDelegation",
                 &created.create_fingerprint,
             )
-            .await,
-            Err(CeremonyError::Forbidden(_))
-        ));
+            .await
+            .unwrap(),
+            AccountSetupStatus::Absent
+        );
         assert!(matches!(
             account_setup_status(
                 &store,
@@ -776,7 +952,7 @@ mod tests {
             .revoke_device(created.account_id, &device_did)
             .await
             .unwrap();
-        assert!(matches!(
+        assert_eq!(
             account_setup_status(
                 &store,
                 &root_did,
@@ -784,9 +960,10 @@ mod tests {
                 &first_device.delegation_cid,
                 &created.create_fingerprint,
             )
-            .await,
-            Err(CeremonyError::Forbidden(_))
-        ));
+            .await
+            .unwrap(),
+            AccountSetupStatus::Absent
+        );
 
         // A legacy/incomplete account row cannot be called accepted merely
         // because the cryptographic proof and a caller-provided hash exist.

--- a/rust/tonk-account-service/src/core/delegation.rs
+++ b/rust/tonk-account-service/src/core/delegation.rs
@@ -2,15 +2,91 @@
 //! creation or device linking.
 
 use dialog_credentials::DidKeyResolver;
-use dialog_ucan_core::DelegationChain;
+use dialog_ucan_core::subject::Subject;
+use dialog_ucan_core::{Delegation, DelegationChain};
+use dialog_varsig::AnySignature;
 
 use crate::core::CeremonyError;
 
+/// Why a purported stable root-to-device grant is not canonical.
+#[derive(Debug)]
+pub(crate) enum DeviceGrantError {
+    /// The container did not resolve to exactly one delegation proof.
+    ProofCount,
+    /// The proof was not issued by the expected account root.
+    WrongIssuer,
+    /// The proof was not addressed to the expected device.
+    WrongAudience,
+    /// The proof narrowed the account subject.
+    SubjectScoped,
+    /// The proof narrowed the commands available to the device.
+    CommandScoped,
+    /// The durable device grant carried a not-before or expiration bound.
+    TimeBounded,
+    /// The proof signature did not verify under its issuer.
+    InvalidSignature(String),
+}
+
+/// Validate the one canonical durable `root → device` grant shape.
+///
+/// Account creation, device registration, and response-loss setup recovery all
+/// call this seam, so none can persist or authenticate a grant another path
+/// would later refuse.
+pub(crate) async fn validate_root_device_grant(
+    proof_count: usize,
+    proof: Option<&Delegation<AnySignature>>,
+    root_did: &str,
+    device_did: &str,
+) -> Result<String, DeviceGrantError> {
+    if proof_count != 1 {
+        return Err(DeviceGrantError::ProofCount);
+    }
+    let Some(proof) = proof else {
+        return Err(DeviceGrantError::ProofCount);
+    };
+    if proof.issuer().to_string() != root_did {
+        return Err(DeviceGrantError::WrongIssuer);
+    }
+    if proof.audience().to_string() != device_did {
+        return Err(DeviceGrantError::WrongAudience);
+    }
+    if proof.subject() != &Subject::Any {
+        return Err(DeviceGrantError::SubjectScoped);
+    }
+    if !proof.command().0.is_empty() {
+        return Err(DeviceGrantError::CommandScoped);
+    }
+    if proof.not_before().is_some() || proof.expiration().is_some() {
+        return Err(DeviceGrantError::TimeBounded);
+    }
+    proof
+        .verify_signature(&DidKeyResolver)
+        .await
+        .map_err(|error| DeviceGrantError::InvalidSignature(error.to_string()))?;
+    Ok(proof.to_cid().to_string())
+}
+
+fn creation_error(error: DeviceGrantError) -> CeremonyError {
+    let message = match error {
+        DeviceGrantError::ProofCount => "delegation chain must have exactly one proof",
+        DeviceGrantError::WrongIssuer => "delegation issuer does not match the claimed root",
+        DeviceGrantError::WrongAudience => "delegation audience does not match the device",
+        DeviceGrantError::SubjectScoped => "root to device delegation must be subject-open",
+        DeviceGrantError::CommandScoped => "root to device delegation must be command-open",
+        DeviceGrantError::TimeBounded => "root to device delegation must be unbounded",
+        DeviceGrantError::InvalidSignature(detail) => {
+            return CeremonyError::Unauthorized(format!("bad delegation signature: {detail}"));
+        }
+    };
+    CeremonyError::Invalid(message.to_string())
+}
+
 /// Parse and check a hex-encoded `root → device` delegation chain.
 ///
-/// Requires exactly one proof, issued by `root_did` to `device_did`,
-/// subject-open, with a valid signature. Returns the delegation's CID,
-/// stringified — the key `devices.delegation_cid` is stored under.
+/// Requires exactly one proof, issued by `root_did` to `device_did`, with a
+/// valid signature and the subject-open, command-open, unbounded shape of a
+/// durable device grant. Returns the delegation's CID, stringified — the key
+/// `devices.delegation_cid` is stored under.
 pub async fn check_device_delegation(
     delegation_hex: &str,
     root_did: &str,
@@ -21,35 +97,12 @@ pub async fn check_device_delegation(
     let chain = DelegationChain::try_from(&bytes[..])
         .map_err(|err| CeremonyError::Invalid(format!("bad delegation chain: {err}")))?;
 
-    if chain.proof_cids().len() != 1 {
-        return Err(CeremonyError::Invalid(
-            "delegation chain must have exactly one proof".to_string(),
-        ));
-    }
-    if chain.issuer().to_string() != root_did {
-        return Err(CeremonyError::Invalid(
-            "delegation issuer does not match the claimed root".to_string(),
-        ));
-    }
-    if chain.audience().to_string() != device_did {
-        return Err(CeremonyError::Invalid(
-            "delegation audience does not match the device".to_string(),
-        ));
-    }
-    if chain.subject().is_some() {
-        return Err(CeremonyError::Invalid(
-            "root to device delegation must be subject-open".to_string(),
-        ));
-    }
-
-    let proof = chain
-        .proofs()
-        .next()
-        .expect("a chain with one proof cid has one proof");
-    proof
-        .verify_signature(&DidKeyResolver)
-        .await
-        .map_err(|err| CeremonyError::Unauthorized(format!("bad delegation signature: {err}")))?;
-
-    Ok(chain.proof_cids()[0].to_string())
+    validate_root_device_grant(
+        chain.proof_cids().len(),
+        chain.proofs().next(),
+        root_did,
+        device_did,
+    )
+    .await
+    .map_err(creation_error)
 }

--- a/rust/tonk-account-service/src/core/delegation.rs
+++ b/rust/tonk-account-service/src/core/delegation.rs
@@ -21,6 +21,8 @@ pub(crate) enum DeviceGrantError {
     SubjectScoped,
     /// The proof narrowed the commands available to the device.
     CommandScoped,
+    /// The proof conditioned the device grant on invocation arguments.
+    PolicyScoped,
     /// The durable device grant carried a not-before or expiration bound.
     TimeBounded,
     /// The proof signature did not verify under its issuer.
@@ -56,6 +58,9 @@ pub(crate) async fn validate_root_device_grant(
     if !proof.command().0.is_empty() {
         return Err(DeviceGrantError::CommandScoped);
     }
+    if !proof.policy().is_empty() {
+        return Err(DeviceGrantError::PolicyScoped);
+    }
     if proof.not_before().is_some() || proof.expiration().is_some() {
         return Err(DeviceGrantError::TimeBounded);
     }
@@ -73,6 +78,9 @@ fn creation_error(error: DeviceGrantError) -> CeremonyError {
         DeviceGrantError::WrongAudience => "delegation audience does not match the device",
         DeviceGrantError::SubjectScoped => "root to device delegation must be subject-open",
         DeviceGrantError::CommandScoped => "root to device delegation must be command-open",
+        DeviceGrantError::PolicyScoped => {
+            "root to device delegation must not contain policy predicates"
+        }
         DeviceGrantError::TimeBounded => "root to device delegation must be unbounded",
         DeviceGrantError::InvalidSignature(detail) => {
             return CeremonyError::Unauthorized(format!("bad delegation signature: {detail}"));
@@ -84,9 +92,9 @@ fn creation_error(error: DeviceGrantError) -> CeremonyError {
 /// Parse and check a hex-encoded `root → device` delegation chain.
 ///
 /// Requires exactly one proof, issued by `root_did` to `device_did`, with a
-/// valid signature and the subject-open, command-open, unbounded shape of a
-/// durable device grant. Returns the delegation's CID, stringified — the key
-/// `devices.delegation_cid` is stored under.
+/// valid signature and the subject-open, command-open, policy-free, unbounded
+/// shape of a durable device grant. Returns the delegation's CID, stringified
+/// — the key `devices.delegation_cid` is stored under.
 pub async fn check_device_delegation(
     delegation_hex: &str,
     root_did: &str,

--- a/rust/tonk-account-service/src/handlers.rs
+++ b/rust/tonk-account-service/src/handlers.rs
@@ -1,8 +1,14 @@
 //! HTTP handlers: thin adapters from worker requests onto the core
 //! ceremony logic.
 
+pub mod capabilities;
 pub mod health;
 pub mod info;
+
+/// Methods allowed by every CORS-readable account-service response.
+pub(crate) const CORS_ALLOW_METHODS: &str = "GET, POST, OPTIONS";
+/// Origins allowed to read public account-service responses.
+pub(crate) const CORS_ALLOW_ORIGIN: &str = "*";
 
 #[cfg(target_arch = "wasm32")]
 pub mod accounts;
@@ -13,11 +19,10 @@ pub mod devices;
 pub mod repository;
 
 /// Add CORS headers permitting cross-origin requests to a response.
-#[cfg(target_arch = "wasm32")]
 pub fn with_cors_headers(response: worker::Response) -> worker::Response {
     let headers = response.headers().clone();
-    let _ = headers.set("Access-Control-Allow-Origin", "*");
-    let _ = headers.set("Access-Control-Allow-Methods", "POST, OPTIONS");
+    let _ = headers.set("Access-Control-Allow-Origin", CORS_ALLOW_ORIGIN);
+    let _ = headers.set("Access-Control-Allow-Methods", CORS_ALLOW_METHODS);
     let _ = headers.set("Access-Control-Allow-Headers", "Content-Type");
     let _ = headers.set("Access-Control-Expose-Headers", "Content-Type");
     response.with_headers(headers)

--- a/rust/tonk-account-service/src/handlers/accounts.rs
+++ b/rust/tonk-account-service/src/handlers/accounts.rs
@@ -4,8 +4,10 @@ use worker::*;
 
 use serde::Deserialize;
 
-use crate::auth::{authorize, authorize_root, optional_passkey_metadata, required_string};
-use crate::core::accounts::{CreateAccount, create_account};
+use crate::auth::{
+    authorize, authorize_root, authorize_setup_device, optional_passkey_metadata, required_string,
+};
+use crate::core::accounts::{CreateAccount, account_setup_status, create_account};
 use crate::core::deletion::delete_account;
 use crate::error::{ErrorCode, ServiceError};
 use crate::handlers::{build_store, ceremony_error, read_body, with_cors_headers};
@@ -88,6 +90,40 @@ pub async fn handle(mut req: Request, ctx: RouteContext<()>) -> Result<Response>
     Ok(with_cors_headers(response))
 }
 
+/// `POST /accounts/setup-status` → proof-bound account-creation state.
+pub async fn handle_setup_status(mut req: Request, ctx: RouteContext<()>) -> Result<Response> {
+    let response = match handle_setup_status_inner(&mut req, &ctx).await {
+        Ok(response) => response,
+        Err(err) => err.to_response()?,
+    };
+    Ok(with_cors_headers(response))
+}
+
+async fn handle_setup_status_inner(
+    req: &mut Request,
+    ctx: &RouteContext<()>,
+) -> std::result::Result<Response, ServiceError> {
+    let body = read_body(req).await?;
+    let caller = authorize_setup_device(&body, &["account", "setup", "status"])
+        .await
+        .map_err(ceremony_error)?;
+    let expected =
+        required_string(&caller.arguments, "createFingerprint").map_err(ceremony_error)?;
+    let store = build_store(ctx)?;
+    let status = account_setup_status(
+        &store,
+        &caller.root_did,
+        &caller.device_did,
+        &caller.delegation_cid,
+        &expected,
+    )
+    .await
+    .map_err(ceremony_error)?;
+    Response::from_json(&status).map_err(|error| {
+        ServiceError::new(ErrorCode::InternalError, format!("response error: {error}"))
+    })
+}
+
 async fn handle_inner(
     req: &mut Request,
     ctx: &RouteContext<()>,
@@ -111,25 +147,16 @@ async fn handle_inner(
         passkey,
     };
     let store = build_store(ctx)?;
-    let account_id = create_account(&store, &request, now)
+    let outcome = create_account(&store, &request, now)
         .await
         .map_err(ceremony_error)?;
-    let account = store
-        .account_by_root(&request.root_did)
-        .await
-        .map_err(|error| ceremony_error(error.into()))?
-        .ok_or_else(|| {
-            ServiceError::new(ErrorCode::InternalError, "created account was not found")
-        })?;
-    let descriptor_hex = account
-        .repository_descriptor
-        .map(hex::encode)
-        .ok_or_else(|| ServiceError::new(ErrorCode::InternalError, "descriptor was not stored"))?;
 
     Response::from_json(&serde_json::json!({
-        "accountId": account_id,
-        "descriptorHex": descriptor_hex,
+        "accountId": outcome.account_id,
+        "descriptorHex": hex::encode(outcome.descriptor),
+        "createFingerprint": outcome.create_fingerprint,
+        "reused": outcome.reused,
     }))
-    .map(|response| response.with_status(201))
+    .map(|response| response.with_status(if outcome.reused { 200 } else { 201 }))
     .map_err(|err| ServiceError::new(ErrorCode::InternalError, format!("response error: {err}")))
 }

--- a/rust/tonk-account-service/src/handlers/capabilities.rs
+++ b/rust/tonk-account-service/src/handlers/capabilities.rs
@@ -1,0 +1,56 @@
+//! Public, privacy-neutral service capability discovery.
+
+use serde::Serialize;
+use worker::*;
+
+use crate::handlers::with_cors_headers;
+
+/// Stable capability versions advertised by the account service.
+#[derive(Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Capabilities {
+    account_setup_recovery: u8,
+}
+
+/// Exact additive response body shared by the Worker and native helper.
+#[derive(Debug, PartialEq, Eq, Serialize)]
+pub(crate) struct CapabilitiesResponse {
+    service: &'static str,
+    capabilities: Capabilities,
+}
+
+/// Build the stable capability response without consulting account state.
+pub(crate) const fn response_body() -> CapabilitiesResponse {
+    CapabilitiesResponse {
+        service: "tonk-account-service",
+        capabilities: Capabilities {
+            account_setup_recovery: 1,
+        },
+    }
+}
+
+/// Return the public account-service capability marker with CORS headers.
+pub async fn handle(_req: Request, _ctx: RouteContext<()>) -> Result<Response> {
+    Response::from_json(&response_body()).map(with_cors_headers)
+}
+
+/// Answer the exact capability-route CORS preflight.
+pub async fn handle_options(_req: Request, _ctx: RouteContext<()>) -> Result<Response> {
+    Ok(with_cors_headers(Response::empty()?.with_status(204)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::response_body;
+    use crate::handlers::{CORS_ALLOW_METHODS, CORS_ALLOW_ORIGIN};
+
+    #[test]
+    fn it_pins_the_worker_and_native_capability_payload() {
+        assert_eq!(
+            serde_json::to_string(&response_body()).unwrap(),
+            r#"{"service":"tonk-account-service","capabilities":{"accountSetupRecovery":1}}"#
+        );
+        assert_eq!(CORS_ALLOW_ORIGIN, "*");
+        assert_eq!(CORS_ALLOW_METHODS, "GET, POST, OPTIONS");
+    }
+}

--- a/rust/tonk-account-service/src/helpers/server.rs
+++ b/rust/tonk-account-service/src/helpers/server.rs
@@ -34,7 +34,8 @@ use crate::core::devices::{
 };
 use crate::email::CapturedEmail;
 use crate::error::{ErrorCode, ServiceError};
-use crate::handlers::ceremony_error;
+use crate::handlers::capabilities::response_body as capabilities_response_body;
+use crate::handlers::{CORS_ALLOW_METHODS, CORS_ALLOW_ORIGIN, ceremony_error};
 use crate::store::Store;
 use crate::store::sqlite::SqliteStore;
 
@@ -128,6 +129,9 @@ async fn handle_request(
     let response = match (req.method().clone(), req.uri().path()) {
         (Method::GET, "/") => return Ok(info_response()),
         (Method::GET, "/health") => return Ok(health_response()),
+        (Method::GET, "/capabilities") => {
+            Ok(json_response(StatusCode::OK, &capabilities_response_body()))
+        }
         (Method::GET, "/_test/emails") => emails_route(&backends),
         (Method::POST, "/accounts") => accounts_route(req, &backends).await,
         (Method::POST, "/accounts/setup-status") => {
@@ -578,10 +582,13 @@ fn no_content() -> Response<Full<Bytes>> {
 /// `crate::handlers::with_cors_headers`.
 fn cors_response<T>(mut response: Response<T>) -> Response<T> {
     let headers = response.headers_mut();
-    headers.insert(ACCESS_CONTROL_ALLOW_ORIGIN, "*".parse().unwrap());
+    headers.insert(
+        ACCESS_CONTROL_ALLOW_ORIGIN,
+        CORS_ALLOW_ORIGIN.parse().unwrap(),
+    );
     headers.insert(
         ACCESS_CONTROL_ALLOW_METHODS,
-        "POST, OPTIONS".parse().unwrap(),
+        CORS_ALLOW_METHODS.parse().unwrap(),
     );
     headers.insert(
         ACCESS_CONTROL_ALLOW_HEADERS,

--- a/rust/tonk-account-service/src/helpers/server.rs
+++ b/rust/tonk-account-service/src/helpers/server.rs
@@ -23,10 +23,10 @@ use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
 
 use crate::auth::{
-    authorize, authorize_root, optional_passkey_metadata, optional_revocation, required_string,
-    string_argument,
+    authorize, authorize_root, authorize_setup_device, optional_passkey_metadata,
+    optional_revocation, required_string, string_argument,
 };
-use crate::core::accounts::{CreateAccount, create_account};
+use crate::core::accounts::{CreateAccount, account_setup_status, create_account};
 use crate::core::deletion::delete_account;
 use crate::core::descriptor::establish_descriptor;
 use crate::core::devices::{
@@ -130,6 +130,9 @@ async fn handle_request(
         (Method::GET, "/health") => return Ok(health_response()),
         (Method::GET, "/_test/emails") => emails_route(&backends),
         (Method::POST, "/accounts") => accounts_route(req, &backends).await,
+        (Method::POST, "/accounts/setup-status") => {
+            account_setup_status_route(req, &backends).await
+        }
         (Method::POST, "/account/summary") => account_summary_route(req, &backends).await,
         (Method::POST, "/account/delete") => account_delete_route(req, &backends).await,
         (Method::POST, "/account/repository/establish") => {
@@ -275,27 +278,46 @@ async fn accounts_route(
         root_did: caller.root_did,
         passkey,
     };
-    let account_id = create_account(&backends.store, &request, now)
+    let outcome = create_account(&backends.store, &request, now)
         .await
         .map_err(ceremony_error)?;
-    let account = backends
-        .store
-        .account_by_root(&request.root_did)
-        .await
-        .map_err(|error| ceremony_error(error.into()))?
-        .ok_or_else(|| ServiceError::new(ErrorCode::InternalError, "created account missing"))?;
-    let descriptor_hex = account
-        .repository_descriptor
-        .map(hex::encode)
-        .ok_or_else(|| ServiceError::new(ErrorCode::InternalError, "descriptor missing"))?;
 
     Ok(json_response(
-        StatusCode::CREATED,
+        if outcome.reused {
+            StatusCode::OK
+        } else {
+            StatusCode::CREATED
+        },
         &serde_json::json!({
-            "accountId": account_id,
-            "descriptorHex": descriptor_hex,
+            "accountId": outcome.account_id,
+            "descriptorHex": hex::encode(outcome.descriptor),
+            "createFingerprint": outcome.create_fingerprint,
+            "reused": outcome.reused,
         }),
     ))
+}
+
+/// `POST /accounts/setup-status` → proof-bound creation recovery state.
+async fn account_setup_status_route(
+    req: Request<Incoming>,
+    backends: &Backends,
+) -> Result<Response<Full<Bytes>>, ServiceError> {
+    let body = body_bytes(req).await?;
+    let caller = authorize_setup_device(&body, &["account", "setup", "status"])
+        .await
+        .map_err(ceremony_error)?;
+    let expected =
+        required_string(&caller.arguments, "createFingerprint").map_err(ceremony_error)?;
+    let status = account_setup_status(
+        &backends.store,
+        &caller.root_did,
+        &caller.device_did,
+        &caller.delegation_cid,
+        &expected,
+    )
+    .await
+    .map_err(ceremony_error)?;
+    Ok(json_response(StatusCode::OK, &status))
 }
 
 /// `POST /account/repository/establish` → establish one descriptor winner.

--- a/rust/tonk-account-service/src/lib.rs
+++ b/rust/tonk-account-service/src/lib.rs
@@ -30,6 +30,11 @@ async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         .get_async("/health", handlers::health::handle)
         .post_async("/accounts", handlers::accounts::handle)
         .options_async("/accounts", handlers::accounts::handle_options)
+        .post_async(
+            "/accounts/setup-status",
+            handlers::accounts::handle_setup_status,
+        )
+        .options_async("/accounts/setup-status", handlers::accounts::handle_options)
         .post_async("/account/summary", handlers::accounts::handle_summary)
         .options_async("/account/summary", handlers::accounts::handle_options)
         .post_async("/account/delete", handlers::accounts::handle_delete)

--- a/rust/tonk-account-service/src/lib.rs
+++ b/rust/tonk-account-service/src/lib.rs
@@ -28,6 +28,8 @@ async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
     Router::new()
         .get_async("/", handlers::info::handle)
         .get_async("/health", handlers::health::handle)
+        .get_async("/capabilities", handlers::capabilities::handle)
+        .options_async("/capabilities", handlers::capabilities::handle_options)
         .post_async("/accounts", handlers::accounts::handle)
         .options_async("/accounts", handlers::accounts::handle_options)
         .post_async(
@@ -71,6 +73,8 @@ async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
     Router::new()
         .get_async("/", handlers::info::handle)
         .get_async("/health", handlers::health::handle)
+        .get_async("/capabilities", handlers::capabilities::handle)
+        .options_async("/capabilities", handlers::capabilities::handle_options)
         .run(req, env)
         .await
 }

--- a/rust/tonk-account-service/tests/service.rs
+++ b/rust/tonk-account-service/tests/service.rs
@@ -283,8 +283,8 @@ async fn it_keeps_setup_status_private_and_structured() {
         "createFingerprint must be 32 bytes of lowercase hex"
     );
 
-    // Another valid device proof under this root is still not the account's
-    // first-device proof and cannot retrieve accepted setup details.
+    // Another valid device proof under this root is indistinguishable from an
+    // absent account; it cannot learn that a different first device exists.
     let root = dialog_credentials::Ed25519Signer::import(&ROOT_PRF)
         .await
         .unwrap();
@@ -299,15 +299,17 @@ async fn it_keeps_setup_status_private_and_structured() {
         .send()
         .await
         .unwrap();
-    assert_eq!(response.status(), 403);
+    assert_eq!(response.status(), 200);
+    let wrong_device: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(wrong_device, absent);
 
-    // Nor can the first device substitute a newly issued delegation CID.
+    // Nor can the first device substitute a newly issued stable delegation
+    // CID. The proof is canonical, but it is not the persisted first grant.
     let alternate = DelegationBuilder::new()
         .issuer(dialog_credentials::Signer::from(root.clone()))
         .audience(&device.did())
         .subject(Subject::Any)
         .command(vec![])
-        .expiration(Timestamp::five_minutes_from_now())
         .try_build()
         .await
         .unwrap();
@@ -318,7 +320,28 @@ async fn it_keeps_setup_status_private_and_structured() {
         .send()
         .await
         .unwrap();
-    assert_eq!(response.status(), 403);
+    assert_eq!(response.status(), 200);
+    let wrong_cid: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(wrong_cid, absent);
+
+    // Deletion removes the account and first-device row, but the caller still
+    // holds the original public proof. It receives the exact same wire result.
+    let response = client
+        .post(format!("{}/account/delete", server.endpoint))
+        .body(account_deletion(&device, &link, "private@example.com").await)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    let response = client
+        .post(format!("{}/accounts/setup-status", server.endpoint))
+        .body(account_setup_status_invocation(&device, &link, fingerprint).await)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    let deleted: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(deleted, absent);
 
     // Direct root proof and a valid device invocation for another command are
     // both refused at the authentication boundary.

--- a/rust/tonk-account-service/tests/service.rs
+++ b/rust/tonk-account-service/tests/service.rs
@@ -527,7 +527,7 @@ async fn it_rejects_an_over_long_expiration_window() {
 #[dialog_common::test]
 async fn it_answers_preflight_with_cors_headers() {
     let server = AccountServer::start().await;
-    for path in ["/accounts", "/accounts/setup-status"] {
+    for path in ["/capabilities", "/accounts", "/accounts/setup-status"] {
         let response = reqwest::Client::new()
             .request(
                 reqwest::Method::OPTIONS,
@@ -539,10 +539,60 @@ async fn it_answers_preflight_with_cors_headers() {
         assert_eq!(response.status(), 204, "wrong preflight status for {path}");
         let headers = response.headers();
         assert_eq!(headers["access-control-allow-origin"], "*");
-        assert_eq!(headers["access-control-allow-methods"], "POST, OPTIONS");
+        assert_eq!(
+            headers["access-control-allow-methods"],
+            "GET, POST, OPTIONS"
+        );
         assert_eq!(headers["access-control-allow-headers"], "Content-Type");
         assert_eq!(headers["access-control-expose-headers"], "Content-Type");
     }
+
+    server.stop().await;
+}
+
+#[dialog_common::test]
+async fn it_advertises_account_setup_recovery_with_cors() {
+    let server = AccountServer::start().await;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(format!("{}/capabilities", server.endpoint))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    let headers = response.headers().clone();
+    assert_eq!(headers["access-control-allow-origin"], "*");
+    assert_eq!(headers["content-type"], "application/json");
+    assert_eq!(
+        headers["access-control-allow-methods"],
+        "GET, POST, OPTIONS"
+    );
+    assert_eq!(headers["access-control-expose-headers"], "Content-Type");
+    assert_eq!(
+        response.json::<serde_json::Value>().await.unwrap(),
+        serde_json::json!({
+            "service": "tonk-account-service",
+            "capabilities": {
+                "accountSetupRecovery": 1,
+            },
+        })
+    );
+
+    let preflight = client
+        .request(
+            reqwest::Method::OPTIONS,
+            format!("{}/capabilities", server.endpoint),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(preflight.status(), 204);
+    assert_eq!(preflight.headers()["access-control-allow-origin"], "*");
+    assert_eq!(
+        preflight.headers()["access-control-allow-methods"],
+        "GET, POST, OPTIONS"
+    );
 
     server.stop().await;
 }

--- a/rust/tonk-account-service/tests/service.rs
+++ b/rust/tonk-account-service/tests/service.rs
@@ -7,9 +7,11 @@ use std::collections::{BTreeMap, HashMap};
 
 use dialog_credentials::Ed25519Signer;
 use dialog_ucan_core::promise::Promised;
+use dialog_ucan_core::subject::Subject;
 use dialog_ucan_core::time::timestamp::{Duration, SystemTime, Timestamp};
-use dialog_ucan_core::{DelegationChain, InvocationBuilder, InvocationChain};
+use dialog_ucan_core::{DelegationBuilder, DelegationChain, InvocationBuilder, InvocationChain};
 use dialog_varsig::Principal;
+use tonk_account::creation::AccountCreationFingerprintInput;
 use tonk_account_service::helpers::AccountServer;
 
 const ROOT_PRF: [u8; 32] = [7u8; 32];
@@ -79,7 +81,9 @@ async fn container_with_expiration(command: Vec<String>, expiration: Timestamp) 
     InvocationChain::new(invocation, proofs).to_bytes().unwrap()
 }
 
-async fn account_registration(email: &str) -> (Vec<u8>, Ed25519Signer, DelegationChain) {
+async fn account_registration_with_fingerprint(
+    email: &str,
+) -> (Vec<u8>, Ed25519Signer, DelegationChain, String) {
     let root = dialog_credentials::Ed25519Signer::import(&ROOT_PRF)
         .await
         .unwrap();
@@ -99,7 +103,33 @@ async fn account_registration(email: &str) -> (Vec<u8>, Ed25519Signer, Delegatio
     )
     .await
     .unwrap();
-    (hex::decode(ceremony.invocation_hex).unwrap(), device, grant)
+    let delegation = grant.to_bytes().unwrap();
+    let delegation_cid = grant.proof_cids()[0].to_string();
+    let descriptor = hex::decode(ceremony.descriptor_hex.as_ref().unwrap()).unwrap();
+    let fingerprint = AccountCreationFingerprintInput {
+        email,
+        root_did: &ceremony.root_did,
+        credential_id: "credential",
+        passkey: None,
+        descriptor: &descriptor,
+        device_did: &ceremony.device_did,
+        device_name: "laptop",
+        delegation_cid: &delegation_cid,
+        delegation: &delegation,
+    }
+    .fingerprint()
+    .to_hex();
+    (
+        hex::decode(ceremony.invocation_hex).unwrap(),
+        device,
+        grant,
+        fingerprint,
+    )
+}
+
+async fn account_registration(email: &str) -> (Vec<u8>, Ed25519Signer, DelegationChain) {
+    let (invocation, device, grant, _) = account_registration_with_fingerprint(email).await;
+    (invocation, device, grant)
 }
 
 async fn account_creation(email: &str) -> Vec<u8> {
@@ -120,6 +150,240 @@ async fn account_deletion(device: &Ed25519Signer, link: &DelegationChain, email:
         )]),
     )
     .await
+}
+
+async fn account_setup_status_invocation(
+    device: &Ed25519Signer,
+    link: &DelegationChain,
+    fingerprint: &str,
+) -> Vec<u8> {
+    container_with_link(
+        device,
+        link,
+        vec!["account".into(), "setup".into(), "status".into()],
+        BTreeMap::from([(
+            "createFingerprint".to_string(),
+            Promised::String(fingerprint.to_string()),
+        )]),
+    )
+    .await
+}
+
+#[dialog_common::test]
+async fn it_recovers_a_lost_creation_response_and_reports_setup_status() {
+    let server = AccountServer::start().await;
+    let client = reqwest::Client::new();
+    let (creation, device, link, expected_fingerprint) =
+        account_registration_with_fingerprint("recover@example.com").await;
+
+    // The provider commits, but the caller loses this response body.
+    let first = client
+        .post(format!("{}/accounts", server.endpoint))
+        .body(creation.clone())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(first.status(), 201);
+    drop(first);
+
+    // The caller retained the shared-contract fingerprint before sending the
+    // request, so it can authenticate and recover the committed winner without
+    // first needing any provider response.
+    let status = account_setup_status_invocation(&device, &link, &expected_fingerprint).await;
+    let response = client
+        .post(format!("{}/accounts/setup-status", server.endpoint))
+        .body(status)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    let accepted: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(accepted["status"], "accepted");
+    assert!(accepted["accountId"].is_i64());
+    assert!(accepted["descriptorHex"].is_string());
+    assert_eq!(accepted["createFingerprint"], expected_fingerprint);
+
+    let replayed = client
+        .post(format!("{}/accounts", server.endpoint))
+        .body(creation)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(replayed.status(), 200);
+    let replayed: serde_json::Value = replayed.json().await.unwrap();
+    assert_eq!(replayed["reused"], true);
+    let fingerprint = replayed["createFingerprint"]
+        .as_str()
+        .expect("replay carries its creation fingerprint")
+        .to_string();
+    assert_eq!(fingerprint, expected_fingerprint);
+    assert_eq!(accepted["accountId"], replayed["accountId"]);
+    assert_eq!(accepted["descriptorHex"], replayed["descriptorHex"]);
+
+    server.stop().await;
+}
+
+#[dialog_common::test]
+async fn it_keeps_setup_status_private_and_structured() {
+    let server = AccountServer::start().await;
+    let client = reqwest::Client::new();
+
+    // A valid proof for a root with no provider row receives Absent. There is
+    // no root or email argument with which to probe somebody else's account.
+    let absent_root = dialog_credentials::Ed25519Signer::import(&[20u8; 32])
+        .await
+        .unwrap();
+    let absent_device = Ed25519Signer::import(&[21u8; 32]).await.unwrap();
+    let absent_link =
+        tonk_identity::delegation::mint_device_delegation(absent_root, &absent_device.did())
+            .await
+            .unwrap();
+    let response = client
+        .post(format!("{}/accounts/setup-status", server.endpoint))
+        .body(account_setup_status_invocation(&absent_device, &absent_link, &"ab".repeat(32)).await)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    let absent: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(absent, serde_json::json!({ "status": "absent" }));
+
+    let (creation, device, link) = account_registration("private@example.com").await;
+    let created = client
+        .post(format!("{}/accounts", server.endpoint))
+        .body(creation)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), 201);
+    let created: serde_json::Value = created.json().await.unwrap();
+    let fingerprint = created["createFingerprint"].as_str().unwrap();
+
+    let response = client
+        .post(format!("{}/accounts/setup-status", server.endpoint))
+        .body(account_setup_status_invocation(&device, &link, &"cd".repeat(32)).await)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    let mismatch: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(mismatch, serde_json::json!({ "status": "mismatch" }));
+
+    let response = client
+        .post(format!("{}/accounts/setup-status", server.endpoint))
+        .body(account_setup_status_invocation(&device, &link, &fingerprint.to_uppercase()).await)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 400);
+    let malformed: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(malformed["error"]["code"], "INVALID_ARGUMENT");
+    assert_eq!(
+        malformed["error"]["message"],
+        "createFingerprint must be 32 bytes of lowercase hex"
+    );
+
+    // Another valid device proof under this root is still not the account's
+    // first-device proof and cannot retrieve accepted setup details.
+    let root = dialog_credentials::Ed25519Signer::import(&ROOT_PRF)
+        .await
+        .unwrap();
+    let other_device = Ed25519Signer::import(&[22u8; 32]).await.unwrap();
+    let other_link =
+        tonk_identity::delegation::mint_device_delegation(root.clone(), &other_device.did())
+            .await
+            .unwrap();
+    let response = client
+        .post(format!("{}/accounts/setup-status", server.endpoint))
+        .body(account_setup_status_invocation(&other_device, &other_link, fingerprint).await)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 403);
+
+    // Nor can the first device substitute a newly issued delegation CID.
+    let alternate = DelegationBuilder::new()
+        .issuer(dialog_credentials::Signer::from(root.clone()))
+        .audience(&device.did())
+        .subject(Subject::Any)
+        .command(vec![])
+        .expiration(Timestamp::five_minutes_from_now())
+        .try_build()
+        .await
+        .unwrap();
+    let alternate = DelegationChain::new(alternate);
+    let response = client
+        .post(format!("{}/accounts/setup-status", server.endpoint))
+        .body(account_setup_status_invocation(&device, &alternate, fingerprint).await)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 403);
+
+    // Direct root proof and a valid device invocation for another command are
+    // both refused at the authentication boundary.
+    let root_did = root.did();
+    let direct = InvocationBuilder::new()
+        .issuer(dialog_credentials::Signer::from(root))
+        .audience(&root_did)
+        .subject(&root_did)
+        .command(vec!["account".into(), "setup".into(), "status".into()])
+        .arguments(BTreeMap::from([(
+            "createFingerprint".to_string(),
+            Promised::String(fingerprint.to_string()),
+        )]))
+        .proofs(vec![])
+        .expiration(Timestamp::five_minutes_from_now())
+        .try_build()
+        .await
+        .unwrap();
+    let direct = InvocationChain::new(direct, HashMap::new())
+        .to_bytes()
+        .unwrap();
+    let response = client
+        .post(format!("{}/accounts/setup-status", server.endpoint))
+        .body(direct)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 401);
+
+    let wrong_command = container_with_link(
+        &device,
+        &link,
+        vec!["account".into(), "device".into(), "list".into()],
+        BTreeMap::new(),
+    )
+    .await;
+    let response = client
+        .post(format!("{}/accounts/setup-status", server.endpoint))
+        .body(wrong_command)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 403);
+    let wrong_command: serde_json::Value = response.json().await.unwrap();
+
+    for body in [malformed, wrong_command] {
+        let rendered = body.to_string();
+        for leak in [
+            "UNIQUE constraint",
+            "accounts.",
+            "devices.",
+            "SQLITE_",
+            "D1Error",
+            "private@example.com",
+            "accountId",
+            "descriptorHex",
+        ] {
+            assert!(
+                !rendered.contains(leak),
+                "setup refusal leaked {leak:?}: {rendered}"
+            );
+        }
+    }
+
+    server.stop().await;
 }
 
 #[dialog_common::test]
@@ -240,20 +504,22 @@ async fn it_rejects_an_over_long_expiration_window() {
 #[dialog_common::test]
 async fn it_answers_preflight_with_cors_headers() {
     let server = AccountServer::start().await;
-    let response = reqwest::Client::new()
-        .request(
-            reqwest::Method::OPTIONS,
-            format!("{}/accounts", server.endpoint),
-        )
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(response.status(), 204);
-    let headers = response.headers();
-    assert_eq!(headers["access-control-allow-origin"], "*");
-    assert_eq!(headers["access-control-allow-methods"], "POST, OPTIONS");
-    assert_eq!(headers["access-control-allow-headers"], "Content-Type");
-    assert_eq!(headers["access-control-expose-headers"], "Content-Type");
+    for path in ["/accounts", "/accounts/setup-status"] {
+        let response = reqwest::Client::new()
+            .request(
+                reqwest::Method::OPTIONS,
+                format!("{}{path}", server.endpoint),
+            )
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 204, "wrong preflight status for {path}");
+        let headers = response.headers();
+        assert_eq!(headers["access-control-allow-origin"], "*");
+        assert_eq!(headers["access-control-allow-methods"], "POST, OPTIONS");
+        assert_eq!(headers["access-control-allow-headers"], "Content-Type");
+        assert_eq!(headers["access-control-expose-headers"], "Content-Type");
+    }
 
     server.stop().await;
 }

--- a/rust/tonk-account/src/creation.rs
+++ b/rust/tonk-account/src/creation.rs
@@ -1,0 +1,180 @@
+//! Canonical account-creation recovery contracts shared by clients and
+//! providers.
+
+use std::fmt;
+use std::str::FromStr;
+
+/// Passkey facts Tonk recorded during the account-creation ceremony.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AccountCreationPasskey<'a> {
+    /// Ceremony time as Unix seconds.
+    pub created_at: u64,
+    /// Browser and operating-system label captured by the creating client.
+    pub created_on: &'a str,
+}
+
+/// Every caller-controlled fact that identifies one account creation.
+///
+/// The algorithm lowercases `email` and trims `passkey.created_on`, matching
+/// the provider's input normalization. Provider attachment IDs and provider
+/// timestamps are intentionally not inputs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AccountCreationFingerprintInput<'a> {
+    /// Email address submitted by the creating client.
+    pub email: &'a str,
+    /// Passkey-derived account root DID.
+    pub root_did: &'a str,
+    /// Opaque WebAuthn credential identifier.
+    pub credential_id: &'a str,
+    /// Optional facts from the passkey creation ceremony.
+    pub passkey: Option<AccountCreationPasskey<'a>>,
+    /// Canonical root-signed account repository descriptor bytes.
+    pub descriptor: &'a [u8],
+    /// DID of the account's first device.
+    pub device_did: &'a str,
+    /// Human-readable name of the account's first device.
+    pub device_name: &'a str,
+    /// CID of the first device's exact root-to-device delegation.
+    pub delegation_cid: &'a str,
+    /// Exact decoded root-to-device delegation container bytes.
+    pub delegation: &'a [u8],
+}
+
+impl AccountCreationFingerprintInput<'_> {
+    /// Compute the version-1, domain-separated creation fingerprint.
+    #[must_use]
+    pub fn fingerprint(&self) -> AccountCreationFingerprint {
+        fn field(hasher: &mut blake3::Hasher, bytes: &[u8]) {
+            hasher.update(&(bytes.len() as u64).to_be_bytes());
+            hasher.update(bytes);
+        }
+
+        let normalized_email = self.email.to_lowercase();
+        let mut hasher = blake3::Hasher::new();
+        field(&mut hasher, b"tonk-account-create-v1");
+        field(&mut hasher, normalized_email.as_bytes());
+        field(&mut hasher, self.root_did.as_bytes());
+        field(&mut hasher, self.credential_id.as_bytes());
+        match self.passkey {
+            None => field(&mut hasher, &[0]),
+            Some(passkey) => {
+                field(&mut hasher, &[1]);
+                field(&mut hasher, &passkey.created_at.to_be_bytes());
+                field(&mut hasher, passkey.created_on.trim().as_bytes());
+            }
+        }
+        field(&mut hasher, self.descriptor);
+        field(&mut hasher, self.device_did.as_bytes());
+        field(&mut hasher, self.device_name.as_bytes());
+        field(&mut hasher, self.delegation_cid.as_bytes());
+        field(&mut hasher, self.delegation);
+        AccountCreationFingerprint(*hasher.finalize().as_bytes())
+    }
+}
+
+/// A version-1 canonical account-creation fingerprint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AccountCreationFingerprint([u8; 32]);
+
+impl AccountCreationFingerprint {
+    /// Parse the canonical wire form: exactly 64 lowercase hexadecimal bytes.
+    pub fn from_hex(value: &str) -> Result<Self, AccountCreationFingerprintError> {
+        if value.len() != 64
+            || !value
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            return Err(AccountCreationFingerprintError::InvalidFormat);
+        }
+        let decoded =
+            hex::decode(value).map_err(|_| AccountCreationFingerprintError::InvalidFormat)?;
+        let bytes: [u8; 32] = decoded
+            .try_into()
+            .map_err(|_| AccountCreationFingerprintError::InvalidFormat)?;
+        Ok(Self(bytes))
+    }
+
+    /// Format the canonical lowercase 64-hex wire form.
+    #[must_use]
+    pub fn to_hex(self) -> String {
+        hex::encode(self.0)
+    }
+
+    /// Borrow the 32 digest bytes.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl fmt::Display for AccountCreationFingerprint {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&hex::encode(self.0))
+    }
+}
+
+impl FromStr for AccountCreationFingerprint {
+    type Err = AccountCreationFingerprintError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::from_hex(value)
+    }
+}
+
+/// Invalid account-creation fingerprint wire input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum AccountCreationFingerprintError {
+    /// The value was not exactly 64 lowercase hexadecimal characters.
+    #[error("createFingerprint must be 32 bytes of lowercase hex")]
+    InvalidFormat,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXED_FINGERPRINT: &str =
+        "35cda4b0895490a01c4307584da2fe045c568b53d9817b3f38c97309a07dbb52";
+
+    fn fixed_input<'a>() -> AccountCreationFingerprintInput<'a> {
+        AccountCreationFingerprintInput {
+            email: "PERSON@EXAMPLE.COM",
+            root_did: "did:key:zRoot",
+            credential_id: "credential-01",
+            passkey: Some(AccountCreationPasskey {
+                created_at: 1_725_000_000,
+                created_on: "  Chrome on macOS  ",
+            }),
+            descriptor: &[0x00, 0x01, 0x02, 0xff],
+            device_did: "did:key:zDevice",
+            device_name: "Jack's MacBook",
+            delegation_cid: "bafydelegation",
+            delegation: &[0x82, 0x01, 0x02],
+        }
+    }
+
+    #[test]
+    fn it_pins_the_versioned_account_creation_fingerprint() {
+        let fingerprint = fixed_input().fingerprint();
+        assert_eq!(fingerprint.to_hex(), FIXED_FINGERPRINT);
+
+        let normalized = AccountCreationFingerprintInput {
+            email: "person@example.com",
+            passkey: Some(AccountCreationPasskey {
+                created_at: 1_725_000_000,
+                created_on: "Chrome on macOS",
+            }),
+            ..fixed_input()
+        };
+        assert_eq!(normalized.fingerprint(), fingerprint);
+    }
+
+    #[test]
+    fn it_accepts_only_the_canonical_fingerprint_wire_format() {
+        let parsed = AccountCreationFingerprint::from_hex(FIXED_FINGERPRINT).unwrap();
+        assert_eq!(parsed.to_hex(), FIXED_FINGERPRINT);
+        assert!(AccountCreationFingerprint::from_hex(&FIXED_FINGERPRINT[..62]).is_err());
+        assert!(AccountCreationFingerprint::from_hex(&"gg".repeat(32)).is_err());
+        assert!(AccountCreationFingerprint::from_hex(&FIXED_FINGERPRINT.to_uppercase()).is_err());
+    }
+}

--- a/rust/tonk-account/src/lib.rs
+++ b/rust/tonk-account/src/lib.rs
@@ -4,6 +4,8 @@
 //! lifecycle outcomes, and remote initialization primitive. Higher-level
 //! mounting and projection policy remains with the worker and CLI adapters.
 
+/// Canonical account-creation recovery contracts.
+pub mod creation;
 /// Customer registration contracts for the access service.
 pub mod customer;
 /// Retaining space authority into the account repository.


### PR DESCRIPTION
## Summary

- make `POST /accounts` recover an exact, already-committed account/device creation without treating a different ceremony as idempotent
- add a shared, versioned creation fingerprint and proof-bound `POST /accounts/setup-status` with privacy-preserving `absent`, `accepted`, and `mismatch` outcomes
- require first-device grants to be stable enough for later recovery: one valid root-to-device proof, subject/command/policy open, and no time bounds
- add CORS-readable `GET /capabilities` with `accountSetupRecovery: 1` so clients can fail closed before creating a passkey
- keep Cloudflare and native-helper routes, status codes, JSON, CORS, and tests aligned without a schema migration

## Safety boundaries

- replay succeeds only after full descriptor/delegation validation and exact comparison of every caller-controlled creation fact
- unknown/deleted accounts and any missing, inactive, or nonmatching first-device state return the same authenticated `absent` body
- only the exact active first-device proof can observe `accepted` or `mismatch`
- provider attachment IDs and provider timestamps are intentionally excluded from the fingerprint; all signed semantic inputs are included
- this is the provider-first foundation only; it does not claim browser reload recovery until the client-side saga lands

## Verification

- `cargo test -p tonk-account`: 35 unit + 1 integration
- `cargo test -p tonk-account-service --features helpers`: 54 unit + 10 HTTP integration
- all-target Clippy with `-D warnings` for both affected packages
- `cargo fmt --all -- --check` and `git diff --check`
- `nix build path:.#tonk-account-service --no-link`
- independent review caught and verified fixes for time/command-scoped grants, setup-state privacy, invocation audience, predicate-scoped grants, and the explicit capability gate

## Rollout

Deploy this account worker before any UI begins the recovery saga. Recovery-aware clients must require numeric `accountSetupRecovery: 1`; a missing, malformed, or different capability fails closed before WebAuthn.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on implementing account-creation recovery and setup-status checks, allowing users to retry lost responses without revealing account details. It introduces a CORS-readable capabilities endpoint and enhances the account creation process with a fingerprint mechanism.

### Detailed summary
- Added `pub mod creation;` in `rust/tonk-account/src/lib.rs`.
- Introduced `/capabilities` endpoint in `rust/tonk-account-service/src/lib.rs`.
- Implemented `handle_setup_status` in `rust/tonk-account-service/src/handlers/accounts.rs`.
- Created `capabilities.rs` to manage capabilities and CORS headers.
- Enhanced CORS handling in `rust/tonk-account-service/src/handlers/accounts.rs` and `src/helpers/server.rs`.
- Added `AccountCreationFingerprintInput` struct in `rust/tonk-account/src/creation.rs`.
- Introduced `validate_root_device_grant` in `rust/tonk-account-service/src/core/delegation.rs`.
- Updated README and audit plan with new endpoints and capabilities.
- Added tests for account setup recovery in `rust/tonk-account-service/tests/service.rs`.

> The following files were skipped due to too many changes: `plan/audit-account-setup-provider.md`, `rust/tonk-account-service/src/core/accounts.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->