### PR TITLE
feat(account): define durable setup recovery foundation

### DIFF
--- a/plan/audit-account-setup-recovery.md
+++ b/plan/audit-account-setup-recovery.md
@@ -1,0 +1,396 @@
+# Durable browser account-setup recovery implementation plan
+
+**Goal:** Recover browser account creation after reload, tab loss, worker restart, and provider response loss from every technically recoverable boundary, while starting at most one WebAuthn creation attempt and describing the one irrecoverable browser boundary honestly.
+**Approach:** Put account-setup ordering behind one deep UI module and one worker saga module. The top document remains the WebAuthn adapter, but the worker is the sole persistence and validation authority. It persists a secret-free versioned checkpoint and a separate credential-store-protected recovery bundle containing a passkey-sealed envelope, bounded authorizations, and a durable root-signed anti-mix manifest. It serializes ownership with a profile-scoped Web Lock plus revision checks, reconciles each durable effect, and uses the provider's proof-bound status and exact-replay contract before attaching local account state and queuing customer/custody work.
+**Base:** branch `fix/audit-account-setup-recovery`, worktree `/Users/jackdouglas/tonk/tonk/.wt/fix/audit-account-setup-recovery`, exact lower-base head `6923a9b16f9f528795d18589c58f601820e005fa`.
+
+**Pending lower-base adoption:** provider PR #835 is reviewed at exact head `305a60f610d221bd6c9c65cc9eaf227bbb0a8162` and supplies `GET /capabilities` v1 plus the setup-status policy correction. After the local foundation passes bounded review, commit it, create a backup ref, and rebase merge-free from `6923a9b16f9f528795d18589c58f601820e005fa` onto that exact head. Only then replace the Base SHA above.
+
+## Lower foundation checkpoint (2026-08-31)
+
+This first stacked slice intentionally stops before production route/effect/UI wiring. It contains the canonical manifest, versioned public wire contract (including the worker-selected ceremony context), private checkpoint/recovery encodings, envelope-first decoding, complete-record reducer, and the single bounded semantic `ValidatedRecoveryBundle` constructor. The constructor independently verifies every signed artifact and classifies current expiry separately from canonical/signature/original-window validity.
+
+Focused evidence at this checkpoint:
+
+- `CARGO_INCREMENTAL=0 cargo test -p tonk-account recovery::tests`: 4 passed.
+- `CARGO_INCREMENTAL=0 cargo test -p tonk-worker-api account_setup::tests`: 4 passed.
+- `CARGO_INCREMENTAL=0 cargo test -p tonk-worker router::account_setup::tests`: 10 passed.
+
+Still deliberately absent from this lower commit: credential-site reads/writes, Web Lock and live-`ClientId` ownership enforcement, provider HTTP effects, identity/customer/custody effects, top-document orchestration, UI copy, browser tests, and Storybook changes. Those remain the upper tasks below and must not be inferred from the foundation types alone.
+
+**Constraints:**
+
+- Do not persist or log an account secret, PRF result, passkey-derived KEK, root private key, owner token, or attempt token. A recovery record may contain the already passkey-sealed envelope and narrowly scoped signed artifacts already held by the pending-custody queue.
+- Keep `LocalRootRecord` provider-neutral. Store unfinished setup in dedicated credential sites `tonk-account-setup-v2` and `tonk-account-setup-recovery-v1`. After `Complete` is durable, overwrite the recovery record with a versioned tombstone rather than assuming credential-storage deletion support.
+- Compute and retain the provider's canonical version-1 creation fingerprint before the first `POST /accounts`. Exact replay never means “same root is success”; provider `Mismatch` remains terminal.
+- Add canonical `AccountSetupRecoveryManifestV1`: a versioned, domain-separated DAG-CBOR payload plus Ed25519 root signature and exact re-encode validation, modeled on `AccountRepositoryDescriptorV1`. It is durable and non-expiring, and binds the worker-minted operation, an immutable `ceremony_created_at`, canonical worker-derived deployment identity, expected credential/root/device and fingerprint, passkey/encryption facts, and domain-separated hashes (including an ordered-list hash) of every staged artifact. It is cross-record anti-mix proof, not provider/customer/custody effect authorization; every referenced artifact is still independently decoded and verified before use.
+- `Arm` writes a separate immutable `armed_at`; later transitions never derive the ceremony reference from mutable `last_transition_at`. At first `Stage`, require `armed_at <= staged_at <= current worker time`, `ceremony_created_at >= armed_at - 60s`, `ceremony_created_at <= staged_at + 60s`, and `staged_at <= ceremony_created_at + 1h`, using checked arithmetic so rollback/overflow fails closed. Historically validate account-create at the signed ceremony time and require expiration within `[created_at + 240s, created_at + 360s]`; require deferred-publish expiration within `[created_at + 30d - 60s, created_at + 30d + 360s]`. Exact boundary values pass. Canonical/signature/original-window violations are invalid; an otherwise valid artifact expired relative to current worker time is `NeedsRefresh`, never corrupt.
+- Query `POST /accounts/setup-status` with a fresh device-signed invocation carrying the exact stable root-to-device proof. Never infer `Absent` from a transport failure, timeout, 404, or malformed body.
+- Order durable effects as sealed recovery bundle, local root, provider acceptance, exact local provider/account state, customer enrollment, and ordered custody `Provision` then `PublishCustody` work.
+- Back or Escape is a true cancellation only before `Armed`. Once armed, Tonk does not claim to cancel `navigator.credentials.create()`; it keeps or restores a recovery surface.
+- The random `AccountSecret` is generated before WebAuthn returns, while it can be sealed only after the credential response supplies/evaluates PRF output. A renderer crash after the authenticator creates the credential but before `RecoveryBundleV1` commits cannot be recovered without forbidden plaintext persistence or a cryptographic redesign. Tests and copy must name this boundary.
+- Before any `navigator.credentials.create()`, new UI must complete an explicit version-2 worker handshake and the worker must confirm the provider advertises version-1 setup-status/exact-replay capability. An old worker, missing route, 404, timeout, malformed capability, or unavailable provider fails closed with “Tonk needs an update before it can safely create this account. Reload before approving a passkey.” New workers coordinate through Web Locks; arbitrary overlap with an already-deployed old UI/worker cannot be made mutually exclusive by new code alone and must remain an explicit deployment constraint.
+- `Handshake`, `Begin`, and `Arm` accept no provider/config URL from the page. The worker canonicalizes the same-origin deployment configuration, derives the exact `account_service_url`, repository remote, and optional service DID, checks the provider capability itself, and binds a configuration hash into the checkpoint. The page receives only the worker-selected ceremony context. `Stage` may echo the selected provider as part of the protected bundle, but the worker requires exact equality and derives remote/service identity from independently verified signed artifacts, never page strings. The worker is never an arbitrary cross-origin fetch proxy.
+- Compose rollout behavior with the service-worker upgrade work in #800/#816: its update prompt must not auto-reload an `Armed` flow. This branch guarantees pre-WebAuthn refusal for incompatible controllers and durable recovery after staging; a page critical-section signal is a dependency unless #816 leaves a non-duplicative integration seam.
+- Preserve existing profiles, spaces, passkeys, local/offline data, and unrelated work. Do not clear storage or unregister workers during testing.
+- Keep Cargo commands serialized with `CARGO_INCREMENTAL=0`; inspect free disk space before and after large Wasm/browser builds.
+- Update Storybook source documentation, regenerate `app/data.json` and `app/data.js`, check links, and run the committed base-impact check before completion.
+- Approval gate satisfied 2026-08-31 with the v2 checkpoint, tombstone, post-stage takeover, capability-handshake, and residual-boundary corrections below. Begin with focused wire/reducer RED tests; do not run broad Cargo until those protocol tests are green.
+
+## Irreducible crash boundary
+
+`tonk_identity::ceremony::create_custody_account` currently executes:
+
+1. `AccountSecret::generate()`;
+2. derive the intended root DID;
+3. `navigator.credentials.create()` through `create_custody_passkey`;
+4. obtain/evaluate PRF output;
+5. seal the random secret under the derived KEK; and
+6. return the sealed ciphertext and signed recovery artifacts to the UI.
+
+A crash after step 3 but before the worker durably saves step 5 may have completed passkey approval, but Tonk cannot know or recover that attempt because a later assertion can reproduce the KEK but cannot reproduce the discarded random account secret. The implementation must stage the returned ciphertext before reporting ceremony success, but it cannot call this interval recoverable. No provider request occurs before staging. Recovery copy must neither assert that a passkey exists nor assert that none was created; it tells the user how to review an unused Tonk passkey in device settings and then explicitly start over.
+
+## Deep module and interfaces
+
+The public UI module is intentionally small:
+
+```rust
+pub(crate) async fn begin_or_resume(
+    email: &str,
+    narrate: impl Fn(&str) + Clone + 'static,
+) -> Result<AccountSetupOutcome, AccountSetupError>;
+
+pub(crate) async fn resume_pending(
+    narrate: impl Fn(&str) + Clone + 'static,
+) -> Result<ResumeDisposition, AccountSetupError>;
+
+pub(crate) async fn cancel() -> Result<CancelDisposition, AccountSetupError>;
+```
+
+Both registration entrypoints use this interface. They do not directly save a root, submit an account invocation, persist an account link, enroll a customer, provision custody, or queue a custody publish.
+
+The worker exposes one tagged command route, `POST /api/account/setup`, through `tonk_worker_api::AccountSetupRequest`. Its variants are internal steps used only by the UI module:
+
+```rust
+pub enum AccountSetupRequest {
+    Handshake(AccountSetupHandshake),
+    Inspect { owner_token: Option<String> },
+    Begin(AccountSetupBegin),
+    Acquire(AccountSetupAcquire),
+    Arm(AccountSetupArm),
+    Stage(AccountSetupStage),
+    Continue(AccountSetupMutation),
+    ReplaceInvocation(AccountSetupInvocation),
+    Cancel(AccountSetupMutation),
+}
+```
+
+`Handshake` requires worker protocol version 2 and makes the worker resolve canonical deployment configuration and probe the explicit provider capability contract before setup can be armed. `Begin` re-resolves that configuration and returns an owner-bound `AccountSetupLease { view, ceremony }`, where `ceremony` is the worker-selected canonical provider, remote, and optional service DID the page must sign into its manifest. `Arm` re-resolves the configuration under the saga lock and compares its stored hash before passkey creation. Every mutation names `operation_id`, `owner_token`, and `expected_revision`; `Arm` and `Stage` additionally carry the document-memory `attempt_token`. General inspection returns only a closed redacted disposition/next-action state: no email, owner or attempt hashes, ciphertext, signed artifacts, provider diagnostic bodies, or raw durable phase. Sealed ciphertext and the minimum fields needed to reopen the same semantic creation may cross back only in a non-`Debug`, owner-authenticated `NeedsPasskey` response, and only when the request's `ClientId` is still the checkpoint's live bound owner; a matching token string alone is insufficient.
+
+The worker saga phase is monotonic:
+
+```text
+Leased
+  -> Armed
+  -> RecoveryStaged
+  -> RootSaved
+  -> ProviderAccepted
+  -> Attached
+  -> CustomerEnrolled
+  -> CustodyQueued
+  -> Complete
+
+Leased -> Cancelled
+Armed without a bundle after its owning document disappears -> InterruptedBeforeRecovery
+malformed/unsupported durable data -> Corrupt/Unsupported (fail closed)
+provider exact-state mismatch -> Conflict (fail closed)
+```
+
+`Continue` owns all post-stage advancement and first reconciles observable durable effects. Callers cannot declare a later phase themselves. A private reducer consumes a fully validated `StoredCheckpointV2` plus a typed command/effect observation and returns the complete next private record, required durable action, and closed next action. It owns revision increments, timestamps, owner/client/attempt clearing, staged/accepted fields, and revalidates every result before returning it. `Leased` may be acquired by a new live `ClientId` only after the previous client is absent. From `RecoveryStaged` onward, a new live `ClientId` may acquire and resume under the same Web Lock and expected revision after the previous client is absent and the exact validated bundle remains present. `Armed` with a bundle repairs the lost checkpoint write to `RecoveryStaged`; `Armed` without one becomes terminal `InterruptedBeforeRecovery`, clears its attempt and owner fields, and is never silently rebound.
+
+## Stored records
+
+`StoredCheckpointV2` at credential site `tonk-account-setup-v2` contains no cryptographic secret or user-facing identity data:
+
+```text
+version, operation_id, revision, owner_hash, bound_client_id,
+provider_hash, phase, armed_at?, staged_at?, attempt_hash?, root_did?, create_fingerprint?, recovery_hash?,
+accepted_descriptor_hash?, last_transition_at
+```
+
+`RecoveryBundleV1` at credential site `tonk-account-setup-recovery-v1` is deliberately not `Debug`. Credential storage protects it, but it still contains PII and bounded signed authorizations in addition to recoverable ciphertext, so it is never described as secret-free:
+
+```text
+version, operation_id, ceremony_created_at, worker-authored staged_at,
+normalized_email, worker-selected provider, credential_id, expected_root_did,
+expected_device_did, device_name,
+delegation_cid, delegation_hex, passkey metadata, encryption recipient,
+canonical descriptor_hex, create_fingerprint, original create invocation,
+account-signed customer deposits, custody DID and consent,
+passkey-sealed envelope, bounded publish invocation, recovery_manifest_hex
+```
+
+`RecoveryTombstoneV1 { version, operation_id, completed_at, recovery_hash }` replaces the recovery bundle only after the `Complete` checkpoint is durable. Inspection retries an interrupted tombstone write; code never relies on a delete/retract API.
+
+`StoredPhaseV2` and `StoredRecoveryBundleV1` are private durable encodings. Wire DTOs convert explicitly into them and public views convert explicitly out; changing a page response enum must not silently migrate credential data. Decode first parses only the bounded version/tag envelope. Unknown versions, record tags, or phase tags are `Unsupported`, never `Corrupt`; only a recognized current shape that fails strict decoding or validation is corrupt.
+
+### Required API/schema migrations
+
+The provider base exposes proof-bound `POST /accounts/setup-status` and exact replay, but current branch base SHA `6923a9b16f9f528795d18589c58f601820e005fa` predates its explicit versioned capability. A plain `OPTIONS`/404 inference is forbidden. Reviewed provider PR #835 at `305a60f610d221bd6c9c65cc9eaf227bbb0a8162` adds the CORS-readable `GET /capabilities` v1 contract; this branch will rebase onto that exact lower head after its foundation review and make `Handshake` require the exact supported value. This is a provider API response migration, not a database migration. No account-service database schema change is required.
+
+The new `AccountSetupRecoveryManifestV1` is an internal signed-artifact schema/API migration shared by `tonk-account`, `tonk-identity`, the top-document bridge, and `tonk-worker`. The creation input gains the worker-minted operation/config context and the output gains the canonical manifest bytes. Existing accounts and provider records need no migration because the artifact exists only for new v2 setup operations.
+
+Loading applies overall-body, per-string, per-hex/blob, deposit-count, and decoded-total limits before expensive parsing. One `ValidatedRecoveryBundle::new` constructor then verifies the manifest signature and every manifest reference; canonical hex/CBOR/UCAN encodings; root-to-device grant and CID; descriptor root/remote; create invocation subject/audience/command/exact facts and historical signature; passkey normalization; recomputed fingerprint; X25519 recipient; exact service-deposit scopes; custody consent; sealed-envelope structure; and deferred-publish scope/checksum. Expired create/publish invocations are valid historical artifacts with a typed `NeedsRefresh` disposition, not corruption. Effects accept only `ValidatedRecoveryBundle`, never raw stored or wire DTOs. Corruption never becomes `Missing` and never permits another passkey ceremony.
+
+## File map
+
+- `plan/audit-account-setup-recovery.md`: durable scope, interfaces, phase invariants, TDD sequence, and evidence.
+- `rust/tonk-account/src/recovery.rs`: canonical root-signed `AccountSetupRecoveryManifestV1`, bounded artifact-hash inputs, exact verification, and mutation/cross-bundle vectors.
+- `rust/tonk-account/src/lib.rs`: export the recovery-manifest contract.
+- `rust/tonk-account/src/pending.rs`: append an exact ordered batch in one queue serialization while retaining duplicate suppression.
+- Provider lower-branch dependency: expose the explicit `GET /capabilities` v1 account-setup recovery capability consistently from the account-service Worker, native helper, and HTTP tests before this branch is publishable.
+- `rust/tonk-identity/src/ceremony.rs`: retain the root through deferred-publish creation, compute the pre-POST canonical fingerprint, sign the durable recovery manifest after every artifact exists, and rebuild an expired create invocation from the same passkey-sealed local envelope after a same-credential assertion.
+- `rust/tonk-identity/src/install.rs`: top-document bridge output for fingerprint/descriptor/delegation CID and the assertion-based resume ceremony.
+- `rust/tonk-identity/src/request.rs`: build the fresh device-signed `account/setup/status` invocation from the stable root-to-device grant.
+- `rust/tonk-worker-api/src/account_setup.rs`: versioned account-setup commands, redacted views, phases, outcomes, and copy-state discriminants.
+- `rust/tonk-worker-api/src/lib.rs`: export the account-setup wire interface.
+- `rust/tonk-worker/src/router/account_setup.rs`: deep saga implementation, record validation, reducer, credential adapter, Web Lock/revision fencing, provider adapter, effect reconciliation, and focused fault tests.
+- `rust/tonk-worker/src/router.rs`: module registration and the single `/api/account/setup` route.
+- `rust/tonk-worker/src/worker.rs`: per-worker account-setup mutex used with the cross-worker Web Lock and initialized in production/test state constructors.
+- `rust/tonk-worker/Cargo.toml`: `web-sys` `Lock`/`LockManager` features needed by the service-worker Web Lock adapter.
+- `rust/tonk-worker/src/router/identity.rs`: exact local-root probe and existing `persist_root` reuse; reject or reconcile mismatches rather than replacing them.
+- `rust/tonk-worker/src/router/account.rs`: exact provider-link probe and idempotent reuse of `persist_link`.
+- `rust/tonk-worker/src/router/customer.rs`: customer-enrollment probe/reuse and one ordered custody-cell plus pending-work promotion operation.
+- `rust/tonk-ui/src/account_setup.rs`: sole top-document orchestration module, session/document tokens, same-passkey resume gesture, progress mapping, and honest copy.
+- `rust/tonk-ui/src/lib.rs`: export the internal account-setup module.
+- `rust/tonk-ui/src/identity_bridge.rs`: typed creation and same-passkey-resume bridge shapes; no secret-bearing debug/log path.
+- `rust/tonk-ui/src/api.rs`: typed client for the single account-setup route.
+- `rust/tonk-ui/src/register_dialog.rs`: render/reopen setup phases and make Back/Escape cross the worker cancellation barrier before closing.
+- `rust/tonk-ui/src/account.rs`: replace the legacy duplicate creation block with the shared module and retain login-only orchestration.
+- `rust/tonk-ui/src/bin/ui.rs`: inspect pending setup after the identity bridge and account UI are installed, reopening only the appropriate recovery surface.
+- `rust/tonk-ui/src/user_error.rs`: map typed setup outcomes to actionable user copy without exposing diagnostics.
+- `rust/tonk-ui/src/account_flow.rs`: representative real-browser cancellation, response-loss, reload, stale-worker, and same-credential recovery coverage.
+- `docs/storybook/accounts/lifecycle.md`: account-creation durability phases and honest interrupt behavior.
+- `docs/storybook/cross-cutting/failure-and-recovery.md`: WebAuthn irreducible boundary and response-loss/reload contract.
+- `docs/storybook/journey-catalog.md`: update `ACCT-B02` and `ACCT-B06` recovery evidence/gaps.
+- `docs/storybook/verification/accounts.md`: stable P1 checks for cancel/arm races, phase reloads, response loss, and incompatible workers.
+- `docs/storybook/screens.json`: update the `WEB-08` behavior summary/source ownership if rendered copy changes.
+- `docs/storybook/app/data.json`, `docs/storybook/app/data.js`: generated product map.
+
+### Task 1: Produce and reconstruct the exact creation operation
+
+**Files:**
+
+- Modify: `rust/tonk-identity/src/ceremony.rs:AccountCeremony, create_account, create_custody_account`
+- Create: `rust/tonk-account/src/recovery.rs:AccountSetupRecoveryManifestV1`
+- Modify: `rust/tonk-account/src/lib.rs:recovery export`
+- Modify: `rust/tonk-identity/src/install.rs:create_account, installed method table`
+- Modify: `rust/tonk-identity/src/request.rs:setup-status builder`
+- Modify: `rust/tonk-ui/src/identity_bridge.rs:CreateAccountOutput and resume bridge`
+- Test: `rust/tonk-identity/src/ceremony.rs:tests`
+- Test: `rust/tonk-account/src/recovery.rs:tests`
+- Test: `rust/tonk-identity/src/request.rs:tests`
+- Test: `rust/tonk-ui/src/identity_bridge.rs:tests`
+
+**Interfaces:**
+
+- Produces: `AccountSetupRecoveryManifestV1::sign(root, RecoveryManifestInput)` only after the delegation, descriptor, create invocation/fingerprint, deposits, consent, sealed envelope, and publish invocation exist. Its exact canonical payload binds a fixed domain, root subject, device audience, operation/config identity, immutable ceremony timestamp, expected credential/fingerprint, passkey/encryption facts, and domain-separated hashes/list-hash of those exact artifact bytes. `validate(bytes)` verifies bounds, exact canonical re-encoding, Ed25519 root signature, domain/audience/subject, and exact expected bindings; it grants no effect authority.
+- Produces: `AccountCeremony { descriptor_hex, create_fingerprint, invocation_hex, .. }` before provider submission, and `CustodyAccountCeremony { recovery_manifest_hex, .. }` before returning to the page.
+- Produces: `resume_custody_account(ResumeCustodyAccount)` which asserts exactly `credential_id`, opens `sealed_hex`, verifies `expected_root_did`, and returns only a freshly signed invocation plus the same canonical fingerprint.
+- Produces: `build_account_setup_status_invocation(device, stable_grant, fingerprint) -> Vec<u8>` with command `account/setup/status`, root subject/audience, one exact proof, and five-minute expiration.
+
+- [x] RED: add deterministic recovery-manifest tests proving canonical bytes and exact validation. Mutate operation, `ceremony_created_at`, canonical deployment URL/config identity, credential, root/device, fingerprint, passkey/encryption facts, each artifact hash, deposit order, subject/audience/domain, signature, version, and canonical encoding; cross two otherwise-valid ceremony bundles and require rejection. Add exact envelope/payload/string/list/body bounds before GREEN.
+- [x] GREEN: implement the durable domain-separated DAG-CBOR manifest in `tonk-account`, modeled on the repository descriptor but with a distinct signing domain. The manifest hashes bytes/facts and never contains an account secret, PRF result, KEK, or private key. `CARGO_INCREMENTAL=0 cargo test -p tonk-account recovery::tests` passes 4 tests.
+- [ ] RED: add `it_computes_the_provider_fingerprint_before_submission` with fixed root/device/delegation/descriptor facts and the independent provider test vector; run `CARGO_INCREMENTAL=0 cargo test -p tonk-identity it_computes_the_provider_fingerprint_before_submission`; expect a compile failure because `AccountCeremony` has no fingerprint.
+- [ ] GREEN: compute through `tonk_account::AccountCreationFingerprintInput`; retain `root.clone()` until the publish artifact exists; sign the manifest with the worker-minted operation and worker-selected configuration context; expose fingerprint, descriptor, device DID, delegation CID, and manifest through the installed bridge; rerun the focused tests successfully.
+- [ ] RED: add `it_rebuilds_only_the_same_semantic_creation_from_a_recovered_secret` using a fixed secret and delegation; mutate credential ID, root DID, device DID, descriptor remote, passkey metadata, and sealed envelope independently; expect exact recovery only for the original tuple. Run the focused filter and observe the missing resume seam.
+- [ ] GREEN: separate assertion/unwrap from a native-testable `create_account_from_recovered_secret` helper; require the same root and canonical fingerprint; return no secret/PRF/KEK. Rerun the focused and adjacent `tonk-identity` tests.
+- [ ] RED/GREEN: add a request-container test proving status uses the exact stable proof, root audience/subject, fingerprint argument, and fresh expiration; malformed or alternate grants must not build a request accepted by the provider verifier.
+- [ ] Run `CARGO_INCREMENTAL=0 cargo test -p tonk-identity ceremony::tests` and `CARGO_INCREMENTAL=0 cargo test -p tonk-identity request::tests`; expect success.
+
+### Task 2: Persist and reduce one exclusively owned setup operation
+
+**Files:**
+
+- Create: `rust/tonk-worker-api/src/account_setup.rs`
+- Modify: `rust/tonk-worker-api/src/lib.rs`
+- Create: `rust/tonk-worker/src/router/account_setup.rs`
+- Modify: `rust/tonk-worker/src/router.rs:module and route table`
+- Modify: `rust/tonk-worker/src/worker.rs:TonkState and test constructors`
+- Modify: `rust/tonk-worker/Cargo.toml:web-sys features`
+- Test: `rust/tonk-worker-api/src/account_setup.rs:tests`
+- Test: `rust/tonk-worker/src/router/account_setup.rs:record/reducer/ownership tests`
+- Test: `rust/tonk-worker/src/router/route_table.rs`
+- Test: `rust/tonk-worker/src/router/wire_compat.rs`
+
+**Interfaces:**
+
+- Consumes: tagged `AccountSetupRequest` through one route and the originating `ClientId` request extension.
+- Produces: redacted `AccountSetupView` with revision, phase, ownership/cancellation disposition, and one explicit next action.
+- Internal seam: private `StoredPhaseV2`/`StoredCheckpointV2`/`StoredRecoveryBundleV1`; envelope-first decoders; one deep reducer returning `{ checkpoint, durable_action, next_action }`; `SetupStore` with production credential-storage and in-memory fault adapters; and `SetupLock` with Web Lock plus per-worker mutex in production and deterministic mutex in tests.
+
+- [ ] RED: add strict serialization tests for every command/view, private v2 checkpoint, private v1 bundle, and v1 tombstone round trips, unsupported versions, truly future record/phase tags, malformed JSON, missing fields, invalid phase data, and corrupted hashes. Parse the minimal bounded version/tag envelope before dispatch so future shapes are `Unsupported`; corrupt or unsupported input must return typed fail-closed state rather than `Missing`.
+- [ ] GREEN: add the wire and stored types, validation, and bounded/redacted error presentation; do not derive `Debug` for recovery payloads.
+- [ ] RED: add table-driven reducer tests for every legal phase edge and every backward/skip transition, including `Leased -> Cancelled`, `Armed -> Cancel` returning `TooLate`, immutable `armed_at`, Armed owner loss with/without a validated recovery record, post-stage takeover with an exact bundle, conflict provenance, stale revision, wrong operation, token/client mismatch, time regression, and arbitrary public phase advancement being impossible.
+- [ ] GREEN: implement a pure monotonic reducer whose only post-stage advance input is a typed verified effect observation. The reducer consumes/returns complete validated private records, increments revision/timestamp itself, clears every transient field at its boundary, and revalidates all no-write and write results.
+- [ ] RED: race two distinct ClientIds and owner tokens against `Begin`/`Arm`; require one owner, one revision winner, and one `Arm`. Cover same-client worker restart, copied session token in another live tab, pre-arm reload after the old client dies, `Armed` owner loss becoming terminal without a bundle, and post-`RecoveryStaged` takeover by a new live ClientId only after the old client is absent.
+- [ ] GREEN: hash tokens with domain-separated BLAKE3, bind the live ClientId, and wrap load/reduce/save in the named Web Lock and expected-revision check.
+- [ ] Add a production Web Lock adapter based on `navigator.locks`; unavailable Web Locks fail setup closed before `Arm` rather than silently falling back to per-worker exclusion.
+- [ ] RED/GREEN: add `Handshake` tests for exact worker protocol 2 and provider recovery capability 1. Missing worker route, worker version mismatch, provider 404/timeout/malformed capability, and provider capability absence all refuse before `Arm`; no test adapter may record a WebAuthn request.
+- [ ] Run `CARGO_INCREMENTAL=0 cargo test -p tonk-worker-api account_setup` and the native `tonk-worker` account-setup reducer filters; expect success.
+- [ ] Run `CARGO_INCREMENTAL=0 nix develop path:. -c test:web:debug -E 'test(account_setup)'`; expect the service-worker Web Lock/storage tests to pass.
+
+### Task 3: Stage ciphertext before root persistence and reconcile every local write
+
+**Files:**
+
+- Modify: `rust/tonk-worker/src/router/account_setup.rs:Stage and recovery reconciliation`
+- Modify: `rust/tonk-worker/src/router/identity.rs:exact local-root observation`
+- Modify: `rust/tonk-worker/src/router/account.rs:exact attachment observation`
+- Test: `rust/tonk-worker/src/router/account_setup.rs:fault-injected store/effect tests`
+
+**Interfaces:**
+
+- `Stage` converts the wire DTO into private `StoredRecoveryBundleV1`, applies cheap bounds, constructs the sole `ValidatedRecoveryBundle`, saves it, reads it back through the same constructor, validates its hash/manifest/fingerprint, advances `RecoveryStaged`, then calls the existing local-root persistence implementation.
+- `observe_local_effects` returns exact/missing/mismatch facts for root and provider link; mismatch is terminal and no stored authority is replaced.
+
+- [ ] RED: add fault tests after recovery save, checkpoint save, root record save, root access projection, and root-phase checkpoint save. Recreate the saga adapter after each injected failure and require convergence without another WebAuthn create.
+- [ ] GREEN: implement save-first staging and root reconciliation. A bundle present behind an `Armed` checkpoint repairs it to `RecoveryStaged`; an exact local root repairs to `RootSaved`; mismatched root/grant fails closed.
+- [ ] RED/GREEN: mutate and oversize every bundle field independently; cross records from two fully valid bundles; alter deposit ordering; and require no root/provider/customer/custody effect. Cover overall input, every string/blob/hex, deposit count/decoded total, canonical encoding, signatures/scopes, manifest binding, fingerprint, and sealed-envelope structure before expensive parsing where possible. Test `ceremony_created_at` at exactly both Stage skew bounds and the one-hour age bound, one second outside each, worker clock rollback, checked-arithmetic overflow, exact create/publish original-expiry bounds, and current `Usable`/`NeedsRefresh`. The constructor structurally validates the envelope without opening it; the manifest proves cross-record origin, while a later same-credential assertion proves the ciphertext opens to the expected root.
+- [ ] Add the explicit `InterruptedBeforeRecovery` observation for `Armed` with a dead owning client and no bundle; it must never offer automatic retry or claim no passkey was created.
+- [ ] Run the focused native fault filters and Wasm credential-storage filters serially; expect success.
+
+### Task 4: Recover provider response loss and finish ordered local/customer/custody effects
+
+**Files:**
+
+- Modify: `rust/tonk-worker/src/router/account_setup.rs:Continue, provider adapter, effect probes`
+- Modify: `rust/tonk-worker/src/router/account.rs:exact link probe`
+- Modify: `rust/tonk-worker/src/router/customer.rs:enrollment probe and persist_custody_setup`
+- Modify: `rust/tonk-account/src/pending.rs:push_all`
+- Test: `rust/tonk-worker/src/router/account_setup.rs:provider/effect fault matrix`
+- Test: `rust/tonk-account/src/pending.rs:ordered batch tests`
+
+**Interfaces:**
+
+- Internal owned-remote port: `AccountSetupProvider::status` and `AccountSetupProvider::create`; production uses the existing bounded worker HTTP adapter and tests use a scripted in-memory adapter.
+- Produces: `Continue` outcome `Complete`, `NeedsPasskey`, `RetryLater`, or terminal `Conflict`; transport uncertainty never becomes provider `Absent`.
+- Produces: `customer::persist_custody_setup` which records the local custody cell, appends `[Provision, PublishCustody]` in one queue save, and then drains best-effort.
+
+- [ ] RED: script provider `Accepted`, `Absent`, `Mismatch`, timeout, malformed body, and lost response after commit. Require status before create on every resume; Accepted advances with the canonical descriptor, Absent submits the exact stored invocation, Mismatch writes nothing, and unknown outcomes remain retryable without WebAuthn.
+- [ ] GREEN: implement the status invocation/HTTP adapter and strict response/fingerprint/descriptor checks. Exact create replay accepts either initial 201 or reused 200 but verifies the returned fingerprint and descriptor.
+- [ ] RED/GREEN: when Absent and the stored invocation is expired, return `NeedsPasskey` with owner-authorized sealed recovery input. `ReplaceInvocation` accepts only a fresh invocation whose decoded semantic facts reproduce the stored fingerprint.
+- [ ] RED: inject failure after provider acceptance, provider-phase checkpoint, provider record save, account-state initialization, enrollment response, customer record, custody cell, ordered queue save, drain, and completion save. Recreate the worker between failures; require monotonic convergence and no duplicate account/device/custody ordering.
+- [ ] GREEN: reconcile exact provider link/customer/custody effects before replaying. Treat enrollment and pending work as at-least-once idempotent operations; never let `PublishCustody` overtake `Provision`.
+- [ ] RED/GREEN: make malformed pending work recoverable from the still-retained bundle, and prove a drained queue followed by checkpoint loss can safely reappend/replay the exact pair.
+- [ ] Save `Complete` before overwriting the recovery bundle with `RecoveryTombstoneV1`. A failed tombstone write leaves credential-store-protected sealed/bounded material and is retried on later inspection; do not assume delete/retract support.
+- [ ] Run `CARGO_INCREMENTAL=0 cargo test -p tonk-account pending::tests` and focused native/wasm worker saga filters; expect success.
+
+### Task 5: Consolidate entrypoints and render truthful cancel/recovery states
+
+**Files:**
+
+- Create: `rust/tonk-ui/src/account_setup.rs`
+- Modify: `rust/tonk-ui/src/lib.rs`
+- Modify: `rust/tonk-ui/src/api.rs:account-setup client`
+- Modify: `rust/tonk-ui/src/identity_bridge.rs:resume ceremony`
+- Modify: `rust/tonk-ui/src/register_dialog.rs:setup presenter, cancel, reload recovery`
+- Modify: `rust/tonk-ui/src/account.rs:run_account_ceremony and duplicate create handler`
+- Modify: `rust/tonk-ui/src/bin/ui.rs:resume inspection after install`
+- Modify: `rust/tonk-ui/src/user_error.rs:typed setup copy`
+- Test: `rust/tonk-ui/src/account_setup.rs:tests`
+- Test: `rust/tonk-ui/src/register_dialog.rs:tests`
+- Test: `rust/tonk-ui/src/account.rs:tests`
+
+**Interfaces:**
+
+- Both account creation surfaces call only `account_setup::begin_or_resume`; the legacy account element cannot perform a separate ordering.
+- `register_dialog` renders a stable view model derived from `AccountSetupView`; it never interprets raw transport text as phase state.
+- Back/Escape awaits `cancel`: close only for `Cancelled`; keep the modal for `TooLate` and explain the recovery state.
+
+- [ ] RED: add an orchestration spy test showing both creation entrypoints produce the same `Begin -> Arm -> WebAuthn once -> Stage -> Continue` sequence and neither directly calls old save/submit/enroll/custody clients.
+- [ ] GREEN: move creation orchestration into `account_setup.rs`, replace the duplicate account-element block, and leave login-only behavior in `complete_remote`.
+- [ ] RED/GREEN: persist the owner token in `sessionStorage`, keep the attempt token document-local, and prove raw tokens never enter diagnostics or stored records. Only domain-separated hashes are stored in the checkpoint, and owner/email/artifacts are absent from general status and logs.
+- [ ] RED: race Back/Escape with `Arm` in both orders. Before arm, expect close plus “Account setup cancelled. No passkey was created.” After arm, expect the dialog to remain with “Your device may still be creating the passkey. Finish or dismiss the device prompt. Tonk won’t start another one.”
+- [ ] GREEN: call `preventDefault` synchronously, then await worker cancellation. Do not wire Back/Escape to a WebAuthn abort claim.
+- [ ] RED/GREEN: render `InProgressElsewhere`, `RecoveryStaged/RetryLater`, `NeedsPasskey`, provider `Conflict`, local-link retry, and `InterruptedBeforeRecovery` with actionable copy and the correct enabled action. The interrupted copy must say: “Passkey approval may have completed, but Tonk cannot know or recover that attempt. Check your device’s passkey settings for an unused Tonk passkey, remove it if present, then choose Start over.” It must not imply the user definitely has or lacks an orphan passkey.
+- [ ] On top-document boot, inspect pending setup. Resume post-stage work automatically; reopen a user-action surface for `Leased`, `Armed`, `NeedsPasskey`, conflict, or interruption. Never invoke WebAuthn without the fresh action click.
+- [ ] Review the touched interface using the interface-polish checklist. Preserve existing geometry/motion unless the new state needs a control; maintain at least 40x40 hit targets, balanced/pretty wrapping, interruptible transitions, and no `transition: all`.
+- [ ] Run focused `tonk-ui` Wasm tests, then `CARGO_INCREMENTAL=0 nix develop path:. -c test:web:debug -E 'package(tonk-ui)'`; expect success.
+
+### Task 6: Prove representative browser faults and incompatible-worker refusal
+
+**Files:**
+
+- Modify: `rust/tonk-ui/src/account_flow.rs:account creation recovery tests and helpers`
+- Test: existing local account/access services and virtual authenticator only; never a live browser profile.
+
+**Interfaces:**
+
+- Whole-journey evidence complements the exhaustive reducer/fault-adapter matrix; it does not duplicate every lower-layer phase.
+
+- [ ] RED/GREEN: add a real-browser test where the provider commits account creation and the response is lost, reload the page, require setup status to recover the canonical descriptor, and require exactly one provider account/device and one virtual credential.
+- [ ] RED/GREEN: reload after `RecoveryStaged`, after provider acceptance, after local link, and after custody queue persistence using deterministic test barriers exposed through the existing test harness rather than production-only methods.
+- [ ] RED/GREEN: two tabs race the same profile; one displays `InProgressElsewhere` and the virtual authenticator records one creation.
+- [ ] RED/GREEN: Escape before arm closes with no credential; Escape after arm does not close or start another ceremony.
+- [ ] RED/GREEN: emulate a worker without `/api/account/setup`, a protocol-v1 response, and a worker whose provider probe returns 404/timeout/malformed/missing capability. New UI must show “Tonk needs an update before it can safely create this account. Reload before approving a passkey.” before invoking the virtual authenticator.
+- [ ] Record the untestable legacy-old-UI/new-worker overlap as a deployment constraint unless the service-worker lifecycle branch is explicitly added as a prerequisite; do not mark exactly-one mixed-version operation verified without that composition test.
+- [ ] Compose with #800/#816 in rollout evidence: an update prompt must not auto-reload an `Armed` flow. If this branch does not own the page critical-section signal, record the exact dependent interface/test rather than duplicating it.
+- [ ] Run each new browser test alone with `CARGO_INCREMENTAL=0 nix develop path:. -c cargo test -p tonk-ui --features integration-tests <exact-test-name> -- --test-threads=1 --nocapture`; expect success. Loopback permission failures are infrastructure failures and must be retried unchanged with permission.
+
+### Task 7: Update the outside-in account recovery contract
+
+**Files:**
+
+- Modify: `docs/storybook/accounts/lifecycle.md`
+- Modify: `docs/storybook/cross-cutting/failure-and-recovery.md`
+- Modify: `docs/storybook/journey-catalog.md`
+- Modify: `docs/storybook/verification/accounts.md`
+- Modify if rendered behavior changes: `docs/storybook/screens.json`
+- Regenerate: `docs/storybook/app/data.json`
+- Regenerate: `docs/storybook/app/data.js`
+
+**Interfaces:**
+
+- Documents: `ACCT-B02` normal, cancel, concurrent-tab, response-loss, reload, corruption, stale-worker, and irreducible WebAuthn boundary behavior without claiming executed evidence before tests run.
+
+- [ ] Update lifecycle/failure source with the exact `Leased -> Armed -> RecoveryStaged` boundary, provider status-first recovery, ordered postconditions, and the possibly-completed-but-unknowable passkey interval.
+- [ ] Add P1 verification rows for cancel-vs-arm, same-profile tab exclusion, every durable-phase reload, provider response loss, corrupt/unsupported recovery state, and incompatible worker refusal.
+- [ ] Update evidence labels only for tests actually executed; leave arbitrary old-worker coexistence as an explicit gap.
+- [ ] Run `python3 docs/storybook/scripts/build.py` to regenerate data.
+- [ ] From `docs/storybook`, run `python3 scripts/build.py --check` and `python3 scripts/check-links.py .`; expect success.
+- [ ] After the documentation/generated files are committed locally, run `python3 docs/storybook/scripts/build.py --check --base 6923a9b16f9f528795d18589c58f601820e005fa`; expect the impact check to pass.
+
+### Task 8: Verify the complete recovery slice without publishing it
+
+**Files:**
+
+- Modify: `plan/audit-account-setup-recovery.md:verification evidence and remaining limits`
+
+- [ ] Run `df -h .` and record available space before broad builds. Do not start overlapping Cargo/Nix processes.
+- [ ] Run `CARGO_INCREMENTAL=0 cargo fmt --all -- --check` and `git diff --check`; expect success.
+- [ ] Run the focused native packages serially: `tonk-account`, `tonk-worker-api`, `tonk-identity`, `tonk-worker`, and `tonk-ui`; expect success.
+- [ ] Run `CARGO_INCREMENTAL=0 nix develop path:. -c test:web:debug -E 'test(account_setup)'`; expect all focused Wasm worker/UI tests to pass.
+- [ ] Run each new real-browser regression serially with one test thread; expect success without touching a live browser profile.
+- [ ] Run the Storybook generation, freshness, link, and committed base-impact checks; expect success.
+- [ ] Run `CARGO_INCREMENTAL=0 cargo clippy -p tonk-account -p tonk-worker-api -p tonk-identity -p tonk-worker -p tonk-ui --all-targets -- -D warnings`; if target-specific code requires the repository Wasm wrapper, run the equivalent scoped Wasm clippy/check and record the distinction.
+- [ ] Inspect `git diff --stat`, `git diff --check`, `git status --short`, free disk, and every changed file against this plan. Preserve unrelated work and report any unverified service-worker composition explicitly.
+- [ ] Request independent review of the local branch. Do not push or open a PR until the parent confirms provider review/publication and approves this branch's review outcome.
+
+## Requirement coverage self-review
+
+- Reload/tab/worker recovery: Tasks 2–6.
+- Versioning, serialization, and corruption: Task 2 and Task 3.
+- Exclusive ownership/revision and concurrent ClientIds: Task 2.
+- Canonical fingerprint before POST and provider status/replay: Tasks 1 and 4.
+- Same-passkey recovery after invocation expiry: Tasks 1, 4, and 5.
+- Provider acceptance before local link/customer/custody: Task 4.
+- Ordered, idempotent custody promotion and checkpoint-write loss: Task 4.
+- Consolidated creation entrypoints: Task 5.
+- Honest Back/Escape semantics and copy: Task 5.
+- Irreducible credential-created-before-stage interval: constraints, Task 3, Task 5, and Storybook Task 7.
+- Outdated service worker behavior: constraints, Task 2, and Task 6.
+- Provider capability/API migration and provider-first rollout: required migration, Task 2, and Task 6.
+- #800/#816 armed-flow reload dependency: constraints and Task 6.
+- Storybook source/generated/impact checks: Task 7.
+- Serialized Cargo, disk monitoring, no live-profile destruction, no premature publication: constraints and Task 8.

--- a/plan/audit-account-setup-recovery.md
+++ b/plan/audit-account-setup-recovery.md
@@ -2,19 +2,21 @@
 
 **Goal:** Recover browser account creation after reload, tab loss, worker restart, and provider response loss from every technically recoverable boundary, while starting at most one WebAuthn creation attempt and describing the one irrecoverable browser boundary honestly.
 **Approach:** Put account-setup ordering behind one deep UI module and one worker saga module. The top document remains the WebAuthn adapter, but the worker is the sole persistence and validation authority. It persists a secret-free versioned checkpoint and a separate credential-store-protected recovery bundle containing a passkey-sealed envelope, bounded authorizations, and a durable root-signed anti-mix manifest. It serializes ownership with a profile-scoped Web Lock plus revision checks, reconciles each durable effect, and uses the provider's proof-bound status and exact-replay contract before attaching local account state and queuing customer/custody work.
-**Base:** branch `fix/audit-account-setup-recovery`, worktree `/Users/jackdouglas/tonk/tonk/.wt/fix/audit-account-setup-recovery`, exact lower-base head `6923a9b16f9f528795d18589c58f601820e005fa`.
+**Base:** branch `fix/audit-account-setup-recovery`, worktree `/Users/jackdouglas/tonk/tonk/.wt/fix/audit-account-setup-recovery`, exact lower-base head `305a60f610d221bd6c9c65cc9eaf227bbb0a8162`.
 
-**Pending lower-base adoption:** provider PR #835 is reviewed at exact head `305a60f610d221bd6c9c65cc9eaf227bbb0a8162` and supplies `GET /capabilities` v1 plus the setup-status policy correction. After the local foundation passes bounded review, commit it, create a backup ref, and rebase merge-free from `6923a9b16f9f528795d18589c58f601820e005fa` onto that exact head. Only then replace the Base SHA above.
+**Lower-base adoption:** provider PR #835 was reviewed and adopted at exact head `305a60f610d221bd6c9c65cc9eaf227bbb0a8162`; it supplies `GET /capabilities` v1 plus the setup-status policy correction.
 
 ## Lower foundation checkpoint (2026-08-31)
 
 This first stacked slice intentionally stops before production route/effect/UI wiring. It contains the canonical manifest, versioned public wire contract (including the worker-selected ceremony context), private checkpoint/recovery encodings, envelope-first decoding, complete-record reducer, and the single bounded semantic `ValidatedRecoveryBundle` constructor. The constructor independently verifies every signed artifact and classifies current expiry separately from canonical/signature/original-window validity.
 
+A bounded foundation review additionally made version classification depend only on a minimal future-safe version envelope before parsing current tags, made `Arm` compare the worker's re-resolved configuration hash inside the reducer, and gave `Stage` a distinct command that must match the one armed attempt before the hash is cleared.
+
 Focused evidence at this checkpoint:
 
 - `CARGO_INCREMENTAL=0 cargo test -p tonk-account recovery::tests`: 4 passed.
 - `CARGO_INCREMENTAL=0 cargo test -p tonk-worker-api account_setup::tests`: 4 passed.
-- `CARGO_INCREMENTAL=0 cargo test -p tonk-worker router::account_setup::tests`: 10 passed.
+- `CARGO_INCREMENTAL=0 cargo test -p tonk-worker router::account_setup::tests`: 12 passed.
 
 Still deliberately absent from this lower commit: credential-site reads/writes, Web Lock and live-`ClientId` ownership enforcement, provider HTTP effects, identity/customer/custody effects, top-document orchestration, UI copy, browser tests, and Storybook changes. Those remain the upper tasks below and must not be inferred from the foundation types alone.
 
@@ -114,7 +116,7 @@ provider exact-state mismatch -> Conflict (fail closed)
 
 ```text
 version, operation_id, revision, owner_hash, bound_client_id,
-provider_hash, phase, armed_at?, staged_at?, attempt_hash?, root_did?, create_fingerprint?, recovery_hash?,
+configuration_hash, phase, armed_at?, staged_at?, attempt_hash?, root_did?, create_fingerprint?, recovery_hash?,
 accepted_descriptor_hash?, last_transition_at
 ```
 

--- a/plan/audit-account-setup-recovery.md
+++ b/plan/audit-account-setup-recovery.md
@@ -80,7 +80,7 @@ pub enum AccountSetupRequest {
     Begin(AccountSetupBegin),
     Acquire(AccountSetupAcquire),
     Arm(AccountSetupArm),
-    Stage(AccountSetupStage),
+    Stage(Box<AccountSetupStage>),
     Continue(AccountSetupMutation),
     ReplaceInvocation(AccountSetupInvocation),
     Cancel(AccountSetupMutation),

--- a/rust/tonk-account/src/lib.rs
+++ b/rust/tonk-account/src/lib.rs
@@ -18,9 +18,14 @@ pub mod pending;
 /// Provider-neutral account space backup artifacts.
 pub mod prefix;
 mod provider;
+/// Durable root-signed anti-mix proof for browser account setup recovery.
+pub mod recovery;
 
 pub use descriptor::{AccountRepositoryDescriptorV1, DescriptorError};
 pub use provider::{AccountProviderError, AccountProviderRecord};
+pub use recovery::{
+    AccountSetupRecoveryManifestInput, AccountSetupRecoveryManifestV1, RecoveryManifestError,
+};
 
 use dialog_capability::{Fork, Provider};
 use dialog_common::ConditionalSync;

--- a/rust/tonk-account/src/recovery.rs
+++ b/rust/tonk-account/src/recovery.rs
@@ -1,0 +1,701 @@
+//! Canonical root-signed account-setup recovery manifest.
+
+use dialog_credentials::{Ed25519Signer, Ed25519Verifier};
+use dialog_varsig::eddsa::Ed25519Signature;
+use dialog_varsig::{Principal as _, Signer as _, Verifier as _};
+use serde_bytes::ByteBuf;
+use thiserror::Error;
+use url::{Host, Url};
+
+use crate::creation::{AccountCreationFingerprint, AccountCreationPasskey};
+
+const VERSION: u64 = 1;
+const SIGNATURE_DOMAIN: &[u8] = b"tonk/account-setup-recovery-manifest/v1\0";
+const HASH_DOMAIN: &[u8] = b"tonk/account-setup-recovery-artifact/v1";
+const MAX_MANIFEST_BYTES: usize = 16 * 1024;
+const MAX_OPERATION_BYTES: usize = 128;
+const MAX_URL_BYTES: usize = 2048;
+const MAX_DID_BYTES: usize = 512;
+const MAX_CREDENTIAL_ID_BYTES: usize = 4096;
+const MAX_PASSKEY_LABEL_CHARS: usize = 120;
+const MAX_DELEGATION_BYTES: usize = 64 * 1024;
+const MAX_DESCRIPTOR_BYTES: usize = 4096;
+const MAX_INVOCATION_BYTES: usize = 128 * 1024;
+const MAX_DEPOSIT_BYTES: usize = 64 * 1024;
+const MAX_DEPOSITS: usize = 8;
+const MAX_CONSENT_BYTES: usize = 64 * 1024;
+const MAX_SEALED_BYTES: usize = 4096;
+const MAX_TOTAL_ARTIFACT_BYTES: usize = 512 * 1024;
+
+type Deployment = (String, String, Option<String>);
+type PasskeyFacts = (u64, String);
+type Identity = (
+    String,
+    String,
+    String,
+    ByteBuf,
+    Option<PasskeyFacts>,
+    Option<String>,
+    String,
+);
+type ArtifactBindings = (
+    ByteBuf,
+    ByteBuf,
+    ByteBuf,
+    u64,
+    ByteBuf,
+    ByteBuf,
+    ByteBuf,
+    ByteBuf,
+);
+type Payload = (u64, String, u64, Deployment, Identity, ArtifactBindings);
+type Envelope = (ByteBuf, ByteBuf);
+
+/// Exact setup facts and artifact bytes bound by a recovery manifest.
+///
+/// Artifact bytes are hashed into the signed payload. The manifest is an
+/// anti-mix proof only; consumers must still decode and authorize each
+/// artifact independently before using it for an effect.
+#[derive(Clone, Copy)]
+pub struct AccountSetupRecoveryManifestInput<'a> {
+    /// Worker-minted setup operation identifier.
+    pub operation_id: &'a str,
+    /// Immutable Unix-seconds reference captured by the ceremony after
+    /// credential creation and before signing bounded invocations.
+    pub ceremony_created_at: u64,
+    /// Canonical deployment-selected account-service base URL.
+    pub provider: &'a str,
+    /// Canonical deployment-selected account repository remote.
+    pub remote: &'a str,
+    /// Canonical deployment service DID, when configured.
+    pub service_did: Option<&'a str>,
+    /// Expected root signer and manifest subject.
+    pub root_did: &'a str,
+    /// Expected first device and manifest audience.
+    pub device_did: &'a str,
+    /// Exact WebAuthn credential identifier.
+    pub credential_id: &'a str,
+    /// Canonical provider creation fingerprint.
+    pub create_fingerprint: AccountCreationFingerprint,
+    /// Normalized passkey creation facts, when present.
+    pub passkey: Option<AccountCreationPasskey<'a>>,
+    /// Account X25519 recipient fact, when present.
+    pub encryption_recipient: Option<&'a str>,
+    /// Custody signer DID named by consent and deferred publish.
+    pub custody_did: &'a str,
+    /// Exact stable root-to-device delegation container bytes.
+    pub delegation: &'a [u8],
+    /// Exact canonical repository descriptor bytes.
+    pub descriptor: &'a [u8],
+    /// Exact original account-create invocation container bytes.
+    pub create_invocation: &'a [u8],
+    /// Exact account-signed deposit containers in their durable order.
+    pub deposits: &'a [Vec<u8>],
+    /// Exact custody-consent container bytes.
+    pub custody_consent: &'a [u8],
+    /// Exact passkey-sealed account-secret envelope bytes.
+    pub sealed_envelope: &'a [u8],
+    /// Exact deferred custody-publish invocation container bytes.
+    pub publish_invocation: &'a [u8],
+}
+
+/// Canonical, root-signed proof that protected setup records came from one
+/// ceremony operation.
+#[derive(Clone, PartialEq, Eq)]
+pub struct AccountSetupRecoveryManifestV1 {
+    bytes: Vec<u8>,
+    hash: [u8; 32],
+}
+
+impl AccountSetupRecoveryManifestV1 {
+    /// Sign a canonical V1 manifest with the account root.
+    pub async fn sign(
+        root: &Ed25519Signer,
+        input: AccountSetupRecoveryManifestInput<'_>,
+    ) -> Result<Self, RecoveryManifestError> {
+        if root.did().to_string() != input.root_did {
+            return Err(RecoveryManifestError::Subject);
+        }
+        let payload = build_payload(input)?;
+        let payload_bytes = encode(&payload)?;
+        let signature = root
+            .sign(&signing_message(&payload_bytes))
+            .await
+            .map_err(|_| RecoveryManifestError::Signature)?;
+        let bytes = encode(&(
+            ByteBuf::from(payload_bytes),
+            ByteBuf::from(signature.to_bytes().to_vec()),
+        ))?;
+        if bytes.len() > MAX_MANIFEST_BYTES {
+            return Err(RecoveryManifestError::TooLarge);
+        }
+        Self::validate(&bytes, input).await
+    }
+
+    /// Verify canonical encoding, the exact root signature, and every
+    /// expected deployment/identity/artifact binding.
+    pub async fn validate(
+        bytes: &[u8],
+        expected: AccountSetupRecoveryManifestInput<'_>,
+    ) -> Result<Self, RecoveryManifestError> {
+        if bytes.len() > MAX_MANIFEST_BYTES {
+            return Err(RecoveryManifestError::TooLarge);
+        }
+        // Bound the expected values before decoding or hashing attacker-held
+        // artifacts. This also constructs the one canonical expected payload.
+        let expected_payload = build_payload(expected)?;
+        let envelope: Envelope = decode(bytes)?;
+        if encode(&envelope)? != bytes {
+            return Err(RecoveryManifestError::NonCanonical);
+        }
+        let payload_bytes = envelope.0.into_vec();
+        let payload: Payload = decode(&payload_bytes)?;
+        if encode(&payload)? != payload_bytes {
+            return Err(RecoveryManifestError::NonCanonical);
+        }
+        if payload.0 != VERSION {
+            return Err(RecoveryManifestError::UnsupportedVersion(payload.0));
+        }
+
+        let subject = &payload.4.0;
+        let verifier: Ed25519Verifier = subject
+            .parse()
+            .map_err(|_| RecoveryManifestError::Subject)?;
+        if verifier.to_string() != *subject {
+            return Err(RecoveryManifestError::Subject);
+        }
+        let signature_bytes: [u8; 64] = envelope
+            .1
+            .as_ref()
+            .try_into()
+            .map_err(|_| RecoveryManifestError::Signature)?;
+        verifier
+            .verify(
+                &signing_message(&payload_bytes),
+                &Ed25519Signature::from_bytes(signature_bytes),
+            )
+            .await
+            .map_err(|_| RecoveryManifestError::Signature)?;
+        if payload != expected_payload {
+            return Err(RecoveryManifestError::Binding);
+        }
+
+        Ok(Self {
+            bytes: bytes.to_vec(),
+            hash: *blake3::hash(bytes).as_bytes(),
+        })
+    }
+
+    /// Exact canonical signed envelope bytes.
+    #[must_use]
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// BLAKE3 hash of the exact canonical signed envelope bytes.
+    #[must_use]
+    pub const fn content_hash(&self) -> [u8; 32] {
+        self.hash
+    }
+}
+
+fn build_payload(
+    input: AccountSetupRecoveryManifestInput<'_>,
+) -> Result<Payload, RecoveryManifestError> {
+    validate_input(&input)?;
+    let passkey = input
+        .passkey
+        .map(|passkey| (passkey.created_at, passkey.created_on.to_string()));
+    let deposits_hash = list_hash(b"deposits", input.deposits);
+    Ok((
+        VERSION,
+        input.operation_id.to_string(),
+        input.ceremony_created_at,
+        (
+            input.provider.to_string(),
+            input.remote.to_string(),
+            input.service_did.map(str::to_string),
+        ),
+        (
+            input.root_did.to_string(),
+            input.device_did.to_string(),
+            input.credential_id.to_string(),
+            ByteBuf::from(input.create_fingerprint.as_bytes().to_vec()),
+            passkey,
+            input.encryption_recipient.map(str::to_string),
+            input.custody_did.to_string(),
+        ),
+        (
+            digest(b"delegation", input.delegation),
+            digest(b"descriptor", input.descriptor),
+            digest(b"create-invocation", input.create_invocation),
+            input.deposits.len() as u64,
+            ByteBuf::from(deposits_hash.to_vec()),
+            digest(b"custody-consent", input.custody_consent),
+            digest(b"sealed-envelope", input.sealed_envelope),
+            digest(b"publish-invocation", input.publish_invocation),
+        ),
+    ))
+}
+
+fn validate_input(
+    input: &AccountSetupRecoveryManifestInput<'_>,
+) -> Result<(), RecoveryManifestError> {
+    if !valid_text(input.operation_id, MAX_OPERATION_BYTES) {
+        return Err(RecoveryManifestError::Input("operation_id"));
+    }
+    if input.ceremony_created_at == 0 || input.ceremony_created_at > 0x001F_FFFF_FFFF_FFFF {
+        return Err(RecoveryManifestError::Input("ceremony_created_at"));
+    }
+    canonical_http_base(input.provider)?;
+    canonical_http_base(input.remote)?;
+    if input.service_did.is_some_and(|did| !canonical_did(did)) {
+        return Err(RecoveryManifestError::Input("service_did"));
+    }
+    let root: Result<Ed25519Verifier, _> = input.root_did.parse();
+    if root.is_err() || root.is_ok_and(|root| root.to_string() != input.root_did) {
+        return Err(RecoveryManifestError::Subject);
+    }
+    if !canonical_did(input.device_did) {
+        return Err(RecoveryManifestError::Input("device_did"));
+    }
+    if !canonical_lower_hex(input.credential_id, MAX_CREDENTIAL_ID_BYTES) {
+        return Err(RecoveryManifestError::Input("credential_id"));
+    }
+    if let Some(passkey) = input.passkey
+        && (passkey.created_at == 0
+            || passkey.created_on.trim() != passkey.created_on
+            || passkey.created_on.is_empty()
+            || passkey.created_on.chars().count() > MAX_PASSKEY_LABEL_CHARS
+            || passkey.created_on.chars().any(char::is_control))
+    {
+        return Err(RecoveryManifestError::Input("passkey"));
+    }
+    if input
+        .encryption_recipient
+        .is_some_and(|did| !valid_text(did, MAX_DID_BYTES))
+    {
+        return Err(RecoveryManifestError::Input("encryption_recipient"));
+    }
+    if !canonical_did(input.custody_did) {
+        return Err(RecoveryManifestError::Input("custody_did"));
+    }
+    if input.delegation.len() > MAX_DELEGATION_BYTES {
+        return Err(RecoveryManifestError::Input("delegation"));
+    }
+    if input.descriptor.len() > MAX_DESCRIPTOR_BYTES {
+        return Err(RecoveryManifestError::Input("descriptor"));
+    }
+    if input.create_invocation.len() > MAX_INVOCATION_BYTES {
+        return Err(RecoveryManifestError::Input("create_invocation"));
+    }
+    if input.deposits.len() > MAX_DEPOSITS
+        || input
+            .deposits
+            .iter()
+            .any(|deposit| deposit.len() > MAX_DEPOSIT_BYTES)
+    {
+        return Err(RecoveryManifestError::Input("deposits"));
+    }
+    if input.custody_consent.len() > MAX_CONSENT_BYTES {
+        return Err(RecoveryManifestError::Input("custody_consent"));
+    }
+    if input.sealed_envelope.len() > MAX_SEALED_BYTES {
+        return Err(RecoveryManifestError::Input("sealed_envelope"));
+    }
+    if input.publish_invocation.len() > MAX_INVOCATION_BYTES {
+        return Err(RecoveryManifestError::Input("publish_invocation"));
+    }
+    let total = [
+        input.delegation.len(),
+        input.descriptor.len(),
+        input.create_invocation.len(),
+        input.custody_consent.len(),
+        input.sealed_envelope.len(),
+        input.publish_invocation.len(),
+    ]
+    .into_iter()
+    .chain(input.deposits.iter().map(Vec::len))
+    .try_fold(0usize, usize::checked_add)
+    .ok_or(RecoveryManifestError::Input("artifact_total"))?;
+    if total > MAX_TOTAL_ARTIFACT_BYTES {
+        return Err(RecoveryManifestError::Input("artifact_total"));
+    }
+    Ok(())
+}
+
+fn digest(label: &[u8], bytes: &[u8]) -> ByteBuf {
+    ByteBuf::from(hash_fields(label, [bytes]).to_vec())
+}
+
+fn list_hash(label: &[u8], values: &[Vec<u8>]) -> [u8; 32] {
+    hash_fields(label, values.iter().map(Vec::as_slice))
+}
+
+fn hash_fields<'a>(label: &[u8], values: impl IntoIterator<Item = &'a [u8]>) -> [u8; 32] {
+    fn field(hasher: &mut blake3::Hasher, value: &[u8]) {
+        hasher.update(&(value.len() as u64).to_be_bytes());
+        hasher.update(value);
+    }
+    let mut hasher = blake3::Hasher::new();
+    field(&mut hasher, HASH_DOMAIN);
+    field(&mut hasher, label);
+    for value in values {
+        field(&mut hasher, value);
+    }
+    *hasher.finalize().as_bytes()
+}
+
+fn signing_message(payload_bytes: &[u8]) -> Vec<u8> {
+    let mut message = Vec::with_capacity(SIGNATURE_DOMAIN.len() + payload_bytes.len());
+    message.extend_from_slice(SIGNATURE_DOMAIN);
+    message.extend_from_slice(payload_bytes);
+    message
+}
+
+fn valid_text(value: &str, max_bytes: usize) -> bool {
+    !value.is_empty() && value.len() <= max_bytes && !value.chars().any(char::is_control)
+}
+
+fn canonical_lower_hex(value: &str, max_bytes: usize) -> bool {
+    !value.is_empty()
+        && value.len() <= max_bytes
+        && value.len().is_multiple_of(2)
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn canonical_did(value: &str) -> bool {
+    if !valid_text(value, MAX_DID_BYTES) {
+        return false;
+    }
+    value
+        .parse::<dialog_varsig::Did>()
+        .is_ok_and(|did| did.to_string() == value)
+}
+
+fn canonical_http_base(value: &str) -> Result<Url, RecoveryManifestError> {
+    if !valid_text(value, MAX_URL_BYTES) {
+        return Err(RecoveryManifestError::Input("url"));
+    }
+    let url = Url::parse(value).map_err(|_| RecoveryManifestError::Input("url"))?;
+    if !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || !url.path().ends_with('/')
+        || url.as_str() != value
+    {
+        return Err(RecoveryManifestError::Input("url"));
+    }
+    match url.scheme() {
+        "https" => Ok(url),
+        "http" if is_loopback(&url) => Ok(url),
+        _ => Err(RecoveryManifestError::Input("url")),
+    }
+}
+
+fn is_loopback(url: &Url) -> bool {
+    match url.host() {
+        Some(Host::Domain("localhost")) => true,
+        Some(Host::Ipv4(address)) => address.is_loopback(),
+        Some(Host::Ipv6(address)) => address.is_loopback(),
+        _ => false,
+    }
+}
+
+fn encode<T: serde::Serialize>(value: &T) -> Result<Vec<u8>, RecoveryManifestError> {
+    serde_ipld_dagcbor::to_vec(value)
+        .map_err(|error| RecoveryManifestError::Encoding(error.to_string()))
+}
+
+fn decode<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> Result<T, RecoveryManifestError> {
+    serde_ipld_dagcbor::from_slice(bytes)
+        .map_err(|error| RecoveryManifestError::Encoding(error.to_string()))
+}
+
+/// Recovery-manifest encoding, binding, or signature failure.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum RecoveryManifestError {
+    /// The signed manifest envelope exceeds its fixed V1 bound.
+    #[error("recovery manifest exceeds 16384 bytes")]
+    TooLarge,
+    /// A named expected fact or artifact exceeds bounds or is non-canonical.
+    #[error("invalid recovery manifest input: {0}")]
+    Input(&'static str),
+    /// DAG-CBOR encoding or decoding failed.
+    #[error("invalid recovery manifest encoding: {0}")]
+    Encoding(String),
+    /// Decoded bytes were not the unique canonical representation.
+    #[error("recovery manifest is not canonically encoded")]
+    NonCanonical,
+    /// The signed payload names an unsupported manifest version.
+    #[error("unsupported recovery manifest version {0}")]
+    UnsupportedVersion(u64),
+    /// The expected/signed root is not the canonical Ed25519 subject.
+    #[error("recovery manifest subject is invalid")]
+    Subject,
+    /// The root signature is absent, malformed, or invalid for this domain.
+    #[error("recovery manifest signature is invalid")]
+    Signature,
+    /// A signed operation, deployment, identity, or artifact binding differs.
+    #[error("recovery manifest does not match the staged setup bundle")]
+    Binding,
+}
+
+#[cfg(test)]
+mod tests {
+    use dialog_credentials::Ed25519Signer;
+    use dialog_varsig::{Principal as _, Signer as _};
+    use serde_bytes::ByteBuf;
+
+    use super::{
+        AccountSetupRecoveryManifestInput, AccountSetupRecoveryManifestV1, Envelope, Payload,
+        RecoveryManifestError, decode, encode, signing_message,
+    };
+    use crate::creation::{AccountCreationFingerprint, AccountCreationPasskey};
+
+    #[derive(Clone)]
+    struct Fixture {
+        operation_id: String,
+        ceremony_created_at: u64,
+        provider: String,
+        remote: String,
+        service_did: Option<String>,
+        root_did: String,
+        device_did: String,
+        credential_id: String,
+        create_fingerprint: AccountCreationFingerprint,
+        passkey_created_at: u64,
+        passkey_created_on: String,
+        encryption_recipient: Option<String>,
+        custody_did: String,
+        delegation: Vec<u8>,
+        descriptor: Vec<u8>,
+        create_invocation: Vec<u8>,
+        deposits: Vec<Vec<u8>>,
+        custody_consent: Vec<u8>,
+        sealed_envelope: Vec<u8>,
+        publish_invocation: Vec<u8>,
+    }
+
+    impl Fixture {
+        fn input(&self) -> AccountSetupRecoveryManifestInput<'_> {
+            AccountSetupRecoveryManifestInput {
+                operation_id: &self.operation_id,
+                ceremony_created_at: self.ceremony_created_at,
+                provider: &self.provider,
+                remote: &self.remote,
+                service_did: self.service_did.as_deref(),
+                root_did: &self.root_did,
+                device_did: &self.device_did,
+                credential_id: &self.credential_id,
+                create_fingerprint: self.create_fingerprint,
+                passkey: Some(AccountCreationPasskey {
+                    created_at: self.passkey_created_at,
+                    created_on: &self.passkey_created_on,
+                }),
+                encryption_recipient: self.encryption_recipient.as_deref(),
+                custody_did: &self.custody_did,
+                delegation: &self.delegation,
+                descriptor: &self.descriptor,
+                create_invocation: &self.create_invocation,
+                deposits: &self.deposits,
+                custody_consent: &self.custody_consent,
+                sealed_envelope: &self.sealed_envelope,
+                publish_invocation: &self.publish_invocation,
+            }
+        }
+    }
+
+    async fn signer(seed: u8) -> Ed25519Signer {
+        Ed25519Signer::import(&[seed; 32]).await.unwrap()
+    }
+
+    async fn fixture() -> Fixture {
+        let root = signer(7).await;
+        Fixture {
+            operation_id: "setup-01".to_string(),
+            ceremony_created_at: 1_754_380_800,
+            provider: "https://accounts.example/".to_string(),
+            remote: "https://app.example/ucan/".to_string(),
+            service_did: Some(signer(8).await.did().to_string()),
+            root_did: root.did().to_string(),
+            device_did: signer(9).await.did().to_string(),
+            credential_id: "aabbccdd".to_string(),
+            create_fingerprint: AccountCreationFingerprint::from_hex(&"11".repeat(32)).unwrap(),
+            passkey_created_at: 1_754_380_800,
+            passkey_created_on: "Chrome on macOS".to_string(),
+            encryption_recipient: Some(
+                "did:key:z6LSgZMqF1tKjEBAB9Kx4w3VmpQ8BzYVUmHgscBpHN3yP7Qq".to_string(),
+            ),
+            custody_did: signer(10).await.did().to_string(),
+            delegation: vec![1, 2, 3],
+            descriptor: vec![4, 5, 6],
+            create_invocation: vec![7, 8, 9],
+            deposits: vec![vec![10, 11], vec![12, 13]],
+            custody_consent: vec![14, 15],
+            sealed_envelope: vec![16, 17, 18],
+            publish_invocation: vec![19, 20],
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_signs_deterministic_canonical_bytes_and_validates_every_binding() {
+        let root = signer(7).await;
+        let fixture = fixture().await;
+        let first = AccountSetupRecoveryManifestV1::sign(&root, fixture.input())
+            .await
+            .unwrap();
+        let second = AccountSetupRecoveryManifestV1::sign(&root, fixture.input())
+            .await
+            .unwrap();
+
+        assert_eq!(first.bytes(), second.bytes());
+        assert_eq!(first.content_hash(), second.content_hash());
+        assert_eq!(
+            first.content_hash(),
+            *blake3::hash(first.bytes()).as_bytes()
+        );
+        assert!(
+            AccountSetupRecoveryManifestV1::validate(first.bytes(), fixture.input())
+                .await
+                .unwrap()
+                == first
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_cross_bundle_mixing_and_every_mutable_binding() {
+        let root = signer(7).await;
+        let fixture = fixture().await;
+        let manifest = AccountSetupRecoveryManifestV1::sign(&root, fixture.input())
+            .await
+            .unwrap();
+
+        let mutations: &[fn(&mut Fixture)] = &[
+            |value| value.operation_id.push('x'),
+            |value| value.ceremony_created_at += 1,
+            |value| value.provider = "https://other-accounts.example/".to_string(),
+            |value| value.remote = "https://other-app.example/ucan/".to_string(),
+            |value| value.service_did = None,
+            |value| value.root_did = value.device_did.clone(),
+            |value| value.device_did = value.custody_did.clone(),
+            |value| value.credential_id.push_str("00"),
+            |value| {
+                value.create_fingerprint =
+                    AccountCreationFingerprint::from_hex(&"22".repeat(32)).unwrap()
+            },
+            |value| value.passkey_created_at += 1,
+            |value| value.passkey_created_on.push('x'),
+            |value| value.encryption_recipient = None,
+            |value| value.custody_did = value.device_did.clone(),
+            |value| value.delegation.push(21),
+            |value| value.descriptor.push(21),
+            |value| value.create_invocation.push(21),
+            |value| value.deposits.swap(0, 1),
+            |value| value.custody_consent.push(21),
+            |value| value.sealed_envelope.push(21),
+            |value| value.publish_invocation.push(21),
+        ];
+        for mutate in mutations {
+            let mut crossed = fixture.clone();
+            mutate(&mut crossed);
+            assert!(
+                AccountSetupRecoveryManifestV1::validate(manifest.bytes(), crossed.input())
+                    .await
+                    .is_err(),
+                "a changed manifest binding was accepted"
+            );
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_oversize_inputs_before_hashing_or_decoding() {
+        let root = signer(7).await;
+        let fixture = fixture().await;
+
+        let mut long_operation = fixture.clone();
+        long_operation.operation_id = "x".repeat(129);
+        assert!(
+            AccountSetupRecoveryManifestV1::sign(&root, long_operation.input())
+                .await
+                .is_err()
+        );
+
+        let mut oversized_artifact = fixture.clone();
+        oversized_artifact.create_invocation = vec![0; 128 * 1024 + 1];
+        assert!(
+            AccountSetupRecoveryManifestV1::sign(&root, oversized_artifact.input())
+                .await
+                .is_err()
+        );
+
+        let manifest = AccountSetupRecoveryManifestV1::sign(&root, fixture.input())
+            .await
+            .unwrap();
+        let mut oversized_manifest = manifest.bytes().to_vec();
+        oversized_manifest.resize(16 * 1024 + 1, 0);
+        assert!(
+            AccountSetupRecoveryManifestV1::validate(&oversized_manifest, fixture.input())
+                .await
+                .is_err()
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_future_versions_wrong_domains_signatures_and_noncanonical_bytes() {
+        let root = signer(7).await;
+        let fixture = fixture().await;
+        let manifest = AccountSetupRecoveryManifestV1::sign(&root, fixture.input())
+            .await
+            .unwrap();
+        let envelope: Envelope = decode(manifest.bytes()).unwrap();
+        let mut payload: Payload = decode(envelope.0.as_ref()).unwrap();
+
+        payload.0 = 99;
+        let future_payload = encode(&payload).unwrap();
+        let future_signature = root.sign(&signing_message(&future_payload)).await.unwrap();
+        let future = encode(&(
+            ByteBuf::from(future_payload),
+            ByteBuf::from(future_signature.to_bytes().to_vec()),
+        ))
+        .unwrap();
+        assert!(matches!(
+            AccountSetupRecoveryManifestV1::validate(&future, fixture.input()).await,
+            Err(RecoveryManifestError::UnsupportedVersion(99))
+        ));
+
+        payload.0 = 1;
+        let payload = encode(&payload).unwrap();
+        let mut wrong_domain_message = b"tonk/wrong-domain/v1\0".to_vec();
+        wrong_domain_message.extend_from_slice(&payload);
+        let wrong_domain_signature = root.sign(&wrong_domain_message).await.unwrap();
+        let wrong_domain = encode(&(
+            ByteBuf::from(payload.clone()),
+            ByteBuf::from(wrong_domain_signature.to_bytes().to_vec()),
+        ))
+        .unwrap();
+        assert!(matches!(
+            AccountSetupRecoveryManifestV1::validate(&wrong_domain, fixture.input()).await,
+            Err(RecoveryManifestError::Signature)
+        ));
+
+        let mut invalid_signature: Envelope = decode(manifest.bytes()).unwrap();
+        invalid_signature.1[0] ^= 1;
+        let invalid_signature = encode(&invalid_signature).unwrap();
+        assert!(matches!(
+            AccountSetupRecoveryManifestV1::validate(&invalid_signature, fixture.input()).await,
+            Err(RecoveryManifestError::Signature)
+        ));
+
+        let mut trailing = manifest.bytes().to_vec();
+        trailing.push(0);
+        assert!(
+            AccountSetupRecoveryManifestV1::validate(&trailing, fixture.input())
+                .await
+                .is_err()
+        );
+    }
+}

--- a/rust/tonk-worker-api/src/account_setup.rs
+++ b/rust/tonk-worker-api/src/account_setup.rs
@@ -1,0 +1,765 @@
+//! Versioned wire contract for durable browser account setup.
+
+use serde::{Deserialize, Serialize};
+
+/// Account-setup protocol implemented by a compatible service worker.
+pub const ACCOUNT_SETUP_PROTOCOL_VERSION: u16 = 2;
+
+/// Provider contract required for proof-bound setup status and exact replay.
+pub const ACCOUNT_SETUP_PROVIDER_RECOVERY_VERSION: u16 = 1;
+
+/// Versions confirmed before the page may request passkey creation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AccountSetupCapabilities {
+    /// Account-setup protocol implemented by the controlling worker.
+    pub worker_protocol_version: u16,
+    /// Recovery contract advertised by the selected account provider.
+    pub provider_recovery_version: u16,
+}
+
+/// Canonical deployment facts selected by the worker for one setup lease.
+///
+/// The page signs these exact facts into the recovery manifest. It never
+/// chooses a provider or turns the worker into a fetch proxy.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AccountSetupCeremonyContext {
+    /// Canonical account-service base URL whose capability the worker checked.
+    pub provider: String,
+    /// Canonical repository remote bound by the root-signed descriptor.
+    pub remote: String,
+    /// Configured access-service DID whose exact deposit scopes are required.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_did: Option<String>,
+}
+
+/// Ask the worker to prove both sides of the recovery contract before the
+/// browser is allowed to request passkey creation.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AccountSetupHandshake {
+    /// Protocol version required by the page.
+    pub protocol_version: u16,
+}
+
+/// Establish a new pre-WebAuthn lease after a successful capability check.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AccountSetupBegin {
+    /// Protocol version required by the page.
+    pub protocol_version: u16,
+    /// High-entropy document owner token. Only a domain-separated hash is
+    /// persisted.
+    pub owner_token: String,
+}
+
+/// Acquire a recoverable operation after its previous document is absent.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AccountSetupAcquire {
+    /// Operation being acquired.
+    pub operation_id: String,
+    /// New high-entropy owner token. Only its hash is persisted.
+    pub owner_token: String,
+    /// Compare-and-swap revision read from the redacted view.
+    pub expected_revision: u64,
+}
+
+/// Common proof of ownership and revision for a setup mutation.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AccountSetupMutation {
+    /// Operation being changed.
+    pub operation_id: String,
+    /// Raw owner token held only by the page.
+    pub owner_token: String,
+    /// Compare-and-swap revision read from the preceding response.
+    pub expected_revision: u64,
+}
+
+/// Arm exactly one passkey-creation attempt.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AccountSetupArm {
+    /// Ownership and revision proof.
+    pub mutation: AccountSetupMutation,
+    /// Document-memory attempt token. Only a domain-separated hash is stored.
+    pub attempt_token: String,
+}
+
+/// Credential-store-protected recovery material produced by account creation.
+///
+/// This is not secret-free: it contains PII, a passkey-sealed envelope, and
+/// bounded signed authorizations. It intentionally does not implement
+/// [`Debug`] and must never be included in general status or logs.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AccountSetupRecoveryBundle {
+    /// Recovery bundle schema version.
+    pub version: u16,
+    /// Root-signed immutable Unix-seconds reference captured after passkey
+    /// creation and before the bounded invocations were minted.
+    pub ceremony_created_at: u64,
+    /// Normalized provider account email.
+    pub normalized_email: String,
+    /// Account-provider base URL.
+    pub provider: String,
+    /// Passkey-derived account root DID.
+    pub root_did: String,
+    /// Current profile/device DID.
+    pub device_did: String,
+    /// Device label bound into the account-creation fingerprint.
+    pub device_name: String,
+    /// Opaque WebAuthn credential identifier.
+    pub credential_id: String,
+    /// CID of the stable root-to-device delegation.
+    pub delegation_cid: String,
+    /// Exact hex-encoded root-to-device delegation.
+    pub delegation_hex: String,
+    /// Informational passkey creation metadata, when captured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub passkey: Option<crate::PasskeyMetadata>,
+    /// Account X25519 recipient published to the account repository.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encryption_key: Option<String>,
+    /// Canonical signed account-repository descriptor.
+    pub descriptor_hex: String,
+    /// Canonical version-1 provider creation fingerprint.
+    pub create_fingerprint: String,
+    /// Original root-signed account-creation invocation.
+    pub invocation_hex: String,
+    /// Account-signed customer enrollment deposits.
+    #[serde(default)]
+    pub deposits_hex: Vec<String>,
+    /// Custody space DID.
+    pub custody_did: String,
+    /// Signed custody provisioning consent.
+    pub consent_hex: String,
+    /// Passkey-sealed account-secret envelope.
+    pub sealed_hex: String,
+    /// Bounded custody-cell publish invocation.
+    pub publish_invocation_hex: String,
+    /// Canonical root-signed anti-mix manifest binding this operation and all
+    /// preceding protected artifacts.
+    pub recovery_manifest_hex: String,
+}
+
+/// Save recovery material for the one armed attempt.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AccountSetupStage {
+    /// Ownership and revision proof.
+    pub mutation: AccountSetupMutation,
+    /// Raw document-memory attempt token matching the armed hash.
+    pub attempt_token: String,
+    /// Protected bundle to durably validate and save before any provider call.
+    pub recovery: AccountSetupRecoveryBundle,
+}
+
+/// Replace an expired create invocation after asserting the same credential.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AccountSetupInvocation {
+    /// Ownership and revision proof.
+    pub mutation: AccountSetupMutation,
+    /// Fresh invocation whose decoded facts must reproduce the stored
+    /// canonical fingerprint.
+    pub invocation_hex: String,
+}
+
+/// Inspect the current operation without granting access to protected state.
+///
+/// A matching owner token lets the worker return a separate protected response
+/// only when a same-passkey resume gesture is required. The public view remains
+/// redacted either way.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AccountSetupInspect {
+    /// Existing document owner token, when this session has one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_token: Option<String>,
+}
+
+/// One command sent to the worker's account-setup coordinator.
+///
+/// This type intentionally does not implement [`Debug`]. Later commands carry
+/// credential-store-protected recovery material and bounded authorizations;
+/// keeping the outer request non-debuggable prevents accidental whole-request
+/// logging as the protocol grows.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "command",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+pub enum AccountSetupRequest {
+    /// Verify the worker protocol and provider recovery capability.
+    Handshake(AccountSetupHandshake),
+    /// Inspect redacted state and authenticate an optional protected resume.
+    Inspect(AccountSetupInspect),
+    /// Begin a new capability-checked lease.
+    Begin(AccountSetupBegin),
+    /// Take over a recoverable operation whose previous client is absent.
+    Acquire(AccountSetupAcquire),
+    /// Fence one passkey creation attempt after rechecking provider support.
+    Arm(AccountSetupArm),
+    /// Durably stage the recoverable ceremony result.
+    Stage(AccountSetupStage),
+    /// Reconcile and advance only verified post-stage effects.
+    Continue(AccountSetupMutation),
+    /// Replace an expired create invocation after a same-credential assertion.
+    ReplaceInvocation(AccountSetupInvocation),
+    /// Cancel a lease before it is armed.
+    Cancel(AccountSetupMutation),
+}
+
+/// Coarse progress label for presentation only.
+///
+/// Durable phases are private worker data. The UI must follow
+/// [`AccountSetupNextAction`] rather than derive behavior from this label.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AccountSetupProgress {
+    /// Capability and ownership checks are being prepared.
+    Preparing,
+    /// The current document may be waiting on the authenticator prompt.
+    PasskeyApproval,
+    /// A staged bundle is being reconciled locally or with the provider.
+    Recovering,
+    /// Provider acceptance and local attachment are being reconciled.
+    ConnectingServices,
+    /// Customer and custody work is being made durable.
+    Finishing,
+    /// Account setup is durably complete.
+    Complete,
+}
+
+/// Closed status category rendered by the UI.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AccountSetupDisposition {
+    /// No operation exists.
+    Missing,
+    /// The named next action is safe now.
+    Ready,
+    /// Another live document owns the operation.
+    InProgressElsewhere,
+    /// No state was lost, but a transient dependency should be retried later.
+    RetryLater,
+    /// A pre-WebAuthn operation was cancelled.
+    Cancelled,
+    /// Cancellation lost the atomic race with arming.
+    CancelTooLate,
+    /// Passkey approval may have completed before recovery was staged.
+    InterruptedBeforeRecovery,
+    /// Durable local or provider facts do not match this operation.
+    Conflict,
+    /// Setup and its completion checkpoint are durable.
+    Complete,
+    /// Stored data is malformed and must not be overwritten.
+    Corrupt,
+    /// Stored data belongs to a future unsupported schema.
+    Unsupported,
+    /// Worker or provider recovery capability is incompatible.
+    UpdateRequired,
+    /// A same-credential assertion is required to replace an expired request.
+    NeedsPasskey,
+}
+
+/// Closed action the UI may offer for a disposition.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AccountSetupNextAction {
+    /// Offer no action.
+    None,
+    /// Begin a new capability-checked operation.
+    Begin,
+    /// Ask for passkey approval after arming.
+    ApprovePasskey,
+    /// Continue deterministic worker reconciliation.
+    Continue,
+    /// Wait for the current owner or authenticator prompt.
+    Wait,
+    /// Acquire a staged operation whose previous client is absent.
+    Acquire,
+    /// Retry a transiently unavailable dependency.
+    Retry,
+    /// Ask for an assertion of the exact staged credential.
+    ResumeWithPasskey,
+    /// Explicitly abandon a terminal interrupted attempt and start over.
+    StartOver,
+    /// Reload only when it is safe to adopt compatible code.
+    Reload,
+}
+
+/// Stable non-sensitive reason for a terminal conflict.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AccountSetupConflictCode {
+    /// Protected recovery data does not match the checkpoint.
+    RecoveryMismatch,
+    /// A different local root is already durable.
+    LocalRootMismatch,
+    /// Provider status returned a semantic mismatch.
+    ProviderMismatch,
+    /// A different local provider link is already durable.
+    AttachmentMismatch,
+}
+
+/// Redacted account-setup status returned by general inspection.
+///
+/// It deliberately contains no email, token or token hash, credential ID,
+/// ciphertext, delegation, invocation, or provider artifact.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AccountSetupView {
+    /// Worker protocol that produced this view.
+    pub worker_protocol_version: u16,
+    /// Opaque operation identifier, absent when no valid operation is decoded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operation_id: Option<String>,
+    /// Compare-and-swap revision, absent when no valid operation is decoded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision: Option<u64>,
+    /// Presentation-only progress, never an instruction to the UI.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub progress: Option<AccountSetupProgress>,
+    /// Closed status category.
+    pub disposition: AccountSetupDisposition,
+    /// Only action the UI may offer for this response.
+    pub next_action: AccountSetupNextAction,
+    /// Stable conflict reason when [`AccountSetupDisposition::Conflict`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub conflict_code: Option<AccountSetupConflictCode>,
+    /// Future stored schema version when safely decoded from its envelope.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stored_version: Option<u16>,
+}
+
+/// Owner-bound lease plus the worker-selected facts for the passkey ceremony.
+///
+/// `Begin` returns this only after capability/configuration checks. `Arm`
+/// rechecks the checkpoint's configuration hash before passkey creation.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AccountSetupLease {
+    /// Redacted leased-operation state and compare-and-swap revision.
+    pub view: AccountSetupView,
+    /// Exact deployment facts the recovery manifest must bind.
+    pub ceremony: AccountSetupCeremonyContext,
+}
+
+/// Minimum protected input for asserting the exact staged credential and
+/// rebuilding only the original semantic account creation.
+///
+/// This type is owner-authenticated and intentionally does not implement
+/// [`Debug`]. It must never be returned by unauthenticated inspection.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AccountSetupResumeInput {
+    /// Operation whose expired invocation is being replaced.
+    pub operation_id: String,
+    /// Exact staged WebAuthn credential identifier.
+    pub credential_id: String,
+    /// Root DID the reopened envelope must reproduce.
+    pub expected_root_did: String,
+    /// Normalized provider account email bound into the fingerprint.
+    pub normalized_email: String,
+    /// Exact device DID receiving the stable delegation.
+    pub device_did: String,
+    /// Exact device label bound into the fingerprint.
+    pub device_name: String,
+    /// Stable root-to-device delegation bytes.
+    pub delegation_hex: String,
+    /// Original canonical signed descriptor bytes.
+    pub descriptor_hex: String,
+    /// Passkey creation metadata bound into the fingerprint, when present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub passkey: Option<crate::PasskeyMetadata>,
+    /// Passkey-sealed account-secret envelope.
+    pub sealed_hex: String,
+}
+
+/// Owner-authenticated response carrying protected recovery material.
+///
+/// It intentionally does not implement [`Debug`].
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "protectedOutcome",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+pub enum AccountSetupProtectedResponse {
+    /// The original invocation expired and the same credential must be asserted.
+    NeedsPasskey {
+        /// Redacted status used for presentation.
+        view: AccountSetupView,
+        /// Minimum protected ceremony input.
+        resume: AccountSetupResumeInput,
+    },
+}
+
+/// Worker response to one account-setup command.
+///
+/// The outer response intentionally does not implement [`Debug`]; an
+/// owner-authenticated response will later carry protected recovery input.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "outcome",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+pub enum AccountSetupResponse {
+    /// Both worker and provider support the required recovery protocols.
+    Capabilities(AccountSetupCapabilities),
+    /// New owner-bound operation and its worker-selected ceremony context.
+    Lease(AccountSetupLease),
+    /// Redacted current status.
+    View(AccountSetupView),
+    /// Owner-authenticated protected response, never returned by public status.
+    Protected(AccountSetupProtectedResponse),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ACCOUNT_SETUP_PROTOCOL_VERSION, ACCOUNT_SETUP_PROVIDER_RECOVERY_VERSION,
+        AccountSetupAcquire, AccountSetupArm, AccountSetupBegin, AccountSetupCapabilities,
+        AccountSetupCeremonyContext, AccountSetupDisposition, AccountSetupHandshake,
+        AccountSetupInspect, AccountSetupInvocation, AccountSetupLease, AccountSetupMutation,
+        AccountSetupNextAction, AccountSetupProgress, AccountSetupProtectedResponse,
+        AccountSetupRecoveryBundle, AccountSetupRequest, AccountSetupResponse,
+        AccountSetupResumeInput, AccountSetupStage, AccountSetupView,
+    };
+
+    #[dialog_common::test]
+    fn it_serializes_the_versioned_handshake_and_a_redacted_view() {
+        let request = AccountSetupRequest::Handshake(AccountSetupHandshake {
+            protocol_version: ACCOUNT_SETUP_PROTOCOL_VERSION,
+        });
+        assert_eq!(
+            serde_json::to_value(request).expect("serialize handshake"),
+            serde_json::json!({
+                "command": "handshake",
+                "protocolVersion": 2,
+            })
+        );
+
+        let view = AccountSetupView {
+            worker_protocol_version: ACCOUNT_SETUP_PROTOCOL_VERSION,
+            operation_id: Some("setup-1".to_string()),
+            revision: Some(7),
+            progress: Some(AccountSetupProgress::Recovering),
+            disposition: AccountSetupDisposition::Ready,
+            next_action: AccountSetupNextAction::Acquire,
+            conflict_code: None,
+            stored_version: None,
+        };
+        let value = serde_json::to_value(view).expect("serialize redacted view");
+        assert_eq!(value["workerProtocolVersion"], 2);
+        assert_eq!(value["operationId"], "setup-1");
+        assert_eq!(value["revision"], 7);
+        assert_eq!(value["progress"], "recovering");
+        assert_eq!(value["disposition"], "ready");
+        assert_eq!(value["nextAction"], "acquire");
+
+        let encoded = serde_json::to_string(&value).expect("encode redacted view");
+        for forbidden in [
+            "email",
+            "owner",
+            "attempt",
+            "credential",
+            "delegation",
+            "invocation",
+            "sealed",
+            "descriptor",
+        ] {
+            assert!(
+                !encoded.to_ascii_lowercase().contains(forbidden),
+                "general setup status leaked {forbidden}: {encoded}"
+            );
+        }
+    }
+
+    #[dialog_common::test]
+    fn it_round_trips_every_command_and_rejects_unknown_wire_fields() {
+        let mutation = AccountSetupMutation {
+            operation_id: "setup-1".to_string(),
+            owner_token: "owner-token".to_string(),
+            expected_revision: 7,
+        };
+        let recovery = AccountSetupRecoveryBundle {
+            version: 1,
+            ceremony_created_at: 1_754_380_800,
+            normalized_email: "person@example.com".to_string(),
+            provider: "https://accounts.example".to_string(),
+            root_did: "did:key:root".to_string(),
+            device_did: "did:key:device".to_string(),
+            device_name: "Jack's laptop".to_string(),
+            credential_id: "aabb".to_string(),
+            delegation_cid: "bafydelegation".to_string(),
+            delegation_hex: "ccdd".to_string(),
+            passkey: Some(crate::PasskeyMetadata {
+                created_at: 1_754_380_800,
+                created_on: "Chrome on macOS".to_string(),
+            }),
+            encryption_key: Some("did:key:z6LSrecipient".to_string()),
+            descriptor_hex: "eeff".to_string(),
+            create_fingerprint: "11".repeat(32),
+            invocation_hex: "2233".to_string(),
+            deposits_hex: vec!["4455".to_string()],
+            custody_did: "did:key:custody".to_string(),
+            consent_hex: "6677".to_string(),
+            sealed_hex: "8899".to_string(),
+            publish_invocation_hex: "aabb".to_string(),
+            recovery_manifest_hex: "bbcc".to_string(),
+        };
+        let requests = [
+            AccountSetupRequest::Inspect(AccountSetupInspect { owner_token: None }),
+            AccountSetupRequest::Begin(AccountSetupBegin {
+                protocol_version: ACCOUNT_SETUP_PROTOCOL_VERSION,
+                owner_token: "owner-token".to_string(),
+            }),
+            AccountSetupRequest::Acquire(AccountSetupAcquire {
+                operation_id: "setup-1".to_string(),
+                owner_token: "new-owner-token".to_string(),
+                expected_revision: 7,
+            }),
+            AccountSetupRequest::Arm(AccountSetupArm {
+                mutation: mutation.clone(),
+                attempt_token: "attempt-token".to_string(),
+            }),
+            AccountSetupRequest::Stage(AccountSetupStage {
+                mutation: mutation.clone(),
+                attempt_token: "attempt-token".to_string(),
+                recovery,
+            }),
+            AccountSetupRequest::Continue(mutation.clone()),
+            AccountSetupRequest::ReplaceInvocation(AccountSetupInvocation {
+                mutation: mutation.clone(),
+                invocation_hex: "deadbeef".to_string(),
+            }),
+            AccountSetupRequest::Cancel(mutation),
+        ];
+        let expected_commands = [
+            "inspect",
+            "begin",
+            "acquire",
+            "arm",
+            "stage",
+            "continue",
+            "replaceInvocation",
+            "cancel",
+        ];
+
+        for (request, command) in requests.into_iter().zip(expected_commands) {
+            let value = serde_json::to_value(&request).expect("serialize command");
+            assert_eq!(value["command"], command);
+            let decoded: AccountSetupRequest =
+                serde_json::from_value(value).expect("deserialize command");
+            assert!(decoded == request, "{command} did not round trip");
+        }
+
+        assert!(
+            serde_json::from_value::<AccountSetupRequest>(serde_json::json!({
+                "command": "begin",
+                "protocolVersion": 2,
+                "ownerToken": "owner-token",
+                "provider": "https://evil.example",
+            }))
+            .is_err(),
+            "provider selection belongs to deployment config, never caller input"
+        );
+        assert!(
+            serde_json::from_value::<AccountSetupRequest>(serde_json::json!({
+                "command": "advance",
+                "phase": "complete",
+            }))
+            .is_err(),
+            "callers must not be able to declare a later phase"
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_names_every_phase_and_capability_without_exposing_protected_state() {
+        let progress = [
+            (AccountSetupProgress::Preparing, "preparing"),
+            (AccountSetupProgress::PasskeyApproval, "passkeyApproval"),
+            (AccountSetupProgress::Recovering, "recovering"),
+            (
+                AccountSetupProgress::ConnectingServices,
+                "connectingServices",
+            ),
+            (AccountSetupProgress::Finishing, "finishing"),
+            (AccountSetupProgress::Complete, "complete"),
+        ];
+        for (progress, expected) in progress {
+            assert_eq!(serde_json::to_value(progress).unwrap(), expected);
+        }
+
+        for (disposition, expected) in [
+            (AccountSetupDisposition::Missing, "missing"),
+            (AccountSetupDisposition::Ready, "ready"),
+            (
+                AccountSetupDisposition::InProgressElsewhere,
+                "inProgressElsewhere",
+            ),
+            (AccountSetupDisposition::RetryLater, "retryLater"),
+            (AccountSetupDisposition::Cancelled, "cancelled"),
+            (AccountSetupDisposition::CancelTooLate, "cancelTooLate"),
+            (
+                AccountSetupDisposition::InterruptedBeforeRecovery,
+                "interruptedBeforeRecovery",
+            ),
+            (AccountSetupDisposition::Conflict, "conflict"),
+            (AccountSetupDisposition::Complete, "complete"),
+            (AccountSetupDisposition::Corrupt, "corrupt"),
+            (AccountSetupDisposition::Unsupported, "unsupported"),
+            (AccountSetupDisposition::UpdateRequired, "updateRequired"),
+            (AccountSetupDisposition::NeedsPasskey, "needsPasskey"),
+        ] {
+            assert_eq!(serde_json::to_value(disposition).unwrap(), expected);
+        }
+
+        let response = AccountSetupResponse::Capabilities(AccountSetupCapabilities {
+            worker_protocol_version: ACCOUNT_SETUP_PROTOCOL_VERSION,
+            provider_recovery_version: ACCOUNT_SETUP_PROVIDER_RECOVERY_VERSION,
+        });
+        assert_eq!(
+            serde_json::to_value(response).unwrap(),
+            serde_json::json!({
+                "outcome": "capabilities",
+                "workerProtocolVersion": 2,
+                "providerRecoveryVersion": 1,
+            })
+        );
+
+        let response = AccountSetupResponse::Lease(AccountSetupLease {
+            view: AccountSetupView {
+                worker_protocol_version: ACCOUNT_SETUP_PROTOCOL_VERSION,
+                operation_id: Some("setup-1".to_string()),
+                revision: Some(1),
+                progress: Some(AccountSetupProgress::Preparing),
+                disposition: AccountSetupDisposition::Ready,
+                next_action: AccountSetupNextAction::ApprovePasskey,
+                conflict_code: None,
+                stored_version: None,
+            },
+            ceremony: AccountSetupCeremonyContext {
+                provider: "https://accounts.example/".to_string(),
+                remote: "https://app.example/ucan/".to_string(),
+                service_did: Some("did:key:service".to_string()),
+            },
+        });
+        assert_eq!(
+            serde_json::to_value(response).unwrap(),
+            serde_json::json!({
+                "outcome": "lease",
+                "view": {
+                    "workerProtocolVersion": 2,
+                    "operationId": "setup-1",
+                    "revision": 1,
+                    "progress": "preparing",
+                    "disposition": "ready",
+                    "nextAction": "approvePasskey",
+                },
+                "ceremony": {
+                    "provider": "https://accounts.example/",
+                    "remote": "https://app.example/ucan/",
+                    "serviceDid": "did:key:service",
+                },
+            })
+        );
+
+        for view in [
+            AccountSetupView {
+                worker_protocol_version: ACCOUNT_SETUP_PROTOCOL_VERSION,
+                operation_id: None,
+                revision: None,
+                progress: None,
+                disposition: AccountSetupDisposition::Missing,
+                next_action: AccountSetupNextAction::Begin,
+                conflict_code: None,
+                stored_version: None,
+            },
+            AccountSetupView {
+                worker_protocol_version: ACCOUNT_SETUP_PROTOCOL_VERSION,
+                operation_id: None,
+                revision: None,
+                progress: None,
+                disposition: AccountSetupDisposition::Corrupt,
+                next_action: AccountSetupNextAction::None,
+                conflict_code: None,
+                stored_version: None,
+            },
+            AccountSetupView {
+                worker_protocol_version: ACCOUNT_SETUP_PROTOCOL_VERSION,
+                operation_id: None,
+                revision: None,
+                progress: None,
+                disposition: AccountSetupDisposition::Unsupported,
+                next_action: AccountSetupNextAction::Reload,
+                conflict_code: None,
+                stored_version: Some(99),
+            },
+        ] {
+            let encoded = serde_json::to_string(&view).unwrap();
+            assert!(!encoded.contains("email"));
+            assert!(!encoded.contains("owner"));
+            assert!(!encoded.contains("invocation"));
+        }
+    }
+
+    #[dialog_common::test]
+    fn it_keeps_same_passkey_resume_material_behind_a_protected_response() {
+        let view = AccountSetupView {
+            worker_protocol_version: ACCOUNT_SETUP_PROTOCOL_VERSION,
+            operation_id: Some("setup-1".to_string()),
+            revision: Some(9),
+            progress: Some(AccountSetupProgress::Recovering),
+            disposition: AccountSetupDisposition::NeedsPasskey,
+            next_action: AccountSetupNextAction::ResumeWithPasskey,
+            conflict_code: None,
+            stored_version: None,
+        };
+        let protected = AccountSetupProtectedResponse::NeedsPasskey {
+            view,
+            resume: AccountSetupResumeInput {
+                operation_id: "setup-1".to_string(),
+                credential_id: "aabb".to_string(),
+                expected_root_did: "did:key:root".to_string(),
+                normalized_email: "person@example.com".to_string(),
+                device_did: "did:key:device".to_string(),
+                device_name: "Jack's laptop".to_string(),
+                delegation_hex: "ccdd".to_string(),
+                descriptor_hex: "eeff".to_string(),
+                passkey: None,
+                sealed_hex: "8899".to_string(),
+            },
+        };
+        let value = serde_json::to_value(AccountSetupResponse::Protected(protected)).unwrap();
+        assert_eq!(value["outcome"], "protected");
+        assert_eq!(value["protectedOutcome"], "needsPasskey");
+        assert_eq!(value["resume"]["credentialId"], "aabb");
+        assert_eq!(value["resume"]["sealedHex"], "8899");
+
+        let public = serde_json::to_string(&AccountSetupResponse::View(AccountSetupView {
+            worker_protocol_version: ACCOUNT_SETUP_PROTOCOL_VERSION,
+            operation_id: Some("setup-1".to_string()),
+            revision: Some(9),
+            progress: Some(AccountSetupProgress::Recovering),
+            disposition: AccountSetupDisposition::RetryLater,
+            next_action: AccountSetupNextAction::Retry,
+            conflict_code: None,
+            stored_version: None,
+        }))
+        .unwrap();
+        for forbidden in ["email", "credential", "delegation", "descriptor", "sealed"] {
+            assert!(!public.contains(forbidden));
+        }
+    }
+}

--- a/rust/tonk-worker-api/src/account_setup.rs
+++ b/rust/tonk-worker-api/src/account_setup.rs
@@ -206,7 +206,7 @@ pub enum AccountSetupRequest {
     /// Fence one passkey creation attempt after rechecking provider support.
     Arm(AccountSetupArm),
     /// Durably stage the recoverable ceremony result.
-    Stage(AccountSetupStage),
+    Stage(Box<AccountSetupStage>),
     /// Reconcile and advance only verified post-stage effects.
     Continue(AccountSetupMutation),
     /// Replace an expired create invocation after a same-credential assertion.
@@ -533,11 +533,11 @@ mod tests {
                 mutation: mutation.clone(),
                 attempt_token: "attempt-token".to_string(),
             }),
-            AccountSetupRequest::Stage(AccountSetupStage {
+            AccountSetupRequest::Stage(Box::new(AccountSetupStage {
                 mutation: mutation.clone(),
                 attempt_token: "attempt-token".to_string(),
                 recovery,
-            }),
+            })),
             AccountSetupRequest::Continue(mutation.clone()),
             AccountSetupRequest::ReplaceInvocation(AccountSetupInvocation {
                 mutation: mutation.clone(),

--- a/rust/tonk-worker-api/src/lib.rs
+++ b/rust/tonk-worker-api/src/lib.rs
@@ -13,6 +13,7 @@
 //! unchanged.
 
 mod account;
+mod account_setup;
 mod claim;
 mod conclusion;
 mod deployment;
@@ -33,6 +34,15 @@ pub use account::{
     AccountDevice, AccountDisplayNameRequest, AccountDisplayNameResponse, AccountLinkRequest,
     AccountSpaceDeletionRequest, AccountStatus, AccountSummary, HostedSpaceDeletionResult,
     RevokeDeviceAcknowledgement, RevokeDeviceRequest,
+};
+pub use account_setup::{
+    ACCOUNT_SETUP_PROTOCOL_VERSION, ACCOUNT_SETUP_PROVIDER_RECOVERY_VERSION, AccountSetupAcquire,
+    AccountSetupArm, AccountSetupBegin, AccountSetupCapabilities, AccountSetupCeremonyContext,
+    AccountSetupConflictCode, AccountSetupDisposition, AccountSetupHandshake, AccountSetupInspect,
+    AccountSetupInvocation, AccountSetupLease, AccountSetupMutation, AccountSetupNextAction,
+    AccountSetupProgress, AccountSetupProtectedResponse, AccountSetupRecoveryBundle,
+    AccountSetupRequest, AccountSetupResponse, AccountSetupResumeInput, AccountSetupStage,
+    AccountSetupView,
 };
 pub use claim::{ClaimResponse, QueryResponse};
 pub use conclusion::{Conclusion, Frame};

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -18,6 +18,10 @@ pub use claim::{AssertPath, AssertResponse, ClaimQuery, ClaimResponse, QueryResp
 
 mod account;
 mod account_deletion;
+// This lower-stack module defines and tests the durable protocol before the
+// next PR wires effects and routes to it.
+#[allow(dead_code)]
+mod account_setup;
 pub(crate) mod customer;
 #[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
 mod email_status;

--- a/rust/tonk-worker/src/router/account_setup.rs
+++ b/rust/tonk-worker/src/router/account_setup.rs
@@ -1,0 +1,2597 @@
+//! Durable, exclusively owned browser account-setup saga.
+
+use std::sync::Arc;
+
+use dialog_common::Checksum;
+use dialog_credentials::DidKeyResolver;
+use dialog_ucan_core::promise::Promised;
+use dialog_ucan_core::subject::Subject;
+use dialog_ucan_core::time::timestamp::{Duration, Timestamp, UNIX_EPOCH};
+use dialog_ucan_core::verification::Environment;
+use dialog_ucan_core::{
+    Delegation, DelegationChain, InvocationChain, UnverifiedRevocations, VerificationContext,
+};
+use dialog_varsig::{AnySignature, Did};
+use serde::{Deserialize, Serialize};
+use tonk_account::creation::{
+    AccountCreationFingerprint, AccountCreationFingerprintInput, AccountCreationPasskey,
+};
+use tonk_account::{
+    AccountRepositoryDescriptorV1, AccountSetupRecoveryManifestInput,
+    AccountSetupRecoveryManifestV1,
+};
+use tonk_identity::clearance::Recovery;
+use tonk_identity::custody::DEFERRED_PUBLISH_TTL_SECONDS;
+use tonk_identity::envelope::{
+    CUSTODY_SECRET_CELL, CUSTODY_SPACE, Envelope as RecoveryEnvelopeV2, KekMethod,
+};
+use tonk_worker_api::PasskeyMetadata;
+use url::Url;
+
+const ACCOUNT_SETUP_CHECKPOINT_SITE: &str = "tonk-account-setup-v2";
+const ACCOUNT_SETUP_RECOVERY_SITE: &str = "tonk-account-setup-recovery-v1";
+const CHECKPOINT_VERSION: u16 = 2;
+const RECOVERY_VERSION: u16 = 1;
+const MAX_CHECKPOINT_BYTES: usize = 32 * 1024;
+const MAX_RECOVERY_RECORD_BYTES: usize = 1024 * 1024;
+const MAX_OPERATION_BYTES: usize = 128;
+const MAX_EMAIL_CHARS: usize = 320;
+const MAX_URL_BYTES: usize = 2048;
+const MAX_DID_BYTES: usize = 512;
+const MAX_DEVICE_NAME_CHARS: usize = 120;
+const MAX_CREDENTIAL_HEX_BYTES: usize = 4096;
+const MAX_CID_BYTES: usize = 512;
+const MAX_DELEGATION_BYTES: usize = 64 * 1024;
+const MAX_DESCRIPTOR_BYTES: usize = 4096;
+const MAX_INVOCATION_BYTES: usize = 128 * 1024;
+const MAX_DEPOSIT_BYTES: usize = 64 * 1024;
+const MAX_DEPOSITS: usize = 8;
+const MAX_CONSENT_BYTES: usize = 64 * 1024;
+const MAX_SEALED_BYTES: usize = 4096;
+const MAX_MANIFEST_BYTES: usize = 16 * 1024;
+const MAX_DECODED_RECOVERY_BYTES: usize = 512 * 1024;
+const STAGE_CLOCK_SKEW_SECONDS: u64 = 60;
+const MAX_STAGE_DELAY_SECONDS: u64 = 60 * 60;
+const CREATE_EXPIRY_MIN_OFFSET: u64 = 4 * 60;
+const CREATE_EXPIRY_MAX_OFFSET: u64 = 6 * 60;
+const PUBLISH_EXPIRY_MIN_OFFSET: u64 = DEFERRED_PUBLISH_TTL_SECONDS - 60;
+const PUBLISH_EXPIRY_MAX_OFFSET: u64 = DEFERRED_PUBLISH_TTL_SECONDS + 6 * 60;
+const SEALED_ACCOUNT_SECRET_BYTES: usize = 68;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum StoredSafePhaseV2 {
+    RecoveryStaged,
+    RootSaved,
+    ProviderAccepted,
+    Attached,
+    CustomerEnrolled,
+    CustodyQueued,
+}
+
+impl StoredSafePhaseV2 {
+    fn has_provider_acceptance(self) -> bool {
+        matches!(
+            self,
+            Self::ProviderAccepted | Self::Attached | Self::CustomerEnrolled | Self::CustodyQueued
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum StoredConflictCodeV2 {
+    RecoveryMismatch,
+    LocalRootMismatch,
+    ProviderMismatch,
+    AttachmentMismatch,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+enum StoredPhaseV2 {
+    Leased,
+    Armed,
+    RecoveryStaged,
+    RootSaved,
+    ProviderAccepted,
+    Attached,
+    CustomerEnrolled,
+    CustodyQueued,
+    Complete,
+    Cancelled,
+    InterruptedBeforeRecovery,
+    Conflict {
+        last_safe_phase: StoredSafePhaseV2,
+        code: StoredConflictCodeV2,
+    },
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct StoredCheckpointV2 {
+    version: u16,
+    operation_id: String,
+    revision: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    owner_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    bound_client_id: Option<String>,
+    provider_hash: String,
+    phase: StoredPhaseV2,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    armed_at: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    staged_at: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    attempt_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    root_did: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    create_fingerprint: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    recovery_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    accepted_descriptor_hash: Option<String>,
+    last_transition_at: u64,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct ValidatedCheckpoint(StoredCheckpointV2);
+
+impl ValidatedCheckpoint {
+    fn new(checkpoint: StoredCheckpointV2) -> Result<Self, StoredSetupError> {
+        validate_checkpoint(&checkpoint)?;
+        Ok(Self(checkpoint))
+    }
+
+    fn as_stored(&self) -> &StoredCheckpointV2 {
+        &self.0
+    }
+
+    fn into_stored(self) -> StoredCheckpointV2 {
+        self.0
+    }
+}
+
+/// Private durable recovery encoding. Wire DTO changes do not alter this
+/// schema; Stage performs an explicit conversion before validation/storage.
+/// This type deliberately has no `Debug` implementation.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct StoredRecoveryBundleV1 {
+    version: u16,
+    operation_id: String,
+    ceremony_created_at: u64,
+    staged_at: u64,
+    normalized_email: String,
+    provider: String,
+    root_did: String,
+    device_did: String,
+    device_name: String,
+    credential_id: String,
+    delegation_cid: String,
+    delegation_hex: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    passkey: Option<PasskeyMetadata>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    encryption_key: Option<String>,
+    descriptor_hex: String,
+    create_fingerprint: String,
+    invocation_hex: String,
+    #[serde(default)]
+    deposits_hex: Vec<String>,
+    custody_did: String,
+    consent_hex: String,
+    sealed_hex: String,
+    publish_invocation_hex: String,
+    recovery_manifest_hex: String,
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RecoveryTombstoneV1 {
+    version: u16,
+    operation_id: String,
+    completed_at: u64,
+    recovery_hash: String,
+}
+
+/// Protected recovery-site record. This deliberately has no `Debug`
+/// implementation because the bundle contains PII and bounded authorizations.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "record",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+enum StoredRecoveryRecord {
+    Bundle(StoredRecoveryBundleV1),
+    Tombstone(RecoveryTombstoneV1),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum StoredSetupError {
+    TooLargeCheckpoint,
+    MalformedCheckpoint,
+    UnsupportedCheckpointVersion(u16),
+    UnsupportedCheckpointPhase,
+    InvalidCheckpoint,
+    TooLargeRecovery,
+    MalformedRecovery,
+    UnsupportedRecoveryVersion(u16),
+    UnsupportedRecoveryRecord,
+    InvalidRecovery,
+    Serialization,
+}
+
+#[derive(Deserialize)]
+struct CheckpointEnvelope {
+    version: u16,
+    phase: PhaseEnvelope,
+}
+
+#[derive(Deserialize)]
+struct PhaseEnvelope {
+    kind: String,
+}
+
+#[derive(Deserialize)]
+struct RecoveryEnvelope {
+    version: u16,
+    record: String,
+}
+
+fn encode_checkpoint(checkpoint: &ValidatedCheckpoint) -> Result<Vec<u8>, StoredSetupError> {
+    let bytes =
+        serde_json::to_vec(checkpoint.as_stored()).map_err(|_| StoredSetupError::Serialization)?;
+    if bytes.len() > MAX_CHECKPOINT_BYTES {
+        return Err(StoredSetupError::TooLargeCheckpoint);
+    }
+    Ok(bytes)
+}
+
+fn decode_checkpoint(bytes: &[u8]) -> Result<ValidatedCheckpoint, StoredSetupError> {
+    if bytes.len() > MAX_CHECKPOINT_BYTES {
+        return Err(StoredSetupError::TooLargeCheckpoint);
+    }
+    let envelope: CheckpointEnvelope =
+        serde_json::from_slice(bytes).map_err(|_| StoredSetupError::MalformedCheckpoint)?;
+    if envelope.version != CHECKPOINT_VERSION {
+        return Err(StoredSetupError::UnsupportedCheckpointVersion(
+            envelope.version,
+        ));
+    }
+    if !matches!(
+        envelope.phase.kind.as_str(),
+        "leased"
+            | "armed"
+            | "recoveryStaged"
+            | "rootSaved"
+            | "providerAccepted"
+            | "attached"
+            | "customerEnrolled"
+            | "custodyQueued"
+            | "complete"
+            | "cancelled"
+            | "interruptedBeforeRecovery"
+            | "conflict"
+    ) {
+        return Err(StoredSetupError::UnsupportedCheckpointPhase);
+    }
+    let checkpoint: StoredCheckpointV2 =
+        serde_json::from_slice(bytes).map_err(|_| StoredSetupError::MalformedCheckpoint)?;
+    ValidatedCheckpoint::new(checkpoint)
+}
+
+fn encode_recovery(record: &StoredRecoveryRecord) -> Result<Vec<u8>, StoredSetupError> {
+    let bytes = serde_json::to_vec(record).map_err(|_| StoredSetupError::Serialization)?;
+    if bytes.len() > MAX_RECOVERY_RECORD_BYTES {
+        return Err(StoredSetupError::TooLargeRecovery);
+    }
+    Ok(bytes)
+}
+
+fn decode_recovery(bytes: &[u8]) -> Result<StoredRecoveryRecord, StoredSetupError> {
+    if bytes.len() > MAX_RECOVERY_RECORD_BYTES {
+        return Err(StoredSetupError::TooLargeRecovery);
+    }
+    let envelope: RecoveryEnvelope =
+        serde_json::from_slice(bytes).map_err(|_| StoredSetupError::MalformedRecovery)?;
+    if envelope.version != RECOVERY_VERSION {
+        return Err(StoredSetupError::UnsupportedRecoveryVersion(
+            envelope.version,
+        ));
+    }
+    if !matches!(envelope.record.as_str(), "bundle" | "tombstone") {
+        return Err(StoredSetupError::UnsupportedRecoveryRecord);
+    }
+    let record: StoredRecoveryRecord =
+        serde_json::from_slice(bytes).map_err(|_| StoredSetupError::MalformedRecovery)?;
+    if let StoredRecoveryRecord::Tombstone(tombstone) = &record
+        && (!valid_identifier(&tombstone.operation_id, 128)
+            || tombstone.completed_at == 0
+            || !valid_hash(&tombstone.recovery_hash))
+    {
+        return Err(StoredSetupError::InvalidRecovery);
+    }
+    Ok(record)
+}
+
+fn validate_checkpoint(checkpoint: &StoredCheckpointV2) -> Result<(), StoredSetupError> {
+    let owner_pair = checkpoint.owner_hash.is_some() == checkpoint.bound_client_id.is_some();
+    let owner_valid = checkpoint.owner_hash.as_deref().is_none_or(valid_hash)
+        && checkpoint
+            .bound_client_id
+            .as_deref()
+            .is_none_or(|client| valid_identifier(client, 512));
+    if checkpoint.version != CHECKPOINT_VERSION
+        || !valid_identifier(&checkpoint.operation_id, 128)
+        || checkpoint.revision == 0
+        || !owner_pair
+        || !owner_valid
+        || !valid_hash(&checkpoint.provider_hash)
+        || checkpoint.last_transition_at == 0
+    {
+        return Err(StoredSetupError::InvalidCheckpoint);
+    }
+
+    let has_owner = checkpoint.owner_hash.is_some();
+    let armed_at_valid = checkpoint
+        .armed_at
+        .is_none_or(|armed_at| armed_at > 0 && armed_at <= checkpoint.last_transition_at);
+    let staged_at_valid = checkpoint.staged_at.is_none_or(|staged_at| {
+        checkpoint
+            .armed_at
+            .is_some_and(|armed_at| staged_at >= armed_at)
+            && staged_at <= checkpoint.last_transition_at
+    });
+    if !armed_at_valid || !staged_at_valid {
+        return Err(StoredSetupError::InvalidCheckpoint);
+    }
+    let has_armed_at = checkpoint.armed_at.is_some();
+    let has_staged_at = checkpoint.staged_at.is_some();
+    let attempt_valid = checkpoint.attempt_hash.as_deref().is_some_and(valid_hash);
+    let staged = checkpoint
+        .root_did
+        .as_deref()
+        .is_some_and(|root| valid_identifier(root, 512))
+        && checkpoint
+            .create_fingerprint
+            .as_deref()
+            .is_some_and(valid_hash)
+        && checkpoint.recovery_hash.as_deref().is_some_and(valid_hash);
+    let has_any_staged = checkpoint.root_did.is_some()
+        || checkpoint.create_fingerprint.is_some()
+        || checkpoint.recovery_hash.is_some();
+    let accepted = checkpoint
+        .accepted_descriptor_hash
+        .as_deref()
+        .is_some_and(valid_hash);
+
+    let legal = match checkpoint.phase {
+        StoredPhaseV2::Leased => {
+            !has_armed_at
+                && !has_staged_at
+                && checkpoint.attempt_hash.is_none()
+                && !has_any_staged
+                && checkpoint.accepted_descriptor_hash.is_none()
+        }
+        StoredPhaseV2::Armed => {
+            has_armed_at
+                && !has_staged_at
+                && has_owner
+                && attempt_valid
+                && !has_any_staged
+                && checkpoint.accepted_descriptor_hash.is_none()
+        }
+        StoredPhaseV2::RecoveryStaged | StoredPhaseV2::RootSaved => {
+            has_armed_at
+                && has_staged_at
+                && checkpoint.attempt_hash.is_none()
+                && staged
+                && checkpoint.accepted_descriptor_hash.is_none()
+        }
+        StoredPhaseV2::ProviderAccepted
+        | StoredPhaseV2::Attached
+        | StoredPhaseV2::CustomerEnrolled
+        | StoredPhaseV2::CustodyQueued => {
+            has_armed_at && has_staged_at && checkpoint.attempt_hash.is_none() && staged && accepted
+        }
+        StoredPhaseV2::Complete => {
+            has_armed_at
+                && has_staged_at
+                && !has_owner
+                && checkpoint.attempt_hash.is_none()
+                && staged
+                && accepted
+        }
+        StoredPhaseV2::Cancelled => {
+            !has_armed_at
+                && !has_staged_at
+                && !has_owner
+                && checkpoint.attempt_hash.is_none()
+                && !has_any_staged
+                && checkpoint.accepted_descriptor_hash.is_none()
+        }
+        StoredPhaseV2::InterruptedBeforeRecovery => {
+            has_armed_at
+                && !has_staged_at
+                && !has_owner
+                && checkpoint.attempt_hash.is_none()
+                && !has_any_staged
+                && checkpoint.accepted_descriptor_hash.is_none()
+        }
+        StoredPhaseV2::Conflict {
+            last_safe_phase, ..
+        } => {
+            has_armed_at
+                && has_staged_at
+                && !has_owner
+                && checkpoint.attempt_hash.is_none()
+                && staged
+                && (accepted == last_safe_phase.has_provider_acceptance())
+        }
+    };
+    legal
+        .then_some(())
+        .ok_or(StoredSetupError::InvalidCheckpoint)
+}
+
+fn valid_identifier(value: &str, max_chars: usize) -> bool {
+    !value.is_empty() && value.chars().count() <= max_chars && !value.chars().any(char::is_control)
+}
+
+fn valid_hash(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+/// Deployment and immutable clock facts selected by the worker, never the
+/// requesting page.
+#[derive(Clone, PartialEq, Eq)]
+struct RecoveryTrustContext {
+    operation_id: String,
+    provider: Url,
+    remote: Url,
+    service_did: Option<Did>,
+    device_did: Did,
+    armed_at: u64,
+    now: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RecoveryFreshness {
+    Usable,
+    NeedsRefresh,
+}
+
+/// The only recovery value post-stage effects may consume. It deliberately
+/// has no `Debug` implementation because it owns PII and bounded authority.
+struct ValidatedRecoveryBundle {
+    stored: StoredRecoveryBundleV1,
+    root_did: Did,
+    delegation: DelegationChain,
+    descriptor: AccountRepositoryDescriptorV1,
+    create_invocation: InvocationChain<AnySignature>,
+    deposits: Vec<Delegation<AnySignature>>,
+    consent: DelegationChain,
+    sealed: RecoveryEnvelopeV2<Recovery>,
+    publish_invocation: InvocationChain<AnySignature>,
+    manifest: AccountSetupRecoveryManifestV1,
+    recovery_hash: String,
+    create_expires_at: u64,
+    publish_expires_at: u64,
+    create_freshness: RecoveryFreshness,
+    publish_freshness: RecoveryFreshness,
+}
+
+impl ValidatedRecoveryBundle {
+    async fn new(
+        stored: StoredRecoveryBundleV1,
+        trust: &RecoveryTrustContext,
+    ) -> Result<Self, RecoveryValidationError> {
+        let decoded = decode_bounded_recovery(&stored)?;
+        validate_trusted_recovery(&stored, trust)?;
+        validate_stage_timestamps(
+            trust.armed_at,
+            stored.ceremony_created_at,
+            stored.staged_at,
+            trust.now,
+        )?;
+
+        let root_did: Did = stored
+            .root_did
+            .parse()
+            .map_err(|_| RecoveryValidationError::Invalid("root_did"))?;
+        if root_did.to_string() != stored.root_did {
+            return Err(RecoveryValidationError::Invalid("root_did"));
+        }
+        let delegation = validate_stable_grant(
+            &decoded.delegation,
+            &stored.delegation_cid,
+            &root_did,
+            &trust.device_did,
+        )
+        .await?;
+        let descriptor = AccountRepositoryDescriptorV1::validate(&decoded.descriptor)
+            .await
+            .map_err(|_| RecoveryValidationError::Artifact("descriptor"))?;
+        if descriptor.account_subject() != &root_did || descriptor.remote() != &trust.remote {
+            return Err(RecoveryValidationError::Trusted("descriptor"));
+        }
+
+        let passkey = stored
+            .passkey
+            .as_ref()
+            .ok_or(RecoveryValidationError::Invalid("passkey"))?;
+        let create_invocation =
+            validate_create_invocation(&decoded.create_invocation, &stored, &root_did, passkey)
+                .await?;
+        let create_expires_at = create_invocation
+            .invocation
+            .expiration()
+            .ok_or(RecoveryValidationError::Artifact("create_expiration"))?
+            .to_unix();
+        validate_original_expiration(
+            stored.ceremony_created_at,
+            create_expires_at,
+            CREATE_EXPIRY_MIN_OFFSET,
+            CREATE_EXPIRY_MAX_OFFSET,
+        )?;
+
+        let fingerprint = AccountCreationFingerprint::from_hex(&stored.create_fingerprint)
+            .map_err(|_| RecoveryValidationError::Invalid("create_fingerprint"))?;
+        let recomputed = AccountCreationFingerprintInput {
+            email: &stored.normalized_email,
+            root_did: &stored.root_did,
+            credential_id: &stored.credential_id,
+            passkey: Some(AccountCreationPasskey {
+                created_at: passkey.created_at,
+                created_on: &passkey.created_on,
+            }),
+            descriptor: &decoded.descriptor,
+            device_did: &stored.device_did,
+            device_name: &stored.device_name,
+            delegation_cid: &stored.delegation_cid,
+            delegation: &decoded.delegation,
+        }
+        .fingerprint();
+        if fingerprint != recomputed {
+            return Err(RecoveryValidationError::Artifact("create_fingerprint"));
+        }
+
+        if let Some(encryption_key) = &stored.encryption_key {
+            let did: Did = encryption_key
+                .parse()
+                .map_err(|_| RecoveryValidationError::Invalid("encryption_key"))?;
+            if did.to_string() != *encryption_key
+                || tonk_identity::sealed::RecipientKey::from_did(&did).is_err()
+            {
+                return Err(RecoveryValidationError::Invalid("encryption_key"));
+            }
+        }
+
+        let deposits =
+            validate_deposits(&decoded.deposits, &root_did, trust.service_did.as_ref()).await?;
+        let custody_did: Did = stored
+            .custody_did
+            .parse()
+            .map_err(|_| RecoveryValidationError::Invalid("custody_did"))?;
+        if custody_did.to_string() != stored.custody_did {
+            return Err(RecoveryValidationError::Invalid("custody_did"));
+        }
+        let consent = validate_custody_consent(&decoded.consent, &custody_did, &root_did).await?;
+        let sealed = validate_sealed_envelope(&decoded.sealed)?;
+        let publish_invocation = validate_publish_invocation(
+            &decoded.publish_invocation,
+            &custody_did,
+            &decoded.sealed,
+            stored.ceremony_created_at,
+        )
+        .await?;
+        let publish_expires_at = publish_invocation
+            .invocation
+            .expiration()
+            .ok_or(RecoveryValidationError::Artifact("publish_expiration"))?
+            .to_unix();
+        validate_original_expiration(
+            stored.ceremony_created_at,
+            publish_expires_at,
+            PUBLISH_EXPIRY_MIN_OFFSET,
+            PUBLISH_EXPIRY_MAX_OFFSET,
+        )?;
+
+        let service_did = trust.service_did.as_ref().map(ToString::to_string);
+        let manifest = AccountSetupRecoveryManifestV1::validate(
+            &decoded.manifest,
+            AccountSetupRecoveryManifestInput {
+                operation_id: &stored.operation_id,
+                ceremony_created_at: stored.ceremony_created_at,
+                provider: trust.provider.as_str(),
+                remote: trust.remote.as_str(),
+                service_did: service_did.as_deref(),
+                root_did: &stored.root_did,
+                device_did: &stored.device_did,
+                credential_id: &stored.credential_id,
+                create_fingerprint: fingerprint,
+                passkey: Some(AccountCreationPasskey {
+                    created_at: passkey.created_at,
+                    created_on: &passkey.created_on,
+                }),
+                encryption_recipient: stored.encryption_key.as_deref(),
+                custody_did: &stored.custody_did,
+                delegation: &decoded.delegation,
+                descriptor: &decoded.descriptor,
+                create_invocation: &decoded.create_invocation,
+                deposits: &decoded.deposits,
+                custody_consent: &decoded.consent,
+                sealed_envelope: &decoded.sealed,
+                publish_invocation: &decoded.publish_invocation,
+            },
+        )
+        .await
+        .map_err(|_| RecoveryValidationError::Artifact("recovery_manifest"))?;
+
+        let record_bytes = encode_recovery(&StoredRecoveryRecord::Bundle(stored.clone()))
+            .map_err(|_| RecoveryValidationError::Invalid("recovery_record"))?;
+        let recovery_hash = blake3::hash(&record_bytes).to_hex().to_string();
+        Ok(Self {
+            stored,
+            root_did,
+            delegation,
+            descriptor,
+            create_invocation,
+            deposits,
+            consent,
+            sealed,
+            publish_invocation,
+            manifest,
+            recovery_hash,
+            create_expires_at,
+            publish_expires_at,
+            create_freshness: freshness(create_expires_at, trust.now),
+            publish_freshness: freshness(publish_expires_at, trust.now),
+        })
+    }
+
+    fn root_did(&self) -> &Did {
+        &self.root_did
+    }
+
+    fn create_expires_at(&self) -> u64 {
+        self.create_expires_at
+    }
+
+    fn create_freshness(&self) -> RecoveryFreshness {
+        self.create_freshness
+    }
+
+    fn publish_freshness(&self) -> RecoveryFreshness {
+        self.publish_freshness
+    }
+
+    fn evidence(&self) -> RecoveryEvidence {
+        RecoveryEvidence {
+            staged_at: self.stored.staged_at,
+            root_did: self.stored.root_did.clone(),
+            create_fingerprint: self.stored.create_fingerprint.clone(),
+            recovery_hash: self.recovery_hash.clone(),
+        }
+    }
+}
+
+struct DecodedRecovery {
+    delegation: Vec<u8>,
+    descriptor: Vec<u8>,
+    create_invocation: Vec<u8>,
+    deposits: Vec<Vec<u8>>,
+    consent: Vec<u8>,
+    sealed: Vec<u8>,
+    publish_invocation: Vec<u8>,
+    manifest: Vec<u8>,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+enum RecoveryValidationError {
+    #[error("recovery field exceeds its fixed bound: {0}")]
+    TooLarge(&'static str),
+    #[error("recovery field is invalid or non-canonical: {0}")]
+    Invalid(&'static str),
+    #[error("recovery field differs from trusted deployment state: {0}")]
+    Trusted(&'static str),
+    #[error("recovery artifact failed semantic validation: {0}")]
+    Artifact(&'static str),
+    #[error("recovery timestamps are outside the setup window")]
+    Timestamp,
+}
+
+fn decode_bounded_recovery(
+    stored: &StoredRecoveryBundleV1,
+) -> Result<DecodedRecovery, RecoveryValidationError> {
+    if stored.version != RECOVERY_VERSION
+        || !bounded_text(&stored.operation_id, MAX_OPERATION_BYTES)
+        || !bounded_text(&stored.normalized_email, MAX_EMAIL_CHARS)
+        || stored.normalized_email.to_lowercase() != stored.normalized_email
+        || !bounded_text(&stored.provider, MAX_URL_BYTES)
+        || !bounded_text(&stored.root_did, MAX_DID_BYTES)
+        || !bounded_text(&stored.device_did, MAX_DID_BYTES)
+        || !bounded_text(&stored.device_name, MAX_DEVICE_NAME_CHARS)
+        || !bounded_text(&stored.delegation_cid, MAX_CID_BYTES)
+        || !bounded_text(&stored.custody_did, MAX_DID_BYTES)
+    {
+        return Err(RecoveryValidationError::Invalid("text"));
+    }
+    if !canonical_hex_text(&stored.credential_id, MAX_CREDENTIAL_HEX_BYTES) {
+        return Err(RecoveryValidationError::Invalid("credential_id"));
+    }
+    if stored.ceremony_created_at == 0 || stored.staged_at == 0 {
+        return Err(RecoveryValidationError::Invalid("timestamp"));
+    }
+    let passkey = stored
+        .passkey
+        .as_ref()
+        .ok_or(RecoveryValidationError::Invalid("passkey"))?;
+    if passkey.created_at != stored.ceremony_created_at
+        || passkey.created_on.trim() != passkey.created_on
+        || !bounded_text(&passkey.created_on, 120)
+    {
+        return Err(RecoveryValidationError::Invalid("passkey"));
+    }
+    if stored
+        .encryption_key
+        .as_deref()
+        .is_some_and(|value| !bounded_text(value, MAX_DID_BYTES))
+    {
+        return Err(RecoveryValidationError::Invalid("encryption_key"));
+    }
+    if !valid_hash(&stored.create_fingerprint) {
+        return Err(RecoveryValidationError::Invalid("create_fingerprint"));
+    }
+    if stored.deposits_hex.len() > MAX_DEPOSITS {
+        return Err(RecoveryValidationError::TooLarge("deposits"));
+    }
+
+    let delegation = decode_hex_field("delegation", &stored.delegation_hex, MAX_DELEGATION_BYTES)?;
+    let descriptor = decode_hex_field("descriptor", &stored.descriptor_hex, MAX_DESCRIPTOR_BYTES)?;
+    let create_invocation =
+        decode_hex_field("invocation", &stored.invocation_hex, MAX_INVOCATION_BYTES)?;
+    let deposits = stored
+        .deposits_hex
+        .iter()
+        .map(|value| decode_hex_field("deposit", value, MAX_DEPOSIT_BYTES))
+        .collect::<Result<Vec<_>, _>>()?;
+    let consent = decode_hex_field("consent", &stored.consent_hex, MAX_CONSENT_BYTES)?;
+    let sealed = decode_hex_field("sealed", &stored.sealed_hex, MAX_SEALED_BYTES)?;
+    let publish_invocation = decode_hex_field(
+        "publish_invocation",
+        &stored.publish_invocation_hex,
+        MAX_INVOCATION_BYTES,
+    )?;
+    let manifest = decode_hex_field(
+        "recovery_manifest",
+        &stored.recovery_manifest_hex,
+        MAX_MANIFEST_BYTES,
+    )?;
+    let total = [
+        delegation.len(),
+        descriptor.len(),
+        create_invocation.len(),
+        consent.len(),
+        sealed.len(),
+        publish_invocation.len(),
+        manifest.len(),
+    ]
+    .into_iter()
+    .chain(deposits.iter().map(Vec::len))
+    .try_fold(0usize, usize::checked_add)
+    .ok_or(RecoveryValidationError::TooLarge("decoded_total"))?;
+    if total > MAX_DECODED_RECOVERY_BYTES {
+        return Err(RecoveryValidationError::TooLarge("decoded_total"));
+    }
+    let encoded = serde_json::to_vec(&StoredRecoveryRecord::Bundle(stored.clone()))
+        .map_err(|_| RecoveryValidationError::Invalid("recovery_record"))?;
+    if encoded.len() > MAX_RECOVERY_RECORD_BYTES {
+        return Err(RecoveryValidationError::TooLarge("recovery_record"));
+    }
+    Ok(DecodedRecovery {
+        delegation,
+        descriptor,
+        create_invocation,
+        deposits,
+        consent,
+        sealed,
+        publish_invocation,
+        manifest,
+    })
+}
+
+fn decode_hex_field(
+    name: &'static str,
+    value: &str,
+    max_bytes: usize,
+) -> Result<Vec<u8>, RecoveryValidationError> {
+    if value.len() > max_bytes.saturating_mul(2) {
+        return Err(RecoveryValidationError::TooLarge(name));
+    }
+    if !canonical_hex_text(value, max_bytes.saturating_mul(2)) {
+        return Err(RecoveryValidationError::Invalid(name));
+    }
+    hex::decode(value).map_err(|_| RecoveryValidationError::Invalid(name))
+}
+
+fn canonical_hex_text(value: &str, max_chars: usize) -> bool {
+    !value.is_empty()
+        && value.len() <= max_chars
+        && value.len().is_multiple_of(2)
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn bounded_text(value: &str, max_chars: usize) -> bool {
+    !value.is_empty() && value.chars().count() <= max_chars && !value.chars().any(char::is_control)
+}
+
+fn validate_trusted_recovery(
+    stored: &StoredRecoveryBundleV1,
+    trust: &RecoveryTrustContext,
+) -> Result<(), RecoveryValidationError> {
+    if stored.operation_id != trust.operation_id
+        || stored.device_did != trust.device_did.to_string()
+    {
+        return Err(RecoveryValidationError::Trusted("operation_or_device"));
+    }
+    let provider: Url = stored
+        .provider
+        .parse()
+        .map_err(|_| RecoveryValidationError::Invalid("provider"))?;
+    if provider.as_str() != stored.provider || provider != trust.provider {
+        return Err(RecoveryValidationError::Trusted("provider"));
+    }
+    Ok(())
+}
+
+fn validate_stage_timestamps(
+    armed_at: u64,
+    ceremony_created_at: u64,
+    staged_at: u64,
+    now: u64,
+) -> Result<(), RecoveryValidationError> {
+    let earliest = armed_at
+        .checked_sub(STAGE_CLOCK_SKEW_SECONDS)
+        .ok_or(RecoveryValidationError::Timestamp)?;
+    let latest = staged_at
+        .checked_add(STAGE_CLOCK_SKEW_SECONDS)
+        .ok_or(RecoveryValidationError::Timestamp)?;
+    let latest_stage = ceremony_created_at
+        .checked_add(MAX_STAGE_DELAY_SECONDS)
+        .ok_or(RecoveryValidationError::Timestamp)?;
+    if staged_at < armed_at
+        || now < staged_at
+        || ceremony_created_at < earliest
+        || ceremony_created_at > latest
+        || staged_at > latest_stage
+    {
+        return Err(RecoveryValidationError::Timestamp);
+    }
+    Ok(())
+}
+
+fn validate_original_expiration(
+    created_at: u64,
+    expires_at: u64,
+    min_offset: u64,
+    max_offset: u64,
+) -> Result<(), RecoveryValidationError> {
+    let earliest = created_at
+        .checked_add(min_offset)
+        .ok_or(RecoveryValidationError::Timestamp)?;
+    let latest = created_at
+        .checked_add(max_offset)
+        .ok_or(RecoveryValidationError::Timestamp)?;
+    if expires_at < earliest || expires_at > latest {
+        return Err(RecoveryValidationError::Artifact("expiration_window"));
+    }
+    Ok(())
+}
+
+fn freshness(expires_at: u64, now: u64) -> RecoveryFreshness {
+    if expires_at < now {
+        RecoveryFreshness::NeedsRefresh
+    } else {
+        RecoveryFreshness::Usable
+    }
+}
+
+async fn validate_stable_grant(
+    bytes: &[u8],
+    expected_cid: &str,
+    root: &Did,
+    device: &Did,
+) -> Result<DelegationChain, RecoveryValidationError> {
+    let chain = DelegationChain::try_from(bytes)
+        .map_err(|_| RecoveryValidationError::Artifact("delegation"))?;
+    if chain
+        .to_bytes()
+        .map_err(|_| RecoveryValidationError::Artifact("delegation"))?
+        != bytes
+        || chain.proof_cids().len() != 1
+        || chain.proof_cids()[0].to_string() != expected_cid
+    {
+        return Err(RecoveryValidationError::Artifact("delegation"));
+    }
+    let proof = chain
+        .proofs()
+        .next()
+        .ok_or(RecoveryValidationError::Artifact("delegation"))?;
+    if proof.issuer() != root
+        || proof.audience() != device
+        || proof.subject() != &Subject::Any
+        || !proof.command().segments().is_empty()
+        || !proof.policy().is_empty()
+        || proof.expiration().is_some()
+        || proof.not_before().is_some()
+        || !proof.meta().is_empty()
+        || nonce_len(proof.nonce()) != 16
+    {
+        return Err(RecoveryValidationError::Artifact("delegation"));
+    }
+    proof
+        .verify_signature(&DidKeyResolver)
+        .await
+        .map_err(|_| RecoveryValidationError::Artifact("delegation"))?;
+    Ok(chain)
+}
+
+async fn validate_create_invocation(
+    bytes: &[u8],
+    stored: &StoredRecoveryBundleV1,
+    root: &Did,
+    passkey: &PasskeyMetadata,
+) -> Result<InvocationChain<AnySignature>, RecoveryValidationError> {
+    let chain = parse_canonical_self_invocation(bytes, root, &["account", "create"], "create")?;
+    let arguments = chain.arguments();
+    if arguments.len() != 8
+        || promised_string(arguments.get("email")) != Some(stored.normalized_email.as_str())
+        || promised_string(arguments.get("credentialId")) != Some(stored.credential_id.as_str())
+        || promised_string(arguments.get("deviceDid")) != Some(stored.device_did.as_str())
+        || promised_string(arguments.get("deviceName")) != Some(stored.device_name.as_str())
+        || promised_string(arguments.get("delegation")) != Some(stored.delegation_hex.as_str())
+        || promised_string(arguments.get("repositoryDescriptor"))
+            != Some(stored.descriptor_hex.as_str())
+        || arguments.get("passkeyCreatedAt")
+            != Some(&Promised::Integer(i128::from(passkey.created_at)))
+        || promised_string(arguments.get("passkeyCreatedOn")) != Some(passkey.created_on.as_str())
+    {
+        return Err(RecoveryValidationError::Artifact("create_arguments"));
+    }
+    verify_invocation_at(&chain, stored.ceremony_created_at, "create").await?;
+    Ok(chain)
+}
+
+async fn validate_deposits(
+    bytes: &[Vec<u8>],
+    root: &Did,
+    service: Option<&Did>,
+) -> Result<Vec<Delegation<AnySignature>>, RecoveryValidationError> {
+    let Some(service) = service else {
+        if bytes.is_empty() {
+            return Ok(Vec::new());
+        }
+        return Err(RecoveryValidationError::Trusted("deposits"));
+    };
+    let expected = tonk_account::customer::deposit_scopes(root, service);
+    if bytes.len() != expected.len() {
+        return Err(RecoveryValidationError::Artifact("deposits"));
+    }
+
+    let mut deposits = Vec::with_capacity(bytes.len());
+    for (raw, scope) in bytes.iter().zip(expected) {
+        let deposit_chain = DelegationChain::from_delegation_bytes(vec![raw.clone()])
+            .map_err(|_| RecoveryValidationError::Artifact("deposit"))?;
+        let deposit = deposit_chain
+            .proofs()
+            .next()
+            .ok_or(RecoveryValidationError::Artifact("deposit"))?
+            .clone();
+        if deposit.encoded() != raw
+            || deposit.issuer() != root
+            || deposit.audience() != service
+            || deposit.subject() != &scope.subject
+            || deposit.command().segments() != scope.command.segments()
+            || deposit.policy() != &scope.policy()
+            || deposit.expiration().is_some()
+            || deposit.not_before().is_some()
+            || !deposit.meta().is_empty()
+            || nonce_len(deposit.nonce()) != 16
+        {
+            return Err(RecoveryValidationError::Artifact("deposit"));
+        }
+        deposit
+            .verify_signature(&DidKeyResolver)
+            .await
+            .map_err(|_| RecoveryValidationError::Artifact("deposit"))?;
+        deposits.push(deposit);
+    }
+    Ok(deposits)
+}
+
+async fn validate_custody_consent(
+    bytes: &[u8],
+    custody: &Did,
+    root: &Did,
+) -> Result<DelegationChain, RecoveryValidationError> {
+    let chain = DelegationChain::try_from(bytes)
+        .map_err(|_| RecoveryValidationError::Artifact("custody_consent"))?;
+    if chain
+        .to_bytes()
+        .map_err(|_| RecoveryValidationError::Artifact("custody_consent"))?
+        != bytes
+        || chain.proof_cids().len() != 1
+    {
+        return Err(RecoveryValidationError::Artifact("custody_consent"));
+    }
+    let proof = chain
+        .proofs()
+        .next()
+        .ok_or(RecoveryValidationError::Artifact("custody_consent"))?;
+    if proof.issuer() != custody
+        || proof.audience() != root
+        || proof.subject() != &Subject::Specific(custody.clone())
+        || !proof.command().segments().is_empty()
+        || !proof.policy().is_empty()
+        || proof.expiration().is_some()
+        || proof.not_before().is_some()
+        || !proof.meta().is_empty()
+        || nonce_len(proof.nonce()) != 16
+    {
+        return Err(RecoveryValidationError::Artifact("custody_consent"));
+    }
+    proof
+        .verify_signature(&DidKeyResolver)
+        .await
+        .map_err(|_| RecoveryValidationError::Artifact("custody_consent"))?;
+    Ok(chain)
+}
+
+fn validate_sealed_envelope(
+    bytes: &[u8],
+) -> Result<RecoveryEnvelopeV2<Recovery>, RecoveryValidationError> {
+    if bytes.len() != SEALED_ACCOUNT_SECRET_BYTES {
+        return Err(RecoveryValidationError::Artifact("sealed"));
+    }
+    let envelope = RecoveryEnvelopeV2::<Recovery>::decode(bytes)
+        .map_err(|_| RecoveryValidationError::Artifact("sealed"))?;
+    if envelope.encode() != bytes
+        || envelope.generation != 0
+        || envelope.method != KekMethod::Passkey
+        || envelope.ciphertext().len() != 48
+    {
+        return Err(RecoveryValidationError::Artifact("sealed"));
+    }
+    Ok(envelope)
+}
+
+async fn validate_publish_invocation(
+    bytes: &[u8],
+    custody: &Did,
+    sealed: &[u8],
+    ceremony_created_at: u64,
+) -> Result<InvocationChain<AnySignature>, RecoveryValidationError> {
+    let chain = parse_canonical_self_invocation(bytes, custody, &["memory", "publish"], "publish")?;
+    let arguments = chain.arguments();
+    let checksum = match arguments.get("checksum") {
+        Some(Promised::Bytes(bytes)) => Checksum::try_from(bytes.clone())
+            .map_err(|_| RecoveryValidationError::Artifact("publish_checksum"))?,
+        _ => return Err(RecoveryValidationError::Artifact("publish_arguments")),
+    };
+    if arguments.len() != 3
+        || promised_string(arguments.get("space")) != Some(CUSTODY_SPACE)
+        || promised_string(arguments.get("cell")) != Some(CUSTODY_SECRET_CELL)
+        || checksum != Checksum::sha256(sealed)
+        || arguments.contains_key("when")
+    {
+        return Err(RecoveryValidationError::Artifact("publish_arguments"));
+    }
+    verify_invocation_at(&chain, ceremony_created_at, "publish").await?;
+    Ok(chain)
+}
+
+fn parse_canonical_self_invocation(
+    bytes: &[u8],
+    principal: &Did,
+    command: &[&str],
+    name: &'static str,
+) -> Result<InvocationChain<AnySignature>, RecoveryValidationError> {
+    let chain =
+        InvocationChain::try_from(bytes).map_err(|_| RecoveryValidationError::Artifact(name))?;
+    if chain
+        .to_bytes()
+        .map_err(|_| RecoveryValidationError::Artifact(name))?
+        != bytes
+        || chain.issuer() != principal
+        || chain.subject() != principal
+        || chain.invocation.audience() != principal
+        || chain
+            .command()
+            .segments()
+            .iter()
+            .map(String::as_str)
+            .ne(command.iter().copied())
+        || !chain.proofs().is_empty()
+        || !proof_store_is_empty(&chain)
+        || chain.invocation.cause().is_some()
+        || !chain.invocation.meta().is_empty()
+        || nonce_len(chain.invocation.nonce()) != 16
+        || chain.invocation.expiration().is_none()
+    {
+        return Err(RecoveryValidationError::Artifact(name));
+    }
+    Ok(chain)
+}
+
+async fn verify_invocation_at(
+    chain: &InvocationChain<AnySignature>,
+    ceremony_created_at: u64,
+    name: &'static str,
+) -> Result<(), RecoveryValidationError> {
+    // Check at the end of the accepted ceremony-skew window. This verifies
+    // signatures, `iat`, and `exp` against the immutable signed ceremony
+    // reference without requiring a currently unexpired invocation.
+    let verify_at = ceremony_created_at
+        .checked_add(STAGE_CLOCK_SKEW_SECONDS)
+        .ok_or(RecoveryValidationError::Timestamp)?;
+    let time = UNIX_EPOCH
+        .checked_add(Duration::from_secs(verify_at))
+        .ok_or(RecoveryValidationError::Timestamp)?;
+    let timestamp = Timestamp::new(time).map_err(|_| RecoveryValidationError::Timestamp)?;
+    let environment: Environment<_, _, _, Arc<Delegation<AnySignature>>> =
+        Environment::new(chain.proof_store(), DidKeyResolver, UnverifiedRevocations);
+    chain
+        .verify(&VerificationContext::at(&environment, Some(timestamp)))
+        .await
+        .map_err(|_| RecoveryValidationError::Artifact(name))?;
+    Ok(())
+}
+
+fn proof_store_is_empty(chain: &InvocationChain<AnySignature>) -> bool {
+    chain
+        .proof_store()
+        .lock()
+        .is_ok_and(|proofs| proofs.is_empty())
+}
+
+fn nonce_len(nonce: &dialog_ucan_core::crypto::nonce::Nonce) -> usize {
+    Vec::<u8>::from(nonce.clone()).len()
+}
+
+fn promised_string(value: Option<&Promised>) -> Option<&str> {
+    match value {
+        Some(Promised::String(value)) => Some(value.as_str()),
+        _ => None,
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct MutationContext {
+    operation_id: String,
+    owner_hash: String,
+    client_id: String,
+    expected_revision: u64,
+    now: u64,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct RecoveryEvidence {
+    staged_at: u64,
+    root_did: String,
+    create_fingerprint: String,
+    recovery_hash: String,
+}
+
+impl RecoveryEvidence {
+    fn is_valid(&self) -> bool {
+        self.staged_at > 0
+            && valid_identifier(&self.root_did, 512)
+            && valid_hash(&self.create_fingerprint)
+            && valid_hash(&self.recovery_hash)
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+enum RecoveryObservation {
+    Absent,
+    Staged(RecoveryEvidence),
+}
+
+#[derive(Clone, PartialEq, Eq)]
+enum VerifiedEvidence {
+    RecoveryStaged(RecoveryEvidence),
+    LocalRootSaved,
+    ProviderAccepted { descriptor_hash: String },
+    AttachmentSaved,
+    CustomerEnrolled,
+    CustodyQueued,
+    CompletionRecorded,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+enum ReducerCommand {
+    Arm {
+        mutation: MutationContext,
+        attempt_hash: String,
+    },
+    Cancel {
+        mutation: MutationContext,
+    },
+    Acquire {
+        operation_id: String,
+        new_owner_hash: String,
+        new_client_id: String,
+        expected_revision: u64,
+        recovery: RecoveryObservation,
+        now: u64,
+    },
+    OwnerAbsent {
+        expected_revision: u64,
+        observed_client_id: String,
+        recovery: RecoveryObservation,
+        now: u64,
+    },
+    Observe {
+        mutation: MutationContext,
+        evidence: VerifiedEvidence,
+    },
+    Conflict {
+        mutation: MutationContext,
+        code: StoredConflictCodeV2,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DurableAction {
+    None,
+    SaveCheckpoint,
+    SaveCheckpointBeforeRecoveryTombstone,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PrivateNextAction {
+    ApprovePasskey,
+    AwaitPasskeyResult,
+    PersistLocalRoot,
+    QueryProviderStatus,
+    PersistAttachment,
+    EnrollCustomer,
+    QueueCustody,
+    RecordCompletion,
+    TombstoneRecovery,
+    Acquire,
+    Wait,
+    CancelTooLate,
+    StartOver,
+    Done,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ReductionError {
+    WrongOperation,
+    StaleRevision,
+    Unauthorized,
+    InvalidTimestamp,
+    InvalidTransition,
+    InvalidEvidence,
+    InvalidResult,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct Reduction {
+    checkpoint: ValidatedCheckpoint,
+    durable_action: DurableAction,
+    next_action: PrivateNextAction,
+}
+
+fn reduce(
+    checkpoint: ValidatedCheckpoint,
+    command: ReducerCommand,
+) -> Result<Reduction, ReductionError> {
+    match command {
+        ReducerCommand::Arm {
+            mutation,
+            attempt_hash,
+        } => {
+            authenticate(&checkpoint, &mutation)?;
+            if checkpoint.as_stored().phase != StoredPhaseV2::Leased || !valid_hash(&attempt_hash) {
+                return Err(ReductionError::InvalidTransition);
+            }
+            transition(
+                checkpoint,
+                mutation.now,
+                |next| {
+                    next.phase = StoredPhaseV2::Armed;
+                    next.armed_at = Some(mutation.now);
+                    next.attempt_hash = Some(attempt_hash);
+                },
+                DurableAction::SaveCheckpoint,
+                PrivateNextAction::AwaitPasskeyResult,
+            )
+        }
+        ReducerCommand::Cancel { mutation } => {
+            authenticate(&checkpoint, &mutation)?;
+            match checkpoint.as_stored().phase {
+                StoredPhaseV2::Leased => transition(
+                    checkpoint,
+                    mutation.now,
+                    |next| {
+                        next.phase = StoredPhaseV2::Cancelled;
+                        clear_owner(next);
+                    },
+                    DurableAction::SaveCheckpoint,
+                    PrivateNextAction::Done,
+                ),
+                StoredPhaseV2::Armed => {
+                    reduction_without_write(checkpoint, PrivateNextAction::CancelTooLate)
+                }
+                _ => Err(ReductionError::InvalidTransition),
+            }
+        }
+        ReducerCommand::Acquire {
+            operation_id,
+            new_owner_hash,
+            new_client_id,
+            expected_revision,
+            recovery,
+            now,
+        } => {
+            let stored = checkpoint.as_stored();
+            if stored.operation_id != operation_id {
+                return Err(ReductionError::WrongOperation);
+            }
+            if stored.revision != expected_revision {
+                return Err(ReductionError::StaleRevision);
+            }
+            if stored.owner_hash.is_some()
+                || !valid_hash(&new_owner_hash)
+                || !valid_identifier(&new_client_id, 512)
+            {
+                return Err(ReductionError::Unauthorized);
+            }
+            if !matches!(
+                stored.phase,
+                StoredPhaseV2::Leased
+                    | StoredPhaseV2::RecoveryStaged
+                    | StoredPhaseV2::RootSaved
+                    | StoredPhaseV2::ProviderAccepted
+                    | StoredPhaseV2::Attached
+                    | StoredPhaseV2::CustomerEnrolled
+                    | StoredPhaseV2::CustodyQueued
+            ) {
+                return Err(ReductionError::InvalidTransition);
+            }
+            require_recovery_observation(stored, &recovery)?;
+            let next_action = next_action_for_phase(&stored.phase);
+            transition(
+                checkpoint,
+                now,
+                |next| {
+                    next.owner_hash = Some(new_owner_hash);
+                    next.bound_client_id = Some(new_client_id);
+                },
+                DurableAction::SaveCheckpoint,
+                next_action,
+            )
+        }
+        ReducerCommand::OwnerAbsent {
+            expected_revision,
+            observed_client_id,
+            recovery,
+            now,
+        } => {
+            let stored = checkpoint.as_stored();
+            if stored.revision != expected_revision {
+                return Err(ReductionError::StaleRevision);
+            }
+            if stored.bound_client_id.as_deref() != Some(observed_client_id.as_str()) {
+                return Err(ReductionError::Unauthorized);
+            }
+            match (&stored.phase, &recovery) {
+                (StoredPhaseV2::Armed, RecoveryObservation::Absent) => transition(
+                    checkpoint,
+                    now,
+                    |next| {
+                        next.phase = StoredPhaseV2::InterruptedBeforeRecovery;
+                        next.attempt_hash = None;
+                        clear_owner(next);
+                    },
+                    DurableAction::SaveCheckpoint,
+                    PrivateNextAction::StartOver,
+                ),
+                (StoredPhaseV2::Armed, RecoveryObservation::Staged(evidence))
+                    if evidence.is_valid() =>
+                {
+                    let evidence = evidence.clone();
+                    transition(
+                        checkpoint,
+                        now,
+                        |next| {
+                            apply_staged_recovery(next, evidence);
+                            clear_owner(next);
+                        },
+                        DurableAction::SaveCheckpoint,
+                        PrivateNextAction::Acquire,
+                    )
+                }
+                (StoredPhaseV2::Leased, RecoveryObservation::Absent) => transition(
+                    checkpoint,
+                    now,
+                    clear_owner,
+                    DurableAction::SaveCheckpoint,
+                    PrivateNextAction::Acquire,
+                ),
+                (
+                    StoredPhaseV2::RecoveryStaged
+                    | StoredPhaseV2::RootSaved
+                    | StoredPhaseV2::ProviderAccepted
+                    | StoredPhaseV2::Attached
+                    | StoredPhaseV2::CustomerEnrolled
+                    | StoredPhaseV2::CustodyQueued,
+                    RecoveryObservation::Staged(_),
+                ) => {
+                    require_recovery_observation(stored, &recovery)?;
+                    transition(
+                        checkpoint,
+                        now,
+                        clear_owner,
+                        DurableAction::SaveCheckpoint,
+                        PrivateNextAction::Acquire,
+                    )
+                }
+                _ => Err(ReductionError::InvalidEvidence),
+            }
+        }
+        ReducerCommand::Observe { mutation, evidence } => {
+            authenticate(&checkpoint, &mutation)?;
+            reduce_evidence(checkpoint, mutation.now, evidence)
+        }
+        ReducerCommand::Conflict { mutation, code } => {
+            authenticate(&checkpoint, &mutation)?;
+            let last_safe_phase = safe_phase(&checkpoint.as_stored().phase)
+                .ok_or(ReductionError::InvalidTransition)?;
+            transition(
+                checkpoint,
+                mutation.now,
+                |next| {
+                    next.phase = StoredPhaseV2::Conflict {
+                        last_safe_phase,
+                        code,
+                    };
+                    next.attempt_hash = None;
+                    clear_owner(next);
+                },
+                DurableAction::SaveCheckpoint,
+                PrivateNextAction::Done,
+            )
+        }
+    }
+}
+
+fn authenticate(
+    checkpoint: &ValidatedCheckpoint,
+    mutation: &MutationContext,
+) -> Result<(), ReductionError> {
+    let stored = checkpoint.as_stored();
+    if stored.operation_id != mutation.operation_id {
+        return Err(ReductionError::WrongOperation);
+    }
+    if stored.revision != mutation.expected_revision {
+        return Err(ReductionError::StaleRevision);
+    }
+    if stored.owner_hash.as_deref() != Some(mutation.owner_hash.as_str())
+        || stored.bound_client_id.as_deref() != Some(mutation.client_id.as_str())
+    {
+        return Err(ReductionError::Unauthorized);
+    }
+    if mutation.now < stored.last_transition_at {
+        return Err(ReductionError::InvalidTimestamp);
+    }
+    Ok(())
+}
+
+fn reduce_evidence(
+    checkpoint: ValidatedCheckpoint,
+    now: u64,
+    evidence: VerifiedEvidence,
+) -> Result<Reduction, ReductionError> {
+    match (checkpoint.as_stored().phase.clone(), evidence) {
+        (StoredPhaseV2::Armed, VerifiedEvidence::RecoveryStaged(evidence))
+            if evidence.is_valid() =>
+        {
+            transition(
+                checkpoint,
+                now,
+                |next| {
+                    apply_staged_recovery(next, evidence);
+                },
+                DurableAction::SaveCheckpoint,
+                PrivateNextAction::PersistLocalRoot,
+            )
+        }
+        (StoredPhaseV2::RecoveryStaged, VerifiedEvidence::LocalRootSaved) => transition(
+            checkpoint,
+            now,
+            |next| next.phase = StoredPhaseV2::RootSaved,
+            DurableAction::SaveCheckpoint,
+            PrivateNextAction::QueryProviderStatus,
+        ),
+        (StoredPhaseV2::RootSaved, VerifiedEvidence::ProviderAccepted { descriptor_hash })
+            if valid_hash(&descriptor_hash) =>
+        {
+            transition(
+                checkpoint,
+                now,
+                |next| {
+                    next.phase = StoredPhaseV2::ProviderAccepted;
+                    next.accepted_descriptor_hash = Some(descriptor_hash);
+                },
+                DurableAction::SaveCheckpoint,
+                PrivateNextAction::PersistAttachment,
+            )
+        }
+        (StoredPhaseV2::ProviderAccepted, VerifiedEvidence::AttachmentSaved) => transition(
+            checkpoint,
+            now,
+            |next| next.phase = StoredPhaseV2::Attached,
+            DurableAction::SaveCheckpoint,
+            PrivateNextAction::EnrollCustomer,
+        ),
+        (StoredPhaseV2::Attached, VerifiedEvidence::CustomerEnrolled) => transition(
+            checkpoint,
+            now,
+            |next| next.phase = StoredPhaseV2::CustomerEnrolled,
+            DurableAction::SaveCheckpoint,
+            PrivateNextAction::QueueCustody,
+        ),
+        (StoredPhaseV2::CustomerEnrolled, VerifiedEvidence::CustodyQueued) => transition(
+            checkpoint,
+            now,
+            |next| next.phase = StoredPhaseV2::CustodyQueued,
+            DurableAction::SaveCheckpoint,
+            PrivateNextAction::RecordCompletion,
+        ),
+        (StoredPhaseV2::CustodyQueued, VerifiedEvidence::CompletionRecorded) => transition(
+            checkpoint,
+            now,
+            |next| {
+                next.phase = StoredPhaseV2::Complete;
+                clear_owner(next);
+            },
+            DurableAction::SaveCheckpointBeforeRecoveryTombstone,
+            PrivateNextAction::TombstoneRecovery,
+        ),
+        _ => Err(ReductionError::InvalidTransition),
+    }
+}
+
+fn safe_phase(phase: &StoredPhaseV2) -> Option<StoredSafePhaseV2> {
+    match phase {
+        StoredPhaseV2::RecoveryStaged => Some(StoredSafePhaseV2::RecoveryStaged),
+        StoredPhaseV2::RootSaved => Some(StoredSafePhaseV2::RootSaved),
+        StoredPhaseV2::ProviderAccepted => Some(StoredSafePhaseV2::ProviderAccepted),
+        StoredPhaseV2::Attached => Some(StoredSafePhaseV2::Attached),
+        StoredPhaseV2::CustomerEnrolled => Some(StoredSafePhaseV2::CustomerEnrolled),
+        StoredPhaseV2::CustodyQueued => Some(StoredSafePhaseV2::CustodyQueued),
+        _ => None,
+    }
+}
+
+fn transition(
+    checkpoint: ValidatedCheckpoint,
+    now: u64,
+    update: impl FnOnce(&mut StoredCheckpointV2),
+    durable_action: DurableAction,
+    next_action: PrivateNextAction,
+) -> Result<Reduction, ReductionError> {
+    let mut next = checkpoint.into_stored();
+    if now < next.last_transition_at {
+        return Err(ReductionError::InvalidTimestamp);
+    }
+    next.revision = next
+        .revision
+        .checked_add(1)
+        .ok_or(ReductionError::InvalidResult)?;
+    next.last_transition_at = now;
+    update(&mut next);
+    let checkpoint = ValidatedCheckpoint::new(next).map_err(|_| ReductionError::InvalidResult)?;
+    Ok(Reduction {
+        checkpoint,
+        durable_action,
+        next_action,
+    })
+}
+
+fn reduction_without_write(
+    checkpoint: ValidatedCheckpoint,
+    next_action: PrivateNextAction,
+) -> Result<Reduction, ReductionError> {
+    ValidatedCheckpoint::new(checkpoint.as_stored().clone())
+        .map_err(|_| ReductionError::InvalidResult)?;
+    Ok(Reduction {
+        checkpoint,
+        durable_action: DurableAction::None,
+        next_action,
+    })
+}
+
+fn clear_owner(checkpoint: &mut StoredCheckpointV2) {
+    checkpoint.owner_hash = None;
+    checkpoint.bound_client_id = None;
+}
+
+fn apply_staged_recovery(checkpoint: &mut StoredCheckpointV2, evidence: RecoveryEvidence) {
+    checkpoint.phase = StoredPhaseV2::RecoveryStaged;
+    checkpoint.attempt_hash = None;
+    checkpoint.staged_at = Some(evidence.staged_at);
+    checkpoint.root_did = Some(evidence.root_did);
+    checkpoint.create_fingerprint = Some(evidence.create_fingerprint);
+    checkpoint.recovery_hash = Some(evidence.recovery_hash);
+}
+
+fn require_recovery_observation(
+    checkpoint: &StoredCheckpointV2,
+    observation: &RecoveryObservation,
+) -> Result<(), ReductionError> {
+    match (&checkpoint.phase, observation) {
+        (StoredPhaseV2::Leased, RecoveryObservation::Absent) => Ok(()),
+        (
+            StoredPhaseV2::RecoveryStaged
+            | StoredPhaseV2::RootSaved
+            | StoredPhaseV2::ProviderAccepted
+            | StoredPhaseV2::Attached
+            | StoredPhaseV2::CustomerEnrolled
+            | StoredPhaseV2::CustodyQueued,
+            RecoveryObservation::Staged(evidence),
+        ) if evidence.is_valid()
+            && checkpoint.staged_at == Some(evidence.staged_at)
+            && checkpoint.root_did.as_deref() == Some(evidence.root_did.as_str())
+            && checkpoint.create_fingerprint.as_deref()
+                == Some(evidence.create_fingerprint.as_str())
+            && checkpoint.recovery_hash.as_deref() == Some(evidence.recovery_hash.as_str()) =>
+        {
+            Ok(())
+        }
+        _ => Err(ReductionError::InvalidEvidence),
+    }
+}
+
+fn next_action_for_phase(phase: &StoredPhaseV2) -> PrivateNextAction {
+    match phase {
+        StoredPhaseV2::Leased => PrivateNextAction::ApprovePasskey,
+        StoredPhaseV2::RecoveryStaged => PrivateNextAction::PersistLocalRoot,
+        StoredPhaseV2::RootSaved => PrivateNextAction::QueryProviderStatus,
+        StoredPhaseV2::ProviderAccepted => PrivateNextAction::PersistAttachment,
+        StoredPhaseV2::Attached => PrivateNextAction::EnrollCustomer,
+        StoredPhaseV2::CustomerEnrolled => PrivateNextAction::QueueCustody,
+        StoredPhaseV2::CustodyQueued => PrivateNextAction::RecordCompletion,
+        StoredPhaseV2::Armed => PrivateNextAction::AwaitPasskeyResult,
+        StoredPhaseV2::Complete => PrivateNextAction::TombstoneRecovery,
+        StoredPhaseV2::Cancelled
+        | StoredPhaseV2::InterruptedBeforeRecovery
+        | StoredPhaseV2::Conflict { .. } => PrivateNextAction::Done,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ACCOUNT_SETUP_CHECKPOINT_SITE, ACCOUNT_SETUP_RECOVERY_SITE, CREATE_EXPIRY_MAX_OFFSET,
+        CREATE_EXPIRY_MIN_OFFSET, DurableAction, MAX_RECOVERY_RECORD_BYTES, MutationContext,
+        PUBLISH_EXPIRY_MAX_OFFSET, PUBLISH_EXPIRY_MIN_OFFSET, PrivateNextAction, RecoveryEvidence,
+        RecoveryFreshness, RecoveryObservation, RecoveryTrustContext, RecoveryValidationError,
+        ReducerCommand, ReductionError, StoredCheckpointV2, StoredConflictCodeV2, StoredPhaseV2,
+        StoredRecoveryBundleV1, StoredRecoveryRecord, StoredSafePhaseV2, StoredSetupError,
+        ValidatedCheckpoint, ValidatedRecoveryBundle, VerifiedEvidence, decode_bounded_recovery,
+        decode_checkpoint, decode_recovery, encode_checkpoint, encode_recovery, reduce,
+        validate_original_expiration, validate_stage_timestamps,
+    };
+    use dialog_credentials::Ed25519Signer;
+    use dialog_ucan_core::time::timestamp::{Duration, Timestamp, UNIX_EPOCH};
+    use dialog_varsig::Principal as _;
+    use tonk_account::creation::{AccountCreationFingerprintInput, AccountCreationPasskey};
+    use tonk_account::{AccountSetupRecoveryManifestInput, AccountSetupRecoveryManifestV1};
+    use tonk_identity::ceremony::{PasskeyCreationMetadata, mint_service_deposits};
+    use tonk_identity::custody::{
+        DEFERRED_PUBLISH_TTL_SECONDS, build_publish_invocation, mint_custody_consent,
+    };
+    use tonk_identity::envelope::{AccountSecret, KekMethod, custody_kek, custody_signer};
+    use tonk_worker_api::PasskeyMetadata;
+
+    fn hash(byte: &str) -> String {
+        byte.repeat(32)
+    }
+
+    fn leased() -> ValidatedCheckpoint {
+        ValidatedCheckpoint::new(StoredCheckpointV2 {
+            version: 2,
+            operation_id: "setup-1".to_string(),
+            revision: 1,
+            owner_hash: Some(hash("11")),
+            bound_client_id: Some("client-1".to_string()),
+            provider_hash: hash("22"),
+            phase: StoredPhaseV2::Leased,
+            armed_at: None,
+            staged_at: None,
+            attempt_hash: None,
+            root_did: None,
+            create_fingerprint: None,
+            recovery_hash: None,
+            accepted_descriptor_hash: None,
+            last_transition_at: 1_754_380_800,
+        })
+        .unwrap()
+    }
+
+    fn mutation(checkpoint: &ValidatedCheckpoint, now: u64) -> MutationContext {
+        MutationContext {
+            operation_id: "setup-1".to_string(),
+            owner_hash: hash("11"),
+            client_id: "client-1".to_string(),
+            expected_revision: checkpoint.as_stored().revision,
+            now,
+        }
+    }
+
+    fn bundle() -> StoredRecoveryBundleV1 {
+        StoredRecoveryBundleV1 {
+            version: 1,
+            operation_id: "setup-1".to_string(),
+            ceremony_created_at: 1_754_380_800,
+            staged_at: 1_754_380_802,
+            normalized_email: "person@example.com".to_string(),
+            provider: "https://accounts.example/".to_string(),
+            root_did: "did:key:root".to_string(),
+            device_did: "did:key:device".to_string(),
+            device_name: "Jack's laptop".to_string(),
+            credential_id: "aabb".to_string(),
+            delegation_cid: "bafydelegation".to_string(),
+            delegation_hex: "ccdd".to_string(),
+            passkey: Some(PasskeyMetadata {
+                created_at: 1_754_380_800,
+                created_on: "Chrome on macOS".to_string(),
+            }),
+            encryption_key: Some("did:key:z6LSrecipient".to_string()),
+            descriptor_hex: "eeff".to_string(),
+            create_fingerprint: hash("33"),
+            invocation_hex: "2233".to_string(),
+            deposits_hex: vec!["4455".to_string()],
+            custody_did: "did:key:custody".to_string(),
+            consent_hex: "6677".to_string(),
+            sealed_hex: "8899".to_string(),
+            publish_invocation_hex: "aabb".to_string(),
+            recovery_manifest_hex: "bbcc".to_string(),
+        }
+    }
+
+    fn recovery_evidence() -> RecoveryEvidence {
+        RecoveryEvidence {
+            staged_at: 1_754_380_802,
+            root_did: "did:key:root".to_string(),
+            create_fingerprint: hash("44"),
+            recovery_hash: hash("55"),
+        }
+    }
+
+    async fn signer(seed: u8) -> Ed25519Signer {
+        Ed25519Signer::import(&[seed; 32]).await.unwrap()
+    }
+
+    async fn valid_recovery(seed: u8) -> (StoredRecoveryBundleV1, RecoveryTrustContext) {
+        let secret = AccountSecret::generate().unwrap();
+        let root = secret.signer().await.unwrap();
+        let device = signer(seed).await;
+        let service = signer(seed.wrapping_add(1)).await;
+        let entry = [seed.wrapping_add(2); 32];
+        let custody = custody_signer(&entry).await.unwrap();
+        let root_did = root.did().to_string();
+        let device_did = device.did().to_string();
+        let service_did = service.did().to_string();
+        let custody_did = custody.did().to_string();
+        let ceremony_created_at = Timestamp::now().to_unix();
+        let armed_at = ceremony_created_at - 1;
+        let staged_at = ceremony_created_at + 1;
+        let provider: url::Url = "https://accounts.example/".parse().unwrap();
+        let remote: url::Url = "https://app.example/ucan/".parse().unwrap();
+        let operation_id = format!("setup-{seed}");
+        let credential_id = format!("{seed:02x}").repeat(16);
+        let device_name = format!("Test device {seed}");
+        let email = format!("person-{seed}@example.com");
+        let passkey = PasskeyMetadata {
+            created_at: ceremony_created_at,
+            created_on: "Chrome on macOS".to_string(),
+        };
+
+        let delegation =
+            tonk_identity::delegation::mint_device_delegation(root.clone(), &device.did())
+                .await
+                .unwrap();
+        let delegation_cid = delegation.proof_cids()[0].to_string();
+        let delegation_bytes = delegation.to_bytes().unwrap();
+        let delegation_hex = hex::encode(&delegation_bytes);
+        let account = tonk_identity::ceremony::create_account(
+            root.clone(),
+            email.clone(),
+            credential_id.clone(),
+            device.did(),
+            device_name.clone(),
+            delegation_hex.clone(),
+            remote.to_string(),
+            Some(PasskeyCreationMetadata {
+                created_at: passkey.created_at,
+                created_on: passkey.created_on.clone(),
+            }),
+        )
+        .await
+        .unwrap();
+        let descriptor_hex = account.descriptor_hex.unwrap();
+        let descriptor = hex::decode(&descriptor_hex).unwrap();
+        let create_invocation = hex::decode(&account.invocation_hex).unwrap();
+        let create_fingerprint = AccountCreationFingerprintInput {
+            email: &email,
+            root_did: &root_did,
+            credential_id: &credential_id,
+            passkey: Some(AccountCreationPasskey {
+                created_at: passkey.created_at,
+                created_on: &passkey.created_on,
+            }),
+            descriptor: &descriptor,
+            device_did: &device_did,
+            device_name: &device_name,
+            delegation_cid: &delegation_cid,
+            delegation: &delegation_bytes,
+        }
+        .fingerprint();
+        let deposits_hex = mint_service_deposits(&root, &service.did()).await.unwrap();
+        let deposits = deposits_hex
+            .iter()
+            .map(|value| hex::decode(value).unwrap())
+            .collect::<Vec<_>>();
+        let consent = mint_custody_consent(custody.clone(), &root.did())
+            .await
+            .unwrap();
+        let consent_bytes = consent.to_bytes().unwrap();
+        let sealed = custody_kek(&entry)
+            .seal(&secret, KekMethod::Passkey)
+            .unwrap()
+            .encode();
+        let publish_expiration = Timestamp::new(
+            UNIX_EPOCH + Duration::from_secs(ceremony_created_at + DEFERRED_PUBLISH_TTL_SECONDS),
+        )
+        .unwrap();
+        let publish_invocation =
+            build_publish_invocation(custody.clone(), &sealed, None, publish_expiration)
+                .await
+                .unwrap();
+        let encryption_key = secret.encryption_key().recipient().did().to_string();
+        let manifest = AccountSetupRecoveryManifestV1::sign(
+            &root,
+            AccountSetupRecoveryManifestInput {
+                operation_id: &operation_id,
+                ceremony_created_at,
+                provider: provider.as_str(),
+                remote: remote.as_str(),
+                service_did: Some(&service_did),
+                root_did: &root_did,
+                device_did: &device_did,
+                credential_id: &credential_id,
+                create_fingerprint,
+                passkey: Some(AccountCreationPasskey {
+                    created_at: passkey.created_at,
+                    created_on: &passkey.created_on,
+                }),
+                encryption_recipient: Some(&encryption_key),
+                custody_did: &custody_did,
+                delegation: &delegation_bytes,
+                descriptor: &descriptor,
+                create_invocation: &create_invocation,
+                deposits: &deposits,
+                custody_consent: &consent_bytes,
+                sealed_envelope: &sealed,
+                publish_invocation: &publish_invocation,
+            },
+        )
+        .await
+        .unwrap();
+
+        let bundle = StoredRecoveryBundleV1 {
+            version: 1,
+            operation_id: operation_id.clone(),
+            ceremony_created_at,
+            staged_at,
+            normalized_email: email,
+            provider: provider.to_string(),
+            root_did,
+            device_did,
+            device_name,
+            credential_id,
+            delegation_cid,
+            delegation_hex,
+            passkey: Some(passkey),
+            encryption_key: Some(encryption_key),
+            descriptor_hex,
+            create_fingerprint: create_fingerprint.to_hex(),
+            invocation_hex: account.invocation_hex,
+            deposits_hex,
+            custody_did,
+            consent_hex: hex::encode(consent_bytes),
+            sealed_hex: hex::encode(sealed),
+            publish_invocation_hex: hex::encode(publish_invocation),
+            recovery_manifest_hex: hex::encode(manifest.bytes()),
+        };
+        let trust = RecoveryTrustContext {
+            operation_id,
+            provider,
+            remote,
+            service_did: Some(service.did()),
+            device_did: device.did(),
+            armed_at,
+            now: staged_at + 1,
+        };
+        (bundle, trust)
+    }
+
+    #[dialog_common::test]
+    fn it_decodes_private_v2_records_and_classifies_future_shapes_as_unsupported() {
+        assert_eq!(ACCOUNT_SETUP_CHECKPOINT_SITE, "tonk-account-setup-v2");
+        assert_eq!(
+            ACCOUNT_SETUP_RECOVERY_SITE,
+            "tonk-account-setup-recovery-v1"
+        );
+
+        let checkpoint = leased();
+        let bytes = encode_checkpoint(&checkpoint).unwrap();
+        assert!(decode_checkpoint(&bytes).unwrap() == checkpoint);
+        let mut invalid_armed_timestamp = checkpoint.as_stored().clone();
+        invalid_armed_timestamp.armed_at = Some(0);
+        assert!(matches!(
+            ValidatedCheckpoint::new(invalid_armed_timestamp),
+            Err(StoredSetupError::InvalidCheckpoint)
+        ));
+
+        let armed = reduce(
+            leased(),
+            ReducerCommand::Arm {
+                mutation: mutation(&leased(), 1_754_380_801),
+                attempt_hash: hash("33"),
+            },
+        )
+        .unwrap()
+        .checkpoint;
+        let staged = reduce(
+            armed.clone(),
+            ReducerCommand::Observe {
+                mutation: mutation(&armed, 1_754_380_802),
+                evidence: VerifiedEvidence::RecoveryStaged(recovery_evidence()),
+            },
+        )
+        .unwrap()
+        .checkpoint;
+        let mut staged_before_arm = staged.as_stored().clone();
+        staged_before_arm.staged_at = staged_before_arm.armed_at.map(|armed_at| armed_at - 1);
+        assert!(matches!(
+            ValidatedCheckpoint::new(staged_before_arm),
+            Err(StoredSetupError::InvalidCheckpoint)
+        ));
+
+        let future = br#"{
+            "version":99,
+            "phase":{"kind":"quantumRecovery","newField":true},
+            "futureRequiredField":{"nested":[1,2,3]}
+        }"#;
+        assert!(matches!(
+            decode_checkpoint(future),
+            Err(StoredSetupError::UnsupportedCheckpointVersion(99))
+        ));
+        assert!(matches!(
+            decode_checkpoint(br#"{"version":2,"phase":{"kind":"future"}}"#),
+            Err(StoredSetupError::UnsupportedCheckpointPhase)
+        ));
+
+        let recovery = StoredRecoveryRecord::Bundle(bundle());
+        let bytes = encode_recovery(&recovery).unwrap();
+        assert!(decode_recovery(&bytes).unwrap() == recovery);
+        let future = br#"{
+            "record":"futureBundle",
+            "version":99,
+            "futureProtectedShape":{"ciphertext":"opaque"}
+        }"#;
+        assert!(matches!(
+            decode_recovery(future),
+            Err(StoredSetupError::UnsupportedRecoveryVersion(99))
+        ));
+        assert!(matches!(
+            decode_recovery(br#"{"record":"futureBundle","version":1,"opaque":true}"#),
+            Err(StoredSetupError::UnsupportedRecoveryRecord)
+        ));
+    }
+
+    #[dialog_common::test]
+    fn it_reduces_complete_records_and_owns_revision_timestamp_and_field_clearing() {
+        let leased_checkpoint = leased();
+        let armed = reduce(
+            leased_checkpoint.clone(),
+            ReducerCommand::Arm {
+                mutation: mutation(&leased_checkpoint, 1_754_380_801),
+                attempt_hash: hash("33"),
+            },
+        )
+        .unwrap();
+        let stored = armed.checkpoint.as_stored();
+        assert_eq!(stored.phase, StoredPhaseV2::Armed);
+        assert_eq!(stored.revision, 2);
+        assert_eq!(stored.last_transition_at, 1_754_380_801);
+        assert_eq!(stored.armed_at, Some(1_754_380_801));
+        assert_eq!(stored.attempt_hash.as_deref(), Some(hash("33").as_str()));
+        assert_eq!(armed.durable_action, DurableAction::SaveCheckpoint);
+        assert_eq!(armed.next_action, PrivateNextAction::AwaitPasskeyResult);
+
+        let cancel = reduce(
+            armed.checkpoint.clone(),
+            ReducerCommand::Cancel {
+                mutation: mutation(&armed.checkpoint, 1_754_380_802),
+            },
+        )
+        .unwrap();
+        assert!(cancel.checkpoint == armed.checkpoint);
+        assert_eq!(cancel.durable_action, DurableAction::None);
+        assert_eq!(cancel.next_action, PrivateNextAction::CancelTooLate);
+
+        let interrupted = reduce(
+            armed.checkpoint,
+            ReducerCommand::OwnerAbsent {
+                expected_revision: 2,
+                observed_client_id: "client-1".to_string(),
+                recovery: RecoveryObservation::Absent,
+                now: 1_754_380_803,
+            },
+        )
+        .unwrap();
+        let stored = interrupted.checkpoint.as_stored();
+        assert_eq!(stored.phase, StoredPhaseV2::InterruptedBeforeRecovery);
+        assert_eq!(stored.revision, 3);
+        assert!(stored.owner_hash.is_none());
+        assert!(stored.bound_client_id.is_none());
+        assert!(stored.attempt_hash.is_none());
+        assert_eq!(stored.armed_at, Some(1_754_380_801));
+        assert_eq!(interrupted.next_action, PrivateNextAction::StartOver);
+    }
+
+    #[dialog_common::test]
+    fn it_accepts_only_the_next_typed_evidence_and_returns_the_next_durable_action() {
+        let armed = reduce(
+            leased(),
+            ReducerCommand::Arm {
+                mutation: mutation(&leased(), 1_754_380_801),
+                attempt_hash: hash("33"),
+            },
+        )
+        .unwrap()
+        .checkpoint;
+
+        let staged = reduce(
+            armed.clone(),
+            ReducerCommand::Observe {
+                mutation: mutation(&armed, 1_754_380_802),
+                evidence: VerifiedEvidence::RecoveryStaged(recovery_evidence()),
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            staged.checkpoint.as_stored().phase,
+            StoredPhaseV2::RecoveryStaged
+        );
+        assert!(staged.checkpoint.as_stored().attempt_hash.is_none());
+        assert_eq!(staged.next_action, PrivateNextAction::PersistLocalRoot);
+
+        assert!(matches!(
+            reduce(
+                staged.checkpoint.clone(),
+                ReducerCommand::Observe {
+                    mutation: mutation(&staged.checkpoint, 1_754_380_803),
+                    evidence: VerifiedEvidence::ProviderAccepted {
+                        descriptor_hash: hash("66"),
+                    },
+                },
+            ),
+            Err(ReductionError::InvalidTransition)
+        ));
+
+        let mut checkpoint = staged.checkpoint;
+        let evidence = [
+            VerifiedEvidence::LocalRootSaved,
+            VerifiedEvidence::ProviderAccepted {
+                descriptor_hash: hash("66"),
+            },
+            VerifiedEvidence::AttachmentSaved,
+            VerifiedEvidence::CustomerEnrolled,
+            VerifiedEvidence::CustodyQueued,
+            VerifiedEvidence::CompletionRecorded,
+        ];
+        let phases = [
+            StoredPhaseV2::RootSaved,
+            StoredPhaseV2::ProviderAccepted,
+            StoredPhaseV2::Attached,
+            StoredPhaseV2::CustomerEnrolled,
+            StoredPhaseV2::CustodyQueued,
+            StoredPhaseV2::Complete,
+        ];
+        let next_actions = [
+            PrivateNextAction::QueryProviderStatus,
+            PrivateNextAction::PersistAttachment,
+            PrivateNextAction::EnrollCustomer,
+            PrivateNextAction::QueueCustody,
+            PrivateNextAction::RecordCompletion,
+            PrivateNextAction::TombstoneRecovery,
+        ];
+        for ((evidence, phase), next) in evidence.into_iter().zip(phases).zip(next_actions) {
+            let now = checkpoint.as_stored().last_transition_at + 1;
+            let reduction = reduce(
+                checkpoint.clone(),
+                ReducerCommand::Observe {
+                    mutation: mutation(&checkpoint, now),
+                    evidence,
+                },
+            )
+            .unwrap();
+            assert_eq!(reduction.checkpoint.as_stored().phase, phase);
+            assert_eq!(reduction.next_action, next);
+            checkpoint = reduction.checkpoint;
+        }
+        assert!(checkpoint.as_stored().owner_hash.is_none());
+        assert!(checkpoint.as_stored().bound_client_id.is_none());
+    }
+
+    #[dialog_common::test]
+    fn it_records_only_staged_conflicts_with_provenance_and_a_stable_code() {
+        let partial = StoredCheckpointV2 {
+            version: 2,
+            operation_id: "setup-1".to_string(),
+            revision: 4,
+            owner_hash: None,
+            bound_client_id: None,
+            provider_hash: hash("22"),
+            phase: StoredPhaseV2::Conflict {
+                last_safe_phase: StoredSafePhaseV2::RootSaved,
+                code: StoredConflictCodeV2::ProviderMismatch,
+            },
+            armed_at: Some(1_754_380_801),
+            staged_at: Some(1_754_380_802),
+            attempt_hash: None,
+            root_did: None,
+            create_fingerprint: None,
+            recovery_hash: None,
+            accepted_descriptor_hash: None,
+            last_transition_at: 1_754_380_900,
+        };
+        assert!(ValidatedCheckpoint::new(partial).is_err());
+
+        let armed = reduce(
+            leased(),
+            ReducerCommand::Arm {
+                mutation: mutation(&leased(), 1_754_380_801),
+                attempt_hash: hash("33"),
+            },
+        )
+        .unwrap()
+        .checkpoint;
+        assert!(matches!(
+            reduce(
+                armed.clone(),
+                ReducerCommand::Conflict {
+                    mutation: mutation(&armed, 1_754_380_802),
+                    code: StoredConflictCodeV2::ProviderMismatch,
+                },
+            ),
+            Err(ReductionError::InvalidTransition)
+        ));
+    }
+
+    #[dialog_common::test]
+    fn it_repairs_a_staged_bundle_behind_armed_and_never_rebinds_an_unstaged_attempt() {
+        let armed = reduce(
+            leased(),
+            ReducerCommand::Arm {
+                mutation: mutation(&leased(), 1_754_380_801),
+                attempt_hash: hash("33"),
+            },
+        )
+        .unwrap()
+        .checkpoint;
+
+        let repaired = reduce(
+            armed,
+            ReducerCommand::OwnerAbsent {
+                expected_revision: 2,
+                observed_client_id: "client-1".to_string(),
+                recovery: RecoveryObservation::Staged(recovery_evidence()),
+                now: 1_754_380_802,
+            },
+        )
+        .unwrap();
+        let stored = repaired.checkpoint.as_stored();
+        assert_eq!(stored.phase, StoredPhaseV2::RecoveryStaged);
+        assert!(stored.owner_hash.is_none());
+        assert!(stored.bound_client_id.is_none());
+        assert!(stored.attempt_hash.is_none());
+        assert_eq!(stored.root_did.as_deref(), Some("did:key:root"));
+        assert_eq!(stored.staged_at, Some(1_754_380_802));
+        assert_eq!(repaired.next_action, PrivateNextAction::Acquire);
+    }
+
+    #[dialog_common::test]
+    fn it_requires_exact_recovery_presence_for_release_and_takeover() {
+        let leased = leased();
+        let released = reduce(
+            leased,
+            ReducerCommand::OwnerAbsent {
+                expected_revision: 1,
+                observed_client_id: "client-1".to_string(),
+                recovery: RecoveryObservation::Absent,
+                now: 1_754_380_801,
+            },
+        )
+        .unwrap()
+        .checkpoint;
+        assert!(released.as_stored().owner_hash.is_none());
+
+        assert!(matches!(
+            reduce(
+                released.clone(),
+                ReducerCommand::Acquire {
+                    operation_id: "setup-1".to_string(),
+                    new_owner_hash: hash("77"),
+                    new_client_id: "client-2".to_string(),
+                    expected_revision: 2,
+                    recovery: RecoveryObservation::Staged(recovery_evidence()),
+                    now: 1_754_380_802,
+                },
+            ),
+            Err(ReductionError::InvalidEvidence)
+        ));
+
+        let acquired = reduce(
+            released,
+            ReducerCommand::Acquire {
+                operation_id: "setup-1".to_string(),
+                new_owner_hash: hash("77"),
+                new_client_id: "client-2".to_string(),
+                expected_revision: 2,
+                recovery: RecoveryObservation::Absent,
+                now: 1_754_380_802,
+            },
+        )
+        .unwrap();
+        assert_eq!(acquired.next_action, PrivateNextAction::ApprovePasskey);
+        assert_eq!(acquired.checkpoint.as_stored().revision, 3);
+        assert_eq!(
+            acquired.checkpoint.as_stored().bound_client_id.as_deref(),
+            Some("client-2")
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_constructs_one_semantically_validated_bundle_from_exact_signed_artifacts() {
+        let (bundle, trust) = valid_recovery(41).await;
+        let validated = ValidatedRecoveryBundle::new(bundle.clone(), &trust)
+            .await
+            .unwrap();
+        assert_eq!(validated.create_freshness(), RecoveryFreshness::Usable);
+        assert_eq!(validated.publish_freshness(), RecoveryFreshness::Usable);
+        assert_eq!(validated.root_did().to_string(), bundle.root_did);
+        assert_eq!(validated.evidence().staged_at, bundle.staged_at);
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_mutated_cross_record_and_untrusted_deployment_bundles() {
+        let (bundle, trust) = valid_recovery(42).await;
+        let mut mutations = Vec::new();
+
+        let mut changed = bundle.clone();
+        changed.operation_id.push('x');
+        mutations.push(changed);
+        let mut changed = bundle.clone();
+        changed.normalized_email.push('x');
+        mutations.push(changed);
+        let mut changed = bundle.clone();
+        changed.credential_id.push_str("00");
+        mutations.push(changed);
+        let mut changed = bundle.clone();
+        changed.delegation_cid.push('x');
+        mutations.push(changed);
+        let mut changed = bundle.clone();
+        changed.delegation_hex.push_str("00");
+        mutations.push(changed);
+        let mut changed = bundle.clone();
+        changed.descriptor_hex.push_str("00");
+        mutations.push(changed);
+        let mut changed = bundle.clone();
+        changed.invocation_hex.push_str("00");
+        mutations.push(changed);
+        let mut changed = bundle.clone();
+        changed.deposits_hex.swap(0, 1);
+        mutations.push(changed);
+        let mut changed = bundle.clone();
+        changed.consent_hex.push_str("00");
+        mutations.push(changed);
+        let mut changed = bundle.clone();
+        changed.sealed_hex.push_str("00");
+        mutations.push(changed);
+        let mut changed = bundle.clone();
+        changed.publish_invocation_hex.push_str("00");
+        mutations.push(changed);
+        let mut changed = bundle.clone();
+        changed.recovery_manifest_hex.push_str("00");
+        mutations.push(changed);
+
+        for changed in mutations {
+            assert!(
+                ValidatedRecoveryBundle::new(changed, &trust).await.is_err(),
+                "mutated protected record was accepted"
+            );
+        }
+
+        let (other, _) = valid_recovery(43).await;
+        let mut crossed = bundle.clone();
+        crossed.custody_did = other.custody_did;
+        crossed.consent_hex = other.consent_hex;
+        crossed.sealed_hex = other.sealed_hex;
+        crossed.publish_invocation_hex = other.publish_invocation_hex;
+        crossed.recovery_manifest_hex = other.recovery_manifest_hex;
+        assert!(ValidatedRecoveryBundle::new(crossed, &trust).await.is_err());
+
+        let mut wrong_provider = trust.clone();
+        wrong_provider.provider = "https://other-accounts.example/".parse().unwrap();
+        assert!(
+            ValidatedRecoveryBundle::new(bundle.clone(), &wrong_provider)
+                .await
+                .is_err()
+        );
+        let mut wrong_remote = trust.clone();
+        wrong_remote.remote = "https://other-app.example/ucan/".parse().unwrap();
+        assert!(
+            ValidatedRecoveryBundle::new(bundle.clone(), &wrong_remote)
+                .await
+                .is_err()
+        );
+        let mut wrong_device = trust.clone();
+        wrong_device.device_did = signer(99).await.did();
+        assert!(
+            ValidatedRecoveryBundle::new(bundle, &wrong_device)
+                .await
+                .is_err()
+        );
+        let (bundle, mut wrong_service) = valid_recovery(42).await;
+        wrong_service.service_did = Some(signer(98).await.did());
+        assert!(
+            ValidatedRecoveryBundle::new(bundle, &wrong_service)
+                .await
+                .is_err()
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_bounds_every_input_before_parsing_and_classifies_current_expiry() {
+        let (bundle, trust) = valid_recovery(44).await;
+        let validated = ValidatedRecoveryBundle::new(bundle.clone(), &trust)
+            .await
+            .unwrap();
+
+        let mut expired_create = trust.clone();
+        expired_create.now = validated.create_expires_at() + 1;
+        let expired = ValidatedRecoveryBundle::new(bundle.clone(), &expired_create)
+            .await
+            .unwrap();
+        assert_eq!(expired.create_freshness(), RecoveryFreshness::NeedsRefresh);
+        assert_eq!(expired.publish_freshness(), RecoveryFreshness::Usable);
+
+        macro_rules! too_large {
+            ($field:ident, $value:expr, $name:literal) => {{
+                let mut changed = bundle.clone();
+                changed.$field = $value;
+                assert!(matches!(
+                    decode_bounded_recovery(&changed),
+                    Err(RecoveryValidationError::TooLarge($name))
+                ));
+            }};
+        }
+        macro_rules! invalid_text {
+            ($field:ident, $value:expr) => {{
+                let mut changed = bundle.clone();
+                changed.$field = $value;
+                assert!(matches!(
+                    decode_bounded_recovery(&changed),
+                    Err(RecoveryValidationError::Invalid("text"))
+                ));
+            }};
+        }
+
+        invalid_text!(operation_id, "x".repeat(129));
+        invalid_text!(normalized_email, "x".repeat(321));
+        invalid_text!(
+            provider,
+            format!("https://example.test/{}/", "x".repeat(2048))
+        );
+        invalid_text!(root_did, "x".repeat(513));
+        invalid_text!(device_did, "x".repeat(513));
+        invalid_text!(device_name, "x".repeat(121));
+        invalid_text!(delegation_cid, "x".repeat(513));
+        invalid_text!(custody_did, "x".repeat(513));
+
+        let mut credential = bundle.clone();
+        credential.credential_id = "aa".repeat(2049);
+        assert!(matches!(
+            decode_bounded_recovery(&credential),
+            Err(RecoveryValidationError::Invalid("credential_id"))
+        ));
+        let mut passkey_label = bundle.clone();
+        passkey_label.passkey.as_mut().unwrap().created_on = "x".repeat(121);
+        assert!(matches!(
+            decode_bounded_recovery(&passkey_label),
+            Err(RecoveryValidationError::Invalid("passkey"))
+        ));
+        let mut encryption_key = bundle.clone();
+        encryption_key.encryption_key = Some("x".repeat(513));
+        assert!(matches!(
+            decode_bounded_recovery(&encryption_key),
+            Err(RecoveryValidationError::Invalid("encryption_key"))
+        ));
+
+        too_large!(delegation_hex, "aa".repeat(64 * 1024 + 1), "delegation");
+        too_large!(descriptor_hex, "aa".repeat(4096 + 1), "descriptor");
+        too_large!(invocation_hex, "aa".repeat(128 * 1024 + 1), "invocation");
+        too_large!(consent_hex, "aa".repeat(64 * 1024 + 1), "consent");
+        too_large!(sealed_hex, "aa".repeat(4096 + 1), "sealed");
+        too_large!(
+            publish_invocation_hex,
+            "aa".repeat(128 * 1024 + 1),
+            "publish_invocation"
+        );
+        too_large!(
+            recovery_manifest_hex,
+            "aa".repeat(16 * 1024 + 1),
+            "recovery_manifest"
+        );
+        let mut oversized_deposit = bundle.clone();
+        oversized_deposit.deposits_hex = vec!["aa".repeat(64 * 1024 + 1)];
+        assert!(matches!(
+            decode_bounded_recovery(&oversized_deposit),
+            Err(RecoveryValidationError::TooLarge("deposit"))
+        ));
+
+        let mut oversized = bundle.clone();
+        oversized.invocation_hex = "aa".repeat(128 * 1024 + 1);
+        assert!(matches!(
+            ValidatedRecoveryBundle::new(oversized, &trust).await,
+            Err(RecoveryValidationError::TooLarge("invocation"))
+        ));
+        let mut too_many_deposits = bundle.clone();
+        too_many_deposits.deposits_hex = vec!["00".to_string(); 9];
+        assert!(matches!(
+            ValidatedRecoveryBundle::new(too_many_deposits, &trust).await,
+            Err(RecoveryValidationError::TooLarge("deposits"))
+        ));
+
+        let mut decoded_total = bundle.clone();
+        decoded_total.delegation_hex = "aa".repeat(64 * 1024);
+        decoded_total.descriptor_hex = "aa".repeat(4096);
+        decoded_total.invocation_hex = "aa".repeat(128 * 1024);
+        decoded_total.deposits_hex = vec!["aa".repeat(64 * 1024); 2];
+        decoded_total.consent_hex = "aa".repeat(64 * 1024);
+        decoded_total.sealed_hex = "aa".repeat(4096);
+        decoded_total.publish_invocation_hex = "aa".repeat(128 * 1024);
+        decoded_total.recovery_manifest_hex = "aa".repeat(16 * 1024);
+        assert!(matches!(
+            decode_bounded_recovery(&decoded_total),
+            Err(RecoveryValidationError::TooLarge("decoded_total"))
+        ));
+
+        let mut oversized_record = decoded_total;
+        oversized_record.publish_invocation_hex = "aa".repeat(106_300);
+        assert!(matches!(
+            decode_bounded_recovery(&oversized_record),
+            Err(RecoveryValidationError::TooLarge("recovery_record"))
+        ));
+        assert!(matches!(
+            decode_recovery(&vec![0; MAX_RECOVERY_RECORD_BYTES + 1]),
+            Err(StoredSetupError::TooLargeRecovery)
+        ));
+
+        let mut noncanonical = bundle;
+        noncanonical.sealed_hex = "AA".to_string();
+        assert!(
+            ValidatedRecoveryBundle::new(noncanonical, &trust)
+                .await
+                .is_err()
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_checks_exact_stage_and_original_expiry_boundaries_without_clock_saturation() {
+        let armed_at = 1_000;
+        for (created_at, staged_at) in [(940, 1_000), (1_060, 1_000), (1_000, 4_600)] {
+            assert!(validate_stage_timestamps(armed_at, created_at, staged_at, staged_at).is_ok());
+        }
+        for (created_at, staged_at, now) in [
+            (940, 999, 1_000),
+            (939, 1_000, 1_000),
+            (1_061, 1_000, 1_000),
+            (1_000, 4_601, 4_601),
+            (1_000, 1_001, 1_000),
+            (u64::MAX, u64::MAX, u64::MAX),
+        ] {
+            assert!(validate_stage_timestamps(armed_at, created_at, staged_at, now).is_err());
+        }
+
+        assert!(
+            validate_original_expiration(
+                10_000,
+                10_000 + CREATE_EXPIRY_MIN_OFFSET,
+                CREATE_EXPIRY_MIN_OFFSET,
+                CREATE_EXPIRY_MAX_OFFSET,
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_original_expiration(
+                10_000,
+                10_000 + CREATE_EXPIRY_MAX_OFFSET,
+                CREATE_EXPIRY_MIN_OFFSET,
+                CREATE_EXPIRY_MAX_OFFSET,
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_original_expiration(
+                10_000,
+                10_000 + CREATE_EXPIRY_MIN_OFFSET - 1,
+                CREATE_EXPIRY_MIN_OFFSET,
+                CREATE_EXPIRY_MAX_OFFSET,
+            )
+            .is_err()
+        );
+        assert!(
+            validate_original_expiration(
+                10_000,
+                10_000 + PUBLISH_EXPIRY_MIN_OFFSET,
+                PUBLISH_EXPIRY_MIN_OFFSET,
+                PUBLISH_EXPIRY_MAX_OFFSET,
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_original_expiration(
+                10_000,
+                10_000 + PUBLISH_EXPIRY_MAX_OFFSET + 1,
+                PUBLISH_EXPIRY_MIN_OFFSET,
+                PUBLISH_EXPIRY_MAX_OFFSET,
+            )
+            .is_err()
+        );
+        assert!(
+            validate_original_expiration(
+                u64::MAX,
+                u64::MAX,
+                CREATE_EXPIRY_MIN_OFFSET,
+                CREATE_EXPIRY_MAX_OFFSET,
+            )
+            .is_err()
+        );
+    }
+}

--- a/rust/tonk-worker/src/router/account_setup.rs
+++ b/rust/tonk-worker/src/router/account_setup.rs
@@ -122,7 +122,7 @@ struct StoredCheckpointV2 {
     owner_hash: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     bound_client_id: Option<String>,
-    provider_hash: String,
+    configuration_hash: String,
     phase: StoredPhaseV2,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     armed_at: Option<u64>,
@@ -220,12 +220,12 @@ enum StoredRecoveryRecord {
 enum StoredSetupError {
     TooLargeCheckpoint,
     MalformedCheckpoint,
-    UnsupportedCheckpointVersion(u16),
+    UnsupportedCheckpointVersion(u64),
     UnsupportedCheckpointPhase,
     InvalidCheckpoint,
     TooLargeRecovery,
     MalformedRecovery,
-    UnsupportedRecoveryVersion(u16),
+    UnsupportedRecoveryVersion(u64),
     UnsupportedRecoveryRecord,
     InvalidRecovery,
     Serialization,
@@ -233,8 +233,12 @@ enum StoredSetupError {
 
 #[derive(Deserialize)]
 struct CheckpointEnvelope {
-    version: u16,
     phase: PhaseEnvelope,
+}
+
+#[derive(Deserialize)]
+struct VersionEnvelope {
+    version: u64,
 }
 
 #[derive(Deserialize)]
@@ -244,7 +248,6 @@ struct PhaseEnvelope {
 
 #[derive(Deserialize)]
 struct RecoveryEnvelope {
-    version: u16,
     record: String,
 }
 
@@ -261,13 +264,15 @@ fn decode_checkpoint(bytes: &[u8]) -> Result<ValidatedCheckpoint, StoredSetupErr
     if bytes.len() > MAX_CHECKPOINT_BYTES {
         return Err(StoredSetupError::TooLargeCheckpoint);
     }
-    let envelope: CheckpointEnvelope =
+    let version: VersionEnvelope =
         serde_json::from_slice(bytes).map_err(|_| StoredSetupError::MalformedCheckpoint)?;
-    if envelope.version != CHECKPOINT_VERSION {
+    if version.version != u64::from(CHECKPOINT_VERSION) {
         return Err(StoredSetupError::UnsupportedCheckpointVersion(
-            envelope.version,
+            version.version,
         ));
     }
+    let envelope: CheckpointEnvelope =
+        serde_json::from_slice(bytes).map_err(|_| StoredSetupError::MalformedCheckpoint)?;
     if !matches!(
         envelope.phase.kind.as_str(),
         "leased"
@@ -302,13 +307,15 @@ fn decode_recovery(bytes: &[u8]) -> Result<StoredRecoveryRecord, StoredSetupErro
     if bytes.len() > MAX_RECOVERY_RECORD_BYTES {
         return Err(StoredSetupError::TooLargeRecovery);
     }
-    let envelope: RecoveryEnvelope =
+    let version: VersionEnvelope =
         serde_json::from_slice(bytes).map_err(|_| StoredSetupError::MalformedRecovery)?;
-    if envelope.version != RECOVERY_VERSION {
+    if version.version != u64::from(RECOVERY_VERSION) {
         return Err(StoredSetupError::UnsupportedRecoveryVersion(
-            envelope.version,
+            version.version,
         ));
     }
+    let envelope: RecoveryEnvelope =
+        serde_json::from_slice(bytes).map_err(|_| StoredSetupError::MalformedRecovery)?;
     if !matches!(envelope.record.as_str(), "bundle" | "tombstone") {
         return Err(StoredSetupError::UnsupportedRecoveryRecord);
     }
@@ -336,7 +343,7 @@ fn validate_checkpoint(checkpoint: &StoredCheckpointV2) -> Result<(), StoredSetu
         || checkpoint.revision == 0
         || !owner_pair
         || !owner_valid
-        || !valid_hash(&checkpoint.provider_hash)
+        || !valid_hash(&checkpoint.configuration_hash)
         || checkpoint.last_transition_at == 0
     {
         return Err(StoredSetupError::InvalidCheckpoint);
@@ -1215,7 +1222,6 @@ enum RecoveryObservation {
 
 #[derive(Clone, PartialEq, Eq)]
 enum VerifiedEvidence {
-    RecoveryStaged(RecoveryEvidence),
     LocalRootSaved,
     ProviderAccepted { descriptor_hash: String },
     AttachmentSaved,
@@ -1229,6 +1235,12 @@ enum ReducerCommand {
     Arm {
         mutation: MutationContext,
         attempt_hash: String,
+        configuration_hash: String,
+    },
+    Stage {
+        mutation: MutationContext,
+        attempt_hash: String,
+        evidence: RecoveryEvidence,
     },
     Cancel {
         mutation: MutationContext,
@@ -1308,8 +1320,12 @@ fn reduce(
         ReducerCommand::Arm {
             mutation,
             attempt_hash,
+            configuration_hash,
         } => {
             authenticate(&checkpoint, &mutation)?;
+            if checkpoint.as_stored().configuration_hash != configuration_hash {
+                return Err(ReductionError::InvalidEvidence);
+            }
             if checkpoint.as_stored().phase != StoredPhaseV2::Leased || !valid_hash(&attempt_hash) {
                 return Err(ReductionError::InvalidTransition);
             }
@@ -1323,6 +1339,29 @@ fn reduce(
                 },
                 DurableAction::SaveCheckpoint,
                 PrivateNextAction::AwaitPasskeyResult,
+            )
+        }
+        ReducerCommand::Stage {
+            mutation,
+            attempt_hash,
+            evidence,
+        } => {
+            authenticate(&checkpoint, &mutation)?;
+            if checkpoint.as_stored().phase != StoredPhaseV2::Armed {
+                return Err(ReductionError::InvalidTransition);
+            }
+            if checkpoint.as_stored().attempt_hash.as_deref() != Some(attempt_hash.as_str()) {
+                return Err(ReductionError::InvalidEvidence);
+            }
+            if !evidence.is_valid() {
+                return Err(ReductionError::InvalidEvidence);
+            }
+            transition(
+                checkpoint,
+                mutation.now,
+                |next| apply_staged_recovery(next, evidence),
+                DurableAction::SaveCheckpoint,
+                PrivateNextAction::PersistLocalRoot,
             )
         }
         ReducerCommand::Cancel { mutation } => {
@@ -1512,19 +1551,6 @@ fn reduce_evidence(
     evidence: VerifiedEvidence,
 ) -> Result<Reduction, ReductionError> {
     match (checkpoint.as_stored().phase.clone(), evidence) {
-        (StoredPhaseV2::Armed, VerifiedEvidence::RecoveryStaged(evidence))
-            if evidence.is_valid() =>
-        {
-            transition(
-                checkpoint,
-                now,
-                |next| {
-                    apply_staged_recovery(next, evidence);
-                },
-                DurableAction::SaveCheckpoint,
-                PrivateNextAction::PersistLocalRoot,
-            )
-        }
         (StoredPhaseV2::RecoveryStaged, VerifiedEvidence::LocalRootSaved) => transition(
             checkpoint,
             now,
@@ -1725,7 +1751,7 @@ mod tests {
             revision: 1,
             owner_hash: Some(hash("11")),
             bound_client_id: Some("client-1".to_string()),
-            provider_hash: hash("22"),
+            configuration_hash: hash("22"),
             phase: StoredPhaseV2::Leased,
             armed_at: None,
             staged_at: None,
@@ -1970,15 +1996,17 @@ mod tests {
             ReducerCommand::Arm {
                 mutation: mutation(&leased(), 1_754_380_801),
                 attempt_hash: hash("33"),
+                configuration_hash: hash("22"),
             },
         )
         .unwrap()
         .checkpoint;
         let staged = reduce(
             armed.clone(),
-            ReducerCommand::Observe {
+            ReducerCommand::Stage {
                 mutation: mutation(&armed, 1_754_380_802),
-                evidence: VerifiedEvidence::RecoveryStaged(recovery_evidence()),
+                attempt_hash: hash("33"),
+                evidence: recovery_evidence(),
             },
         )
         .unwrap()
@@ -1991,13 +2019,13 @@ mod tests {
         ));
 
         let future = br#"{
-            "version":99,
-            "phase":{"kind":"quantumRecovery","newField":true},
+            "version":65536,
             "futureRequiredField":{"nested":[1,2,3]}
         }"#;
         assert!(matches!(
             decode_checkpoint(future),
-            Err(StoredSetupError::UnsupportedCheckpointVersion(99))
+            Err(StoredSetupError::UnsupportedCheckpointVersion(version))
+                if version as u128 == 65_536
         ));
         assert!(matches!(
             decode_checkpoint(br#"{"version":2,"phase":{"kind":"future"}}"#),
@@ -2008,13 +2036,13 @@ mod tests {
         let bytes = encode_recovery(&recovery).unwrap();
         assert!(decode_recovery(&bytes).unwrap() == recovery);
         let future = br#"{
-            "record":"futureBundle",
-            "version":99,
+            "version":65536,
             "futureProtectedShape":{"ciphertext":"opaque"}
         }"#;
         assert!(matches!(
             decode_recovery(future),
-            Err(StoredSetupError::UnsupportedRecoveryVersion(99))
+            Err(StoredSetupError::UnsupportedRecoveryVersion(version))
+                if version as u128 == 65_536
         ));
         assert!(matches!(
             decode_recovery(br#"{"record":"futureBundle","version":1,"opaque":true}"#),
@@ -2030,6 +2058,7 @@ mod tests {
             ReducerCommand::Arm {
                 mutation: mutation(&leased_checkpoint, 1_754_380_801),
                 attempt_hash: hash("33"),
+                configuration_hash: hash("22"),
             },
         )
         .unwrap();
@@ -2074,12 +2103,79 @@ mod tests {
     }
 
     #[dialog_common::test]
+    fn it_refuses_to_arm_after_the_worker_configuration_changes() {
+        let checkpoint = leased();
+        assert!(matches!(
+            reduce(
+                checkpoint.clone(),
+                ReducerCommand::Arm {
+                    mutation: mutation(&checkpoint, 1_754_380_801),
+                    attempt_hash: hash("33"),
+                    configuration_hash: hash("99"),
+                },
+            ),
+            Err(ReductionError::InvalidEvidence)
+        ));
+    }
+
+    #[dialog_common::test]
+    fn it_requires_the_exact_armed_attempt_to_stage_once() {
+        let leased_checkpoint = leased();
+        let armed = reduce(
+            leased_checkpoint.clone(),
+            ReducerCommand::Arm {
+                mutation: mutation(&leased_checkpoint, 1_754_380_801),
+                attempt_hash: hash("33"),
+                configuration_hash: hash("22"),
+            },
+        )
+        .unwrap()
+        .checkpoint;
+
+        assert!(matches!(
+            reduce(
+                armed.clone(),
+                ReducerCommand::Stage {
+                    mutation: mutation(&armed, 1_754_380_802),
+                    attempt_hash: hash("44"),
+                    evidence: recovery_evidence(),
+                },
+            ),
+            Err(ReductionError::InvalidEvidence)
+        ));
+
+        let staged = reduce(
+            armed.clone(),
+            ReducerCommand::Stage {
+                mutation: mutation(&armed, 1_754_380_802),
+                attempt_hash: hash("33"),
+                evidence: recovery_evidence(),
+            },
+        )
+        .unwrap()
+        .checkpoint;
+        assert!(staged.as_stored().attempt_hash.is_none());
+        assert!(matches!(
+            reduce(
+                staged.clone(),
+                ReducerCommand::Stage {
+                    mutation: mutation(&staged, 1_754_380_803),
+                    attempt_hash: hash("33"),
+                    evidence: recovery_evidence(),
+                },
+            ),
+            Err(ReductionError::InvalidTransition)
+        ));
+    }
+
+    #[dialog_common::test]
     fn it_accepts_only_the_next_typed_evidence_and_returns_the_next_durable_action() {
         let armed = reduce(
             leased(),
             ReducerCommand::Arm {
                 mutation: mutation(&leased(), 1_754_380_801),
                 attempt_hash: hash("33"),
+                configuration_hash: hash("22"),
             },
         )
         .unwrap()
@@ -2087,9 +2183,10 @@ mod tests {
 
         let staged = reduce(
             armed.clone(),
-            ReducerCommand::Observe {
+            ReducerCommand::Stage {
                 mutation: mutation(&armed, 1_754_380_802),
-                evidence: VerifiedEvidence::RecoveryStaged(recovery_evidence()),
+                attempt_hash: hash("33"),
+                evidence: recovery_evidence(),
             },
         )
         .unwrap();
@@ -2166,7 +2263,7 @@ mod tests {
             revision: 4,
             owner_hash: None,
             bound_client_id: None,
-            provider_hash: hash("22"),
+            configuration_hash: hash("22"),
             phase: StoredPhaseV2::Conflict {
                 last_safe_phase: StoredSafePhaseV2::RootSaved,
                 code: StoredConflictCodeV2::ProviderMismatch,
@@ -2187,6 +2284,7 @@ mod tests {
             ReducerCommand::Arm {
                 mutation: mutation(&leased(), 1_754_380_801),
                 attempt_hash: hash("33"),
+                configuration_hash: hash("22"),
             },
         )
         .unwrap()
@@ -2210,6 +2308,7 @@ mod tests {
             ReducerCommand::Arm {
                 mutation: mutation(&leased(), 1_754_380_801),
                 attempt_hash: hash("33"),
+                configuration_hash: hash("22"),
             },
         )
         .unwrap()

--- a/rust/tonk-worker/src/router/account_setup.rs
+++ b/rust/tonk-worker/src/router/account_setup.rs
@@ -79,12 +79,15 @@ impl StoredSafePhaseV2 {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 enum StoredConflictCodeV2 {
-    RecoveryMismatch,
-    LocalRootMismatch,
-    ProviderMismatch,
-    AttachmentMismatch,
+    #[serde(rename = "recoveryMismatch")]
+    Recovery,
+    #[serde(rename = "localRootMismatch")]
+    LocalRoot,
+    #[serde(rename = "providerMismatch")]
+    Provider,
+    #[serde(rename = "attachmentMismatch")]
+    Attachment,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -212,7 +215,7 @@ struct RecoveryTombstoneV1 {
     deny_unknown_fields
 )]
 enum StoredRecoveryRecord {
-    Bundle(StoredRecoveryBundleV1),
+    Bundle(Box<StoredRecoveryBundleV1>),
     Tombstone(RecoveryTombstoneV1),
 }
 
@@ -648,7 +651,7 @@ impl ValidatedRecoveryBundle {
         .await
         .map_err(|_| RecoveryValidationError::Artifact("recovery_manifest"))?;
 
-        let record_bytes = encode_recovery(&StoredRecoveryRecord::Bundle(stored.clone()))
+        let record_bytes = encode_recovery(&StoredRecoveryRecord::Bundle(Box::new(stored.clone())))
             .map_err(|_| RecoveryValidationError::Invalid("recovery_record"))?;
         let recovery_hash = blake3::hash(&record_bytes).to_hex().to_string();
         Ok(Self {
@@ -804,7 +807,7 @@ fn decode_bounded_recovery(
     if total > MAX_DECODED_RECOVERY_BYTES {
         return Err(RecoveryValidationError::TooLarge("decoded_total"));
     }
-    let encoded = serde_json::to_vec(&StoredRecoveryRecord::Bundle(stored.clone()))
+    let encoded = serde_json::to_vec(&StoredRecoveryRecord::Bundle(Box::new(stored.clone())))
         .map_err(|_| RecoveryValidationError::Invalid("recovery_record"))?;
     if encoded.len() > MAX_RECOVERY_RECORD_BYTES {
         return Err(RecoveryValidationError::TooLarge("recovery_record"));
@@ -2032,7 +2035,7 @@ mod tests {
             Err(StoredSetupError::UnsupportedCheckpointPhase)
         ));
 
-        let recovery = StoredRecoveryRecord::Bundle(bundle());
+        let recovery = StoredRecoveryRecord::Bundle(Box::new(bundle()));
         let bytes = encode_recovery(&recovery).unwrap();
         assert!(decode_recovery(&bytes).unwrap() == recovery);
         let future = br#"{
@@ -2266,7 +2269,7 @@ mod tests {
             configuration_hash: hash("22"),
             phase: StoredPhaseV2::Conflict {
                 last_safe_phase: StoredSafePhaseV2::RootSaved,
-                code: StoredConflictCodeV2::ProviderMismatch,
+                code: StoredConflictCodeV2::Provider,
             },
             armed_at: Some(1_754_380_801),
             staged_at: Some(1_754_380_802),
@@ -2277,6 +2280,11 @@ mod tests {
             accepted_descriptor_hash: None,
             last_transition_at: 1_754_380_900,
         };
+        assert!(
+            serde_json::to_string(&partial)
+                .unwrap()
+                .contains("\"code\":\"providerMismatch\"")
+        );
         assert!(ValidatedCheckpoint::new(partial).is_err());
 
         let armed = reduce(
@@ -2294,7 +2302,7 @@ mod tests {
                 armed.clone(),
                 ReducerCommand::Conflict {
                     mutation: mutation(&armed, 1_754_380_802),
-                    code: StoredConflictCodeV2::ProviderMismatch,
+                    code: StoredConflictCodeV2::Provider,
                 },
             ),
             Err(ReductionError::InvalidTransition)


### PR DESCRIPTION
## Summary

- define the versioned, redacted account-setup command and status contract
- add a canonical root-signed anti-mix manifest and bounded semantic recovery validation
- add private checkpoint, recovery bundle, tombstone, and monotonic reducer foundations
- fence Arm against deployment configuration changes and Stage against wrong or replayed attempts
- classify genuinely future durable shapes as unsupported before current-tag decoding

This is deliberately a production-unwired foundation stacked on #835. Credential storage, Web Locks, live-client ownership, effects, UI, browser coverage, and Storybook remain in follow-up slices described by the checked-in plan.

## Verification

- CARGO_INCREMENTAL=0 cargo test -p tonk-account recovery::tests — 4 passed
- CARGO_INCREMENTAL=0 cargo test -p tonk-worker-api account_setup::tests — 4 passed
- CARGO_INCREMENTAL=0 cargo test -p tonk-worker router::account_setup::tests — 12 passed
- cargo fmt --all -- --check
- git diff --check

Independent review found and drove RED/GREEN fixes for the configuration fence, exact attempt fence, and version-first decoder.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a durable account setup recovery mechanism, enhancing the protocol for browser account creation. It includes a new recovery module and updates to existing structures to ensure robust handling of account setup processes.

### Detailed summary
- Added `account_setup` module for durable protocol definition and testing.
- Introduced `recovery` module in `tonk-account` for root-signed recovery manifests.
- Defined types and constants for recovery manifest operations and validations.
- Implemented `AccountSetupRecoveryManifestInput` and `AccountSetupRecoveryManifestV1` structures.
- Added signing and validation methods for recovery manifests.
- Enhanced error handling with `RecoveryManifestError` enum.
- Updated `account_setup` API to expose new recovery-related types and functions.
- Added tests for recovery manifest signing, validation, and error scenarios.
- Documented the recovery process and constraints in `audit-account-setup-recovery.md`.

> The following files were skipped due to too many changes: `plan/audit-account-setup-recovery.md`, `rust/tonk-worker/src/router/account_setup.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->