### PR TITLE
feat(account): make browser setup recoverable

### DIFF
--- a/plan/audit-account-setup-recovery.md
+++ b/plan/audit-account-setup-recovery.md
@@ -20,6 +20,21 @@ Focused evidence at this checkpoint:
 
 Still deliberately absent from this lower commit: credential-site reads/writes, Web Lock and live-`ClientId` ownership enforcement, provider HTTP effects, identity/customer/custody effects, top-document orchestration, UI copy, browser tests, and Storybook changes. Those remain the upper tasks below and must not be inferred from the foundation types alone.
 
+## Production saga checkpoint (2026-08-31)
+
+The next stacked slice starts from the reviewed foundation follow-up `89f9627b3` and wires Tasks 1–4 through the worker boundary without invoking the new flow from `tonk-ui` yet. It adds the pre-submit provider fingerprint and proof-bound status invocation, dedicated credential sites, profile-scoped Web Lock plus per-worker serialization, live-`ClientId`/token/revision fencing, a re-resolved canonical-configuration fence on every protected recovery validation, the bounded `/api/account/setup` route, recovery-before-root staging, status-first exact provider replay, exact local observations, ordered custody work, and complete-before-tombstone cleanup. Test-only store and provider ports cover unauthorized stage attempts, configuration drift, recovery/checkpoint loss, provider response loss, unknown provider outcomes, and tombstone-write loss without exposing protected payloads through `Debug` or logs.
+
+Deliberately deferred to the UI/WebAuthn slice: passing the worker-minted ceremony context into identity, producing the final root-signed manifest from the real browser ceremony, same-credential assertion/resume invocation, top-document owner/attempt-token orchestration, recovery copy, browser Web Lock races, service-worker critical-section composition, and Storybook. The production route is therefore wired and compile-checked but remains unreachable from existing UI entrypoints in this slice.
+
+Focused evidence after the final parent integration:
+
+- `CARGO_INCREMENTAL=0 cargo test -p tonk-worker router::account_setup::tests --no-fail-fast`: 17 passed, 90 filtered.
+- `CARGO_INCREMENTAL=0 cargo test -p tonk-identity --lib`: 69 passed.
+- `CARGO_INCREMENTAL=0 cargo test -p tonk-account pending::tests --no-fail-fast`: 4 passed, 36 filtered.
+- `CARGO_INCREMENTAL=0 cargo test -p tonk-worker-api account_setup::tests --no-fail-fast`: 4 passed, 30 filtered.
+- `CARGO_INCREMENTAL=0 cargo test -p tonk-worker router::route_table:: --no-fail-fast`: 2 passed, 105 filtered.
+- `CARGO_INCREMENTAL=0 cargo clippy -p tonk-account -p tonk-identity -p tonk-worker --all-targets -- -D warnings` and `CARGO_INCREMENTAL=0 cargo check -p tonk-worker --target wasm32-unknown-unknown`: passed.
+
 **Constraints:**
 
 - Do not persist or log an account secret, PRF result, passkey-derived KEK, root private key, owner token, or attempt token. A recovery record may contain the already passkey-sealed envelope and narrowly scoped signed artifacts already held by the pending-custody queue.
@@ -203,11 +218,11 @@ Loading applies overall-body, per-string, per-hex/blob, deposit-count, and decod
 
 - [x] RED: add deterministic recovery-manifest tests proving canonical bytes and exact validation. Mutate operation, `ceremony_created_at`, canonical deployment URL/config identity, credential, root/device, fingerprint, passkey/encryption facts, each artifact hash, deposit order, subject/audience/domain, signature, version, and canonical encoding; cross two otherwise-valid ceremony bundles and require rejection. Add exact envelope/payload/string/list/body bounds before GREEN.
 - [x] GREEN: implement the durable domain-separated DAG-CBOR manifest in `tonk-account`, modeled on the repository descriptor but with a distinct signing domain. The manifest hashes bytes/facts and never contains an account secret, PRF result, KEK, or private key. `CARGO_INCREMENTAL=0 cargo test -p tonk-account recovery::tests` passes 4 tests.
-- [ ] RED: add `it_computes_the_provider_fingerprint_before_submission` with fixed root/device/delegation/descriptor facts and the independent provider test vector; run `CARGO_INCREMENTAL=0 cargo test -p tonk-identity it_computes_the_provider_fingerprint_before_submission`; expect a compile failure because `AccountCeremony` has no fingerprint.
+- [x] RED: add `it_computes_the_provider_fingerprint_before_submission` with fixed root/device/delegation/descriptor facts and the independent provider test vector; run `CARGO_INCREMENTAL=0 cargo test -p tonk-identity it_computes_the_provider_fingerprint_before_submission`; expect a compile failure because `AccountCeremony` has no fingerprint.
 - [ ] GREEN: compute through `tonk_account::AccountCreationFingerprintInput`; retain `root.clone()` until the publish artifact exists; sign the manifest with the worker-minted operation and worker-selected configuration context; expose fingerprint, descriptor, device DID, delegation CID, and manifest through the installed bridge; rerun the focused tests successfully.
 - [ ] RED: add `it_rebuilds_only_the_same_semantic_creation_from_a_recovered_secret` using a fixed secret and delegation; mutate credential ID, root DID, device DID, descriptor remote, passkey metadata, and sealed envelope independently; expect exact recovery only for the original tuple. Run the focused filter and observe the missing resume seam.
 - [ ] GREEN: separate assertion/unwrap from a native-testable `create_account_from_recovered_secret` helper; require the same root and canonical fingerprint; return no secret/PRF/KEK. Rerun the focused and adjacent `tonk-identity` tests.
-- [ ] RED/GREEN: add a request-container test proving status uses the exact stable proof, root audience/subject, fingerprint argument, and fresh expiration; malformed or alternate grants must not build a request accepted by the provider verifier.
+- [x] RED/GREEN: add a request-container test proving status uses the exact stable proof, root audience/subject, fingerprint argument, and fresh expiration; malformed or alternate grants must not build a request accepted by the provider verifier.
 - [ ] Run `CARGO_INCREMENTAL=0 cargo test -p tonk-identity ceremony::tests` and `CARGO_INCREMENTAL=0 cargo test -p tonk-identity request::tests`; expect success.
 
 ### Task 2: Persist and reduce one exclusively owned setup operation
@@ -236,8 +251,8 @@ Loading applies overall-body, per-string, per-hex/blob, deposit-count, and decod
 - [ ] RED: add table-driven reducer tests for every legal phase edge and every backward/skip transition, including `Leased -> Cancelled`, `Armed -> Cancel` returning `TooLate`, immutable `armed_at`, Armed owner loss with/without a validated recovery record, post-stage takeover with an exact bundle, conflict provenance, stale revision, wrong operation, token/client mismatch, time regression, and arbitrary public phase advancement being impossible.
 - [ ] GREEN: implement a pure monotonic reducer whose only post-stage advance input is a typed verified effect observation. The reducer consumes/returns complete validated private records, increments revision/timestamp itself, clears every transient field at its boundary, and revalidates all no-write and write results.
 - [ ] RED: race two distinct ClientIds and owner tokens against `Begin`/`Arm`; require one owner, one revision winner, and one `Arm`. Cover same-client worker restart, copied session token in another live tab, pre-arm reload after the old client dies, `Armed` owner loss becoming terminal without a bundle, and post-`RecoveryStaged` takeover by a new live ClientId only after the old client is absent.
-- [ ] GREEN: hash tokens with domain-separated BLAKE3, bind the live ClientId, and wrap load/reduce/save in the named Web Lock and expected-revision check.
-- [ ] Add a production Web Lock adapter based on `navigator.locks`; unavailable Web Locks fail setup closed before `Arm` rather than silently falling back to per-worker exclusion.
+- [x] GREEN: hash tokens with domain-separated BLAKE3, bind the live ClientId, and wrap load/reduce/save in the named Web Lock and expected-revision check.
+- [x] Add a production Web Lock adapter based on `navigator.locks`; unavailable Web Locks fail setup closed before `Arm` rather than silently falling back to per-worker exclusion.
 - [ ] RED/GREEN: add `Handshake` tests for exact worker protocol 2 and provider recovery capability 1. Missing worker route, worker version mismatch, provider 404/timeout/malformed capability, and provider capability absence all refuse before `Arm`; no test adapter may record a WebAuthn request.
 - [ ] Run `CARGO_INCREMENTAL=0 cargo test -p tonk-worker-api account_setup` and the native `tonk-worker` account-setup reducer filters; expect success.
 - [ ] Run `CARGO_INCREMENTAL=0 nix develop path:. -c test:web:debug -E 'test(account_setup)'`; expect the service-worker Web Lock/storage tests to pass.
@@ -257,9 +272,9 @@ Loading applies overall-body, per-string, per-hex/blob, deposit-count, and decod
 - `observe_local_effects` returns exact/missing/mismatch facts for root and provider link; mismatch is terminal and no stored authority is replaced.
 
 - [ ] RED: add fault tests after recovery save, checkpoint save, root record save, root access projection, and root-phase checkpoint save. Recreate the saga adapter after each injected failure and require convergence without another WebAuthn create.
-- [ ] GREEN: implement save-first staging and root reconciliation. A bundle present behind an `Armed` checkpoint repairs it to `RecoveryStaged`; an exact local root repairs to `RootSaved`; mismatched root/grant fails closed.
+- [x] GREEN: implement save-first staging and root reconciliation. A bundle present behind an `Armed` checkpoint repairs it to `RecoveryStaged`; an exact local root repairs to `RootSaved`; mismatched root/grant fails closed.
 - [ ] RED/GREEN: mutate and oversize every bundle field independently; cross records from two fully valid bundles; alter deposit ordering; and require no root/provider/customer/custody effect. Cover overall input, every string/blob/hex, deposit count/decoded total, canonical encoding, signatures/scopes, manifest binding, fingerprint, and sealed-envelope structure before expensive parsing where possible. Test `ceremony_created_at` at exactly both Stage skew bounds and the one-hour age bound, one second outside each, worker clock rollback, checked-arithmetic overflow, exact create/publish original-expiry bounds, and current `Usable`/`NeedsRefresh`. The constructor structurally validates the envelope without opening it; the manifest proves cross-record origin, while a later same-credential assertion proves the ciphertext opens to the expected root.
-- [ ] Add the explicit `InterruptedBeforeRecovery` observation for `Armed` with a dead owning client and no bundle; it must never offer automatic retry or claim no passkey was created.
+- [x] Add the explicit `InterruptedBeforeRecovery` observation for `Armed` with a dead owning client and no bundle; it must never offer automatic retry or claim no passkey was created.
 - [ ] Run the focused native fault filters and Wasm credential-storage filters serially; expect success.
 
 ### Task 4: Recover provider response loss and finish ordered local/customer/custody effects
@@ -279,13 +294,13 @@ Loading applies overall-body, per-string, per-hex/blob, deposit-count, and decod
 - Produces: `Continue` outcome `Complete`, `NeedsPasskey`, `RetryLater`, or terminal `Conflict`; transport uncertainty never becomes provider `Absent`.
 - Produces: `customer::persist_custody_setup` which records the local custody cell, appends `[Provision, PublishCustody]` in one queue save, and then drains best-effort.
 
-- [ ] RED: script provider `Accepted`, `Absent`, `Mismatch`, timeout, malformed body, and lost response after commit. Require status before create on every resume; Accepted advances with the canonical descriptor, Absent submits the exact stored invocation, Mismatch writes nothing, and unknown outcomes remain retryable without WebAuthn.
-- [ ] GREEN: implement the status invocation/HTTP adapter and strict response/fingerprint/descriptor checks. Exact create replay accepts either initial 201 or reused 200 but verifies the returned fingerprint and descriptor.
+- [x] RED: script provider `Accepted`, `Absent`, `Mismatch`, timeout, malformed body, and lost response after commit. Require status before create on every resume; Accepted advances with the canonical descriptor, Absent submits the exact stored invocation, Mismatch writes nothing, and unknown outcomes remain retryable without WebAuthn.
+- [x] GREEN: implement the status invocation/HTTP adapter and strict response/fingerprint/descriptor checks. Exact create replay accepts either initial 201 or reused 200 but verifies the returned fingerprint and descriptor.
 - [ ] RED/GREEN: when Absent and the stored invocation is expired, return `NeedsPasskey` with owner-authorized sealed recovery input. `ReplaceInvocation` accepts only a fresh invocation whose decoded semantic facts reproduce the stored fingerprint.
 - [ ] RED: inject failure after provider acceptance, provider-phase checkpoint, provider record save, account-state initialization, enrollment response, customer record, custody cell, ordered queue save, drain, and completion save. Recreate the worker between failures; require monotonic convergence and no duplicate account/device/custody ordering.
-- [ ] GREEN: reconcile exact provider link/customer/custody effects before replaying. Treat enrollment and pending work as at-least-once idempotent operations; never let `PublishCustody` overtake `Provision`.
+- [x] GREEN: reconcile exact provider link/customer/custody effects before replaying. Treat enrollment and pending work as at-least-once idempotent operations; never let `PublishCustody` overtake `Provision`.
 - [ ] RED/GREEN: make malformed pending work recoverable from the still-retained bundle, and prove a drained queue followed by checkpoint loss can safely reappend/replay the exact pair.
-- [ ] Save `Complete` before overwriting the recovery bundle with `RecoveryTombstoneV1`. A failed tombstone write leaves credential-store-protected sealed/bounded material and is retried on later inspection; do not assume delete/retract support.
+- [x] Save `Complete` before overwriting the recovery bundle with `RecoveryTombstoneV1`. A failed tombstone write leaves credential-store-protected sealed/bounded material and is retried on later inspection; do not assume delete/retract support.
 - [ ] Run `CARGO_INCREMENTAL=0 cargo test -p tonk-account pending::tests` and focused native/wasm worker saga filters; expect success.
 
 ### Task 5: Consolidate entrypoints and render truthful cancel/recovery states

--- a/plan/audit-account-setup-recovery.md
+++ b/plan/audit-account-setup-recovery.md
@@ -24,7 +24,7 @@ Still deliberately absent from this lower commit: credential-site reads/writes, 
 
 The next stacked slice starts from the reviewed foundation follow-up `89f9627b3` and wires Tasks 1–4 through the worker boundary without invoking the new flow from `tonk-ui` yet. It adds the pre-submit provider fingerprint and proof-bound status invocation, dedicated credential sites, profile-scoped Web Lock plus per-worker serialization, live-`ClientId`/token/revision fencing, a re-resolved canonical-configuration fence on every protected recovery validation, the bounded `/api/account/setup` route, recovery-before-root staging, status-first exact provider replay, exact local observations, ordered custody work, and complete-before-tombstone cleanup. Test-only store and provider ports cover unauthorized stage attempts, configuration drift, recovery/checkpoint loss, provider response loss, unknown provider outcomes, and tombstone-write loss without exposing protected payloads through `Debug` or logs.
 
-Deliberately deferred to the UI/WebAuthn slice: passing the worker-minted ceremony context into identity, producing the final root-signed manifest from the real browser ceremony, same-credential assertion/resume invocation, top-document owner/attempt-token orchestration, recovery copy, browser Web Lock races, service-worker critical-section composition, and Storybook. The production route is therefore wired and compile-checked but remains unreachable from existing UI entrypoints in this slice.
+Deliberately deferred to the UI/WebAuthn slice: passing the worker-minted ceremony context into identity, producing the final root-signed manifest from the real browser ceremony, performing the browser same-credential assertion and invoking the worker's phase-specific replacement command, top-document owner/attempt-token orchestration, recovery copy, browser Web Lock races, service-worker critical-section composition, and Storybook. The production route is therefore wired and compile-checked but remains unreachable from existing UI entrypoints in this slice.
 
 Focused evidence after the final parent integration:
 
@@ -34,6 +34,31 @@ Focused evidence after the final parent integration:
 - `CARGO_INCREMENTAL=0 cargo test -p tonk-worker-api account_setup::tests --no-fail-fast`: 4 passed, 30 filtered.
 - `CARGO_INCREMENTAL=0 cargo test -p tonk-worker router::route_table:: --no-fail-fast`: 2 passed, 105 filtered.
 - `CARGO_INCREMENTAL=0 cargo clippy -p tonk-account -p tonk-identity -p tonk-worker --all-targets -- -D warnings` and `CARGO_INCREMENTAL=0 cargo check -p tonk-worker --target wasm32-unknown-unknown`: passed.
+
+## Independent production-saga review remediation (2026-08-31)
+
+The first production wiring commit was held for independent review rather than published. The review found nine recovery gaps, all addressed in this stacked follow-up before UI invocation:
+
+- `Inspect` and `Begin` now classify the checkpoint and recovery site together. A surviving bundle or tombstone behind a missing checkpoint is corrupt and cannot authorize another ceremony; phase/record combinations impossible for the current checkpoint also fail closed.
+- Replacement create and publish invocations carry a worker-authored immutable receipt-time reference. Canonical scope, exact semantic arguments, signature, and the original expiry window are validated against that stored reference; current expiry remains the recoverable `NeedsRefresh` state.
+- Enrollment advances only after both the device-local `CustomerRecord` and the exact profile-main `AccountCustomer` projection are durable. Projection failures propagate and idempotently replay without moving past `Attached`.
+- Every pending-work mutation holds one profile-scoped browser Web Lock and the matching per-worker mutex across load/append-or-drain/save. The ordered custody `[Provision, PublishCustody]` pair is appended in one serialized queue write, and a concurrency contract test permits either lock-acquisition order but no lost or crossed pair.
+- Repeated `Begin` by the exact live owner and `Acquire` after a dead pre-arm owner return the original worker-selected non-secret ceremony. A different live client still receives only the redacted in-progress view.
+- Provider status remains authoritative and transport-unknown. After exact status `Absent`, an account-create HTTP 409 is classified as the typed terminal provider conflict rather than retried forever; upstream bodies never enter the public response.
+- The coordinator rejects a request whose origin is not exactly the worker-global service origin before configuration resolution or any provider fetch. All setup context is derived from that trusted origin.
+- `NeedsPasskey` uses a tagged, phase-minimal protected input. `RootSaved` may receive only the fields needed to refresh create; `CustomerEnrolled` receives only operation/credential/root/custody/sealed fields for the custody publish invocation. Provider-accepted and later phases never disclose create-resume material merely because the already-consumed create invocation expired.
+- Test clocks plus in-memory store/provider/effect ports now execute the production `handle_locked` and `reconcile_with_provider` seams, including lost-checkpoint, configuration/origin, ownership/takeover, provider-conflict, projection-failure, phase-specific-expiry, and completion/tombstone paths.
+
+This remediation remains deliberately production-uninvoked from `tonk-ui`: the UI/WebAuthn adapter, copy, browser journey tests, service-worker critical-section composition, and Storybook behavior changes remain Tasks 5–7. Native queue tests prove the shared mutation seam and Wasm compilation proves its Web Lock adapter; a two-live-worker browser race remains browser-only evidence for Task 6.
+
+Focused review-remediation evidence:
+
+- `CARGO_INCREMENTAL=0 cargo test -p tonk-worker --lib router::account_setup::tests -- --nocapture`: 28 passed, 91 filtered.
+- `CARGO_INCREMENTAL=0 cargo test -p tonk-worker --lib router::customer::tests::concurrent_custody_appends_never_lose_or_cross_the_ordered_pair -- --exact --nocapture`: 1 passed, 118 filtered.
+- `CARGO_INCREMENTAL=0 cargo test -p tonk-worker-api --lib account_setup::tests -- --nocapture`: 4 passed, 30 filtered.
+- An earlier complete native `tonk-worker --lib` sweep in this remediation passed 111 of 119 inside the restricted sandbox; all eight failures stopped at loopback setup with `Operation not permitted`. The unchanged failing families then passed with loopback access: `router::account_state::tests` 11 passed and `router::http::tests` 3 passed. The final phase-minimal protected-response refinement was rerun through the 28 saga and 4 wire tests above.
+- `CARGO_INCREMENTAL=0 cargo clippy -p tonk-account -p tonk-worker-api -p tonk-identity -p tonk-worker --all-targets -- -D warnings`: passed. `AccountSetupResponse::Protected` is boxed to keep the wire JSON unchanged while satisfying the all-target enum-size lint.
+- `CARGO_INCREMENTAL=0 cargo check -p tonk-worker --target wasm32-unknown-unknown`: passed, including the shared Web Lock adapter.
 
 **Constraints:**
 
@@ -98,6 +123,7 @@ pub enum AccountSetupRequest {
     Stage(Box<AccountSetupStage>),
     Continue(AccountSetupMutation),
     ReplaceInvocation(AccountSetupInvocation),
+    ReplacePublishInvocation(AccountSetupInvocation),
     Cancel(AccountSetupMutation),
 }
 ```
@@ -143,8 +169,11 @@ normalized_email, worker-selected provider, credential_id, expected_root_did,
 expected_device_did, device_name,
 delegation_cid, delegation_hex, passkey metadata, encryption recipient,
 canonical descriptor_hex, create_fingerprint, original create invocation,
+optional replacement create invocation plus immutable receipt reference,
 account-signed customer deposits, custody DID and consent,
-passkey-sealed envelope, bounded publish invocation, recovery_manifest_hex
+passkey-sealed envelope, bounded publish invocation,
+optional replacement publish invocation plus immutable receipt reference,
+recovery_manifest_hex
 ```
 
 `RecoveryTombstoneV1 { version, operation_id, completed_at, recovery_hash }` replaces the recovery bundle only after the `Complete` checkpoint is durable. Inspection retries an interrupted tombstone write; code never relies on a delete/retract API.
@@ -296,10 +325,10 @@ Loading applies overall-body, per-string, per-hex/blob, deposit-count, and decod
 
 - [x] RED: script provider `Accepted`, `Absent`, `Mismatch`, timeout, malformed body, and lost response after commit. Require status before create on every resume; Accepted advances with the canonical descriptor, Absent submits the exact stored invocation, Mismatch writes nothing, and unknown outcomes remain retryable without WebAuthn.
 - [x] GREEN: implement the status invocation/HTTP adapter and strict response/fingerprint/descriptor checks. Exact create replay accepts either initial 201 or reused 200 but verifies the returned fingerprint and descriptor.
-- [ ] RED/GREEN: when Absent and the stored invocation is expired, return `NeedsPasskey` with owner-authorized sealed recovery input. `ReplaceInvocation` accepts only a fresh invocation whose decoded semantic facts reproduce the stored fingerprint.
-- [ ] RED: inject failure after provider acceptance, provider-phase checkpoint, provider record save, account-state initialization, enrollment response, customer record, custody cell, ordered queue save, drain, and completion save. Recreate the worker between failures; require monotonic convergence and no duplicate account/device/custody ordering.
+- [x] RED/GREEN: when Absent and the stored invocation is expired, return `NeedsPasskey` with owner-authorized sealed recovery input. `ReplaceInvocation` accepts only a fresh invocation whose decoded semantic facts reproduce the stored fingerprint. The same phase-specific contract now refreshes an expired custody publish authorization through `ReplacePublishInvocation` without exposing create material after provider acceptance.
+- [ ] RED: inject failure after provider acceptance, provider-phase checkpoint, provider record save, account-state initialization, enrollment response, customer record, custody cell, ordered queue save, drain, and completion save. Recreate the worker between failures; require monotonic convergence and no duplicate account/device/custody ordering. The production-seam matrix now covers provider 409, customer projection failure, custody completion, and tombstone loss; the remaining exhaustive crash-point/browser restart matrix stays open.
 - [x] GREEN: reconcile exact provider link/customer/custody effects before replaying. Treat enrollment and pending work as at-least-once idempotent operations; never let `PublishCustody` overtake `Provision`.
-- [ ] RED/GREEN: make malformed pending work recoverable from the still-retained bundle, and prove a drained queue followed by checkpoint loss can safely reappend/replay the exact pair.
+- [ ] RED/GREEN: make malformed pending work recoverable from the still-retained bundle, and prove a drained queue followed by checkpoint loss can safely reappend/replay the exact pair. Concurrent append loss/crossing is now covered under the shared mutation seam; the drained-queue/checkpoint-loss browser restart case remains open.
 - [x] Save `Complete` before overwriting the recovery bundle with `RecoveryTombstoneV1`. A failed tombstone write leaves credential-store-protected sealed/bounded material and is retried on later inspection; do not assume delete/retract support.
 - [ ] Run `CARGO_INCREMENTAL=0 cargo test -p tonk-account pending::tests` and focused native/wasm worker saga filters; expect success.
 

--- a/plan/audit-account-setup-recovery.md
+++ b/plan/audit-account-setup-recovery.md
@@ -125,6 +125,67 @@ Focused second-review evidence:
   wasm32-unknown-unknown`: passed in 1m 08s.
 - `cargo fmt --all -- --check` and `git diff --check`: passed.
 
+## Final production-saga review remediation (2026-08-31)
+
+The final independent review concentrated on checkpoint-loss and inter-write
+states at the production queue, recovery, and customer-projection seams. Four
+remaining recovery gaps were closed without changing the public wire schema:
+
+- Retrying the full custody batch after a partial drain now restores any
+  missing prerequisite before a surviving later batch entry. In particular,
+  `[PublishCustody]` plus a replayed `[Provision, PublishCustody]` converges to
+  the exact original order rather than appending Provision behind Publish.
+- A queued publish refresh uses a private, bounded replacement intent. The
+  worker first saves the fresh exact artifact plus the exact prior invocation,
+  then performs the production named-lock queue replacement, and only then
+  clears the intent. Failure of the first write leaves the queue untouched;
+  failure of the queue or final recovery write leaves enough validated state
+  for reload to idempotently repair either the previous or already-current
+  queue entry. Intent metadata is excluded from the immutable recovery hash,
+  is never sent on the public wire, and carries no new secret material.
+- Customer enrollment observation now compares immutable customer identity,
+  email, recognized lifecycle statuses, and a syntactically safe HTTP(S)
+  provider address. Independently advanced valid statuses are accepted as the
+  same enrollment, including the normal local `Registered` plus profile-main
+  `Active` state after activation; wrong subjects, unknown statuses, and unsafe
+  provider values remain mismatches.
+- A re-resolved configuration hash that differs after staging now returns the
+  same redacted `UpdateRequired`/`Reload` response used by Begin, Stage, and
+  Acquire. The fence runs before reconciliation or replacement persistence, so
+  the protected recovery bundle and queued checkpoint remain byte-for-byte
+  unchanged instead of becoming a terminal recovery conflict.
+
+Focused final-review evidence:
+
+- RED: the production partial-drain test observed `[PublishCustody, Provision]`
+  instead of the original `[Provision, PublishCustody]`; it now passes through
+  the production append wrapper.
+- RED: injected recovery-save failure previously advanced the pending queue;
+  injected queue replacement failure previously left the fresh recovery
+  receipt unable to reconcile on reload. Both exact crash-window tests now
+  converge while retaining the original receipt time and exact invocation
+  bytes.
+- RED: local `Registered` plus profile-main `Active` entered a terminal
+  mismatch, while a wrong projected customer was incorrectly classified
+  `Exact`; the production projection tests now advance the valid state and
+  reject invalid identity/provider data.
+- The configuration-drift test first exposed an invalid test clock as
+  `InProgressElsewhere`; after correcting that precondition it passes through
+  the production Continue fence and proves checkpoint and recovery bytes are
+  unchanged. The original conflict path was established by the review trace
+  from failed recovery validation to `persist_conflict`.
+- `CARGO_INCREMENTAL=0 cargo test -p tonk-worker --lib
+  router::account_setup::tests -- --nocapture`: 37 passed, 93 filtered.
+- `CARGO_INCREMENTAL=0 cargo test -p tonk-worker --lib
+  router::customer::tests -- --nocapture`: 3 passed, 127 filtered.
+- `CARGO_INCREMENTAL=0 cargo test -p tonk-account pending::tests --
+  --nocapture`: 4 passed, 36 filtered.
+- `CARGO_INCREMENTAL=0 cargo clippy -p tonk-worker --all-targets -- -D
+  warnings`: passed after boxing the large repair-result variant identified by
+  the first lint run.
+- `CARGO_INCREMENTAL=0 cargo check -p tonk-worker --target
+  wasm32-unknown-unknown`: passed.
+
 **Constraints:**
 
 - Do not persist or log an account secret, PRF result, passkey-derived KEK, root private key, owner token, or attempt token. A recovery record may contain the already passkey-sealed envelope and narrowly scoped signed artifacts already held by the pending-custody queue.
@@ -238,6 +299,8 @@ optional replacement create invocation plus immutable receipt reference,
 account-signed customer deposits, custody DID and consent,
 passkey-sealed envelope, bounded publish invocation,
 optional replacement publish invocation plus immutable receipt reference,
+optional private pending-publish replacement source retained only across the
+two durable replacement writes,
 recovery_manifest_hex
 ```
 

--- a/plan/audit-account-setup-recovery.md
+++ b/plan/audit-account-setup-recovery.md
@@ -60,6 +60,71 @@ Focused review-remediation evidence:
 - `CARGO_INCREMENTAL=0 cargo clippy -p tonk-account -p tonk-worker-api -p tonk-identity -p tonk-worker --all-targets -- -D warnings`: passed. `AccountSetupResponse::Protected` is boxed to keep the wire JSON unchanged while satisfying the all-target enum-size lint.
 - `CARGO_INCREMENTAL=0 cargo check -p tonk-worker --target wasm32-unknown-unknown`: passed, including the shared Web Lock adapter.
 
+## Second production-saga re-review remediation (2026-08-31)
+
+A second independent review held the follow-up because queue durability was
+being mistaken for custody execution, replacement receipt times were not
+explicitly idempotent, and two claimed production fault tests still exercised
+test-only shortcuts. This follow-up tightens those boundaries:
+
+- `CustodyQueued` remains a protected, owner-recoverable phase. Saving the
+  ordered pending pair no longer records `Complete` or tombstones recovery.
+  `Continue` and an authenticated `Inspect` inspect the exact serialized pair;
+  only absence after the durable queued checkpoint (the state produced when a
+  successful drain removes the pair) may advance to `Complete` and then the
+  tombstone. Unreadable queue bytes fail closed rather than being replaced by
+  an empty queue.
+- If a deferred publish expires, the queued pair stays in place and the saga
+  returns the phase-minimal `ReplacePublishInvocation` input. The replacement
+  atomically substitutes only the matching publish entry in its existing
+  position behind Provision. If activation already drained the pair, it is not
+  re-queued. Recovery is retained until the refreshed publish actually drains.
+- Exact lost-response retries of create and publish replacements compare the
+  already accepted artifact before assigning a receipt time. Identical bytes
+  keep the original immutable receipt and continue idempotent reconciliation;
+  only a distinct, independently validated artifact receives the new worker
+  receipt time.
+- Customer enrollment ordering and exact observation now live behind the same
+  production projection port used by `enroll_customer` and the setup saga.
+  The fault test lets `CustomerRecord` succeed, fails the profile-main
+  `AccountCustomer` write, proves the checkpoint remains `Attached`, and then
+  proves the idempotent retry converges both projections before advancing.
+- Native concurrency coverage now calls the production pending-queue append
+  wrapper with two distinct per-worker mutexes and the same canonical named
+  lock. The native test adapter models the browser named-lock registry; no
+  test-only external mutex hides a missing or mismatched production lock.
+
+The production assumptions remain narrow: the `CustodyQueued` checkpoint is
+proof that the exact pair was saved once; thereafter an absent exact subject is
+treated as successful idempotent drain removal. A conflicting same-subject
+entry is not absence and fails closed. Browser Web Locks remain mandatory in
+production; a real two-service-worker browser race is still deferred to Task 6.
+
+Focused second-review evidence:
+
+- RED: the custody-only-queued reconciliation test observed `Complete` before
+  execution; the corrected test retains `CustodyQueued` and the bundle.
+- RED: temporarily restoring sliding receipt assignment made the identical
+  create retry stop before provider reconciliation and the identical publish
+  retry stop before the queue replacement seam.
+- RED: treating a surviving device-local customer projection as exact after the
+  profile-main projection failed skipped the production retry; the final effect
+  order was `customer, custody` rather than `customer, customer, custody`.
+- RED: changing the production pending-work lock name to include each worker's
+  local mutex identity allowed two concurrent appends to overwrite one ordered
+  pair. Restoring the canonical profile-derived name retained both pairs.
+- `CARGO_INCREMENTAL=0 cargo test -p tonk-worker --lib
+  router::account_setup::tests -- --nocapture`: 32 passed, 92 filtered.
+- `CARGO_INCREMENTAL=0 cargo test -p tonk-worker --lib
+  router::customer::tests::production_ -- --nocapture`: 2 passed, 122 filtered;
+  these execute the production projection and shared pending-queue mutation
+  seams, including the partial-projection fault and two-worker lock race.
+- `CARGO_INCREMENTAL=0 cargo clippy -p tonk-worker --all-targets -- -D
+  warnings`: passed.
+- `CARGO_INCREMENTAL=0 cargo check -p tonk-worker --target
+  wasm32-unknown-unknown`: passed in 1m 08s.
+- `cargo fmt --all -- --check` and `git diff --check`: passed.
+
 **Constraints:**
 
 - Do not persist or log an account secret, PRF result, passkey-derived KEK, root private key, owner token, or attempt token. A recovery record may contain the already passkey-sealed envelope and narrowly scoped signed artifacts already held by the pending-custody queue.

--- a/rust/tonk-account/src/pending.rs
+++ b/rust/tonk-account/src/pending.rs
@@ -103,8 +103,20 @@ impl PendingQueue {
     /// already present without allowing later entries to overtake earlier
     /// ones. Callers serialize the queue once after this returns.
     pub fn push_all(&mut self, work: impl IntoIterator<Item = PendingWork>) {
-        for entry in work {
-            self.push(entry);
+        let batch = work.into_iter().collect::<Vec<_>>();
+        for (index, entry) in batch.iter().cloned().enumerate() {
+            if self.0.contains(&entry) {
+                continue;
+            }
+            let insert_at = batch[index + 1..]
+                .iter()
+                .filter_map(|later| self.0.iter().position(|queued| queued == later))
+                .min();
+            if let Some(insert_at) = insert_at {
+                self.0.insert(insert_at, entry);
+            } else {
+                self.0.push(entry);
+            }
         }
     }
 

--- a/rust/tonk-account/src/pending.rs
+++ b/rust/tonk-account/src/pending.rs
@@ -99,6 +99,15 @@ impl PendingQueue {
         }
     }
 
+    /// Append a related batch in its supplied order, suppressing exact work
+    /// already present without allowing later entries to overtake earlier
+    /// ones. Callers serialize the queue once after this returns.
+    pub fn push_all(&mut self, work: impl IntoIterator<Item = PendingWork>) {
+        for entry in work {
+            self.push(entry);
+        }
+    }
+
     /// The entries in replay order.
     pub fn entries(&self) -> &[PendingWork] {
         &self.0
@@ -139,6 +148,29 @@ mod tests {
             matches!(queue.entries()[1], PendingWork::PublishCustody { .. }),
             "the publish must stay behind the provision that makes it servable"
         );
+    }
+
+    #[test]
+    fn it_appends_an_ordered_batch_without_splitting_or_reordering_it() {
+        let mut queue = PendingQueue::default();
+        queue.push(provision("did:key:zEarlier"));
+        let provision = provision("did:key:zCustody");
+        let publish = PendingWork::PublishCustody {
+            custody: "did:key:zCustody".to_string(),
+            sealed_hex: "bb".to_string(),
+            invocation_hex: "c0de".to_string(),
+        };
+
+        queue.push_all([provision.clone(), publish.clone()]);
+        queue.push_all([provision, publish]);
+
+        assert_eq!(queue.len(), 3);
+        assert_eq!(queue.entries()[0].subject(), "did:key:zEarlier");
+        assert!(matches!(queue.entries()[1], PendingWork::Provision { .. }));
+        assert!(matches!(
+            queue.entries()[2],
+            PendingWork::PublishCustody { .. }
+        ));
     }
 
     #[test]

--- a/rust/tonk-identity/src/ceremony.rs
+++ b/rust/tonk-identity/src/ceremony.rs
@@ -27,8 +27,12 @@ pub struct AccountCeremony {
     pub device_did: String,
     /// Hex-encoded `root → device` delegation chain.
     pub delegation_hex: String,
+    /// CID of the exact stable `root → device` delegation.
+    pub delegation_cid: String,
     /// Exact signed account repository descriptor, only during creation.
     pub descriptor_hex: Option<String>,
+    /// Canonical provider creation fingerprint, only during creation.
+    pub create_fingerprint: Option<String>,
     /// Hex-encoded root-signed invocation container for the account service.
     pub invocation_hex: String,
 }
@@ -123,13 +127,19 @@ fn strings(values: impl IntoIterator<Item = (&'static str, String)>) -> BTreeMap
         .collect()
 }
 
+struct AccountCeremonyArtifacts {
+    device_did: String,
+    delegation_hex: String,
+    delegation_cid: String,
+    descriptor_hex: Option<String>,
+    create_fingerprint: Option<String>,
+}
+
 async fn build(
     root: Ed25519Signer,
     command: Vec<String>,
     arguments: BTreeMap<String, Promised>,
-    device_did: String,
-    delegation_hex: String,
-    descriptor_hex: Option<String>,
+    artifacts: AccountCeremonyArtifacts,
 ) -> Result<AccountCeremony> {
     let root_did = root.did();
     let invocation = InvocationBuilder::new()
@@ -153,9 +163,11 @@ async fn build(
 
     Ok(AccountCeremony {
         root_did: root_did.to_string(),
-        device_did,
-        delegation_hex,
-        descriptor_hex,
+        device_did: artifacts.device_did,
+        delegation_hex: artifacts.delegation_hex,
+        delegation_cid: artifacts.delegation_cid,
+        descriptor_hex: artifacts.descriptor_hex,
+        create_fingerprint: artifacts.create_fingerprint,
         invocation_hex,
     })
 }
@@ -192,6 +204,7 @@ pub async fn create_account(
         .await
         .context("failed to sign account repository descriptor")?;
     let descriptor_hex = hex::encode(descriptor.bytes());
+    let descriptor_bytes = descriptor.bytes().to_vec();
     let device_did_string = device_did.to_string();
     let bytes = hex::decode(&delegation_hex).context("invalid existing delegation hex")?;
     let delegation = DelegationChain::try_from(bytes.as_slice())
@@ -199,6 +212,25 @@ pub async fn create_account(
     if delegation.issuer() != &root.did() || delegation.audience() != &device_did {
         anyhow::bail!("existing delegation does not match the evaluated root and device");
     }
+    let delegation_cid = delegation.proof_cids()[0].to_string();
+    let fingerprint = tonk_account::creation::AccountCreationFingerprintInput {
+        email: &email,
+        root_did: root.did().as_ref(),
+        credential_id: &credential_id,
+        passkey: passkey
+            .as_ref()
+            .map(|passkey| tonk_account::creation::AccountCreationPasskey {
+                created_at: passkey.created_at,
+                created_on: &passkey.created_on,
+            }),
+        descriptor: &descriptor_bytes,
+        device_did: &device_did_string,
+        device_name: &device_name,
+        delegation_cid: &delegation_cid,
+        delegation: &bytes,
+    }
+    .fingerprint()
+    .to_hex();
     let mut arguments = strings([
         ("email", email),
         ("credentialId", credential_id),
@@ -221,9 +253,13 @@ pub async fn create_account(
         root,
         vec!["account".into(), "create".into()],
         arguments,
-        device_did_string,
-        delegation_hex,
-        Some(descriptor_hex),
+        AccountCeremonyArtifacts {
+            device_did: device_did_string,
+            delegation_hex,
+            delegation_cid,
+            descriptor_hex: Some(descriptor_hex),
+            create_fingerprint: Some(fingerprint),
+        },
     )
     .await
 }
@@ -569,6 +605,7 @@ pub async fn link_device(
             .to_bytes()
             .context("failed to serialize root to device delegation")?,
     );
+    let delegation_cid = delegation.proof_cids()[0].to_string();
     build(
         root,
         vec!["account".into(), "device".into(), "link".into()],
@@ -577,9 +614,13 @@ pub async fn link_device(
             ("deviceName", device_name),
             ("delegation", delegation_hex.clone()),
         ]),
-        device_did_string,
-        delegation_hex,
-        None,
+        AccountCeremonyArtifacts {
+            device_did: device_did_string,
+            delegation_hex,
+            delegation_cid,
+            descriptor_hex: None,
+            create_fingerprint: None,
+        },
     )
     .await
 }
@@ -733,6 +774,56 @@ mod tests {
         let chain = InvocationChain::try_from(bytes.as_slice()).unwrap();
         assert!(!chain.arguments().contains_key("passkeyCreatedAt"));
         assert!(!chain.arguments().contains_key("passkeyCreatedOn"));
+    }
+
+    #[dialog_common::test]
+    async fn it_computes_the_provider_fingerprint_before_submission() {
+        let (root, device) = fixture().await;
+        let root_did = root.did().to_string();
+        let delegation = crate::delegation::mint_device_delegation(root.clone(), &device)
+            .await
+            .unwrap();
+        let delegation_bytes = delegation.to_bytes().unwrap();
+        let delegation_cid = delegation.proof_cids()[0].to_string();
+        let passkey = PasskeyCreationMetadata {
+            created_at: 1_754_380_800,
+            created_on: " Chrome on macOS ".into(),
+        };
+        let output = create_account(
+            root,
+            "PERSON@EXAMPLE.COM".into(),
+            "credential".into(),
+            device.clone(),
+            "laptop".into(),
+            hex::encode(&delegation_bytes),
+            "https://accounts.example/ucan/".into(),
+            Some(passkey.clone()),
+        )
+        .await
+        .unwrap();
+        let descriptor = hex::decode(output.descriptor_hex.as_ref().unwrap()).unwrap();
+        let expected = tonk_account::creation::AccountCreationFingerprintInput {
+            email: "PERSON@EXAMPLE.COM",
+            root_did: &root_did,
+            credential_id: "credential",
+            passkey: Some(tonk_account::creation::AccountCreationPasskey {
+                created_at: passkey.created_at,
+                created_on: &passkey.created_on,
+            }),
+            descriptor: &descriptor,
+            device_did: device.as_ref(),
+            device_name: "laptop",
+            delegation_cid: &delegation_cid,
+            delegation: &delegation_bytes,
+        }
+        .fingerprint()
+        .to_hex();
+
+        assert_eq!(output.delegation_cid, delegation_cid);
+        assert_eq!(
+            output.create_fingerprint.as_deref(),
+            Some(expected.as_str())
+        );
     }
 
     #[dialog_common::test]

--- a/rust/tonk-identity/src/install.rs
+++ b/rust/tonk-identity/src/install.rs
@@ -147,11 +147,23 @@ fn ceremony_result(ceremony: crate::ceremony::AccountCeremony) -> Result<JsValue
     Reflect::set(&result, &"deviceDid".into(), &ceremony.device_did.into())?;
     Reflect::set(
         &result,
+        &"delegationCid".into(),
+        &ceremony.delegation_cid.into(),
+    )?;
+    Reflect::set(
+        &result,
         &"delegationHex".into(),
         &ceremony.delegation_hex.into(),
     )?;
     if let Some(descriptor_hex) = ceremony.descriptor_hex {
         Reflect::set(&result, &"descriptorHex".into(), &descriptor_hex.into())?;
+    }
+    if let Some(create_fingerprint) = ceremony.create_fingerprint {
+        Reflect::set(
+            &result,
+            &"createFingerprint".into(),
+            &create_fingerprint.into(),
+        )?;
     }
     Reflect::set(
         &result,
@@ -214,6 +226,13 @@ async fn create_account(input: JsValue) -> Result<JsValue, JsValue> {
     )?;
     if let Some(descriptor_hex) = ceremony.account.descriptor_hex {
         Reflect::set(&result, &"descriptorHex".into(), &descriptor_hex.into())?;
+    }
+    if let Some(create_fingerprint) = ceremony.account.create_fingerprint {
+        Reflect::set(
+            &result,
+            &"createFingerprint".into(),
+            &create_fingerprint.into(),
+        )?;
     }
     set_deposits(&result, &ceremony.deposits_hex)?;
     Reflect::set(&result, &"custodyDid".into(), &ceremony.custody_did.into())?;

--- a/rust/tonk-identity/src/request.rs
+++ b/rust/tonk-identity/src/request.rs
@@ -64,6 +64,34 @@ pub async fn build_device_invocation(
         .context("failed to serialize the device invocation")
 }
 
+/// Build the provider's proof-bound account-setup status query.
+///
+/// The query carries the exact stable root-to-device proof and the canonical
+/// provider fingerprint. It is deliberately distinct from the root-signed
+/// create invocation so a restarted worker can ask what committed without
+/// retaining the account root key.
+pub async fn build_account_setup_status_invocation(
+    device: impl Into<Signer>,
+    link: &DelegationChain,
+    create_fingerprint: &str,
+) -> Result<Vec<u8>> {
+    tonk_account::creation::AccountCreationFingerprint::from_hex(create_fingerprint)
+        .context("create fingerprint is not canonical")?;
+    if link.proof_cids().len() != 1 {
+        anyhow::bail!("account setup status requires one stable root to device proof");
+    }
+    build_device_invocation(
+        device,
+        link,
+        vec!["account".into(), "setup".into(), "status".into()],
+        BTreeMap::from([(
+            "createFingerprint".into(),
+            Promised::String(create_fingerprint.to_owned()),
+        )]),
+    )
+    .await
+}
+
 /// Build a `/customer/enroll` container for the access service.
 ///
 /// The invocation is device-signed on the account's subject, exactly as
@@ -288,6 +316,44 @@ mod tests {
                 "put".to_string()
             ],
         );
+    }
+
+    #[dialog_common::test]
+    async fn it_builds_the_proof_bound_account_setup_status_invocation() {
+        let root = Ed25519Signer::import(&[17u8; 32]).await.unwrap();
+        let root_did = root.did();
+        let device = Ed25519Signer::import(&[18u8; 32]).await.unwrap();
+        let device_did = device.did();
+        let link = crate::delegation::mint_device_delegation(root, &device_did)
+            .await
+            .unwrap();
+        let fingerprint = "ab".repeat(32);
+
+        let bytes = build_account_setup_status_invocation(device, &link, &fingerprint)
+            .await
+            .unwrap();
+        let chain = InvocationChain::try_from(bytes.as_slice()).unwrap();
+
+        chain
+            .verify(&dialog_ucan_core::verification::VerificationContext::new(
+                &dialog_ucan_core::verification::Environment::new(
+                    chain.proof_store(),
+                    dialog_credentials::DidKeyResolver,
+                    dialog_ucan_core::revocation::UnverifiedRevocations,
+                ),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(chain.issuer(), &device_did);
+        assert_eq!(chain.invocation.audience(), &root_did);
+        assert_eq!(chain.subject(), &root_did);
+        assert_eq!(chain.command().0, vec!["account", "setup", "status"]);
+        assert_eq!(
+            chain.arguments().get("createFingerprint"),
+            Some(&Promised::String(fingerprint))
+        );
+        assert_eq!(chain.proof_store().lock().unwrap().len(), 1);
+        assert!(chain.invocation.expiration().is_some());
     }
 
     #[dialog_common::test]

--- a/rust/tonk-worker-api/src/account_setup.rs
+++ b/rust/tonk-worker-api/src/account_setup.rs
@@ -211,6 +211,9 @@ pub enum AccountSetupRequest {
     Continue(AccountSetupMutation),
     /// Replace an expired create invocation after a same-credential assertion.
     ReplaceInvocation(AccountSetupInvocation),
+    /// Replace an expired custody publish invocation after asserting the same
+    /// staged credential and reopening the same sealed account secret.
+    ReplacePublishInvocation(AccountSetupInvocation),
     /// Cancel a lease before it is armed.
     Cancel(AccountSetupMutation),
 }
@@ -352,34 +355,55 @@ pub struct AccountSetupLease {
 }
 
 /// Minimum protected input for asserting the exact staged credential and
-/// rebuilding only the original semantic account creation.
+/// rebuilding only the authorization consumed by the current durable phase.
 ///
 /// This type is owner-authenticated and intentionally does not implement
 /// [`Debug`]. It must never be returned by unauthenticated inspection.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct AccountSetupResumeInput {
-    /// Operation whose expired invocation is being replaced.
-    pub operation_id: String,
-    /// Exact staged WebAuthn credential identifier.
-    pub credential_id: String,
-    /// Root DID the reopened envelope must reproduce.
-    pub expected_root_did: String,
-    /// Normalized provider account email bound into the fingerprint.
-    pub normalized_email: String,
-    /// Exact device DID receiving the stable delegation.
-    pub device_did: String,
-    /// Exact device label bound into the fingerprint.
-    pub device_name: String,
-    /// Stable root-to-device delegation bytes.
-    pub delegation_hex: String,
-    /// Original canonical signed descriptor bytes.
-    pub descriptor_hex: String,
-    /// Passkey creation metadata bound into the fingerprint, when present.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub passkey: Option<crate::PasskeyMetadata>,
-    /// Passkey-sealed account-secret envelope.
-    pub sealed_hex: String,
+#[serde(
+    tag = "refresh",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+pub enum AccountSetupResumeInput {
+    /// Rebuild the root-signed provider account-creation invocation.
+    Create {
+        /// Operation whose expired invocation is being replaced.
+        operation_id: String,
+        /// Exact staged WebAuthn credential identifier.
+        credential_id: String,
+        /// Root DID the reopened envelope must reproduce.
+        expected_root_did: String,
+        /// Normalized provider account email bound into the fingerprint.
+        normalized_email: String,
+        /// Exact device DID receiving the stable delegation.
+        device_did: String,
+        /// Exact device label bound into the fingerprint.
+        device_name: String,
+        /// Stable root-to-device delegation bytes.
+        delegation_hex: String,
+        /// Original canonical signed descriptor bytes.
+        descriptor_hex: String,
+        /// Passkey creation metadata bound into the fingerprint, when present.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        passkey: Option<crate::PasskeyMetadata>,
+        /// Passkey-sealed account-secret envelope used to recover the root.
+        sealed_hex: String,
+    },
+    /// Rebuild the custody-signed secret-cell publish invocation.
+    Publish {
+        /// Operation whose expired invocation is being replaced.
+        operation_id: String,
+        /// Exact staged WebAuthn credential identifier.
+        credential_id: String,
+        /// Root DID the reopened envelope must reproduce before custody use.
+        expected_root_did: String,
+        /// Exact custody DID whose signer the reopened secret must reproduce.
+        custody_did: String,
+        /// Passkey-sealed account-secret envelope used to derive custody.
+        sealed_hex: String,
+    },
 }
 
 /// Owner-authenticated response carrying protected recovery material.
@@ -421,7 +445,7 @@ pub enum AccountSetupResponse {
     /// Redacted current status.
     View(AccountSetupView),
     /// Owner-authenticated protected response, never returned by public status.
-    Protected(AccountSetupProtectedResponse),
+    Protected(Box<AccountSetupProtectedResponse>),
 }
 
 #[cfg(test)]
@@ -543,6 +567,10 @@ mod tests {
                 mutation: mutation.clone(),
                 invocation_hex: "deadbeef".to_string(),
             }),
+            AccountSetupRequest::ReplacePublishInvocation(AccountSetupInvocation {
+                mutation: mutation.clone(),
+                invocation_hex: "feedface".to_string(),
+            }),
             AccountSetupRequest::Cancel(mutation),
         ];
         let expected_commands = [
@@ -553,6 +581,7 @@ mod tests {
             "stage",
             "continue",
             "replaceInvocation",
+            "replacePublishInvocation",
             "cancel",
         ];
 
@@ -728,24 +757,30 @@ mod tests {
         };
         let protected = AccountSetupProtectedResponse::NeedsPasskey {
             view,
-            resume: AccountSetupResumeInput {
+            resume: AccountSetupResumeInput::Publish {
                 operation_id: "setup-1".to_string(),
                 credential_id: "aabb".to_string(),
                 expected_root_did: "did:key:root".to_string(),
-                normalized_email: "person@example.com".to_string(),
-                device_did: "did:key:device".to_string(),
-                device_name: "Jack's laptop".to_string(),
-                delegation_hex: "ccdd".to_string(),
-                descriptor_hex: "eeff".to_string(),
-                passkey: None,
                 sealed_hex: "8899".to_string(),
+                custody_did: "did:key:custody".to_string(),
             },
         };
-        let value = serde_json::to_value(AccountSetupResponse::Protected(protected)).unwrap();
+        let value =
+            serde_json::to_value(AccountSetupResponse::Protected(Box::new(protected))).unwrap();
         assert_eq!(value["outcome"], "protected");
         assert_eq!(value["protectedOutcome"], "needsPasskey");
         assert_eq!(value["resume"]["credentialId"], "aabb");
         assert_eq!(value["resume"]["sealedHex"], "8899");
+        assert_eq!(value["resume"]["custodyDid"], "did:key:custody");
+        assert_eq!(value["resume"]["refresh"], "publish");
+        assert!(value["resume"].get("normalizedEmail").is_none());
+        assert!(value["resume"].get("delegationHex").is_none());
+        assert!(value["resume"].get("descriptorHex").is_none());
+        let decoded: AccountSetupResponse = serde_json::from_value(value.clone()).unwrap();
+        assert!(matches!(decoded, AccountSetupResponse::Protected(_)));
+        let mut cross_phase = value;
+        cross_phase["resume"]["normalizedEmail"] = "must-not-cross-phases".into();
+        assert!(serde_json::from_value::<AccountSetupResponse>(cross_phase).is_err());
 
         let public = serde_json::to_string(&AccountSetupResponse::View(AccountSetupView {
             worker_protocol_version: ACCOUNT_SETUP_PROTOCOL_VERSION,

--- a/rust/tonk-worker/Cargo.toml
+++ b/rust/tonk-worker/Cargo.toml
@@ -80,6 +80,7 @@ web-sys = { workspace = true, features = [
     "Cache",
     "CacheStorage",
     "Client",
+    "ClientQueryOptions",
     "Clients",
     "CryptoKey",
     "ExtendableEvent",

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -18,9 +18,6 @@ pub use claim::{AssertPath, AssertResponse, ClaimQuery, ClaimResponse, QueryResp
 
 mod account;
 mod account_deletion;
-// This lower-stack module defines and tests the durable protocol before the
-// next PR wires effects and routes to it.
-#[allow(dead_code)]
 mod account_setup;
 pub(crate) mod customer;
 #[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
@@ -179,6 +176,12 @@ pub fn api_router_from_state(state: AppState) -> (Router, Arc<LspHub>) {
         .route("/api/account", get(account::get).delete(account::unlink))
         .route("/api/account/deletion/plan", get(account_deletion::plan))
         .route("/api/account/delete", post(account_deletion::delete))
+        .route(
+            "/api/account/setup",
+            post(account_setup::handle).layer(DefaultBodyLimit::max(
+                account_setup::ACCOUNT_SETUP_BODY_LIMIT,
+            )),
+        )
         .route(
             "/api/account/spaces/delete",
             post(account_deletion::delete_space),
@@ -565,6 +568,7 @@ pub mod tests {
             sync_queue: Default::default(),
             commands: super::command_registry(),
             clients: Default::default(),
+            account_setup_lock: Default::default(),
             account_keys: Default::default(),
             registry,
         }

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -114,6 +114,8 @@ pub use host::{ClientId, ViewBinding, ViewBindings};
 
 mod blob;
 
+mod browser_lock;
+
 mod migration;
 
 mod navigate;
@@ -562,6 +564,7 @@ pub mod tests {
             storage,
             session_expires_at: session.expires_at,
             profile_name,
+            service_origin: None,
             reactor,
             view_bindings: Default::default(),
             bridges: Default::default(),
@@ -569,6 +572,7 @@ pub mod tests {
             commands: super::command_registry(),
             clients: Default::default(),
             account_setup_lock: Default::default(),
+            pending_work_lock: Default::default(),
             account_keys: Default::default(),
             registry,
         }

--- a/rust/tonk-worker/src/router/account.rs
+++ b/rust/tonk-worker/src/router/account.rs
@@ -29,7 +29,7 @@ fn provider_error(error: tonk_account::AccountProviderError) -> TonkWorkerError 
     }
 }
 
-async fn load_provider(
+pub(crate) async fn load_provider(
     state: &crate::worker::TonkState,
     root_did: &dialog_varsig::Did,
 ) -> Result<Option<AccountProviderRecord>, TonkWorkerError> {
@@ -54,6 +54,34 @@ async fn load_provider(
         .map_err(|error| {
             TonkWorkerError::Internal(format!("stored account provider is unusable: {error}"))
         })
+}
+
+/// Exact attachment observation for monotonic account-setup reconciliation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AttachmentObservation {
+    Missing,
+    Exact,
+    Mismatch,
+}
+
+pub(crate) async fn observe_attachment(
+    state: &crate::worker::TonkState,
+    root_did: &dialog_varsig::Did,
+    provider: &str,
+    descriptor: &[u8],
+) -> Result<AttachmentObservation, TonkWorkerError> {
+    let Some(record) = load_provider(state, root_did).await? else {
+        return Ok(AttachmentObservation::Missing);
+    };
+    let exact = record.provider() == provider
+        && record
+            .descriptor()
+            .is_some_and(|stored| stored.bytes() == descriptor);
+    Ok(if exact {
+        AttachmentObservation::Exact
+    } else {
+        AttachmentObservation::Mismatch
+    })
 }
 
 async fn save_provider(

--- a/rust/tonk-worker/src/router/account_setup.rs
+++ b/rust/tonk-worker/src/router/account_setup.rs
@@ -211,6 +211,8 @@ struct StoredRecoveryBundleV1 {
     /// Fresh exact-semantic replay invocation. The immutable original remains
     /// manifest-bound; replacing it would invalidate the anti-mix signature.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    replacement_invocation_created_at: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     replacement_invocation_hex: Option<String>,
     #[serde(default)]
     deposits_hex: Vec<String>,
@@ -218,6 +220,12 @@ struct StoredRecoveryBundleV1 {
     consent_hex: String,
     sealed_hex: String,
     publish_invocation_hex: String,
+    /// Fresh exact-semantic custody publish authorization. The immutable
+    /// manifest-bound original remains retained for anti-mix validation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    replacement_publish_invocation_created_at: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    replacement_publish_invocation_hex: Option<String>,
     recovery_manifest_hex: String,
 }
 
@@ -517,6 +525,7 @@ struct ValidatedRecoveryBundle {
     delegation: DelegationChain,
     descriptor: AccountRepositoryDescriptorV1,
     create_invocation: InvocationChain<AnySignature>,
+    publish_invocation: InvocationChain<AnySignature>,
     recovery_hash: String,
     #[cfg(test)]
     create_expires_at: u64,
@@ -577,12 +586,20 @@ impl ValidatedRecoveryBundle {
             CREATE_EXPIRY_MIN_OFFSET,
             CREATE_EXPIRY_MAX_OFFSET,
         )?;
-        let replacement_invocation = match decoded.replacement_invocation.as_deref() {
-            Some(bytes) => Some(
-                validate_replacement_invocation(bytes, &stored, &root_did, passkey, trust.now)
+        let replacement_invocation = match (
+            stored.replacement_invocation_created_at,
+            decoded.replacement_invocation.as_deref(),
+        ) {
+            (Some(created_at), Some(bytes)) if created_at > 0 => Some(
+                validate_replacement_invocation(bytes, &stored, &root_did, passkey, created_at)
                     .await?,
             ),
-            None => None,
+            (None, None) => None,
+            _ => {
+                return Err(RecoveryValidationError::Invalid(
+                    "replacement_invocation_reference",
+                ));
+            }
         };
 
         let fingerprint = AccountCreationFingerprint::from_hex(&stored.create_fingerprint)
@@ -645,6 +662,26 @@ impl ValidatedRecoveryBundle {
             PUBLISH_EXPIRY_MIN_OFFSET,
             PUBLISH_EXPIRY_MAX_OFFSET,
         )?;
+        let replacement_publish_invocation = match (
+            stored.replacement_publish_invocation_created_at,
+            decoded.replacement_publish_invocation.as_deref(),
+        ) {
+            (Some(created_at), Some(bytes)) if created_at > 0 => Some(
+                validate_replacement_publish_invocation(
+                    bytes,
+                    &custody_did,
+                    &decoded.sealed,
+                    created_at,
+                )
+                .await?,
+            ),
+            (None, None) => None,
+            _ => {
+                return Err(RecoveryValidationError::Invalid(
+                    "replacement_publish_invocation_reference",
+                ));
+            }
+        };
 
         let service_did = trust.service_did.as_ref().map(ToString::to_string);
         AccountSetupRecoveryManifestV1::validate(
@@ -682,17 +719,22 @@ impl ValidatedRecoveryBundle {
             .as_ref()
             .and_then(|chain| chain.invocation.expiration())
             .map_or(create_expires_at, |expiration| expiration.to_unix());
+        let effective_publish_expires_at = replacement_publish_invocation
+            .as_ref()
+            .and_then(|chain| chain.invocation.expiration())
+            .map_or(publish_expires_at, |expiration| expiration.to_unix());
         Ok(Self {
             stored,
             root_did,
             delegation,
             descriptor,
             create_invocation: replacement_invocation.unwrap_or(create_invocation),
+            publish_invocation: replacement_publish_invocation.unwrap_or(publish_invocation),
             recovery_hash,
             #[cfg(test)]
             create_expires_at,
             create_freshness: freshness(effective_expires_at, trust.now),
-            publish_freshness: freshness(publish_expires_at, trust.now),
+            publish_freshness: freshness(effective_publish_expires_at, trust.now),
         })
     }
 
@@ -735,6 +777,13 @@ impl ValidatedRecoveryBundle {
             .to_bytes()
             .map_err(|_| RecoveryValidationError::Artifact("create"))
     }
+
+    fn publish_invocation_hex(&self) -> Result<String, RecoveryValidationError> {
+        self.publish_invocation
+            .to_bytes()
+            .map(hex::encode)
+            .map_err(|_| RecoveryValidationError::Artifact("publish"))
+    }
 }
 
 struct DecodedRecovery {
@@ -746,6 +795,7 @@ struct DecodedRecovery {
     consent: Vec<u8>,
     sealed: Vec<u8>,
     publish_invocation: Vec<u8>,
+    replacement_publish_invocation: Option<Vec<u8>>,
     manifest: Vec<u8>,
 }
 
@@ -875,6 +925,13 @@ enum RecoveryLoad {
     Unsupported,
 }
 
+enum SetupLoad {
+    Missing,
+    Ready(Box<ValidatedCheckpoint>),
+    Corrupt,
+    Unsupported(Option<u16>),
+}
+
 async fn load_recovery(store: &impl SetupStore) -> Result<RecoveryLoad, SetupStoreError> {
     let Some(bytes) = store.load_recovery().await? else {
         return Ok(RecoveryLoad::Missing);
@@ -888,6 +945,60 @@ async fn load_recovery(store: &impl SetupStore) -> Result<RecoveryLoad, SetupSto
         ) => RecoveryLoad::Unsupported,
         Err(_) => RecoveryLoad::Corrupt,
     })
+}
+
+async fn load_setup(store: &impl SetupStore) -> Result<SetupLoad, SetupStoreError> {
+    match load_checkpoint(store).await? {
+        CheckpointLoad::Missing => match load_recovery(store).await? {
+            RecoveryLoad::Missing => Ok(SetupLoad::Missing),
+            RecoveryLoad::Unsupported => Ok(SetupLoad::Unsupported(None)),
+            RecoveryLoad::Bundle(_) | RecoveryLoad::Tombstone(_) | RecoveryLoad::Corrupt => {
+                Ok(SetupLoad::Corrupt)
+            }
+        },
+        CheckpointLoad::Ready(checkpoint) => match load_recovery(store).await? {
+            RecoveryLoad::Unsupported => Ok(SetupLoad::Unsupported(None)),
+            RecoveryLoad::Corrupt => Ok(SetupLoad::Corrupt),
+            recovery if recovery_shape_matches(&checkpoint, &recovery) => {
+                Ok(SetupLoad::Ready(checkpoint))
+            }
+            RecoveryLoad::Missing | RecoveryLoad::Bundle(_) | RecoveryLoad::Tombstone(_) => {
+                Ok(SetupLoad::Corrupt)
+            }
+        },
+        CheckpointLoad::Corrupt => Ok(SetupLoad::Corrupt),
+        CheckpointLoad::Unsupported(version) => Ok(SetupLoad::Unsupported(version)),
+    }
+}
+
+fn recovery_shape_matches(checkpoint: &ValidatedCheckpoint, recovery: &RecoveryLoad) -> bool {
+    let stored = checkpoint.as_stored();
+    match (&stored.phase, recovery) {
+        (
+            StoredPhaseV2::Leased
+            | StoredPhaseV2::Cancelled
+            | StoredPhaseV2::InterruptedBeforeRecovery,
+            RecoveryLoad::Missing,
+        )
+        | (StoredPhaseV2::Armed, RecoveryLoad::Missing | RecoveryLoad::Bundle(_))
+        | (
+            StoredPhaseV2::RecoveryStaged
+            | StoredPhaseV2::RootSaved
+            | StoredPhaseV2::ProviderAccepted
+            | StoredPhaseV2::Attached
+            | StoredPhaseV2::CustomerEnrolled
+            | StoredPhaseV2::CustodyQueued
+            | StoredPhaseV2::Conflict { .. },
+            RecoveryLoad::Bundle(_),
+        )
+        | (StoredPhaseV2::Complete, RecoveryLoad::Bundle(_)) => true,
+        (StoredPhaseV2::Complete, RecoveryLoad::Tombstone(tombstone)) => {
+            tombstone.operation_id == stored.operation_id
+                && Some(tombstone.recovery_hash.as_str()) == stored.recovery_hash.as_deref()
+        }
+        (_, RecoveryLoad::Corrupt | RecoveryLoad::Unsupported) => false,
+        _ => false,
+    }
 }
 
 async fn save_recovery(
@@ -930,19 +1041,17 @@ struct ProviderCapabilityVersions {
     account_setup_recovery: u16,
 }
 
-async fn resolve_setup_context(
-    origin: &crate::axum::RequestOrigin,
-) -> Result<CanonicalSetupContext, ()> {
-    let config_url = origin.url().join(".well-known/tonk").map_err(|_| ())?;
+async fn resolve_setup_context(origin: &Url) -> Result<CanonicalSetupContext, ()> {
+    let config_url = origin.join(".well-known/tonk").map_err(|_| ())?;
     let response = super::http::get(&config_url).await.map_err(|_| ())?;
     if response.body.len() > MAX_PROVIDER_RESPONSE_BYTES {
         return Err(());
     }
     let config: tonk_worker_api::DeploymentConfig =
         serde_json::from_slice(&response.body).map_err(|_| ())?;
-    let service_origin = canonical_base_url(origin.url().clone())?;
+    let service_origin = canonical_base_url(origin.clone())?;
     let provider = canonical_base_url(config.account_service_url)?;
-    let remote = canonical_base_url(origin.url().join("ucan/").map_err(|_| ())?)?;
+    let remote = canonical_base_url(origin.join("ucan/").map_err(|_| ())?)?;
     let service_did = config
         .service_did
         .map(|value| value.parse::<Did>().map_err(|_| ()))
@@ -955,6 +1064,27 @@ async fn resolve_setup_context(
         service_did,
         configuration_hash,
     })
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+trait SetupContextSource {
+    async fn resolve(&self, origin: &Url) -> Result<CanonicalSetupContext, ()>;
+    async fn supports_recovery(&self, context: &CanonicalSetupContext) -> bool;
+}
+
+struct HttpSetupContextSource;
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl SetupContextSource for HttpSetupContextSource {
+    async fn resolve(&self, origin: &Url) -> Result<CanonicalSetupContext, ()> {
+        resolve_setup_context(origin).await
+    }
+
+    async fn supports_recovery(&self, context: &CanonicalSetupContext) -> bool {
+        provider_supports_recovery(context).await
+    }
 }
 
 fn canonical_base_url(mut url: Url) -> Result<Url, ()> {
@@ -1035,63 +1165,6 @@ fn now_seconds() -> u64 {
         .as_secs()
 }
 
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-struct CrossWorkerSetupGuard(Option<tokio::sync::oneshot::Sender<()>>);
-
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-struct CrossWorkerSetupGuard;
-
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-impl Drop for CrossWorkerSetupGuard {
-    fn drop(&mut self) {
-        if let Some(release) = self.0.take() {
-            let _ = release.send(());
-        }
-    }
-}
-
-/// Acquire the profile-scoped browser Web Lock. There is intentionally no
-/// fallback to the per-worker mutex: without this lock two coexisting worker
-/// generations cannot prove exclusive ownership before WebAuthn is armed.
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-async fn acquire_cross_worker_setup_lock(lock_name: &str) -> Result<CrossWorkerSetupGuard, ()> {
-    use wasm_bindgen::{JsCast as _, JsValue, closure::Closure};
-    use wasm_bindgen_futures::{JsFuture, future_to_promise, spawn_local};
-
-    let global = js_sys::global();
-    let navigator =
-        js_sys::Reflect::get(&global, &JsValue::from_str("navigator")).map_err(|_| ())?;
-    let locks = js_sys::Reflect::get(&navigator, &JsValue::from_str("locks")).map_err(|_| ())?;
-    let request: js_sys::Function = js_sys::Reflect::get(&locks, &JsValue::from_str("request"))
-        .map_err(|_| ())?
-        .dyn_into()
-        .map_err(|_| ())?;
-    let (acquired_tx, acquired_rx) = tokio::sync::oneshot::channel();
-    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
-    let callback = Closure::once_into_js(move |_lock: JsValue| -> js_sys::Promise {
-        let _ = acquired_tx.send(());
-        future_to_promise(async move {
-            let _ = release_rx.await;
-            Ok(JsValue::UNDEFINED)
-        })
-    });
-    let request_promise: js_sys::Promise = request
-        .call2(&locks, &JsValue::from_str(lock_name), &callback)
-        .map_err(|_| ())?
-        .dyn_into()
-        .map_err(|_| ())?;
-    spawn_local(async move {
-        let _ = JsFuture::from(request_promise).await;
-    });
-    acquired_rx.await.map_err(|_| ())?;
-    Ok(CrossWorkerSetupGuard(Some(release_tx)))
-}
-
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-async fn acquire_cross_worker_setup_lock(_lock_name: &str) -> Result<CrossWorkerSetupGuard, ()> {
-    Ok(CrossWorkerSetupGuard)
-}
-
 async fn mark_request_client_live(state: &crate::worker::TonkState, client: &crate::ClientId) {
     let mut clients = state.clients.write().await;
     clients.entry(client.clone()).or_default().seen_live = true;
@@ -1146,13 +1219,22 @@ enum ProviderSetupStatus {
 enum ProviderPortError {
     Retry,
     Invalid,
+    Conflict,
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 trait AccountSetupProvider {
-    async fn status(&self, invocation: &[u8]) -> Result<ProviderSetupStatus, ProviderPortError>;
-    async fn create(&self, invocation: &[u8]) -> Result<ProviderAcceptance, ProviderPortError>;
+    async fn status(
+        &self,
+        context: &CanonicalSetupContext,
+        invocation: &[u8],
+    ) -> Result<ProviderSetupStatus, ProviderPortError>;
+    async fn create(
+        &self,
+        context: &CanonicalSetupContext,
+        invocation: &[u8],
+    ) -> Result<ProviderAcceptance, ProviderPortError>;
 }
 
 #[derive(PartialEq, Eq)]
@@ -1168,27 +1250,33 @@ enum ProviderResolution {
 /// result permits an exact replay of a still-fresh invocation.
 async fn resolve_provider_acceptance(
     provider: &impl AccountSetupProvider,
+    context: &CanonicalSetupContext,
     status_invocation: &[u8],
     create_invocation: &[u8],
     freshness: RecoveryFreshness,
 ) -> ProviderResolution {
-    match provider.status(status_invocation).await {
+    match provider.status(context, status_invocation).await {
         Ok(ProviderSetupStatus::Accepted(accepted)) => ProviderResolution::Accepted(accepted),
         Ok(ProviderSetupStatus::Mismatch) => ProviderResolution::Mismatch,
         Ok(ProviderSetupStatus::Absent) if freshness == RecoveryFreshness::NeedsRefresh => {
             ProviderResolution::NeedsPasskey
         }
-        Ok(ProviderSetupStatus::Absent) => match provider.create(create_invocation).await {
-            Ok(accepted) => ProviderResolution::Accepted(accepted),
-            Err(ProviderPortError::Retry | ProviderPortError::Invalid) => ProviderResolution::Retry,
-        },
-        Err(ProviderPortError::Retry | ProviderPortError::Invalid) => ProviderResolution::Retry,
+        Ok(ProviderSetupStatus::Absent) => {
+            match provider.create(context, create_invocation).await {
+                Ok(accepted) => ProviderResolution::Accepted(accepted),
+                Err(ProviderPortError::Conflict) => ProviderResolution::Mismatch,
+                Err(ProviderPortError::Retry | ProviderPortError::Invalid) => {
+                    ProviderResolution::Retry
+                }
+            }
+        }
+        Err(
+            ProviderPortError::Retry | ProviderPortError::Invalid | ProviderPortError::Conflict,
+        ) => ProviderResolution::Retry,
     }
 }
 
-struct HttpAccountSetupProvider<'a> {
-    context: &'a CanonicalSetupContext,
-}
+struct HttpAccountSetupProvider;
 
 #[derive(Deserialize)]
 #[serde(
@@ -1216,12 +1304,24 @@ struct ProviderCreateBody {
     reused: bool,
 }
 
+fn classify_provider_create_error(error: &super::http::HttpError) -> ProviderPortError {
+    match error {
+        super::http::HttpError::Upstream(failure) if failure.status == 409 => {
+            ProviderPortError::Conflict
+        }
+        _ => ProviderPortError::Retry,
+    }
+}
+
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl AccountSetupProvider for HttpAccountSetupProvider<'_> {
-    async fn status(&self, invocation: &[u8]) -> Result<ProviderSetupStatus, ProviderPortError> {
-        let endpoint = self
-            .context
+impl AccountSetupProvider for HttpAccountSetupProvider {
+    async fn status(
+        &self,
+        context: &CanonicalSetupContext,
+        invocation: &[u8],
+    ) -> Result<ProviderSetupStatus, ProviderPortError> {
+        let endpoint = context
             .provider
             .join("accounts/setup-status")
             .map_err(|_| ProviderPortError::Invalid)?;
@@ -1246,15 +1346,19 @@ impl AccountSetupProvider for HttpAccountSetupProvider<'_> {
         }
     }
 
-    async fn create(&self, invocation: &[u8]) -> Result<ProviderAcceptance, ProviderPortError> {
-        let endpoint = self
-            .context
+    async fn create(
+        &self,
+        context: &CanonicalSetupContext,
+        invocation: &[u8],
+    ) -> Result<ProviderAcceptance, ProviderPortError> {
+        let endpoint = context
             .provider
             .join("accounts")
             .map_err(|_| ProviderPortError::Invalid)?;
-        let response = super::http::post_cbor(&endpoint, invocation)
-            .await
-            .map_err(|_| ProviderPortError::Retry)?;
+        let response = match super::http::post_cbor(&endpoint, invocation).await {
+            Ok(response) => response,
+            Err(error) => return Err(classify_provider_create_error(&error)),
+        };
         if !matches!(response.status, 200 | 201)
             || response.body.len() > MAX_PROVIDER_RESPONSE_BYTES
         {
@@ -1297,6 +1401,164 @@ async fn client_is_live(state: &crate::worker::TonkState, client: &str) -> bool 
         .await
         .get(&crate::ClientId(client.to_owned()))
         .is_some_and(|entry| entry.seen_live)
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+trait SetupEffects {
+    fn device_did(&self) -> Did;
+    fn now_seconds(&self) -> u64;
+    async fn client_is_live(&self, client: &str) -> bool;
+    async fn observe_root(
+        &self,
+        expected_root_did: &str,
+        request: &SaveRootRequest,
+    ) -> Result<super::identity::LocalRootObservation, ()>;
+    async fn persist_root(&self, request: SaveRootRequest) -> Result<(), ()>;
+    async fn build_status_invocation(
+        &self,
+        delegation: &DelegationChain,
+        create_fingerprint: &str,
+    ) -> Result<Vec<u8>, ()>;
+    async fn observe_attachment(
+        &self,
+        root_did: &Did,
+        provider: &str,
+        descriptor: &[u8],
+    ) -> Result<super::account::AttachmentObservation, ()>;
+    async fn persist_attachment(&self, request: &AccountLinkRequest) -> Result<(), ()>;
+    async fn ensure_account_state(&self) -> bool;
+    async fn observe_customer(
+        &self,
+        expected_root: &str,
+        expected_email: &str,
+    ) -> Result<super::customer::CustomerObservation, ()>;
+    async fn enroll_customer(
+        &self,
+        origin: &Url,
+        email: String,
+        deposits: &[String],
+    ) -> Result<(), ()>;
+    async fn persist_custody_setup(
+        &self,
+        custody: &str,
+        consent_hex: &str,
+        sealed_hex: &str,
+        invocation_hex: &str,
+    ) -> Result<(), ()>;
+}
+
+struct WorkerSetupEffects<'a> {
+    state: &'a crate::worker::TonkState,
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl SetupEffects for WorkerSetupEffects<'_> {
+    fn device_did(&self) -> Did {
+        self.state.profile.did()
+    }
+
+    fn now_seconds(&self) -> u64 {
+        now_seconds()
+    }
+
+    async fn client_is_live(&self, client: &str) -> bool {
+        client_is_live(self.state, client).await
+    }
+
+    async fn observe_root(
+        &self,
+        expected_root_did: &str,
+        request: &SaveRootRequest,
+    ) -> Result<super::identity::LocalRootObservation, ()> {
+        super::identity::observe_root(self.state, expected_root_did, request)
+            .await
+            .map_err(|_| ())
+    }
+
+    async fn persist_root(&self, request: SaveRootRequest) -> Result<(), ()> {
+        super::identity::persist_root(self.state, request)
+            .await
+            .map(|_| ())
+            .map_err(|_| ())
+    }
+
+    async fn build_status_invocation(
+        &self,
+        delegation: &DelegationChain,
+        create_fingerprint: &str,
+    ) -> Result<Vec<u8>, ()> {
+        tonk_identity::request::build_account_setup_status_invocation(
+            self.state.profile.signer().signer().clone(),
+            delegation,
+            create_fingerprint,
+        )
+        .await
+        .map_err(|_| ())
+    }
+
+    async fn observe_attachment(
+        &self,
+        root_did: &Did,
+        provider: &str,
+        descriptor: &[u8],
+    ) -> Result<super::account::AttachmentObservation, ()> {
+        super::account::observe_attachment(self.state, root_did, provider, descriptor)
+            .await
+            .map_err(|_| ())
+    }
+
+    async fn persist_attachment(&self, request: &AccountLinkRequest) -> Result<(), ()> {
+        super::account::persist_link(self.state, request)
+            .await
+            .map_err(|_| ())
+    }
+
+    async fn ensure_account_state(&self) -> bool {
+        super::account_state::ensure_account_state(self.state).await
+            == tonk_account::AccountStateStatus::Ready
+    }
+
+    async fn observe_customer(
+        &self,
+        expected_root: &str,
+        expected_email: &str,
+    ) -> Result<super::customer::CustomerObservation, ()> {
+        super::customer::observe_customer(self.state, expected_root, expected_email)
+            .await
+            .map_err(|_| ())
+    }
+
+    async fn enroll_customer(
+        &self,
+        origin: &Url,
+        email: String,
+        deposits: &[String],
+    ) -> Result<(), ()> {
+        super::customer::enroll_customer(self.state, origin, Some(email), deposits)
+            .await
+            .map(|_| ())
+            .map_err(|_| ())
+    }
+
+    async fn persist_custody_setup(
+        &self,
+        custody: &str,
+        consent_hex: &str,
+        sealed_hex: &str,
+        invocation_hex: &str,
+    ) -> Result<(), ()> {
+        super::customer::persist_custody_setup(
+            self.state,
+            custody,
+            consent_hex,
+            sealed_hex,
+            invocation_hex,
+        )
+        .await
+        .map_err(|_| ())
+    }
 }
 
 fn decode_bounded_recovery(
@@ -1366,6 +1628,17 @@ fn decode_bounded_recovery(
         &stored.publish_invocation_hex,
         MAX_INVOCATION_BYTES,
     )?;
+    let replacement_publish_invocation = stored
+        .replacement_publish_invocation_hex
+        .as_deref()
+        .map(|value| {
+            decode_hex_field(
+                "replacement_publish_invocation",
+                value,
+                MAX_INVOCATION_BYTES,
+            )
+        })
+        .transpose()?;
     let manifest = decode_hex_field(
         "recovery_manifest",
         &stored.recovery_manifest_hex,
@@ -1379,6 +1652,7 @@ fn decode_bounded_recovery(
         consent.len(),
         sealed.len(),
         publish_invocation.len(),
+        replacement_publish_invocation.as_ref().map_or(0, Vec::len),
         manifest.len(),
     ]
     .into_iter()
@@ -1402,6 +1676,7 @@ fn decode_bounded_recovery(
         consent,
         sealed,
         publish_invocation,
+        replacement_publish_invocation,
         manifest,
     })
 }
@@ -1411,7 +1686,10 @@ fn recovery_hash(stored: &StoredRecoveryBundleV1) -> Result<String, RecoveryVali
     // manifest and immutable recovery identity. Hash the original bundle so a
     // freshness repair cannot detach the checkpoint or tombstone from it.
     let mut original = stored.clone();
+    original.replacement_invocation_created_at = None;
     original.replacement_invocation_hex = None;
+    original.replacement_publish_invocation_created_at = None;
+    original.replacement_publish_invocation_hex = None;
     let record_bytes = encode_recovery(&StoredRecoveryRecord::Bundle(Box::new(original)))
         .map_err(|_| RecoveryValidationError::Invalid("recovery_record"))?;
     Ok(blake3::hash(&record_bytes).to_hex().to_string())
@@ -1595,7 +1873,7 @@ async fn validate_replacement_invocation(
     stored: &StoredRecoveryBundleV1,
     root: &Did,
     passkey: &PasskeyMetadata,
-    now: u64,
+    created_at: u64,
 ) -> Result<InvocationChain<AnySignature>, RecoveryValidationError> {
     let chain = parse_canonical_self_invocation(
         bytes,
@@ -1609,16 +1887,16 @@ async fn validate_replacement_invocation(
         .expiration()
         .ok_or(RecoveryValidationError::Artifact("replacement_expiration"))?
         .to_unix();
-    let min = now
+    let min = created_at
         .checked_add(CREATE_EXPIRY_MIN_OFFSET)
         .ok_or(RecoveryValidationError::Timestamp)?;
-    let max = now
+    let max = created_at
         .checked_add(CREATE_EXPIRY_MAX_OFFSET)
         .ok_or(RecoveryValidationError::Timestamp)?;
     if expires_at < min || expires_at > max {
         return Err(RecoveryValidationError::Artifact("replacement_expiration"));
     }
-    verify_invocation_exact_at(&chain, now, "replacement_invocation").await?;
+    verify_invocation_exact_at(&chain, created_at, "replacement_invocation").await?;
     Ok(chain)
 }
 
@@ -1732,6 +2010,50 @@ async fn validate_publish_invocation(
     ceremony_created_at: u64,
 ) -> Result<InvocationChain<AnySignature>, RecoveryValidationError> {
     let chain = parse_canonical_self_invocation(bytes, custody, &["memory", "publish"], "publish")?;
+    validate_publish_arguments(&chain, sealed)?;
+    verify_invocation_at(&chain, ceremony_created_at, "publish").await?;
+    Ok(chain)
+}
+
+async fn validate_replacement_publish_invocation(
+    bytes: &[u8],
+    custody: &Did,
+    sealed: &[u8],
+    created_at: u64,
+) -> Result<InvocationChain<AnySignature>, RecoveryValidationError> {
+    let chain = parse_canonical_self_invocation(
+        bytes,
+        custody,
+        &["memory", "publish"],
+        "replacement_publish_invocation",
+    )?;
+    validate_publish_arguments(&chain, sealed)?;
+    let expires_at = chain
+        .invocation
+        .expiration()
+        .ok_or(RecoveryValidationError::Artifact(
+            "replacement_publish_expiration",
+        ))?
+        .to_unix();
+    let min = created_at
+        .checked_add(PUBLISH_EXPIRY_MIN_OFFSET)
+        .ok_or(RecoveryValidationError::Timestamp)?;
+    let max = created_at
+        .checked_add(PUBLISH_EXPIRY_MAX_OFFSET)
+        .ok_or(RecoveryValidationError::Timestamp)?;
+    if expires_at < min || expires_at > max {
+        return Err(RecoveryValidationError::Artifact(
+            "replacement_publish_expiration",
+        ));
+    }
+    verify_invocation_exact_at(&chain, created_at, "replacement_publish_invocation").await?;
+    Ok(chain)
+}
+
+fn validate_publish_arguments(
+    chain: &InvocationChain<AnySignature>,
+    sealed: &[u8],
+) -> Result<(), RecoveryValidationError> {
     let arguments = chain.arguments();
     let checksum = match arguments.get("checksum") {
         Some(Promised::Bytes(bytes)) => Checksum::try_from(bytes.clone())
@@ -1746,8 +2068,7 @@ async fn validate_publish_invocation(
     {
         return Err(RecoveryValidationError::Artifact("publish_arguments"));
     }
-    verify_invocation_at(&chain, ceremony_created_at, "publish").await?;
-    Ok(chain)
+    Ok(())
 }
 
 fn parse_canonical_self_invocation(
@@ -2516,13 +2837,19 @@ fn retry_view(checkpoint: &ValidatedCheckpoint) -> AccountSetupView {
     view
 }
 
+#[derive(Clone, Copy)]
+enum PasskeyRefresh {
+    Create,
+    Publish,
+}
+
 fn needs_passkey_response(
     recovery: &ValidatedRecoveryBundle,
     view: AccountSetupView,
+    refresh: PasskeyRefresh,
 ) -> AccountSetupResponse {
-    AccountSetupResponse::Protected(AccountSetupProtectedResponse::NeedsPasskey {
-        view,
-        resume: AccountSetupResumeInput {
+    let resume = match refresh {
+        PasskeyRefresh::Create => AccountSetupResumeInput::Create {
             operation_id: recovery.stored.operation_id.clone(),
             credential_id: recovery.stored.credential_id.clone(),
             expected_root_did: recovery.stored.root_did.clone(),
@@ -2534,7 +2861,18 @@ fn needs_passkey_response(
             passkey: recovery.stored.passkey.clone(),
             sealed_hex: recovery.stored.sealed_hex.clone(),
         },
-    })
+        PasskeyRefresh::Publish => AccountSetupResumeInput::Publish {
+            operation_id: recovery.stored.operation_id.clone(),
+            credential_id: recovery.stored.credential_id.clone(),
+            expected_root_did: recovery.stored.root_did.clone(),
+            custody_did: recovery.stored.custody_did.clone(),
+            sealed_hex: recovery.stored.sealed_hex.clone(),
+        },
+    };
+    AccountSetupResponse::Protected(Box::new(AccountSetupProtectedResponse::NeedsPasskey {
+        view,
+        resume,
+    }))
 }
 
 fn owns_checkpoint(
@@ -2603,12 +2941,15 @@ fn stored_recovery_from_wire(
         descriptor_hex: recovery.descriptor_hex,
         create_fingerprint: recovery.create_fingerprint,
         invocation_hex: recovery.invocation_hex,
+        replacement_invocation_created_at: None,
         replacement_invocation_hex: None,
         deposits_hex: recovery.deposits_hex,
         custody_did: recovery.custody_did,
         consent_hex: recovery.consent_hex,
         sealed_hex: recovery.sealed_hex,
         publish_invocation_hex: recovery.publish_invocation_hex,
+        replacement_publish_invocation_created_at: None,
+        replacement_publish_invocation_hex: None,
         recovery_manifest_hex: recovery.recovery_manifest_hex,
     }
 }
@@ -2857,7 +3198,7 @@ async fn repair_completion_tombstone(
 }
 
 async fn reconcile_with_provider(
-    state: &crate::worker::TonkState,
+    effects: &impl SetupEffects,
     store: &impl SetupStore,
     provider: &impl AccountSetupProvider,
     context: &CanonicalSetupContext,
@@ -2866,13 +3207,13 @@ async fn reconcile_with_provider(
     client_id: &str,
 ) -> Result<AccountSetupResponse, SetupStoreError> {
     loop {
-        let now = now_seconds();
+        let now = effects.now_seconds();
         if checkpoint.as_stored().phase == StoredPhaseV2::Complete {
             return match repair_completion_tombstone(
                 store,
                 &checkpoint,
                 context,
-                state.profile.did(),
+                effects.device_did(),
                 now,
             )
             .await?
@@ -2933,7 +3274,7 @@ async fn reconcile_with_provider(
             bundle,
             &checkpoint,
             context,
-            state.profile.did(),
+            effects.device_did(),
             now,
         )
         .await
@@ -2958,15 +3299,13 @@ async fn reconcile_with_provider(
                     passkey: recovery.stored.passkey.clone(),
                     encryption_key: recovery.stored.encryption_key.clone(),
                 };
-                match super::identity::observe_root(state, &recovery.stored.root_did, &request)
+                match effects
+                    .observe_root(&recovery.stored.root_did, &request)
                     .await
                     .map_err(|_| SetupStoreError::Read)?
                 {
                     super::identity::LocalRootObservation::Missing => {
-                        if super::identity::persist_root(state, request.clone())
-                            .await
-                            .is_err()
-                        {
+                        if effects.persist_root(request.clone()).await.is_err() {
                             return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
                         }
                     }
@@ -2981,7 +3320,8 @@ async fn reconcile_with_provider(
                         .await;
                     }
                 }
-                if super::identity::observe_root(state, &recovery.stored.root_did, &request)
+                if effects
+                    .observe_root(&recovery.stored.root_did, &request)
                     .await
                     .ok()
                     != Some(super::identity::LocalRootObservation::Exact)
@@ -3002,22 +3342,22 @@ async fn reconcile_with_provider(
                 .await?;
             }
             StoredPhaseV2::RootSaved => {
-                let status_invocation =
-                    match tonk_identity::request::build_account_setup_status_invocation(
-                        state.profile.signer().signer().clone(),
+                let status_invocation = match effects
+                    .build_status_invocation(
                         recovery.delegation(),
                         &recovery.stored.create_fingerprint,
                     )
                     .await
-                    {
-                        Ok(invocation) => invocation,
-                        Err(_) => return Ok(AccountSetupResponse::View(retry_view(&checkpoint))),
-                    };
+                {
+                    Ok(invocation) => invocation,
+                    Err(_) => return Ok(AccountSetupResponse::View(retry_view(&checkpoint))),
+                };
                 let create_invocation = recovery
                     .create_invocation_bytes()
                     .map_err(|_| SetupStoreError::Read)?;
                 let accepted = match resolve_provider_acceptance(
                     provider,
+                    context,
                     &status_invocation,
                     &create_invocation,
                     recovery.create_freshness(),
@@ -3035,7 +3375,7 @@ async fn reconcile_with_provider(
                         .await;
                     }
                     ProviderResolution::NeedsPasskey => {
-                        if !client_is_live(state, client_id).await {
+                        if !effects.client_is_live(client_id).await {
                             return Ok(AccountSetupResponse::View(checkpoint_view(
                                 &checkpoint,
                                 false,
@@ -3044,7 +3384,11 @@ async fn reconcile_with_provider(
                         let mut view = checkpoint_view(&checkpoint, true);
                         view.disposition = AccountSetupDisposition::NeedsPasskey;
                         view.next_action = AccountSetupNextAction::ResumeWithPasskey;
-                        return Ok(needs_passkey_response(&recovery, view));
+                        return Ok(needs_passkey_response(
+                            &recovery,
+                            view,
+                            PasskeyRefresh::Create,
+                        ));
                     }
                     ProviderResolution::Retry => {
                         return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
@@ -3076,14 +3420,14 @@ async fn reconcile_with_provider(
                 .await?;
             }
             StoredPhaseV2::ProviderAccepted => {
-                match super::account::observe_attachment(
-                    state,
-                    recovery.root_did(),
-                    context.provider.as_str(),
-                    recovery.descriptor_bytes(),
-                )
-                .await
-                .map_err(|_| SetupStoreError::Read)?
+                match effects
+                    .observe_attachment(
+                        recovery.root_did(),
+                        context.provider.as_str(),
+                        recovery.descriptor_bytes(),
+                    )
+                    .await
+                    .map_err(|_| SetupStoreError::Read)?
                 {
                     super::account::AttachmentObservation::Missing => {
                         let link = AccountLinkRequest {
@@ -3094,7 +3438,7 @@ async fn reconcile_with_provider(
                             descriptor_hex: recovery.stored.descriptor_hex.clone(),
                             initialize_name: true,
                         };
-                        if super::account::persist_link(state, &link).await.is_err() {
+                        if effects.persist_attachment(&link).await.is_err() {
                             return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
                         }
                     }
@@ -3109,17 +3453,16 @@ async fn reconcile_with_provider(
                         .await;
                     }
                 }
-                if super::account::observe_attachment(
-                    state,
-                    recovery.root_did(),
-                    context.provider.as_str(),
-                    recovery.descriptor_bytes(),
-                )
-                .await
-                .ok()
+                if effects
+                    .observe_attachment(
+                        recovery.root_did(),
+                        context.provider.as_str(),
+                        recovery.descriptor_bytes(),
+                    )
+                    .await
+                    .ok()
                     != Some(super::account::AttachmentObservation::Exact)
-                    || super::account_state::ensure_account_state(state).await
-                        != tonk_account::AccountStateStatus::Ready
+                    || !effects.ensure_account_state().await
                 {
                     return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
                 }
@@ -3137,23 +3480,20 @@ async fn reconcile_with_provider(
                 .await?;
             }
             StoredPhaseV2::Attached => {
-                match super::customer::observe_customer(
-                    state,
-                    &recovery.stored.root_did,
-                    &recovery.stored.normalized_email,
-                )
-                .await
-                .map_err(|_| SetupStoreError::Read)?
+                match effects
+                    .observe_customer(&recovery.stored.root_did, &recovery.stored.normalized_email)
+                    .await
+                    .map_err(|_| SetupStoreError::Read)?
                 {
                     super::customer::CustomerObservation::Missing => {
-                        if super::customer::enroll_customer(
-                            state,
-                            &context.service_origin,
-                            Some(recovery.stored.normalized_email.clone()),
-                            &recovery.stored.deposits_hex,
-                        )
-                        .await
-                        .is_err()
+                        if effects
+                            .enroll_customer(
+                                &context.service_origin,
+                                recovery.stored.normalized_email.clone(),
+                                &recovery.stored.deposits_hex,
+                            )
+                            .await
+                            .is_err()
                         {
                             return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
                         }
@@ -3169,13 +3509,10 @@ async fn reconcile_with_provider(
                         .await;
                     }
                 }
-                if super::customer::observe_customer(
-                    state,
-                    &recovery.stored.root_did,
-                    &recovery.stored.normalized_email,
-                )
-                .await
-                .ok()
+                if effects
+                    .observe_customer(&recovery.stored.root_did, &recovery.stored.normalized_email)
+                    .await
+                    .ok()
                     != Some(super::customer::CustomerObservation::Exact)
                 {
                     return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
@@ -3195,17 +3532,33 @@ async fn reconcile_with_provider(
             }
             StoredPhaseV2::CustomerEnrolled => {
                 if recovery.publish_freshness() == RecoveryFreshness::NeedsRefresh {
-                    return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+                    if !effects.client_is_live(client_id).await {
+                        return Ok(AccountSetupResponse::View(checkpoint_view(
+                            &checkpoint,
+                            false,
+                        )));
+                    }
+                    let mut view = checkpoint_view(&checkpoint, true);
+                    view.disposition = AccountSetupDisposition::NeedsPasskey;
+                    view.next_action = AccountSetupNextAction::ResumeWithPasskey;
+                    return Ok(needs_passkey_response(
+                        &recovery,
+                        view,
+                        PasskeyRefresh::Publish,
+                    ));
                 }
-                if super::customer::persist_custody_setup(
-                    state,
-                    &recovery.stored.custody_did,
-                    &recovery.stored.consent_hex,
-                    &recovery.stored.sealed_hex,
-                    &recovery.stored.publish_invocation_hex,
-                )
-                .await
-                .is_err()
+                let publish_invocation_hex = recovery
+                    .publish_invocation_hex()
+                    .map_err(|_| SetupStoreError::Read)?;
+                if effects
+                    .persist_custody_setup(
+                        &recovery.stored.custody_did,
+                        &recovery.stored.consent_hex,
+                        &recovery.stored.sealed_hex,
+                        &publish_invocation_hex,
+                    )
+                    .await
+                    .is_err()
                 {
                     return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
                 }
@@ -3271,39 +3624,40 @@ async fn reconcile_with_provider(
 }
 
 async fn inspect_response(
-    state: &crate::worker::TonkState,
+    effects: &impl SetupEffects,
     store: &impl SetupStore,
-    origin: &crate::axum::RequestOrigin,
+    contexts: &impl SetupContextSource,
+    trusted_origin: &Url,
     owner_token: Option<&str>,
     client_id: &str,
 ) -> Result<AccountSetupResponse, SetupStoreError> {
-    let checkpoint = match load_checkpoint(store).await? {
-        CheckpointLoad::Missing => return Ok(AccountSetupResponse::View(missing_view())),
-        CheckpointLoad::Corrupt => {
+    let checkpoint = match load_setup(store).await? {
+        SetupLoad::Missing => return Ok(AccountSetupResponse::View(missing_view())),
+        SetupLoad::Corrupt => {
             return Ok(AccountSetupResponse::View(closed_view(
                 AccountSetupDisposition::Corrupt,
                 AccountSetupNextAction::None,
                 None,
             )));
         }
-        CheckpointLoad::Unsupported(version) => {
+        SetupLoad::Unsupported(version) => {
             return Ok(AccountSetupResponse::View(closed_view(
                 AccountSetupDisposition::Unsupported,
                 AccountSetupNextAction::None,
                 version,
             )));
         }
-        CheckpointLoad::Ready(checkpoint) => *checkpoint,
+        SetupLoad::Ready(checkpoint) => *checkpoint,
     };
     if checkpoint.as_stored().phase == StoredPhaseV2::Complete
-        && let Ok(context) = resolve_setup_context(origin).await
+        && let Ok(context) = contexts.resolve(trusted_origin).await
     {
         match repair_completion_tombstone(
             store,
             &checkpoint,
             &context,
-            state.profile.did(),
-            now_seconds(),
+            effects.device_did(),
+            effects.now_seconds(),
         )
         .await?
         {
@@ -3325,32 +3679,42 @@ async fn inspect_response(
         }
     }
     let owns = owns_checkpoint(&checkpoint, owner_token, client_id)
-        && client_is_live(state, client_id).await;
+        && effects.client_is_live(client_id).await;
     if owns
         && matches!(
             checkpoint.as_stored().phase,
-            StoredPhaseV2::RootSaved
-                | StoredPhaseV2::ProviderAccepted
-                | StoredPhaseV2::Attached
-                | StoredPhaseV2::CustomerEnrolled
-                | StoredPhaseV2::CustodyQueued
+            StoredPhaseV2::RootSaved | StoredPhaseV2::CustomerEnrolled
         )
-        && let Ok(context) = resolve_setup_context(origin).await
+        && let Ok(context) = contexts.resolve(trusted_origin).await
         && let Ok(RecoveryLoad::Bundle(bundle)) = load_recovery(store).await
         && let Ok(recovery) = validate_recovery_for_checkpoint(
             *bundle,
             &checkpoint,
             &context,
-            state.profile.did(),
-            now_seconds(),
+            effects.device_did(),
+            effects.now_seconds(),
         )
         .await
-        && recovery.create_freshness() == RecoveryFreshness::NeedsRefresh
     {
-        let mut view = checkpoint_view(&checkpoint, true);
-        view.disposition = AccountSetupDisposition::NeedsPasskey;
-        view.next_action = AccountSetupNextAction::ResumeWithPasskey;
-        return Ok(needs_passkey_response(&recovery, view));
+        let refresh = match checkpoint.as_stored().phase {
+            StoredPhaseV2::RootSaved
+                if recovery.create_freshness() == RecoveryFreshness::NeedsRefresh =>
+            {
+                Some(PasskeyRefresh::Create)
+            }
+            StoredPhaseV2::CustomerEnrolled
+                if recovery.publish_freshness() == RecoveryFreshness::NeedsRefresh =>
+            {
+                Some(PasskeyRefresh::Publish)
+            }
+            _ => None,
+        };
+        if let Some(refresh) = refresh {
+            let mut view = checkpoint_view(&checkpoint, true);
+            view.disposition = AccountSetupDisposition::NeedsPasskey;
+            view.next_action = AccountSetupNextAction::ResumeWithPasskey;
+            return Ok(needs_passkey_response(&recovery, view, refresh));
+        }
     }
     Ok(AccountSetupResponse::View(checkpoint_view(
         &checkpoint,
@@ -3358,13 +3722,33 @@ async fn inspect_response(
     )))
 }
 
+#[derive(Clone, Copy)]
+struct SetupRequestScope<'a> {
+    trusted_origin: &'a Url,
+    request_origin: &'a Url,
+    client_id: &'a str,
+}
+
 async fn handle_locked(
-    state: &crate::worker::TonkState,
-    origin: &crate::axum::RequestOrigin,
-    client_id: &str,
+    effects: &impl SetupEffects,
+    store: &impl SetupStore,
+    contexts: &impl SetupContextSource,
+    provider: &impl AccountSetupProvider,
+    scope: SetupRequestScope<'_>,
     request: AccountSetupRequest,
 ) -> Result<AccountSetupResponse, SetupStoreError> {
-    let store = CredentialSetupStore { state };
+    let SetupRequestScope {
+        trusted_origin,
+        request_origin,
+        client_id,
+    } = scope;
+    if request_origin != trusted_origin {
+        return Ok(AccountSetupResponse::View(closed_view(
+            AccountSetupDisposition::UpdateRequired,
+            AccountSetupNextAction::Reload,
+            None,
+        )));
+    }
     match request {
         AccountSetupRequest::Handshake(handshake) => {
             if handshake.protocol_version != ACCOUNT_SETUP_PROTOCOL_VERSION {
@@ -3374,14 +3758,14 @@ async fn handle_locked(
                     None,
                 )));
             }
-            let Ok(context) = resolve_setup_context(origin).await else {
+            let Ok(context) = contexts.resolve(trusted_origin).await else {
                 return Ok(AccountSetupResponse::View(closed_view(
                     AccountSetupDisposition::UpdateRequired,
                     AccountSetupNextAction::Reload,
                     None,
                 )));
             };
-            if !provider_supports_recovery(&context).await {
+            if !contexts.supports_recovery(&context).await {
                 return Ok(AccountSetupResponse::View(closed_view(
                     AccountSetupDisposition::UpdateRequired,
                     AccountSetupNextAction::Reload,
@@ -3397,9 +3781,10 @@ async fn handle_locked(
         }
         AccountSetupRequest::Inspect(inspect) => {
             inspect_response(
-                state,
-                &store,
-                origin,
+                effects,
+                store,
+                contexts,
+                trusted_origin,
                 inspect.owner_token.as_deref(),
                 client_id,
             )
@@ -3413,39 +3798,45 @@ async fn handle_locked(
                     None,
                 )));
             }
-            let Ok(context) = resolve_setup_context(origin).await else {
+            let Ok(context) = contexts.resolve(trusted_origin).await else {
                 return Ok(AccountSetupResponse::View(closed_view(
                     AccountSetupDisposition::UpdateRequired,
                     AccountSetupNextAction::Reload,
                     None,
                 )));
             };
-            if !provider_supports_recovery(&context).await {
-                return Ok(AccountSetupResponse::View(closed_view(
-                    AccountSetupDisposition::UpdateRequired,
-                    AccountSetupNextAction::Reload,
-                    None,
-                )));
-            }
-            match load_checkpoint(&store).await? {
-                CheckpointLoad::Ready(existing)
-                    if !matches!(
+            match load_setup(store).await? {
+                SetupLoad::Ready(existing)
+                    if matches!(
                         existing.as_stored().phase,
                         StoredPhaseV2::Cancelled | StoredPhaseV2::InterruptedBeforeRecovery
-                    ) =>
-                {
-                    return Ok(AccountSetupResponse::View(checkpoint_view(
-                        &existing, false,
-                    )));
+                    ) => {}
+                SetupLoad::Ready(existing) => {
+                    if existing.as_stored().configuration_hash != context.configuration_hash {
+                        return Ok(AccountSetupResponse::View(closed_view(
+                            AccountSetupDisposition::UpdateRequired,
+                            AccountSetupNextAction::Reload,
+                            None,
+                        )));
+                    }
+                    let owns = owns_checkpoint(&existing, Some(&begin.owner_token), client_id)
+                        && effects.client_is_live(client_id).await;
+                    if existing.as_stored().phase == StoredPhaseV2::Leased && owns {
+                        return Ok(AccountSetupResponse::Lease(AccountSetupLease {
+                            view: checkpoint_view(&existing, true),
+                            ceremony: context.ceremony(),
+                        }));
+                    }
+                    return Ok(AccountSetupResponse::View(checkpoint_view(&existing, owns)));
                 }
-                CheckpointLoad::Corrupt => {
+                SetupLoad::Corrupt => {
                     return Ok(AccountSetupResponse::View(closed_view(
                         AccountSetupDisposition::Corrupt,
                         AccountSetupNextAction::None,
                         None,
                     )));
                 }
-                CheckpointLoad::Unsupported(version) => {
+                SetupLoad::Unsupported(version) => {
                     return Ok(AccountSetupResponse::View(closed_view(
                         AccountSetupDisposition::Unsupported,
                         AccountSetupNextAction::None,
@@ -3453,6 +3844,17 @@ async fn handle_locked(
                     )));
                 }
                 _ => {}
+            }
+            // A saved lease already passed the capability gate. Repeating a
+            // lost Begin response needs only the exact owner/client/config
+            // fences above; a transient capability outage must not hide the
+            // worker-selected ceremony from that same owner.
+            if !contexts.supports_recovery(&context).await {
+                return Ok(AccountSetupResponse::View(closed_view(
+                    AccountSetupDisposition::UpdateRequired,
+                    AccountSetupNextAction::Reload,
+                    None,
+                )));
             }
             let operation_id = hex::encode(rand::random::<[u8; 32]>());
             let owner_hash = match token_hash(
@@ -3469,7 +3871,7 @@ async fn handle_locked(
                     )));
                 }
             };
-            let now = now_seconds().max(1);
+            let now = effects.now_seconds().max(1);
             let checkpoint = ValidatedCheckpoint::new(StoredCheckpointV2 {
                 version: CHECKPOINT_VERSION,
                 operation_id,
@@ -3488,25 +3890,26 @@ async fn handle_locked(
                 last_transition_at: now,
             })
             .map_err(|_| SetupStoreError::Write)?;
-            save_checkpoint(&store, &checkpoint).await?;
+            save_checkpoint(store, &checkpoint).await?;
             Ok(AccountSetupResponse::Lease(AccountSetupLease {
                 view: checkpoint_view(&checkpoint, true),
                 ceremony: context.ceremony(),
             }))
         }
         AccountSetupRequest::Arm(arm) => {
-            let CheckpointLoad::Ready(checkpoint) = load_checkpoint(&store).await? else {
-                return inspect_response(state, &store, origin, None, client_id).await;
+            let CheckpointLoad::Ready(checkpoint) = load_checkpoint(store).await? else {
+                return inspect_response(effects, store, contexts, trusted_origin, None, client_id)
+                    .await;
             };
             let checkpoint = *checkpoint;
-            let Ok(context) = resolve_setup_context(origin).await else {
+            let Ok(context) = contexts.resolve(trusted_origin).await else {
                 return Ok(AccountSetupResponse::View(closed_view(
                     AccountSetupDisposition::UpdateRequired,
                     AccountSetupNextAction::Reload,
                     None,
                 )));
             };
-            if !provider_supports_recovery(&context).await {
+            if !contexts.supports_recovery(&context).await {
                 return Ok(AccountSetupResponse::View(closed_view(
                     AccountSetupDisposition::UpdateRequired,
                     AccountSetupNextAction::Reload,
@@ -3514,7 +3917,7 @@ async fn handle_locked(
                 )));
             }
             let Ok(mutation) =
-                mutation_context(&arm.mutation, &checkpoint, client_id, now_seconds())
+                mutation_context(&arm.mutation, &checkpoint, client_id, effects.now_seconds())
             else {
                 return Ok(AccountSetupResponse::View(checkpoint_view(
                     &checkpoint,
@@ -3547,21 +3950,29 @@ async fn handle_locked(
                     )));
                 }
             };
-            let checkpoint = persist_reduction(&store, reduction).await?;
+            let checkpoint = persist_reduction(store, reduction).await?;
             Ok(AccountSetupResponse::View(checkpoint_view(
                 &checkpoint,
                 true,
             )))
         }
         AccountSetupRequest::Stage(stage) => {
-            let CheckpointLoad::Ready(checkpoint) = load_checkpoint(&store).await? else {
-                return inspect_response(state, &store, origin, None, client_id).await;
+            let CheckpointLoad::Ready(checkpoint) = load_checkpoint(store).await? else {
+                return inspect_response(effects, store, contexts, trusted_origin, None, client_id)
+                    .await;
             };
             let checkpoint = *checkpoint;
-            let Ok(context) = resolve_setup_context(origin).await else {
+            let Ok(context) = contexts.resolve(trusted_origin).await else {
                 return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
             };
-            let now = now_seconds();
+            if checkpoint.as_stored().configuration_hash != context.configuration_hash {
+                return Ok(AccountSetupResponse::View(closed_view(
+                    AccountSetupDisposition::UpdateRequired,
+                    AccountSetupNextAction::Reload,
+                    None,
+                )));
+            }
+            let now = effects.now_seconds();
             let Ok(mutation) = mutation_context(&stage.mutation, &checkpoint, client_id, now)
             else {
                 return Ok(AccountSetupResponse::View(checkpoint_view(
@@ -3584,14 +3995,14 @@ async fn handle_locked(
             // The load-bearing ordering: protected recovery first, same-path
             // readback/validation second, checkpoint phase third, root last.
             let readback = match persist_staged_recovery(
-                &store,
+                store,
                 stored,
                 StagePersistenceContext {
                     checkpoint: &checkpoint,
                     mutation: &mutation,
                     attempt_hash: &attempt_hash,
                     setup: &context,
-                    device_did: state.profile.did(),
+                    device_did: effects.device_did(),
                     now,
                 },
             )
@@ -3621,31 +4032,29 @@ async fn handle_locked(
                 },
             )
             .map_err(|_| SetupStoreError::Write)?;
-            let checkpoint = persist_reduction(&store, reduction).await?;
+            let checkpoint = persist_reduction(store, reduction).await?;
             let owner_hash = checkpoint
                 .as_stored()
                 .owner_hash
                 .clone()
                 .ok_or(SetupStoreError::Read)?;
             reconcile_with_provider(
-                state,
-                &store,
-                &HttpAccountSetupProvider { context: &context },
-                &context,
-                checkpoint,
-                owner_hash,
-                client_id,
+                effects, store, provider, &context, checkpoint, owner_hash, client_id,
             )
             .await
         }
         AccountSetupRequest::Continue(mutation_wire) => {
-            let CheckpointLoad::Ready(checkpoint) = load_checkpoint(&store).await? else {
-                return inspect_response(state, &store, origin, None, client_id).await;
+            let CheckpointLoad::Ready(checkpoint) = load_checkpoint(store).await? else {
+                return inspect_response(effects, store, contexts, trusted_origin, None, client_id)
+                    .await;
             };
             let checkpoint = *checkpoint;
-            let Ok(mutation) =
-                mutation_context(&mutation_wire, &checkpoint, client_id, now_seconds())
-            else {
+            let Ok(mutation) = mutation_context(
+                &mutation_wire,
+                &checkpoint,
+                client_id,
+                effects.now_seconds(),
+            ) else {
                 return Ok(AccountSetupResponse::View(checkpoint_view(
                     &checkpoint,
                     false,
@@ -3657,13 +4066,13 @@ async fn handle_locked(
                     false,
                 )));
             }
-            let Ok(context) = resolve_setup_context(origin).await else {
+            let Ok(context) = contexts.resolve(trusted_origin).await else {
                 return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
             };
             reconcile_with_provider(
-                state,
-                &store,
-                &HttpAccountSetupProvider { context: &context },
+                effects,
+                store,
+                provider,
                 &context,
                 checkpoint,
                 mutation.owner_hash,
@@ -3672,12 +4081,13 @@ async fn handle_locked(
             .await
         }
         AccountSetupRequest::ReplaceInvocation(replacement) => {
-            let CheckpointLoad::Ready(checkpoint) = load_checkpoint(&store).await? else {
-                return inspect_response(state, &store, origin, None, client_id).await;
+            let CheckpointLoad::Ready(checkpoint) = load_checkpoint(store).await? else {
+                return inspect_response(effects, store, contexts, trusted_origin, None, client_id)
+                    .await;
             };
             let checkpoint = *checkpoint;
-            let Ok(mutation) =
-                mutation_context(&replacement.mutation, &checkpoint, client_id, now_seconds())
+            let now = effects.now_seconds();
+            let Ok(mutation) = mutation_context(&replacement.mutation, &checkpoint, client_id, now)
             else {
                 return Ok(AccountSetupResponse::View(checkpoint_view(
                     &checkpoint,
@@ -3690,19 +4100,26 @@ async fn handle_locked(
                     false,
                 )));
             }
-            let Ok(context) = resolve_setup_context(origin).await else {
+            if checkpoint.as_stored().phase != StoredPhaseV2::RootSaved {
+                return Ok(AccountSetupResponse::View(checkpoint_view(
+                    &checkpoint,
+                    true,
+                )));
+            }
+            let Ok(context) = contexts.resolve(trusted_origin).await else {
                 return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
             };
-            let RecoveryLoad::Bundle(mut bundle) = load_recovery(&store).await? else {
+            let RecoveryLoad::Bundle(mut bundle) = load_recovery(store).await? else {
                 return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
             };
+            bundle.replacement_invocation_created_at = Some(now);
             bundle.replacement_invocation_hex = Some(replacement.invocation_hex);
             let validated = match validate_recovery_for_checkpoint(
                 *bundle,
                 &checkpoint,
                 &context,
-                state.profile.did(),
-                now_seconds(),
+                effects.device_did(),
+                now,
             )
             .await
             {
@@ -3710,14 +4127,76 @@ async fn handle_locked(
                 Err(_) => return Ok(AccountSetupResponse::View(retry_view(&checkpoint))),
             };
             save_recovery(
-                &store,
+                store,
                 &StoredRecoveryRecord::Bundle(Box::new(validated.stored.clone())),
             )
             .await?;
             reconcile_with_provider(
-                state,
-                &store,
-                &HttpAccountSetupProvider { context: &context },
+                effects,
+                store,
+                provider,
+                &context,
+                checkpoint,
+                mutation.owner_hash,
+                client_id,
+            )
+            .await
+        }
+        AccountSetupRequest::ReplacePublishInvocation(replacement) => {
+            let CheckpointLoad::Ready(checkpoint) = load_checkpoint(store).await? else {
+                return inspect_response(effects, store, contexts, trusted_origin, None, client_id)
+                    .await;
+            };
+            let checkpoint = *checkpoint;
+            let now = effects.now_seconds();
+            let Ok(mutation) = mutation_context(&replacement.mutation, &checkpoint, client_id, now)
+            else {
+                return Ok(AccountSetupResponse::View(checkpoint_view(
+                    &checkpoint,
+                    false,
+                )));
+            };
+            if authenticate(&checkpoint, &mutation).is_err() {
+                return Ok(AccountSetupResponse::View(checkpoint_view(
+                    &checkpoint,
+                    false,
+                )));
+            }
+            if checkpoint.as_stored().phase != StoredPhaseV2::CustomerEnrolled {
+                return Ok(AccountSetupResponse::View(checkpoint_view(
+                    &checkpoint,
+                    true,
+                )));
+            }
+            let Ok(context) = contexts.resolve(trusted_origin).await else {
+                return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+            };
+            let RecoveryLoad::Bundle(mut bundle) = load_recovery(store).await? else {
+                return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+            };
+            bundle.replacement_publish_invocation_created_at = Some(now);
+            bundle.replacement_publish_invocation_hex = Some(replacement.invocation_hex);
+            let validated = match validate_recovery_for_checkpoint(
+                *bundle,
+                &checkpoint,
+                &context,
+                effects.device_did(),
+                now,
+            )
+            .await
+            {
+                Ok(validated) => validated,
+                Err(_) => return Ok(AccountSetupResponse::View(retry_view(&checkpoint))),
+            };
+            save_recovery(
+                store,
+                &StoredRecoveryRecord::Bundle(Box::new(validated.stored.clone())),
+            )
+            .await?;
+            reconcile_with_provider(
+                effects,
+                store,
+                provider,
                 &context,
                 checkpoint,
                 mutation.owner_hash,
@@ -3726,11 +4205,13 @@ async fn handle_locked(
             .await
         }
         AccountSetupRequest::Cancel(cancel) => {
-            let CheckpointLoad::Ready(checkpoint) = load_checkpoint(&store).await? else {
-                return inspect_response(state, &store, origin, None, client_id).await;
+            let CheckpointLoad::Ready(checkpoint) = load_checkpoint(store).await? else {
+                return inspect_response(effects, store, contexts, trusted_origin, None, client_id)
+                    .await;
             };
             let checkpoint = *checkpoint;
-            let Ok(mutation) = mutation_context(&cancel, &checkpoint, client_id, now_seconds())
+            let Ok(mutation) =
+                mutation_context(&cancel, &checkpoint, client_id, effects.now_seconds())
             else {
                 return Ok(AccountSetupResponse::View(checkpoint_view(
                     &checkpoint,
@@ -3747,7 +4228,7 @@ async fn handle_locked(
                 }
             };
             let too_late = reduction.next_action == PrivateNextAction::CancelTooLate;
-            let checkpoint = persist_reduction(&store, reduction).await?;
+            let checkpoint = persist_reduction(store, reduction).await?;
             let mut view = checkpoint_view(&checkpoint, true);
             if too_late {
                 view.disposition = AccountSetupDisposition::CancelTooLate;
@@ -3756,27 +4237,35 @@ async fn handle_locked(
             Ok(AccountSetupResponse::View(view))
         }
         AccountSetupRequest::Acquire(acquire) => {
-            let CheckpointLoad::Ready(checkpoint) = load_checkpoint(&store).await? else {
-                return inspect_response(state, &store, origin, None, client_id).await;
+            let CheckpointLoad::Ready(checkpoint) = load_checkpoint(store).await? else {
+                return inspect_response(effects, store, contexts, trusted_origin, None, client_id)
+                    .await;
             };
             let mut checkpoint = *checkpoint;
-            let Ok(context) = resolve_setup_context(origin).await else {
+            let Ok(context) = contexts.resolve(trusted_origin).await else {
                 return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
             };
-            let now = now_seconds();
+            if checkpoint.as_stored().configuration_hash != context.configuration_hash {
+                return Ok(AccountSetupResponse::View(closed_view(
+                    AccountSetupDisposition::UpdateRequired,
+                    AccountSetupNextAction::Reload,
+                    None,
+                )));
+            }
+            let now = effects.now_seconds();
             let mut acquire_revision = acquire.expected_revision;
             if let Some(bound) = checkpoint.as_stored().bound_client_id.clone() {
-                if client_is_live(state, &bound).await {
+                if effects.client_is_live(&bound).await {
                     return Ok(AccountSetupResponse::View(checkpoint_view(
                         &checkpoint,
                         false,
                     )));
                 }
                 let observation = match recovery_observation(
-                    &store,
+                    store,
                     &checkpoint,
                     &context,
-                    state.profile.did(),
+                    effects.device_did(),
                     now,
                 )
                 .await
@@ -3807,7 +4296,7 @@ async fn handle_locked(
                         )));
                     }
                 };
-                checkpoint = persist_reduction(&store, reduction).await?;
+                checkpoint = persist_reduction(store, reduction).await?;
                 acquire_revision = checkpoint.as_stored().revision;
                 if matches!(
                     checkpoint.as_stored().phase,
@@ -3820,7 +4309,7 @@ async fn handle_locked(
                 }
             }
             let observation =
-                recovery_observation(&store, &checkpoint, &context, state.profile.did(), now)
+                recovery_observation(store, &checkpoint, &context, effects.device_did(), now)
                     .await
                     .map_err(|_| SetupStoreError::Read)?;
             let Ok(owner_hash) = token_hash(
@@ -3852,7 +4341,13 @@ async fn handle_locked(
                     )));
                 }
             };
-            let checkpoint = persist_reduction(&store, reduction).await?;
+            let checkpoint = persist_reduction(store, reduction).await?;
+            if checkpoint.as_stored().phase == StoredPhaseV2::Leased {
+                return Ok(AccountSetupResponse::Lease(AccountSetupLease {
+                    view: checkpoint_view(&checkpoint, true),
+                    ceremony: context.ceremony(),
+                }));
+            }
             Ok(AccountSetupResponse::View(checkpoint_view(
                 &checkpoint,
                 true,
@@ -3903,7 +4398,7 @@ pub(super) async fn handle(
             )
         )
     };
-    let _cross_worker = match acquire_cross_worker_setup_lock(&lock_name).await {
+    let _cross_worker = match super::browser_lock::acquire(&lock_name).await {
         Ok(guard) => guard,
         Err(()) => {
             return Ok(AccountSetupJson(AccountSetupResponse::View(closed_view(
@@ -3917,14 +4412,30 @@ pub(super) async fn handle(
     let _local_guard = local.lock().await;
     let state = state.read().await;
     mark_request_client_live(&state, &client).await;
-    let response = handle_locked(&state, &origin, &client.0, request)
-        .await
-        .map_err(|error| {
-            crate::TonkWorkerError::Internal(match error {
-                SetupStoreError::Read => "account setup credential read failed".into(),
-                SetupStoreError::Write => "account setup credential write failed".into(),
-            })
-        })?;
+    let trusted_origin = state.service_origin.clone().ok_or_else(|| {
+        crate::TonkWorkerError::Router("account setup requires the worker origin".into())
+    })?;
+    let effects = WorkerSetupEffects { state: &state };
+    let store = CredentialSetupStore { state: &state };
+    let response = handle_locked(
+        &effects,
+        &store,
+        &HttpSetupContextSource,
+        &HttpAccountSetupProvider,
+        SetupRequestScope {
+            trusted_origin: &trusted_origin,
+            request_origin: origin.url(),
+            client_id: &client.0,
+        },
+        request,
+    )
+    .await
+    .map_err(|error| {
+        crate::TonkWorkerError::Internal(match error {
+            SetupStoreError::Read => "account setup credential read failed".into(),
+            SetupStoreError::Write => "account setup credential write failed".into(),
+        })
+    })?;
     Ok(AccountSetupJson(response))
 }
 
@@ -3936,16 +4447,18 @@ mod tests {
         CompletionTombstoneOutcome, DurableAction, MAX_RECOVERY_RECORD_BYTES, MutationContext,
         PUBLISH_EXPIRY_MAX_OFFSET, PUBLISH_EXPIRY_MIN_OFFSET, PrivateNextAction,
         ProviderAcceptance, ProviderPortError, ProviderResolution, ProviderSetupStatus,
-        RecoveryEvidence, RecoveryFreshness, RecoveryObservation, RecoveryTrustContext,
-        RecoveryValidationError, ReducerCommand, ReductionError, SetupStore, SetupStoreError,
-        StagePersistenceContext, StagePersistenceError, StoredCheckpointV2, StoredConflictCodeV2,
-        StoredPhaseV2, StoredRecoveryBundleV1, StoredRecoveryRecord, StoredSafePhaseV2,
-        StoredSetupError, ValidatedCheckpoint, ValidatedRecoveryBundle, VerifiedEvidence,
-        decode_bounded_recovery, decode_checkpoint, decode_recovery, domain_hash,
-        encode_checkpoint, encode_recovery, load_checkpoint, persist_reduction,
-        persist_staged_recovery, recovery_observation, reduce, repair_completion_tombstone,
-        resolve_provider_acceptance, supports_provider_capabilities, validate_original_expiration,
-        validate_stage_timestamps,
+        RecoveryEvidence, RecoveryFreshness, RecoveryObservation, RecoveryTombstoneV1,
+        RecoveryTrustContext, RecoveryValidationError, ReducerCommand, ReductionError,
+        SetupContextSource, SetupEffects, SetupLoad, SetupRequestScope, SetupStore,
+        SetupStoreError, StagePersistenceContext, StagePersistenceError, StoredCheckpointV2,
+        StoredConflictCodeV2, StoredPhaseV2, StoredRecoveryBundleV1, StoredRecoveryRecord,
+        StoredSafePhaseV2, StoredSetupError, ValidatedCheckpoint, ValidatedRecoveryBundle,
+        VerifiedEvidence, classify_provider_create_error, decode_bounded_recovery,
+        decode_checkpoint, decode_recovery, domain_hash, encode_checkpoint, encode_recovery,
+        handle_locked, load_checkpoint, load_setup, persist_reduction, persist_staged_recovery,
+        reconcile_with_provider, recovery_observation, reduce, repair_completion_tombstone,
+        resolve_provider_acceptance, supports_provider_capabilities, token_hash,
+        validate_original_expiration, validate_stage_timestamps,
     };
     use async_trait::async_trait;
     use dialog_credentials::Ed25519Signer;
@@ -3958,12 +4471,17 @@ mod tests {
         DEFERRED_PUBLISH_TTL_SECONDS, build_publish_invocation, mint_custody_consent,
     };
     use tonk_identity::envelope::{AccountSecret, KekMethod, custody_kek, custody_signer};
-    use tonk_worker_api::PasskeyMetadata;
+    use tonk_worker_api::{
+        ACCOUNT_SETUP_PROTOCOL_VERSION, AccountLinkRequest, AccountSetupAcquire, AccountSetupBegin,
+        AccountSetupDisposition, AccountSetupInspect, AccountSetupInvocation, AccountSetupMutation,
+        AccountSetupProtectedResponse, AccountSetupRequest, AccountSetupResponse,
+        AccountSetupResumeInput, PasskeyMetadata, SaveRootRequest,
+    };
 
-    use std::collections::VecDeque;
+    use std::collections::{BTreeSet, VecDeque};
     use std::sync::{
         Mutex,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
     };
 
     struct ScriptedProvider {
@@ -3994,6 +4512,7 @@ mod tests {
     impl AccountSetupProvider for ScriptedProvider {
         async fn status(
             &self,
+            _context: &CanonicalSetupContext,
             invocation: &[u8],
         ) -> Result<ProviderSetupStatus, ProviderPortError> {
             self.calls
@@ -4007,7 +4526,11 @@ mod tests {
                 .expect("scripted status result")
         }
 
-        async fn create(&self, invocation: &[u8]) -> Result<ProviderAcceptance, ProviderPortError> {
+        async fn create(
+            &self,
+            _context: &CanonicalSetupContext,
+            invocation: &[u8],
+        ) -> Result<ProviderAcceptance, ProviderPortError> {
             self.calls
                 .lock()
                 .unwrap()
@@ -4080,6 +4603,169 @@ mod tests {
         }
     }
 
+    struct FixedContextSource {
+        context: CanonicalSetupContext,
+        resolves: AtomicUsize,
+        supports: AtomicBool,
+    }
+
+    impl FixedContextSource {
+        fn new(context: CanonicalSetupContext) -> Self {
+            Self {
+                context,
+                resolves: AtomicUsize::new(0),
+                supports: AtomicBool::new(true),
+            }
+        }
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    impl SetupContextSource for FixedContextSource {
+        async fn resolve(&self, _origin: &url::Url) -> Result<CanonicalSetupContext, ()> {
+            self.resolves.fetch_add(1, Ordering::SeqCst);
+            Ok(self.context.clone())
+        }
+
+        async fn supports_recovery(&self, _context: &CanonicalSetupContext) -> bool {
+            self.supports.load(Ordering::SeqCst)
+        }
+    }
+
+    struct TestEffects {
+        device_did: dialog_varsig::Did,
+        now: AtomicU64,
+        live_clients: Mutex<BTreeSet<String>>,
+        root: Mutex<super::super::identity::LocalRootObservation>,
+        attachment: Mutex<super::super::account::AttachmentObservation>,
+        customer: Mutex<super::super::customer::CustomerObservation>,
+        account_state_ready: AtomicBool,
+        fail_root_persist: AtomicBool,
+        fail_attachment_persist: AtomicBool,
+        fail_enroll: AtomicBool,
+        fail_custody: AtomicBool,
+        events: Mutex<Vec<&'static str>>,
+    }
+
+    impl TestEffects {
+        fn new(device_did: dialog_varsig::Did) -> Self {
+            Self {
+                device_did,
+                now: AtomicU64::new(Timestamp::now().to_unix()),
+                live_clients: Mutex::new(BTreeSet::new()),
+                root: Mutex::new(super::super::identity::LocalRootObservation::Missing),
+                attachment: Mutex::new(super::super::account::AttachmentObservation::Missing),
+                customer: Mutex::new(super::super::customer::CustomerObservation::Missing),
+                account_state_ready: AtomicBool::new(true),
+                fail_root_persist: AtomicBool::new(false),
+                fail_attachment_persist: AtomicBool::new(false),
+                fail_enroll: AtomicBool::new(false),
+                fail_custody: AtomicBool::new(false),
+                events: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    impl SetupEffects for TestEffects {
+        fn device_did(&self) -> dialog_varsig::Did {
+            self.device_did.clone()
+        }
+
+        fn now_seconds(&self) -> u64 {
+            self.now.load(Ordering::SeqCst)
+        }
+
+        async fn client_is_live(&self, client: &str) -> bool {
+            self.live_clients.lock().unwrap().contains(client)
+        }
+
+        async fn observe_root(
+            &self,
+            _expected_root_did: &str,
+            _request: &SaveRootRequest,
+        ) -> Result<super::super::identity::LocalRootObservation, ()> {
+            Ok(*self.root.lock().unwrap())
+        }
+
+        async fn persist_root(&self, _request: SaveRootRequest) -> Result<(), ()> {
+            self.events.lock().unwrap().push("root");
+            if self.fail_root_persist.load(Ordering::SeqCst) {
+                return Err(());
+            }
+            *self.root.lock().unwrap() = super::super::identity::LocalRootObservation::Exact;
+            Ok(())
+        }
+
+        async fn build_status_invocation(
+            &self,
+            _delegation: &dialog_ucan_core::DelegationChain,
+            _create_fingerprint: &str,
+        ) -> Result<Vec<u8>, ()> {
+            Ok(b"status-invocation".to_vec())
+        }
+
+        async fn observe_attachment(
+            &self,
+            _root_did: &dialog_varsig::Did,
+            _provider: &str,
+            _descriptor: &[u8],
+        ) -> Result<super::super::account::AttachmentObservation, ()> {
+            Ok(*self.attachment.lock().unwrap())
+        }
+
+        async fn persist_attachment(&self, _request: &AccountLinkRequest) -> Result<(), ()> {
+            self.events.lock().unwrap().push("attachment");
+            if self.fail_attachment_persist.load(Ordering::SeqCst) {
+                return Err(());
+            }
+            *self.attachment.lock().unwrap() = super::super::account::AttachmentObservation::Exact;
+            Ok(())
+        }
+
+        async fn ensure_account_state(&self) -> bool {
+            self.account_state_ready.load(Ordering::SeqCst)
+        }
+
+        async fn observe_customer(
+            &self,
+            _expected_root: &str,
+            _expected_email: &str,
+        ) -> Result<super::super::customer::CustomerObservation, ()> {
+            Ok(*self.customer.lock().unwrap())
+        }
+
+        async fn enroll_customer(
+            &self,
+            _origin: &url::Url,
+            _email: String,
+            _deposits: &[String],
+        ) -> Result<(), ()> {
+            self.events.lock().unwrap().push("customer");
+            if self.fail_enroll.load(Ordering::SeqCst) {
+                return Err(());
+            }
+            *self.customer.lock().unwrap() = super::super::customer::CustomerObservation::Exact;
+            Ok(())
+        }
+
+        async fn persist_custody_setup(
+            &self,
+            _custody: &str,
+            _consent_hex: &str,
+            _sealed_hex: &str,
+            _invocation_hex: &str,
+        ) -> Result<(), ()> {
+            self.events.lock().unwrap().push("custody");
+            if self.fail_custody.load(Ordering::SeqCst) {
+                Err(())
+            } else {
+                Ok(())
+            }
+        }
+    }
+
     fn hash(byte: &str) -> String {
         byte.repeat(32)
     }
@@ -4089,6 +4775,24 @@ mod tests {
             account_id: 7,
             descriptor_hex: "aabb".to_string(),
             create_fingerprint: hash("44"),
+        }
+    }
+
+    fn provider_context() -> CanonicalSetupContext {
+        CanonicalSetupContext {
+            service_origin: "https://app.example/".parse().unwrap(),
+            provider: "https://accounts.example/".parse().unwrap(),
+            remote: "https://app.example/ucan/".parse().unwrap(),
+            service_did: None,
+            configuration_hash: hash("22"),
+        }
+    }
+
+    fn request_scope<'a>(origin: &'a url::Url, client_id: &'a str) -> SetupRequestScope<'a> {
+        SetupRequestScope {
+            trusted_origin: origin,
+            request_origin: origin,
+            client_id,
         }
     }
 
@@ -4111,13 +4815,193 @@ mod tests {
     }
 
     #[dialog_common::test]
+    async fn it_refuses_cross_origin_requests_before_loading_deployment_configuration() {
+        let trusted_origin: url::Url = "https://app.example/".parse().unwrap();
+        let request_origin: url::Url = "https://evil.example/".parse().unwrap();
+        let contexts = FixedContextSource::new(provider_context());
+        let effects = TestEffects::new(signer(60).await.did());
+        let store = MemorySetupStore::default();
+        let provider = ScriptedProvider::new(
+            std::iter::empty::<Result<ProviderSetupStatus, ProviderPortError>>(),
+            std::iter::empty::<Result<ProviderAcceptance, ProviderPortError>>(),
+        );
+
+        let response = handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            SetupRequestScope {
+                trusted_origin: &trusted_origin,
+                request_origin: &request_origin,
+                client_id: "client-1",
+            },
+            AccountSetupRequest::Handshake(tonk_worker_api::AccountSetupHandshake {
+                protocol_version: ACCOUNT_SETUP_PROTOCOL_VERSION,
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            response,
+            AccountSetupResponse::View(view)
+                if view.disposition == AccountSetupDisposition::UpdateRequired
+        ));
+        assert_eq!(contexts.resolves.load(Ordering::SeqCst), 0);
+    }
+
+    #[dialog_common::test]
+    async fn it_recovers_a_lost_begin_response_only_for_the_exact_owner_and_client() {
+        let origin: url::Url = "https://app.example/".parse().unwrap();
+        let contexts = FixedContextSource::new(provider_context());
+        let effects = TestEffects::new(signer(61).await.did());
+        effects
+            .live_clients
+            .lock()
+            .unwrap()
+            .insert("client-1".to_string());
+        let store = MemorySetupStore::default();
+        let provider = ScriptedProvider::new(
+            std::iter::empty::<Result<ProviderSetupStatus, ProviderPortError>>(),
+            std::iter::empty::<Result<ProviderAcceptance, ProviderPortError>>(),
+        );
+        let owner_token = "owner".repeat(8);
+
+        let first = handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-1"),
+            AccountSetupRequest::Begin(AccountSetupBegin {
+                protocol_version: ACCOUNT_SETUP_PROTOCOL_VERSION,
+                owner_token: owner_token.clone(),
+            }),
+        )
+        .await
+        .unwrap();
+        let AccountSetupResponse::Lease(first) = first else {
+            panic!("first begin must establish a lease");
+        };
+        contexts.supports.store(false, Ordering::SeqCst);
+
+        let repeated = handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-1"),
+            AccountSetupRequest::Begin(AccountSetupBegin {
+                protocol_version: ACCOUNT_SETUP_PROTOCOL_VERSION,
+                owner_token,
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            repeated,
+            AccountSetupResponse::Lease(lease)
+                if lease.view.operation_id == first.view.operation_id
+                    && lease.view.revision == first.view.revision
+                    && lease.ceremony == first.ceremony
+        ));
+    }
+
+    #[dialog_common::test]
+    async fn it_returns_the_ceremony_only_after_a_dead_pre_arm_owner_is_acquired() {
+        let origin: url::Url = "https://app.example/".parse().unwrap();
+        let contexts = FixedContextSource::new(provider_context());
+        let effects = TestEffects::new(signer(62).await.did());
+        effects
+            .live_clients
+            .lock()
+            .unwrap()
+            .insert("client-1".to_string());
+        let store = MemorySetupStore::default();
+        let provider = ScriptedProvider::new(
+            std::iter::empty::<Result<ProviderSetupStatus, ProviderPortError>>(),
+            std::iter::empty::<Result<ProviderAcceptance, ProviderPortError>>(),
+        );
+
+        let AccountSetupResponse::Lease(first) = handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-1"),
+            AccountSetupRequest::Begin(AccountSetupBegin {
+                protocol_version: ACCOUNT_SETUP_PROTOCOL_VERSION,
+                owner_token: "owner".repeat(8),
+            }),
+        )
+        .await
+        .unwrap() else {
+            panic!("begin must establish a lease");
+        };
+        let operation_id = first.view.operation_id.clone().unwrap();
+        let revision = first.view.revision.unwrap();
+
+        let denied = handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-2"),
+            AccountSetupRequest::Acquire(AccountSetupAcquire {
+                operation_id: operation_id.clone(),
+                owner_token: "new-owner".repeat(4),
+                expected_revision: revision,
+            }),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            denied,
+            AccountSetupResponse::View(view)
+                if view.disposition == AccountSetupDisposition::InProgressElsewhere
+        ));
+
+        effects.live_clients.lock().unwrap().remove("client-1");
+        effects
+            .live_clients
+            .lock()
+            .unwrap()
+            .insert("client-2".to_string());
+        let acquired = handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-2"),
+            AccountSetupRequest::Acquire(AccountSetupAcquire {
+                operation_id,
+                owner_token: "new-owner".repeat(4),
+                expected_revision: revision,
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            acquired,
+            AccountSetupResponse::Lease(lease)
+                if lease.ceremony == provider_context().ceremony()
+                    && lease.view.revision == Some(revision + 2)
+        ));
+    }
+
+    #[dialog_common::test]
     async fn it_queries_status_before_exact_replay_and_recovers_a_lost_create_response() {
         let accepted = provider_acceptance();
+        let context = provider_context();
         let first_create =
             ScriptedProvider::new([Ok(ProviderSetupStatus::Absent)], [Ok(accepted.clone())]);
         assert!(matches!(
             resolve_provider_acceptance(
                 &first_create,
+                &context,
                 b"first-status",
                 b"exact-stored-create",
                 RecoveryFreshness::Usable,
@@ -4146,6 +5030,7 @@ mod tests {
         assert!(matches!(
             resolve_provider_acceptance(
                 &provider,
+                &context,
                 status_invocation,
                 create_invocation,
                 RecoveryFreshness::Usable,
@@ -4156,6 +5041,7 @@ mod tests {
         assert!(matches!(
             resolve_provider_acceptance(
                 &provider,
+                &context,
                 status_invocation,
                 create_invocation,
                 RecoveryFreshness::Usable,
@@ -4175,6 +5061,27 @@ mod tests {
 
     #[dialog_common::test]
     async fn it_never_turns_unknown_provider_outcomes_into_absent_or_create() {
+        assert_eq!(
+            classify_provider_create_error(&super::super::http::HttpError::Upstream(
+                super::super::http::UpstreamFailure {
+                    status: 409,
+                    code: Some("AccountConflict".to_string()),
+                    message: "sensitive provider detail".to_string(),
+                },
+            )),
+            ProviderPortError::Conflict
+        );
+        assert_eq!(
+            classify_provider_create_error(&super::super::http::HttpError::Upstream(
+                super::super::http::UpstreamFailure {
+                    status: 500,
+                    code: None,
+                    message: "transient".to_string(),
+                },
+            )),
+            ProviderPortError::Retry
+        );
+        let context = provider_context();
         let cases = [
             (Err(ProviderPortError::Retry), ProviderResolution::Retry),
             (Err(ProviderPortError::Invalid), ProviderResolution::Retry),
@@ -4187,6 +5094,7 @@ mod tests {
             let provider = ScriptedProvider::new([status], []);
             let result = resolve_provider_acceptance(
                 &provider,
+                &context,
                 b"status",
                 b"create",
                 RecoveryFreshness::Usable,
@@ -4200,6 +5108,7 @@ mod tests {
         assert!(matches!(
             resolve_provider_acceptance(
                 &provider,
+                &context,
                 b"status",
                 b"expired-create",
                 RecoveryFreshness::NeedsRefresh,
@@ -4208,6 +5117,29 @@ mod tests {
             ProviderResolution::NeedsPasskey
         ));
         assert_eq!(provider.calls(), vec![("status", b"status".to_vec())]);
+
+        let provider = ScriptedProvider::new(
+            [Ok(ProviderSetupStatus::Absent)],
+            [Err(ProviderPortError::Conflict)],
+        );
+        assert!(matches!(
+            resolve_provider_acceptance(
+                &provider,
+                &context,
+                b"status",
+                b"create",
+                RecoveryFreshness::Usable,
+            )
+            .await,
+            ProviderResolution::Mismatch
+        ));
+        assert_eq!(
+            provider.calls(),
+            vec![
+                ("status", b"status".to_vec()),
+                ("create", b"create".to_vec())
+            ]
+        );
     }
 
     fn leased() -> ValidatedCheckpoint {
@@ -4263,12 +5195,15 @@ mod tests {
             descriptor_hex: "eeff".to_string(),
             create_fingerprint: hash("33"),
             invocation_hex: "2233".to_string(),
+            replacement_invocation_created_at: None,
             replacement_invocation_hex: None,
             deposits_hex: vec!["4455".to_string()],
             custody_did: "did:key:custody".to_string(),
             consent_hex: "6677".to_string(),
             sealed_hex: "8899".to_string(),
             publish_invocation_hex: "aabb".to_string(),
+            replacement_publish_invocation_created_at: None,
+            replacement_publish_invocation_hex: None,
             recovery_manifest_hex: "bbcc".to_string(),
         }
     }
@@ -4421,12 +5356,15 @@ mod tests {
             descriptor_hex,
             create_fingerprint: create_fingerprint.to_hex(),
             invocation_hex: account.invocation_hex,
+            replacement_invocation_created_at: None,
             replacement_invocation_hex: None,
             deposits_hex,
             custody_did,
             consent_hex: hex::encode(consent_bytes),
             sealed_hex: hex::encode(sealed),
             publish_invocation_hex: hex::encode(publish_invocation),
+            replacement_publish_invocation_created_at: None,
+            replacement_publish_invocation_hex: None,
             recovery_manifest_hex: hex::encode(manifest.bytes()),
         };
         let trust = RecoveryTrustContext {
@@ -4439,6 +5377,24 @@ mod tests {
             now: staged_at + 1,
         };
         (bundle, trust)
+    }
+
+    async fn fresh_publish_invocation(
+        seed: u8,
+        bundle: &StoredRecoveryBundleV1,
+        created_at: u64,
+    ) -> String {
+        let custody = custody_signer(&[seed.wrapping_add(2); 32]).await.unwrap();
+        assert_eq!(custody.did().to_string(), bundle.custody_did);
+        let sealed = hex::decode(&bundle.sealed_hex).unwrap();
+        let expiration = Timestamp::new(
+            UNIX_EPOCH + Duration::from_secs(created_at + DEFERRED_PUBLISH_TTL_SECONDS),
+        )
+        .unwrap();
+        let invocation = build_publish_invocation(custody, &sealed, None, expiration)
+            .await
+            .unwrap();
+        hex::encode(invocation)
     }
 
     async fn completed_recovery_fixture(
@@ -4486,6 +5442,392 @@ mod tests {
         *store.recovery.lock().unwrap() =
             Some(encode_recovery(&StoredRecoveryRecord::Bundle(Box::new(bundle))).unwrap());
         (store, checkpoint, context, trust.device_did)
+    }
+
+    async fn active_recovery_fixture(
+        seed: u8,
+        phase: StoredPhaseV2,
+    ) -> (
+        MemorySetupStore,
+        ValidatedCheckpoint,
+        CanonicalSetupContext,
+        dialog_varsig::Did,
+    ) {
+        let (store, completed, context, device_did) = completed_recovery_fixture(seed).await;
+        let mut stored = completed.into_stored();
+        stored.revision = 7;
+        stored.owner_hash = Some(hash("11"));
+        stored.bound_client_id = Some("client-1".to_string());
+        stored.phase = phase;
+        if matches!(
+            stored.phase,
+            StoredPhaseV2::RecoveryStaged | StoredPhaseV2::RootSaved
+        ) {
+            stored.accepted_descriptor_hash = None;
+        }
+        let checkpoint = ValidatedCheckpoint::new(stored).unwrap();
+        *store.checkpoint.lock().unwrap() = Some(encode_checkpoint(&checkpoint).unwrap());
+        (store, checkpoint, context, device_did)
+    }
+
+    #[dialog_common::test]
+    async fn it_does_not_advance_when_the_customer_projection_write_fails() {
+        let (store, checkpoint, context, device_did) =
+            active_recovery_fixture(65, StoredPhaseV2::Attached).await;
+        let effects = TestEffects::new(device_did);
+        effects.now.store(
+            checkpoint.as_stored().last_transition_at + 1,
+            Ordering::SeqCst,
+        );
+        effects
+            .live_clients
+            .lock()
+            .unwrap()
+            .insert("client-1".to_string());
+        effects.fail_enroll.store(true, Ordering::SeqCst);
+        let provider = ScriptedProvider::new(
+            std::iter::empty::<Result<ProviderSetupStatus, ProviderPortError>>(),
+            std::iter::empty::<Result<ProviderAcceptance, ProviderPortError>>(),
+        );
+
+        let response = reconcile_with_provider(
+            &effects,
+            &store,
+            &provider,
+            &context,
+            checkpoint,
+            hash("11"),
+            "client-1",
+        )
+        .await
+        .unwrap();
+        let AccountSetupResponse::View(view) = response else {
+            panic!("projection failure must return a redacted view");
+        };
+        assert_eq!(view.disposition, AccountSetupDisposition::RetryLater);
+        let CheckpointLoad::Ready(still_attached) = load_checkpoint(&store).await.unwrap() else {
+            panic!("checkpoint must survive a projection failure");
+        };
+        assert_eq!(still_attached.as_stored().phase, StoredPhaseV2::Attached);
+
+        effects.fail_enroll.store(false, Ordering::SeqCst);
+        let response = reconcile_with_provider(
+            &effects,
+            &store,
+            &provider,
+            &context,
+            *still_attached,
+            hash("11"),
+            "client-1",
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            response,
+            AccountSetupResponse::View(view)
+                if view.disposition == AccountSetupDisposition::Complete
+        ));
+        assert_eq!(
+            effects.events.lock().unwrap().as_slice(),
+            ["customer", "customer", "custody"]
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_persists_a_terminal_conflict_when_absent_create_returns_http_409() {
+        let (store, checkpoint, context, device_did) =
+            active_recovery_fixture(68, StoredPhaseV2::RootSaved).await;
+        let effects = TestEffects::new(device_did);
+        effects.now.store(
+            checkpoint.as_stored().last_transition_at + 1,
+            Ordering::SeqCst,
+        );
+        effects
+            .live_clients
+            .lock()
+            .unwrap()
+            .insert("client-1".to_string());
+        let provider = ScriptedProvider::new(
+            [Ok(ProviderSetupStatus::Absent)],
+            [Err(ProviderPortError::Conflict)],
+        );
+
+        let response = reconcile_with_provider(
+            &effects,
+            &store,
+            &provider,
+            &context,
+            checkpoint,
+            hash("11"),
+            "client-1",
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            response,
+            AccountSetupResponse::View(view)
+                if view.disposition == AccountSetupDisposition::Conflict
+                    && view.conflict_code
+                        == Some(tonk_worker_api::AccountSetupConflictCode::ProviderMismatch)
+        ));
+        let CheckpointLoad::Ready(checkpoint) = load_checkpoint(&store).await.unwrap() else {
+            panic!("terminal conflict must be durable");
+        };
+        assert!(matches!(
+            checkpoint.as_stored().phase,
+            StoredPhaseV2::Conflict {
+                code: StoredConflictCodeV2::Provider,
+                ..
+            }
+        ));
+    }
+
+    #[dialog_common::test]
+    async fn it_never_requests_an_expired_create_artifact_after_provider_acceptance() {
+        let (store, checkpoint, context, device_did) =
+            active_recovery_fixture(66, StoredPhaseV2::ProviderAccepted).await;
+        let owner_token = "owner-token".repeat(4);
+        let mut stored = checkpoint.into_stored();
+        stored.owner_hash = Some(
+            token_hash(
+                b"tonk-account-setup-owner-v1",
+                &stored.operation_id,
+                &owner_token,
+            )
+            .unwrap(),
+        );
+        let checkpoint = ValidatedCheckpoint::new(stored).unwrap();
+        *store.checkpoint.lock().unwrap() = Some(encode_checkpoint(&checkpoint).unwrap());
+        let StoredRecoveryRecord::Bundle(bundle) = store.recovery_record() else {
+            panic!("fixture must retain protected recovery");
+        };
+        let effects = TestEffects::new(device_did);
+        effects.now.store(
+            bundle.ceremony_created_at + CREATE_EXPIRY_MAX_OFFSET + 1,
+            Ordering::SeqCst,
+        );
+        effects
+            .live_clients
+            .lock()
+            .unwrap()
+            .insert("client-1".to_string());
+        let contexts = FixedContextSource::new(context);
+        let provider = ScriptedProvider::new(
+            std::iter::empty::<Result<ProviderSetupStatus, ProviderPortError>>(),
+            std::iter::empty::<Result<ProviderAcceptance, ProviderPortError>>(),
+        );
+        let origin: url::Url = "https://app.example/".parse().unwrap();
+
+        let inspected = handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-1"),
+            AccountSetupRequest::Inspect(AccountSetupInspect {
+                owner_token: Some(owner_token.clone()),
+            }),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            inspected,
+            AccountSetupResponse::View(view)
+                if view.disposition == AccountSetupDisposition::Ready
+        ));
+
+        let continued = handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-1"),
+            AccountSetupRequest::Continue(AccountSetupMutation {
+                operation_id: checkpoint.as_stored().operation_id.clone(),
+                owner_token,
+                expected_revision: checkpoint.as_stored().revision,
+            }),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            continued,
+            AccountSetupResponse::View(view)
+                if view.disposition == AccountSetupDisposition::Complete
+        ));
+    }
+
+    #[dialog_common::test]
+    async fn it_resumes_an_expired_publish_with_only_the_same_custody_artifact() {
+        let seed = 67;
+        let (store, checkpoint, context, device_did) =
+            active_recovery_fixture(seed, StoredPhaseV2::CustomerEnrolled).await;
+        let owner_token = "owner-token".repeat(4);
+        let mut stored = checkpoint.into_stored();
+        stored.owner_hash = Some(
+            token_hash(
+                b"tonk-account-setup-owner-v1",
+                &stored.operation_id,
+                &owner_token,
+            )
+            .unwrap(),
+        );
+        let checkpoint = ValidatedCheckpoint::new(stored).unwrap();
+        *store.checkpoint.lock().unwrap() = Some(encode_checkpoint(&checkpoint).unwrap());
+        let StoredRecoveryRecord::Bundle(bundle) = store.recovery_record() else {
+            panic!("fixture must retain protected recovery");
+        };
+        let refresh_time = bundle.ceremony_created_at + DEFERRED_PUBLISH_TTL_SECONDS + 1;
+        let replacement = fresh_publish_invocation(seed, &bundle, refresh_time).await;
+        let effects = TestEffects::new(device_did);
+        effects.now.store(refresh_time, Ordering::SeqCst);
+        effects
+            .live_clients
+            .lock()
+            .unwrap()
+            .insert("client-1".to_string());
+        let contexts = FixedContextSource::new(context);
+        let provider = ScriptedProvider::new(
+            std::iter::empty::<Result<ProviderSetupStatus, ProviderPortError>>(),
+            std::iter::empty::<Result<ProviderAcceptance, ProviderPortError>>(),
+        );
+        let origin: url::Url = "https://app.example/".parse().unwrap();
+
+        let inspected = handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-1"),
+            AccountSetupRequest::Inspect(AccountSetupInspect {
+                owner_token: Some(owner_token.clone()),
+            }),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            inspected,
+            AccountSetupResponse::Protected(boxed)
+                if matches!(
+                    boxed.as_ref(),
+                    AccountSetupProtectedResponse::NeedsPasskey {
+                        resume: AccountSetupResumeInput::Publish { .. },
+                        ..
+                    }
+                )
+        ));
+
+        let resumed = handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-1"),
+            AccountSetupRequest::ReplacePublishInvocation(AccountSetupInvocation {
+                mutation: AccountSetupMutation {
+                    operation_id: checkpoint.as_stored().operation_id.clone(),
+                    owner_token,
+                    expected_revision: checkpoint.as_stored().revision,
+                },
+                invocation_hex: replacement,
+            }),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            resumed,
+            AccountSetupResponse::View(view)
+                if view.disposition == AccountSetupDisposition::Complete
+        ));
+        assert_eq!(effects.events.lock().unwrap().as_slice(), ["custody"]);
+    }
+
+    #[dialog_common::test]
+    async fn it_fails_closed_when_recovery_survives_a_lost_checkpoint() {
+        let store = MemorySetupStore::default();
+        *store.recovery.lock().unwrap() = Some(
+            encode_recovery(&StoredRecoveryRecord::Tombstone(RecoveryTombstoneV1 {
+                version: 1,
+                operation_id: "orphaned-operation".to_string(),
+                completed_at: 1_000,
+                recovery_hash: hash("44"),
+            }))
+            .unwrap(),
+        );
+        assert!(matches!(
+            load_setup(&store).await.unwrap(),
+            SetupLoad::Corrupt
+        ));
+
+        let origin: url::Url = "https://app.example/".parse().unwrap();
+        let contexts = FixedContextSource::new(provider_context());
+        let effects = TestEffects::new(signer(69).await.did());
+        let provider = ScriptedProvider::new(
+            std::iter::empty::<Result<ProviderSetupStatus, ProviderPortError>>(),
+            std::iter::empty::<Result<ProviderAcceptance, ProviderPortError>>(),
+        );
+        for request in [
+            AccountSetupRequest::Inspect(AccountSetupInspect { owner_token: None }),
+            AccountSetupRequest::Begin(AccountSetupBegin {
+                protocol_version: ACCOUNT_SETUP_PROTOCOL_VERSION,
+                owner_token: "new-owner".repeat(4),
+            }),
+        ] {
+            let response = handle_locked(
+                &effects,
+                &store,
+                &contexts,
+                &provider,
+                request_scope(&origin, "client-1"),
+                request,
+            )
+            .await
+            .unwrap();
+            assert!(matches!(
+                response,
+                AccountSetupResponse::View(view)
+                    if view.disposition == AccountSetupDisposition::Corrupt
+            ));
+        }
+        assert!(store.checkpoint.lock().unwrap().is_none());
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_recovery_records_that_are_impossible_for_the_checkpoint_phase() {
+        let store = MemorySetupStore::default();
+        let checkpoint = ValidatedCheckpoint::new(StoredCheckpointV2 {
+            version: 2,
+            operation_id: "cancelled-operation".to_string(),
+            revision: 2,
+            owner_hash: None,
+            bound_client_id: None,
+            configuration_hash: hash("22"),
+            phase: StoredPhaseV2::Cancelled,
+            armed_at: None,
+            staged_at: None,
+            attempt_hash: None,
+            root_did: None,
+            create_fingerprint: None,
+            recovery_hash: None,
+            accepted_descriptor_hash: None,
+            last_transition_at: 1_000,
+        })
+        .unwrap();
+        *store.checkpoint.lock().unwrap() = Some(encode_checkpoint(&checkpoint).unwrap());
+        *store.recovery.lock().unwrap() = Some(
+            encode_recovery(&StoredRecoveryRecord::Tombstone(RecoveryTombstoneV1 {
+                version: 1,
+                operation_id: "cancelled-operation".to_string(),
+                completed_at: 1_000,
+                recovery_hash: hash("44"),
+            }))
+            .unwrap(),
+        );
+
+        assert!(matches!(
+            load_setup(&store).await.unwrap(),
+            SetupLoad::Corrupt
+        ));
     }
 
     async fn armed_recovery_fixture(
@@ -5187,6 +6529,58 @@ mod tests {
         assert_eq!(validated.publish_freshness(), RecoveryFreshness::Usable);
         assert_eq!(validated.root_did().to_string(), bundle.root_did);
         assert_eq!(validated.evidence().staged_at, bundle.staged_at);
+    }
+
+    #[dialog_common::test]
+    async fn it_validates_a_stored_replacement_against_its_immutable_reference_time() {
+        let (mut bundle, mut trust) = valid_recovery(63).await;
+        bundle.replacement_invocation_created_at = Some(bundle.ceremony_created_at);
+        bundle.replacement_invocation_hex = Some(bundle.invocation_hex.clone());
+        trust.now = bundle.ceremony_created_at + 120;
+
+        let validated = ValidatedRecoveryBundle::new(bundle.clone(), &trust)
+            .await
+            .expect("time advancing must not make a canonical stored replacement corrupt");
+
+        assert_eq!(validated.create_freshness(), RecoveryFreshness::Usable);
+
+        trust.now = validated.create_expires_at() + 1;
+        let expired = ValidatedRecoveryBundle::new(bundle, &trust)
+            .await
+            .expect("current expiry is a recoverable state, not stored corruption");
+        assert_eq!(expired.create_freshness(), RecoveryFreshness::NeedsRefresh);
+    }
+
+    #[dialog_common::test]
+    async fn it_refreshes_an_expired_publish_without_reclassifying_it_as_corrupt() {
+        let seed = 64;
+        let (mut bundle, mut trust) = valid_recovery(seed).await;
+        let original_expiration = bundle.ceremony_created_at + DEFERRED_PUBLISH_TTL_SECONDS;
+        trust.now = original_expiration + 1;
+
+        let expired = ValidatedRecoveryBundle::new(bundle.clone(), &trust)
+            .await
+            .expect("current expiry is recoverable, not corrupt storage");
+        assert_eq!(expired.publish_freshness(), RecoveryFreshness::NeedsRefresh);
+
+        let replacement_created_at = trust.now;
+        bundle.replacement_publish_invocation_created_at = Some(replacement_created_at);
+        bundle.replacement_publish_invocation_hex =
+            Some(fresh_publish_invocation(seed, &bundle, replacement_created_at).await);
+        trust.now += 120;
+        let refreshed = ValidatedRecoveryBundle::new(bundle.clone(), &trust)
+            .await
+            .expect("elapsed time must not invalidate the immutable refresh reference");
+        assert_eq!(refreshed.publish_freshness(), RecoveryFreshness::Usable);
+
+        trust.now = replacement_created_at + DEFERRED_PUBLISH_TTL_SECONDS + 1;
+        let expired_again = ValidatedRecoveryBundle::new(bundle, &trust)
+            .await
+            .expect("a second expiry remains refreshable");
+        assert_eq!(
+            expired_again.publish_freshness(),
+            RecoveryFreshness::NeedsRefresh
+        );
     }
 
     #[dialog_common::test]

--- a/rust/tonk-worker/src/router/account_setup.rs
+++ b/rust/tonk-worker/src/router/account_setup.rs
@@ -1436,6 +1436,7 @@ trait SetupEffects {
     async fn enroll_customer(
         &self,
         origin: &Url,
+        expected_root: &str,
         email: String,
         deposits: &[String],
     ) -> Result<(), ()>;
@@ -1446,6 +1447,22 @@ trait SetupEffects {
         sealed_hex: &str,
         invocation_hex: &str,
     ) -> Result<(), ()>;
+    async fn observe_custody_setup(
+        &self,
+        custody: &str,
+        consent_hex: &str,
+        sealed_hex: &str,
+        invocation_hex: &str,
+    ) -> Result<super::customer::CustodySetupObservation, ()>;
+    async fn replace_custody_publish(
+        &self,
+        custody: &str,
+        consent_hex: &str,
+        sealed_hex: &str,
+        previous_invocation_hex: &str,
+        replacement_invocation_hex: &str,
+    ) -> Result<super::customer::CustodySetupObservation, ()>;
+    async fn drain_pending_custody(&self);
 }
 
 struct WorkerSetupEffects<'a> {
@@ -1533,13 +1550,16 @@ impl SetupEffects for WorkerSetupEffects<'_> {
     async fn enroll_customer(
         &self,
         origin: &Url,
+        expected_root: &str,
         email: String,
         deposits: &[String],
     ) -> Result<(), ()> {
-        super::customer::enroll_customer(self.state, origin, Some(email), deposits)
+        let receipt = super::customer::enroll_customer(self.state, origin, Some(email), deposits)
             .await
-            .map(|_| ())
-            .map_err(|_| ())
+            .map_err(|_| ())?;
+        (receipt.customer.to_string() == expected_root)
+            .then_some(())
+            .ok_or(())
     }
 
     async fn persist_custody_setup(
@@ -1558,6 +1578,48 @@ impl SetupEffects for WorkerSetupEffects<'_> {
         )
         .await
         .map_err(|_| ())
+    }
+
+    async fn observe_custody_setup(
+        &self,
+        custody: &str,
+        consent_hex: &str,
+        sealed_hex: &str,
+        invocation_hex: &str,
+    ) -> Result<super::customer::CustodySetupObservation, ()> {
+        super::customer::observe_custody_setup(
+            self.state,
+            custody,
+            consent_hex,
+            sealed_hex,
+            invocation_hex,
+        )
+        .await
+        .map_err(|_| ())
+    }
+
+    async fn replace_custody_publish(
+        &self,
+        custody: &str,
+        consent_hex: &str,
+        sealed_hex: &str,
+        previous_invocation_hex: &str,
+        replacement_invocation_hex: &str,
+    ) -> Result<super::customer::CustodySetupObservation, ()> {
+        super::customer::replace_custody_publish(
+            self.state,
+            custody,
+            consent_hex,
+            sealed_hex,
+            previous_invocation_hex,
+            replacement_invocation_hex,
+        )
+        .await
+        .map_err(|_| ())
+    }
+
+    async fn drain_pending_custody(&self) {
+        super::customer::drain_pending(self.state).await;
     }
 }
 
@@ -3489,6 +3551,7 @@ async fn reconcile_with_provider(
                         if effects
                             .enroll_customer(
                                 &context.service_origin,
+                                &recovery.stored.root_did,
                                 recovery.stored.normalized_email.clone(),
                                 &recovery.stored.deposits_hex,
                             )
@@ -3576,6 +3639,62 @@ async fn reconcile_with_provider(
                 .await?;
             }
             StoredPhaseV2::CustodyQueued => {
+                let publish_invocation_hex = recovery
+                    .publish_invocation_hex()
+                    .map_err(|_| SetupStoreError::Read)?;
+                let observe = || {
+                    effects.observe_custody_setup(
+                        &recovery.stored.custody_did,
+                        &recovery.stored.consent_hex,
+                        &recovery.stored.sealed_hex,
+                        &publish_invocation_hex,
+                    )
+                };
+                let mut observation = observe().await.map_err(|_| SetupStoreError::Read)?;
+                if observation == super::customer::CustodySetupObservation::Mismatch {
+                    return persist_conflict(
+                        store,
+                        checkpoint,
+                        mutation,
+                        StoredConflictCodeV2::Recovery,
+                    )
+                    .await;
+                }
+                if observation == super::customer::CustodySetupObservation::Pending {
+                    if recovery.publish_freshness() == RecoveryFreshness::NeedsRefresh {
+                        if !effects.client_is_live(client_id).await {
+                            return Ok(AccountSetupResponse::View(checkpoint_view(
+                                &checkpoint,
+                                false,
+                            )));
+                        }
+                        let mut view = checkpoint_view(&checkpoint, true);
+                        view.disposition = AccountSetupDisposition::NeedsPasskey;
+                        view.next_action = AccountSetupNextAction::ResumeWithPasskey;
+                        return Ok(needs_passkey_response(
+                            &recovery,
+                            view,
+                            PasskeyRefresh::Publish,
+                        ));
+                    }
+                    effects.drain_pending_custody().await;
+                    observation = observe().await.map_err(|_| SetupStoreError::Read)?;
+                    match observation {
+                        super::customer::CustodySetupObservation::Pending => {
+                            return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+                        }
+                        super::customer::CustodySetupObservation::Mismatch => {
+                            return persist_conflict(
+                                store,
+                                checkpoint,
+                                mutation,
+                                StoredConflictCodeV2::Recovery,
+                            )
+                            .await;
+                        }
+                        super::customer::CustodySetupObservation::Complete => {}
+                    }
+                }
                 checkpoint = persist_reduction(
                     store,
                     reduce(
@@ -3780,12 +3899,40 @@ async fn handle_locked(
             ))
         }
         AccountSetupRequest::Inspect(inspect) => {
-            inspect_response(
+            let response = inspect_response(
                 effects,
                 store,
                 contexts,
                 trusted_origin,
                 inspect.owner_token.as_deref(),
+                client_id,
+            )
+            .await?;
+            if !matches!(response, AccountSetupResponse::View(_)) {
+                return Ok(response);
+            }
+            let CheckpointLoad::Ready(checkpoint) = load_checkpoint(store).await? else {
+                return Ok(response);
+            };
+            if checkpoint.as_stored().phase != StoredPhaseV2::CustodyQueued
+                || !owns_checkpoint(&checkpoint, inspect.owner_token.as_deref(), client_id)
+                || !effects.client_is_live(client_id).await
+            {
+                return Ok(response);
+            }
+            let Ok(context) = contexts.resolve(trusted_origin).await else {
+                return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+            };
+            let Some(owner_hash) = checkpoint.as_stored().owner_hash.clone() else {
+                return Ok(response);
+            };
+            reconcile_with_provider(
+                effects,
+                store,
+                provider,
+                &context,
+                *checkpoint,
+                owner_hash,
                 client_id,
             )
             .await
@@ -4112,8 +4259,12 @@ async fn handle_locked(
             let RecoveryLoad::Bundle(mut bundle) = load_recovery(store).await? else {
                 return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
             };
-            bundle.replacement_invocation_created_at = Some(now);
-            bundle.replacement_invocation_hex = Some(replacement.invocation_hex);
+            if bundle.replacement_invocation_hex.as_deref()
+                != Some(replacement.invocation_hex.as_str())
+            {
+                bundle.replacement_invocation_created_at = Some(now);
+                bundle.replacement_invocation_hex = Some(replacement.invocation_hex);
+            }
             let validated = match validate_recovery_for_checkpoint(
                 *bundle,
                 &checkpoint,
@@ -4162,7 +4313,10 @@ async fn handle_locked(
                     false,
                 )));
             }
-            if checkpoint.as_stored().phase != StoredPhaseV2::CustomerEnrolled {
+            if !matches!(
+                checkpoint.as_stored().phase,
+                StoredPhaseV2::CustomerEnrolled | StoredPhaseV2::CustodyQueued
+            ) {
                 return Ok(AccountSetupResponse::View(checkpoint_view(
                     &checkpoint,
                     true,
@@ -4174,8 +4328,14 @@ async fn handle_locked(
             let RecoveryLoad::Bundle(mut bundle) = load_recovery(store).await? else {
                 return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
             };
-            bundle.replacement_publish_invocation_created_at = Some(now);
-            bundle.replacement_publish_invocation_hex = Some(replacement.invocation_hex);
+            let previous_invocation_hex = bundle
+                .replacement_publish_invocation_hex
+                .clone()
+                .unwrap_or_else(|| bundle.publish_invocation_hex.clone());
+            if previous_invocation_hex != replacement.invocation_hex {
+                bundle.replacement_publish_invocation_created_at = Some(now);
+                bundle.replacement_publish_invocation_hex = Some(replacement.invocation_hex);
+            }
             let validated = match validate_recovery_for_checkpoint(
                 *bundle,
                 &checkpoint,
@@ -4188,6 +4348,27 @@ async fn handle_locked(
                 Ok(validated) => validated,
                 Err(_) => return Ok(AccountSetupResponse::View(retry_view(&checkpoint))),
             };
+            let replacement_invocation_hex = validated
+                .publish_invocation_hex()
+                .map_err(|_| SetupStoreError::Read)?;
+            if checkpoint.as_stored().phase == StoredPhaseV2::CustodyQueued {
+                match effects
+                    .replace_custody_publish(
+                        &validated.stored.custody_did,
+                        &validated.stored.consent_hex,
+                        &validated.stored.sealed_hex,
+                        &previous_invocation_hex,
+                        &replacement_invocation_hex,
+                    )
+                    .await
+                {
+                    Ok(super::customer::CustodySetupObservation::Pending)
+                    | Ok(super::customer::CustodySetupObservation::Complete) => {}
+                    Ok(super::customer::CustodySetupObservation::Mismatch) | Err(()) => {
+                        return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+                    }
+                }
+            }
             save_recovery(
                 store,
                 &StoredRecoveryRecord::Bundle(Box::new(validated.stored.clone())),
@@ -4463,6 +4644,7 @@ mod tests {
     use async_trait::async_trait;
     use dialog_credentials::Ed25519Signer;
     use dialog_ucan_core::time::timestamp::{Duration, Timestamp, UNIX_EPOCH};
+    use dialog_ucan_core::{InvocationBuilder, InvocationChain};
     use dialog_varsig::Principal as _;
     use tonk_account::creation::{AccountCreationFingerprintInput, AccountCreationPasskey};
     use tonk_account::{AccountSetupRecoveryManifestInput, AccountSetupRecoveryManifestV1};
@@ -4632,18 +4814,75 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct MemoryCustomerProjectionPort {
+        local: Mutex<Option<super::super::customer::CustomerRecord>>,
+        account: Mutex<Option<super::super::customer::AccountCustomerProjection>>,
+        fail_account_save: AtomicBool,
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    impl super::super::customer::CustomerProjectionPort for MemoryCustomerProjectionPort {
+        async fn load_customer_record(
+            &self,
+        ) -> Result<super::super::customer::CustomerRecordProjection, crate::TonkWorkerError>
+        {
+            Ok(self.local.lock().unwrap().clone().map_or(
+                super::super::customer::CustomerRecordProjection::Missing,
+                super::super::customer::CustomerRecordProjection::Present,
+            ))
+        }
+
+        async fn load_account_customer(
+            &self,
+        ) -> Result<Option<super::super::customer::AccountCustomerProjection>, crate::TonkWorkerError>
+        {
+            Ok(self.account.lock().unwrap().clone())
+        }
+
+        async fn save_customer_record(
+            &self,
+            record: &super::super::customer::CustomerRecord,
+        ) -> Result<(), crate::TonkWorkerError> {
+            *self.local.lock().unwrap() = Some(record.clone());
+            Ok(())
+        }
+
+        async fn save_account_customer(
+            &self,
+            status: tonk_account::customer::CustomerStatus,
+            email: &str,
+            _provider: Option<&str>,
+        ) -> Result<(), crate::TonkWorkerError> {
+            if self.fail_account_save.load(Ordering::SeqCst) {
+                return Err(crate::TonkWorkerError::Internal(
+                    "injected profile-main projection failure".to_string(),
+                ));
+            }
+            *self.account.lock().unwrap() =
+                Some(super::super::customer::AccountCustomerProjection {
+                    status: status.as_str().to_string(),
+                    email: email.to_string(),
+                });
+            Ok(())
+        }
+    }
+
     struct TestEffects {
         device_did: dialog_varsig::Did,
         now: AtomicU64,
         live_clients: Mutex<BTreeSet<String>>,
         root: Mutex<super::super::identity::LocalRootObservation>,
         attachment: Mutex<super::super::account::AttachmentObservation>,
-        customer: Mutex<super::super::customer::CustomerObservation>,
+        customer_projections: MemoryCustomerProjectionPort,
         account_state_ready: AtomicBool,
         fail_root_persist: AtomicBool,
         fail_attachment_persist: AtomicBool,
-        fail_enroll: AtomicBool,
         fail_custody: AtomicBool,
+        complete_custody_on_drain: AtomicBool,
+        replace_custody_calls: AtomicUsize,
+        custody: Mutex<super::super::customer::CustodySetupObservation>,
         events: Mutex<Vec<&'static str>>,
     }
 
@@ -4655,12 +4894,14 @@ mod tests {
                 live_clients: Mutex::new(BTreeSet::new()),
                 root: Mutex::new(super::super::identity::LocalRootObservation::Missing),
                 attachment: Mutex::new(super::super::account::AttachmentObservation::Missing),
-                customer: Mutex::new(super::super::customer::CustomerObservation::Missing),
+                customer_projections: MemoryCustomerProjectionPort::default(),
                 account_state_ready: AtomicBool::new(true),
                 fail_root_persist: AtomicBool::new(false),
                 fail_attachment_persist: AtomicBool::new(false),
-                fail_enroll: AtomicBool::new(false),
                 fail_custody: AtomicBool::new(false),
+                complete_custody_on_drain: AtomicBool::new(true),
+                replace_custody_calls: AtomicUsize::new(0),
+                custody: Mutex::new(super::super::customer::CustodySetupObservation::Pending),
                 events: Mutex::new(Vec::new()),
             }
         }
@@ -4730,24 +4971,38 @@ mod tests {
 
         async fn observe_customer(
             &self,
-            _expected_root: &str,
-            _expected_email: &str,
+            expected_root: &str,
+            expected_email: &str,
         ) -> Result<super::super::customer::CustomerObservation, ()> {
-            Ok(*self.customer.lock().unwrap())
+            super::super::customer::observe_customer_projections(
+                &self.customer_projections,
+                expected_root,
+                expected_email,
+            )
+            .await
+            .map_err(|_| ())
         }
 
         async fn enroll_customer(
             &self,
             _origin: &url::Url,
-            _email: String,
+            expected_root: &str,
+            email: String,
             _deposits: &[String],
         ) -> Result<(), ()> {
             self.events.lock().unwrap().push("customer");
-            if self.fail_enroll.load(Ordering::SeqCst) {
-                return Err(());
-            }
-            *self.customer.lock().unwrap() = super::super::customer::CustomerObservation::Exact;
-            Ok(())
+            super::super::customer::persist_customer_projections(
+                &self.customer_projections,
+                &super::super::customer::CustomerRecord {
+                    customer: expected_root.to_string(),
+                    email,
+                    status: tonk_account::customer::CustomerStatus::Registered,
+                    enrolled_at: self.now_seconds(),
+                },
+                None,
+            )
+            .await
+            .map_err(|_| ())
         }
 
         async fn persist_custody_setup(
@@ -4761,7 +5016,38 @@ mod tests {
             if self.fail_custody.load(Ordering::SeqCst) {
                 Err(())
             } else {
+                *self.custody.lock().unwrap() =
+                    super::super::customer::CustodySetupObservation::Pending;
                 Ok(())
+            }
+        }
+
+        async fn observe_custody_setup(
+            &self,
+            _custody: &str,
+            _consent_hex: &str,
+            _sealed_hex: &str,
+            _invocation_hex: &str,
+        ) -> Result<super::super::customer::CustodySetupObservation, ()> {
+            Ok(*self.custody.lock().unwrap())
+        }
+
+        async fn replace_custody_publish(
+            &self,
+            _custody: &str,
+            _consent_hex: &str,
+            _sealed_hex: &str,
+            _previous_invocation_hex: &str,
+            _replacement_invocation_hex: &str,
+        ) -> Result<super::super::customer::CustodySetupObservation, ()> {
+            self.replace_custody_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(*self.custody.lock().unwrap())
+        }
+
+        async fn drain_pending_custody(&self) {
+            if self.complete_custody_on_drain.load(Ordering::SeqCst) {
+                *self.custody.lock().unwrap() =
+                    super::super::customer::CustodySetupObservation::Complete;
             }
         }
     }
@@ -5397,6 +5683,46 @@ mod tests {
         hex::encode(invocation)
     }
 
+    async fn fresh_create_invocation(
+        seed: u8,
+        bundle: &StoredRecoveryBundleV1,
+        created_at: u64,
+    ) -> String {
+        let sealed =
+            tonk_identity::envelope::Envelope::<tonk_identity::clearance::Recovery>::decode(
+                &hex::decode(&bundle.sealed_hex).unwrap(),
+            )
+            .unwrap();
+        let secret = custody_kek(&[seed.wrapping_add(2); 32])
+            .open(&sealed)
+            .unwrap();
+        let root = secret.signer().await.unwrap();
+        let original = InvocationChain::<dialog_varsig::AnySignature>::try_from(
+            hex::decode(&bundle.invocation_hex).unwrap().as_slice(),
+        )
+        .unwrap();
+        let issued_at = Timestamp::new(UNIX_EPOCH + Duration::from_secs(created_at)).unwrap();
+        let expiration =
+            Timestamp::new(UNIX_EPOCH + Duration::from_secs(created_at + 5 * 60)).unwrap();
+        let invocation = InvocationBuilder::new()
+            .issuer(dialog_credentials::Signer::from(root))
+            .audience(original.invocation.audience())
+            .subject(original.invocation.subject())
+            .command(original.invocation.command().segments().clone())
+            .arguments(original.invocation.arguments().clone())
+            .proofs(original.invocation.proofs().clone())
+            .issued_at(issued_at)
+            .expiration(expiration)
+            .try_build()
+            .await
+            .unwrap();
+        hex::encode(
+            InvocationChain::new(invocation, std::collections::HashMap::new())
+                .to_bytes()
+                .unwrap(),
+        )
+    }
+
     async fn completed_recovery_fixture(
         seed: u8,
     ) -> (
@@ -5484,7 +5810,10 @@ mod tests {
             .lock()
             .unwrap()
             .insert("client-1".to_string());
-        effects.fail_enroll.store(true, Ordering::SeqCst);
+        effects
+            .customer_projections
+            .fail_account_save
+            .store(true, Ordering::SeqCst);
         let provider = ScriptedProvider::new(
             std::iter::empty::<Result<ProviderSetupStatus, ProviderPortError>>(),
             std::iter::empty::<Result<ProviderAcceptance, ProviderPortError>>(),
@@ -5509,8 +5838,20 @@ mod tests {
             panic!("checkpoint must survive a projection failure");
         };
         assert_eq!(still_attached.as_stored().phase, StoredPhaseV2::Attached);
+        assert!(effects.customer_projections.local.lock().unwrap().is_some());
+        assert!(
+            effects
+                .customer_projections
+                .account
+                .lock()
+                .unwrap()
+                .is_none()
+        );
 
-        effects.fail_enroll.store(false, Ordering::SeqCst);
+        effects
+            .customer_projections
+            .fail_account_save
+            .store(false, Ordering::SeqCst);
         let response = reconcile_with_provider(
             &effects,
             &store,
@@ -5530,6 +5871,457 @@ mod tests {
         assert_eq!(
             effects.events.lock().unwrap().as_slice(),
             ["customer", "customer", "custody"]
+        );
+        assert!(
+            effects
+                .customer_projections
+                .account
+                .lock()
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_retains_recovery_while_custody_publish_is_only_queued() {
+        let (store, checkpoint, context, device_did) =
+            active_recovery_fixture(70, StoredPhaseV2::CustomerEnrolled).await;
+        let effects = TestEffects::new(device_did);
+        effects
+            .complete_custody_on_drain
+            .store(false, Ordering::SeqCst);
+        effects.now.store(
+            checkpoint.as_stored().last_transition_at + 1,
+            Ordering::SeqCst,
+        );
+        effects
+            .live_clients
+            .lock()
+            .unwrap()
+            .insert("client-1".to_string());
+        let provider = ScriptedProvider::new(
+            std::iter::empty::<Result<ProviderSetupStatus, ProviderPortError>>(),
+            std::iter::empty::<Result<ProviderAcceptance, ProviderPortError>>(),
+        );
+
+        let response = reconcile_with_provider(
+            &effects,
+            &store,
+            &provider,
+            &context,
+            checkpoint,
+            hash("11"),
+            "client-1",
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            response,
+            AccountSetupResponse::View(view)
+                if view.disposition == AccountSetupDisposition::RetryLater
+        ));
+        let CheckpointLoad::Ready(checkpoint) = load_checkpoint(&store).await.unwrap() else {
+            panic!("queued custody must retain a recoverable checkpoint");
+        };
+        assert_eq!(checkpoint.as_stored().phase, StoredPhaseV2::CustodyQueued);
+        assert!(matches!(
+            store.recovery_record(),
+            StoredRecoveryRecord::Bundle(_)
+        ));
+    }
+
+    #[dialog_common::test]
+    async fn it_refreshes_a_deferred_publish_then_completes_after_activation_drain() {
+        let seed = 71;
+        let (store, checkpoint, context, device_did) =
+            active_recovery_fixture(seed, StoredPhaseV2::CustomerEnrolled).await;
+        let owner_token = "owner-token".repeat(4);
+        let mut stored = checkpoint.into_stored();
+        stored.owner_hash = Some(
+            token_hash(
+                b"tonk-account-setup-owner-v1",
+                &stored.operation_id,
+                &owner_token,
+            )
+            .unwrap(),
+        );
+        let checkpoint = ValidatedCheckpoint::new(stored).unwrap();
+        *store.checkpoint.lock().unwrap() = Some(encode_checkpoint(&checkpoint).unwrap());
+        let StoredRecoveryRecord::Bundle(bundle) = store.recovery_record() else {
+            panic!("fixture must retain protected recovery");
+        };
+        let effects = TestEffects::new(device_did);
+        effects
+            .complete_custody_on_drain
+            .store(false, Ordering::SeqCst);
+        effects
+            .live_clients
+            .lock()
+            .unwrap()
+            .insert("client-1".to_string());
+        effects.now.store(
+            checkpoint.as_stored().last_transition_at + 1,
+            Ordering::SeqCst,
+        );
+        let contexts = FixedContextSource::new(context);
+        let provider = ScriptedProvider::new(
+            std::iter::empty::<Result<ProviderSetupStatus, ProviderPortError>>(),
+            std::iter::empty::<Result<ProviderAcceptance, ProviderPortError>>(),
+        );
+        let origin: url::Url = "https://app.example/".parse().unwrap();
+
+        let queued = handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-1"),
+            AccountSetupRequest::Continue(AccountSetupMutation {
+                operation_id: checkpoint.as_stored().operation_id.clone(),
+                owner_token: owner_token.clone(),
+                expected_revision: checkpoint.as_stored().revision,
+            }),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            queued,
+            AccountSetupResponse::View(view)
+                if view.disposition == AccountSetupDisposition::RetryLater
+        ));
+        let CheckpointLoad::Ready(queued_checkpoint) = load_checkpoint(&store).await.unwrap()
+        else {
+            panic!("queued custody checkpoint must be durable");
+        };
+        assert_eq!(
+            queued_checkpoint.as_stored().phase,
+            StoredPhaseV2::CustodyQueued
+        );
+
+        let refresh_time = bundle.ceremony_created_at + DEFERRED_PUBLISH_TTL_SECONDS + 1;
+        effects.now.store(refresh_time, Ordering::SeqCst);
+        let inspected = handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-1"),
+            AccountSetupRequest::Inspect(AccountSetupInspect {
+                owner_token: Some(owner_token.clone()),
+            }),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            inspected,
+            AccountSetupResponse::Protected(boxed)
+                if matches!(
+                    boxed.as_ref(),
+                    AccountSetupProtectedResponse::NeedsPasskey {
+                        resume: AccountSetupResumeInput::Publish { .. },
+                        ..
+                    }
+                )
+        ));
+
+        let replacement = fresh_publish_invocation(seed, &bundle, refresh_time).await;
+        let resumed = handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-1"),
+            AccountSetupRequest::ReplacePublishInvocation(AccountSetupInvocation {
+                mutation: AccountSetupMutation {
+                    operation_id: queued_checkpoint.as_stored().operation_id.clone(),
+                    owner_token: owner_token.clone(),
+                    expected_revision: queued_checkpoint.as_stored().revision,
+                },
+                invocation_hex: replacement,
+            }),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            resumed,
+            AccountSetupResponse::View(view)
+                if view.disposition == AccountSetupDisposition::RetryLater
+        ));
+        assert!(matches!(
+            store.recovery_record(),
+            StoredRecoveryRecord::Bundle(_)
+        ));
+
+        effects
+            .complete_custody_on_drain
+            .store(true, Ordering::SeqCst);
+        let completed = handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-1"),
+            AccountSetupRequest::Inspect(AccountSetupInspect {
+                owner_token: Some(owner_token),
+            }),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            completed,
+            AccountSetupResponse::View(view)
+                if view.disposition == AccountSetupDisposition::Complete
+        ));
+        let CheckpointLoad::Ready(completed_checkpoint) = load_checkpoint(&store).await.unwrap()
+        else {
+            panic!("completed custody checkpoint must be durable");
+        };
+        assert_eq!(
+            completed_checkpoint.as_stored().phase,
+            StoredPhaseV2::Complete
+        );
+        assert!(matches!(
+            store.recovery_record(),
+            StoredRecoveryRecord::Tombstone(_)
+        ));
+    }
+
+    #[dialog_common::test]
+    async fn it_keeps_the_create_replacement_receipt_on_identical_lost_response_retry() {
+        let seed = 72;
+        let (store, checkpoint, context, device_did) =
+            active_recovery_fixture(seed, StoredPhaseV2::RootSaved).await;
+        let owner_token = "owner-token".repeat(4);
+        let mut stored = checkpoint.into_stored();
+        stored.owner_hash = Some(
+            token_hash(
+                b"tonk-account-setup-owner-v1",
+                &stored.operation_id,
+                &owner_token,
+            )
+            .unwrap(),
+        );
+        let checkpoint = ValidatedCheckpoint::new(stored).unwrap();
+        *store.checkpoint.lock().unwrap() = Some(encode_checkpoint(&checkpoint).unwrap());
+        let StoredRecoveryRecord::Bundle(bundle) = store.recovery_record() else {
+            panic!("fixture must retain protected recovery");
+        };
+        let receipt_time = checkpoint.as_stored().last_transition_at + 1;
+        let first = fresh_create_invocation(seed, &bundle, receipt_time).await;
+        let effects = TestEffects::new(device_did);
+        effects
+            .live_clients
+            .lock()
+            .unwrap()
+            .insert("client-1".to_string());
+        effects.now.store(receipt_time, Ordering::SeqCst);
+        let contexts = FixedContextSource::new(context);
+        let provider = ScriptedProvider::new(
+            [
+                Err(ProviderPortError::Retry),
+                Err(ProviderPortError::Retry),
+                Err(ProviderPortError::Retry),
+            ],
+            std::iter::empty::<Result<ProviderAcceptance, ProviderPortError>>(),
+        );
+        let origin: url::Url = "https://app.example/".parse().unwrap();
+        let request = |invocation_hex: String| {
+            AccountSetupRequest::ReplaceInvocation(AccountSetupInvocation {
+                mutation: AccountSetupMutation {
+                    operation_id: checkpoint.as_stored().operation_id.clone(),
+                    owner_token: owner_token.clone(),
+                    expected_revision: checkpoint.as_stored().revision,
+                },
+                invocation_hex,
+            })
+        };
+
+        handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-1"),
+            request(first.clone()),
+        )
+        .await
+        .unwrap();
+        let StoredRecoveryRecord::Bundle(saved) = store.recovery_record() else {
+            panic!("replacement retry must retain protected recovery");
+        };
+        assert_eq!(saved.replacement_invocation_created_at, Some(receipt_time));
+
+        effects.now.store(receipt_time + 61, Ordering::SeqCst);
+        handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-1"),
+            request(first.clone()),
+        )
+        .await
+        .unwrap();
+        let StoredRecoveryRecord::Bundle(retried) = store.recovery_record() else {
+            panic!("identical retry must retain protected recovery");
+        };
+        assert_eq!(
+            retried.replacement_invocation_hex.as_deref(),
+            Some(first.as_str())
+        );
+        assert_eq!(
+            retried.replacement_invocation_created_at,
+            Some(receipt_time),
+            "an identical artifact must not acquire a sliding receipt time"
+        );
+        assert_eq!(
+            provider.calls().len(),
+            2,
+            "the identical retry must be accepted and reconciled, not rejected before provider status"
+        );
+
+        let next_time = receipt_time + 62;
+        let differing = fresh_create_invocation(seed, &bundle, next_time).await;
+        assert_ne!(differing, first);
+        effects.now.store(next_time, Ordering::SeqCst);
+        handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-1"),
+            request(differing.clone()),
+        )
+        .await
+        .unwrap();
+        let StoredRecoveryRecord::Bundle(replaced) = store.recovery_record() else {
+            panic!("new replacement must retain protected recovery");
+        };
+        assert_eq!(replaced.replacement_invocation_hex, Some(differing));
+        assert_eq!(replaced.replacement_invocation_created_at, Some(next_time));
+    }
+
+    #[dialog_common::test]
+    async fn it_keeps_the_publish_replacement_receipt_on_identical_lost_response_retry() {
+        let seed = 73;
+        let (store, checkpoint, context, device_did) =
+            active_recovery_fixture(seed, StoredPhaseV2::CustomerEnrolled).await;
+        let owner_token = "owner-token".repeat(4);
+        let mut stored = checkpoint.into_stored();
+        stored.owner_hash = Some(
+            token_hash(
+                b"tonk-account-setup-owner-v1",
+                &stored.operation_id,
+                &owner_token,
+            )
+            .unwrap(),
+        );
+        let checkpoint = ValidatedCheckpoint::new(stored).unwrap();
+        *store.checkpoint.lock().unwrap() = Some(encode_checkpoint(&checkpoint).unwrap());
+        let StoredRecoveryRecord::Bundle(bundle) = store.recovery_record() else {
+            panic!("fixture must retain protected recovery");
+        };
+        let receipt_time = checkpoint.as_stored().last_transition_at + 1;
+        let first = fresh_publish_invocation(seed, &bundle, receipt_time).await;
+        let effects = TestEffects::new(device_did);
+        effects
+            .complete_custody_on_drain
+            .store(false, Ordering::SeqCst);
+        effects
+            .live_clients
+            .lock()
+            .unwrap()
+            .insert("client-1".to_string());
+        effects.now.store(receipt_time, Ordering::SeqCst);
+        let contexts = FixedContextSource::new(context);
+        let provider = ScriptedProvider::new(
+            std::iter::empty::<Result<ProviderSetupStatus, ProviderPortError>>(),
+            std::iter::empty::<Result<ProviderAcceptance, ProviderPortError>>(),
+        );
+        let origin: url::Url = "https://app.example/".parse().unwrap();
+        let first_response = handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-1"),
+            AccountSetupRequest::ReplacePublishInvocation(AccountSetupInvocation {
+                mutation: AccountSetupMutation {
+                    operation_id: checkpoint.as_stored().operation_id.clone(),
+                    owner_token: owner_token.clone(),
+                    expected_revision: checkpoint.as_stored().revision,
+                },
+                invocation_hex: first.clone(),
+            }),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            first_response,
+            AccountSetupResponse::View(view)
+                if view.disposition == AccountSetupDisposition::RetryLater
+        ));
+        let CheckpointLoad::Ready(queued) = load_checkpoint(&store).await.unwrap() else {
+            panic!("first publish replacement must queue custody");
+        };
+        let request = |invocation_hex: String| {
+            AccountSetupRequest::ReplacePublishInvocation(AccountSetupInvocation {
+                mutation: AccountSetupMutation {
+                    operation_id: queued.as_stored().operation_id.clone(),
+                    owner_token: owner_token.clone(),
+                    expected_revision: queued.as_stored().revision,
+                },
+                invocation_hex,
+            })
+        };
+
+        effects.now.store(receipt_time + 61, Ordering::SeqCst);
+        handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-1"),
+            request(first.clone()),
+        )
+        .await
+        .unwrap();
+        let StoredRecoveryRecord::Bundle(retried) = store.recovery_record() else {
+            panic!("identical retry must retain protected recovery");
+        };
+        assert_eq!(
+            retried.replacement_publish_invocation_created_at,
+            Some(receipt_time),
+            "an identical artifact must not acquire a sliding receipt time"
+        );
+        assert_eq!(
+            effects.replace_custody_calls.load(Ordering::SeqCst),
+            1,
+            "the identical retry must reach the idempotent production queue replacement seam"
+        );
+
+        let next_time = receipt_time + 62;
+        let differing = fresh_publish_invocation(seed, &bundle, next_time).await;
+        assert_ne!(differing, first);
+        effects.now.store(next_time, Ordering::SeqCst);
+        handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-1"),
+            request(differing.clone()),
+        )
+        .await
+        .unwrap();
+        let StoredRecoveryRecord::Bundle(replaced) = store.recovery_record() else {
+            panic!("new publish replacement must retain protected recovery");
+        };
+        assert_eq!(replaced.replacement_publish_invocation_hex, Some(differing));
+        assert_eq!(
+            replaced.replacement_publish_invocation_created_at,
+            Some(next_time)
         );
     }
 

--- a/rust/tonk-worker/src/router/account_setup.rs
+++ b/rust/tonk-worker/src/router/account_setup.rs
@@ -2,6 +2,13 @@
 
 use std::sync::Arc;
 
+use async_trait::async_trait;
+use axum::{
+    Json,
+    extract::{Extension, State},
+    response::{IntoResponse, Response},
+};
+use axum_wasm_macros::wasm_compat;
 use dialog_common::Checksum;
 use dialog_credentials::DidKeyResolver;
 use dialog_ucan_core::promise::Promised;
@@ -13,6 +20,8 @@ use dialog_ucan_core::{
 };
 use dialog_varsig::{AnySignature, Did};
 use serde::{Deserialize, Serialize};
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use tokio::sync::oneshot;
 use tonk_account::creation::{
     AccountCreationFingerprint, AccountCreationFingerprintInput, AccountCreationPasskey,
 };
@@ -25,7 +34,14 @@ use tonk_identity::custody::DEFERRED_PUBLISH_TTL_SECONDS;
 use tonk_identity::envelope::{
     CUSTODY_SECRET_CELL, CUSTODY_SPACE, Envelope as RecoveryEnvelopeV2, KekMethod,
 };
-use tonk_worker_api::PasskeyMetadata;
+use tonk_worker_api::{
+    ACCOUNT_SETUP_PROTOCOL_VERSION, ACCOUNT_SETUP_PROVIDER_RECOVERY_VERSION, AccountLinkRequest,
+    AccountSetupCapabilities, AccountSetupCeremonyContext, AccountSetupConflictCode,
+    AccountSetupDisposition, AccountSetupLease, AccountSetupMutation, AccountSetupNextAction,
+    AccountSetupProgress, AccountSetupProtectedResponse, AccountSetupRecoveryBundle,
+    AccountSetupRequest, AccountSetupResponse, AccountSetupResumeInput, AccountSetupView,
+    PasskeyMetadata, SaveRootRequest,
+};
 use url::Url;
 
 const ACCOUNT_SETUP_CHECKPOINT_SITE: &str = "tonk-account-setup-v2";
@@ -34,6 +50,7 @@ const CHECKPOINT_VERSION: u16 = 2;
 const RECOVERY_VERSION: u16 = 1;
 const MAX_CHECKPOINT_BYTES: usize = 32 * 1024;
 const MAX_RECOVERY_RECORD_BYTES: usize = 1024 * 1024;
+pub(super) const ACCOUNT_SETUP_BODY_LIMIT: usize = MAX_RECOVERY_RECORD_BYTES + 64 * 1024;
 const MAX_OPERATION_BYTES: usize = 128;
 const MAX_EMAIL_CHARS: usize = 320;
 const MAX_URL_BYTES: usize = 2048;
@@ -57,6 +74,10 @@ const CREATE_EXPIRY_MAX_OFFSET: u64 = 6 * 60;
 const PUBLISH_EXPIRY_MIN_OFFSET: u64 = DEFERRED_PUBLISH_TTL_SECONDS - 60;
 const PUBLISH_EXPIRY_MAX_OFFSET: u64 = DEFERRED_PUBLISH_TTL_SECONDS + 6 * 60;
 const SEALED_ACCOUNT_SECRET_BYTES: usize = 68;
+const MAX_TOKEN_BYTES: usize = 512;
+const MIN_TOKEN_BYTES: usize = 32;
+const MAX_PROVIDER_RESPONSE_BYTES: usize = 64 * 1024;
+const ACCOUNT_SETUP_LOCK_NAME: &str = "tonk-account-setup-v2";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -187,6 +208,10 @@ struct StoredRecoveryBundleV1 {
     descriptor_hex: String,
     create_fingerprint: String,
     invocation_hex: String,
+    /// Fresh exact-semantic replay invocation. The immutable original remains
+    /// manifest-bound; replacing it would invalidate the anti-mix signature.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    replacement_invocation_hex: Option<String>,
     #[serde(default)]
     deposits_hex: Vec<String>,
     custody_did: String,
@@ -492,14 +517,9 @@ struct ValidatedRecoveryBundle {
     delegation: DelegationChain,
     descriptor: AccountRepositoryDescriptorV1,
     create_invocation: InvocationChain<AnySignature>,
-    deposits: Vec<Delegation<AnySignature>>,
-    consent: DelegationChain,
-    sealed: RecoveryEnvelopeV2<Recovery>,
-    publish_invocation: InvocationChain<AnySignature>,
-    manifest: AccountSetupRecoveryManifestV1,
     recovery_hash: String,
+    #[cfg(test)]
     create_expires_at: u64,
-    publish_expires_at: u64,
     create_freshness: RecoveryFreshness,
     publish_freshness: RecoveryFreshness,
 }
@@ -557,6 +577,13 @@ impl ValidatedRecoveryBundle {
             CREATE_EXPIRY_MIN_OFFSET,
             CREATE_EXPIRY_MAX_OFFSET,
         )?;
+        let replacement_invocation = match decoded.replacement_invocation.as_deref() {
+            Some(bytes) => Some(
+                validate_replacement_invocation(bytes, &stored, &root_did, passkey, trust.now)
+                    .await?,
+            ),
+            None => None,
+        };
 
         let fingerprint = AccountCreationFingerprint::from_hex(&stored.create_fingerprint)
             .map_err(|_| RecoveryValidationError::Invalid("create_fingerprint"))?;
@@ -590,8 +617,7 @@ impl ValidatedRecoveryBundle {
             }
         }
 
-        let deposits =
-            validate_deposits(&decoded.deposits, &root_did, trust.service_did.as_ref()).await?;
+        validate_deposits(&decoded.deposits, &root_did, trust.service_did.as_ref()).await?;
         let custody_did: Did = stored
             .custody_did
             .parse()
@@ -599,8 +625,8 @@ impl ValidatedRecoveryBundle {
         if custody_did.to_string() != stored.custody_did {
             return Err(RecoveryValidationError::Invalid("custody_did"));
         }
-        let consent = validate_custody_consent(&decoded.consent, &custody_did, &root_did).await?;
-        let sealed = validate_sealed_envelope(&decoded.sealed)?;
+        validate_custody_consent(&decoded.consent, &custody_did, &root_did).await?;
+        validate_sealed_envelope(&decoded.sealed)?;
         let publish_invocation = validate_publish_invocation(
             &decoded.publish_invocation,
             &custody_did,
@@ -621,7 +647,7 @@ impl ValidatedRecoveryBundle {
         )?;
 
         let service_did = trust.service_did.as_ref().map(ToString::to_string);
-        let manifest = AccountSetupRecoveryManifestV1::validate(
+        AccountSetupRecoveryManifestV1::validate(
             &decoded.manifest,
             AccountSetupRecoveryManifestInput {
                 operation_id: &stored.operation_id,
@@ -651,24 +677,21 @@ impl ValidatedRecoveryBundle {
         .await
         .map_err(|_| RecoveryValidationError::Artifact("recovery_manifest"))?;
 
-        let record_bytes = encode_recovery(&StoredRecoveryRecord::Bundle(Box::new(stored.clone())))
-            .map_err(|_| RecoveryValidationError::Invalid("recovery_record"))?;
-        let recovery_hash = blake3::hash(&record_bytes).to_hex().to_string();
+        let recovery_hash = recovery_hash(&stored)?;
+        let effective_expires_at = replacement_invocation
+            .as_ref()
+            .and_then(|chain| chain.invocation.expiration())
+            .map_or(create_expires_at, |expiration| expiration.to_unix());
         Ok(Self {
             stored,
             root_did,
             delegation,
             descriptor,
-            create_invocation,
-            deposits,
-            consent,
-            sealed,
-            publish_invocation,
-            manifest,
+            create_invocation: replacement_invocation.unwrap_or(create_invocation),
             recovery_hash,
+            #[cfg(test)]
             create_expires_at,
-            publish_expires_at,
-            create_freshness: freshness(create_expires_at, trust.now),
+            create_freshness: freshness(effective_expires_at, trust.now),
             publish_freshness: freshness(publish_expires_at, trust.now),
         })
     }
@@ -677,6 +700,7 @@ impl ValidatedRecoveryBundle {
         &self.root_did
     }
 
+    #[cfg(test)]
     fn create_expires_at(&self) -> u64 {
         self.create_expires_at
     }
@@ -697,12 +721,27 @@ impl ValidatedRecoveryBundle {
             recovery_hash: self.recovery_hash.clone(),
         }
     }
+
+    fn delegation(&self) -> &DelegationChain {
+        &self.delegation
+    }
+
+    fn descriptor_bytes(&self) -> &[u8] {
+        self.descriptor.bytes()
+    }
+
+    fn create_invocation_bytes(&self) -> Result<Vec<u8>, RecoveryValidationError> {
+        self.create_invocation
+            .to_bytes()
+            .map_err(|_| RecoveryValidationError::Artifact("create"))
+    }
 }
 
 struct DecodedRecovery {
     delegation: Vec<u8>,
     descriptor: Vec<u8>,
     create_invocation: Vec<u8>,
+    replacement_invocation: Option<Vec<u8>>,
     deposits: Vec<Vec<u8>>,
     consent: Vec<u8>,
     sealed: Vec<u8>,
@@ -722,6 +761,542 @@ enum RecoveryValidationError {
     Artifact(&'static str),
     #[error("recovery timestamps are outside the setup window")]
     Timestamp,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SetupStoreError {
+    Read,
+    Write,
+}
+
+/// Narrow persistence port: only bounded opaque bytes cross this seam, so the
+/// credential adapter cannot accidentally log or serialize protected fields.
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+trait SetupStore {
+    async fn load_checkpoint(&self) -> Result<Option<Vec<u8>>, SetupStoreError>;
+    async fn save_checkpoint(&self, bytes: Vec<u8>) -> Result<(), SetupStoreError>;
+    async fn load_recovery(&self) -> Result<Option<Vec<u8>>, SetupStoreError>;
+    async fn save_recovery(&self, bytes: Vec<u8>) -> Result<(), SetupStoreError>;
+}
+
+struct CredentialSetupStore<'a> {
+    state: &'a crate::worker::TonkState,
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl SetupStore for CredentialSetupStore<'_> {
+    async fn load_checkpoint(&self) -> Result<Option<Vec<u8>>, SetupStoreError> {
+        load_credential_site(self.state, ACCOUNT_SETUP_CHECKPOINT_SITE).await
+    }
+
+    async fn save_checkpoint(&self, bytes: Vec<u8>) -> Result<(), SetupStoreError> {
+        save_credential_site(self.state, ACCOUNT_SETUP_CHECKPOINT_SITE, bytes).await
+    }
+
+    async fn load_recovery(&self) -> Result<Option<Vec<u8>>, SetupStoreError> {
+        load_credential_site(self.state, ACCOUNT_SETUP_RECOVERY_SITE).await
+    }
+
+    async fn save_recovery(&self, bytes: Vec<u8>) -> Result<(), SetupStoreError> {
+        save_credential_site(self.state, ACCOUNT_SETUP_RECOVERY_SITE, bytes).await
+    }
+}
+
+async fn load_credential_site(
+    state: &crate::worker::TonkState,
+    name: &str,
+) -> Result<Option<Vec<u8>>, SetupStoreError> {
+    match state
+        .profile
+        .credential()
+        .site(name)
+        .load::<Vec<u8>>()
+        .perform(&state.operator)
+        .await
+    {
+        Ok(bytes) if bytes.is_empty() => Ok(None),
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(error) if crate::credential::is_missing(&error) => Ok(None),
+        Err(_) => Err(SetupStoreError::Read),
+    }
+}
+
+async fn save_credential_site(
+    state: &crate::worker::TonkState,
+    name: &str,
+    bytes: Vec<u8>,
+) -> Result<(), SetupStoreError> {
+    state
+        .profile
+        .credential()
+        .site(name)
+        .save(bytes)
+        .perform(&state.operator)
+        .await
+        .map_err(|_| SetupStoreError::Write)
+}
+
+enum CheckpointLoad {
+    Missing,
+    Ready(Box<ValidatedCheckpoint>),
+    Corrupt,
+    Unsupported(Option<u16>),
+}
+
+async fn load_checkpoint(store: &impl SetupStore) -> Result<CheckpointLoad, SetupStoreError> {
+    let Some(bytes) = store.load_checkpoint().await? else {
+        return Ok(CheckpointLoad::Missing);
+    };
+    Ok(match decode_checkpoint(&bytes) {
+        Ok(checkpoint) => CheckpointLoad::Ready(Box::new(checkpoint)),
+        Err(StoredSetupError::UnsupportedCheckpointVersion(version)) => {
+            CheckpointLoad::Unsupported(u16::try_from(version).ok())
+        }
+        Err(StoredSetupError::UnsupportedCheckpointPhase) => CheckpointLoad::Unsupported(None),
+        Err(_) => CheckpointLoad::Corrupt,
+    })
+}
+
+async fn save_checkpoint(
+    store: &impl SetupStore,
+    checkpoint: &ValidatedCheckpoint,
+) -> Result<(), SetupStoreError> {
+    let bytes = encode_checkpoint(checkpoint).map_err(|_| SetupStoreError::Write)?;
+    store.save_checkpoint(bytes).await
+}
+
+enum RecoveryLoad {
+    Missing,
+    Bundle(Box<StoredRecoveryBundleV1>),
+    Tombstone(RecoveryTombstoneV1),
+    Corrupt,
+    Unsupported,
+}
+
+async fn load_recovery(store: &impl SetupStore) -> Result<RecoveryLoad, SetupStoreError> {
+    let Some(bytes) = store.load_recovery().await? else {
+        return Ok(RecoveryLoad::Missing);
+    };
+    Ok(match decode_recovery(&bytes) {
+        Ok(StoredRecoveryRecord::Bundle(bundle)) => RecoveryLoad::Bundle(bundle),
+        Ok(StoredRecoveryRecord::Tombstone(tombstone)) => RecoveryLoad::Tombstone(tombstone),
+        Err(
+            StoredSetupError::UnsupportedRecoveryVersion(_)
+            | StoredSetupError::UnsupportedRecoveryRecord,
+        ) => RecoveryLoad::Unsupported,
+        Err(_) => RecoveryLoad::Corrupt,
+    })
+}
+
+async fn save_recovery(
+    store: &impl SetupStore,
+    record: &StoredRecoveryRecord,
+) -> Result<(), SetupStoreError> {
+    let bytes = encode_recovery(record).map_err(|_| SetupStoreError::Write)?;
+    store.save_recovery(bytes).await
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct CanonicalSetupContext {
+    service_origin: Url,
+    provider: Url,
+    remote: Url,
+    service_did: Option<Did>,
+    configuration_hash: String,
+}
+
+impl CanonicalSetupContext {
+    fn ceremony(&self) -> AccountSetupCeremonyContext {
+        AccountSetupCeremonyContext {
+            provider: self.provider.to_string(),
+            remote: self.remote.to_string(),
+            service_did: self.service_did.as_ref().map(ToString::to_string),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ProviderCapabilities {
+    service: String,
+    capabilities: ProviderCapabilityVersions,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ProviderCapabilityVersions {
+    account_setup_recovery: u16,
+}
+
+async fn resolve_setup_context(
+    origin: &crate::axum::RequestOrigin,
+) -> Result<CanonicalSetupContext, ()> {
+    let config_url = origin.url().join(".well-known/tonk").map_err(|_| ())?;
+    let response = super::http::get(&config_url).await.map_err(|_| ())?;
+    if response.body.len() > MAX_PROVIDER_RESPONSE_BYTES {
+        return Err(());
+    }
+    let config: tonk_worker_api::DeploymentConfig =
+        serde_json::from_slice(&response.body).map_err(|_| ())?;
+    let service_origin = canonical_base_url(origin.url().clone())?;
+    let provider = canonical_base_url(config.account_service_url)?;
+    let remote = canonical_base_url(origin.url().join("ucan/").map_err(|_| ())?)?;
+    let service_did = config
+        .service_did
+        .map(|value| value.parse::<Did>().map_err(|_| ()))
+        .transpose()?;
+    let configuration_hash = configuration_hash(&provider, &remote, service_did.as_ref());
+    Ok(CanonicalSetupContext {
+        service_origin,
+        provider,
+        remote,
+        service_did,
+        configuration_hash,
+    })
+}
+
+fn canonical_base_url(mut url: Url) -> Result<Url, ()> {
+    if !matches!(url.scheme(), "http" | "https")
+        || url.cannot_be_a_base()
+        || url.username() != ""
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(());
+    }
+    if !url.path().ends_with('/') {
+        let path = format!("{}/", url.path());
+        url.set_path(&path);
+    }
+    Ok(url)
+}
+
+fn domain_hash(domain: &[u8], fields: &[&[u8]]) -> String {
+    let mut hash = blake3::Hasher::new();
+    for field in std::iter::once(domain).chain(fields.iter().copied()) {
+        hash.update(&(field.len() as u64).to_be_bytes());
+        hash.update(field);
+    }
+    hash.finalize().to_hex().to_string()
+}
+
+fn configuration_hash(provider: &Url, remote: &Url, service_did: Option<&Did>) -> String {
+    domain_hash(
+        b"tonk-account-setup-configuration-v1",
+        &[
+            provider.as_str().as_bytes(),
+            remote.as_str().as_bytes(),
+            service_did.map_or(&[][..], |did| did.as_ref().as_bytes()),
+        ],
+    )
+}
+
+fn token_hash(domain: &[u8], operation_id: &str, token: &str) -> Result<String, ()> {
+    if token.len() < MIN_TOKEN_BYTES
+        || token.len() > MAX_TOKEN_BYTES
+        || token.chars().any(char::is_control)
+    {
+        return Err(());
+    }
+    Ok(domain_hash(
+        domain,
+        &[operation_id.as_bytes(), token.as_bytes()],
+    ))
+}
+
+async fn provider_supports_recovery(context: &CanonicalSetupContext) -> bool {
+    let Ok(endpoint) = context.provider.join("capabilities") else {
+        return false;
+    };
+    let Ok(response) = super::http::get(&endpoint).await else {
+        return false;
+    };
+    if response.body.len() > MAX_PROVIDER_RESPONSE_BYTES {
+        return false;
+    }
+    supports_provider_capabilities(&response.body)
+}
+
+fn supports_provider_capabilities(body: &[u8]) -> bool {
+    serde_json::from_slice::<ProviderCapabilities>(body).is_ok_and(|capabilities| {
+        capabilities.service == "tonk-account-service"
+            && capabilities.capabilities.account_setup_recovery
+                == ACCOUNT_SETUP_PROVIDER_RECOVERY_VERSION
+    })
+}
+
+fn now_seconds() -> u64 {
+    web_time::SystemTime::now()
+        .duration_since(web_time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+struct CrossWorkerSetupGuard(Option<tokio::sync::oneshot::Sender<()>>);
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+struct CrossWorkerSetupGuard;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl Drop for CrossWorkerSetupGuard {
+    fn drop(&mut self) {
+        if let Some(release) = self.0.take() {
+            let _ = release.send(());
+        }
+    }
+}
+
+/// Acquire the profile-scoped browser Web Lock. There is intentionally no
+/// fallback to the per-worker mutex: without this lock two coexisting worker
+/// generations cannot prove exclusive ownership before WebAuthn is armed.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn acquire_cross_worker_setup_lock(lock_name: &str) -> Result<CrossWorkerSetupGuard, ()> {
+    use wasm_bindgen::{JsCast as _, JsValue, closure::Closure};
+    use wasm_bindgen_futures::{JsFuture, future_to_promise, spawn_local};
+
+    let global = js_sys::global();
+    let navigator =
+        js_sys::Reflect::get(&global, &JsValue::from_str("navigator")).map_err(|_| ())?;
+    let locks = js_sys::Reflect::get(&navigator, &JsValue::from_str("locks")).map_err(|_| ())?;
+    let request: js_sys::Function = js_sys::Reflect::get(&locks, &JsValue::from_str("request"))
+        .map_err(|_| ())?
+        .dyn_into()
+        .map_err(|_| ())?;
+    let (acquired_tx, acquired_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    let callback = Closure::once_into_js(move |_lock: JsValue| -> js_sys::Promise {
+        let _ = acquired_tx.send(());
+        future_to_promise(async move {
+            let _ = release_rx.await;
+            Ok(JsValue::UNDEFINED)
+        })
+    });
+    let request_promise: js_sys::Promise = request
+        .call2(&locks, &JsValue::from_str(lock_name), &callback)
+        .map_err(|_| ())?
+        .dyn_into()
+        .map_err(|_| ())?;
+    spawn_local(async move {
+        let _ = JsFuture::from(request_promise).await;
+    });
+    acquired_rx.await.map_err(|_| ())?;
+    Ok(CrossWorkerSetupGuard(Some(release_tx)))
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+async fn acquire_cross_worker_setup_lock(_lock_name: &str) -> Result<CrossWorkerSetupGuard, ()> {
+    Ok(CrossWorkerSetupGuard)
+}
+
+async fn mark_request_client_live(state: &crate::worker::TonkState, client: &crate::ClientId) {
+    let mut clients = state.clients.write().await;
+    clients.entry(client.clone()).or_default().seen_live = true;
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn client_is_live(state: &crate::worker::TonkState, client: &str) -> bool {
+    use wasm_bindgen::JsCast as _;
+    let Ok(global) = js_sys::global().dyn_into::<web_sys::ServiceWorkerGlobalScope>() else {
+        return true;
+    };
+    let options = web_sys::ClientQueryOptions::new();
+    options.set_include_uncontrolled(true);
+    let Ok(value) =
+        wasm_bindgen_futures::JsFuture::from(global.clients().match_all_with_options(&options))
+            .await
+    else {
+        return true;
+    };
+    let live = js_sys::Array::from(&value).iter().any(|value| {
+        value
+            .dyn_into::<web_sys::Client>()
+            .is_ok_and(|candidate| candidate.id() == client)
+    });
+    if live {
+        state
+            .clients
+            .write()
+            .await
+            .entry(crate::ClientId(client.to_owned()))
+            .or_default()
+            .seen_live = true;
+    }
+    live
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct ProviderAcceptance {
+    account_id: i64,
+    descriptor_hex: String,
+    create_fingerprint: String,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+enum ProviderSetupStatus {
+    Absent,
+    Accepted(ProviderAcceptance),
+    Mismatch,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProviderPortError {
+    Retry,
+    Invalid,
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+trait AccountSetupProvider {
+    async fn status(&self, invocation: &[u8]) -> Result<ProviderSetupStatus, ProviderPortError>;
+    async fn create(&self, invocation: &[u8]) -> Result<ProviderAcceptance, ProviderPortError>;
+}
+
+#[derive(PartialEq, Eq)]
+enum ProviderResolution {
+    Accepted(ProviderAcceptance),
+    NeedsPasskey,
+    Mismatch,
+    Retry,
+}
+
+/// Resolve a possibly lost account-create response without guessing. Every
+/// attempt starts with the proof-bound status query; only an explicit Absent
+/// result permits an exact replay of a still-fresh invocation.
+async fn resolve_provider_acceptance(
+    provider: &impl AccountSetupProvider,
+    status_invocation: &[u8],
+    create_invocation: &[u8],
+    freshness: RecoveryFreshness,
+) -> ProviderResolution {
+    match provider.status(status_invocation).await {
+        Ok(ProviderSetupStatus::Accepted(accepted)) => ProviderResolution::Accepted(accepted),
+        Ok(ProviderSetupStatus::Mismatch) => ProviderResolution::Mismatch,
+        Ok(ProviderSetupStatus::Absent) if freshness == RecoveryFreshness::NeedsRefresh => {
+            ProviderResolution::NeedsPasskey
+        }
+        Ok(ProviderSetupStatus::Absent) => match provider.create(create_invocation).await {
+            Ok(accepted) => ProviderResolution::Accepted(accepted),
+            Err(ProviderPortError::Retry | ProviderPortError::Invalid) => ProviderResolution::Retry,
+        },
+        Err(ProviderPortError::Retry | ProviderPortError::Invalid) => ProviderResolution::Retry,
+    }
+}
+
+struct HttpAccountSetupProvider<'a> {
+    context: &'a CanonicalSetupContext,
+}
+
+#[derive(Deserialize)]
+#[serde(
+    tag = "status",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+enum ProviderStatusBody {
+    Absent,
+    Accepted {
+        account_id: i64,
+        descriptor_hex: String,
+        create_fingerprint: String,
+    },
+    Mismatch,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ProviderCreateBody {
+    account_id: i64,
+    descriptor_hex: String,
+    create_fingerprint: String,
+    reused: bool,
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl AccountSetupProvider for HttpAccountSetupProvider<'_> {
+    async fn status(&self, invocation: &[u8]) -> Result<ProviderSetupStatus, ProviderPortError> {
+        let endpoint = self
+            .context
+            .provider
+            .join("accounts/setup-status")
+            .map_err(|_| ProviderPortError::Invalid)?;
+        let response = super::http::post_cbor(&endpoint, invocation)
+            .await
+            .map_err(|_| ProviderPortError::Retry)?;
+        if response.status != 200 || response.body.len() > MAX_PROVIDER_RESPONSE_BYTES {
+            return Err(ProviderPortError::Invalid);
+        }
+        match serde_json::from_slice(&response.body).map_err(|_| ProviderPortError::Invalid)? {
+            ProviderStatusBody::Absent => Ok(ProviderSetupStatus::Absent),
+            ProviderStatusBody::Mismatch => Ok(ProviderSetupStatus::Mismatch),
+            ProviderStatusBody::Accepted {
+                account_id,
+                descriptor_hex,
+                create_fingerprint,
+            } => Ok(ProviderSetupStatus::Accepted(ProviderAcceptance {
+                account_id,
+                descriptor_hex,
+                create_fingerprint,
+            })),
+        }
+    }
+
+    async fn create(&self, invocation: &[u8]) -> Result<ProviderAcceptance, ProviderPortError> {
+        let endpoint = self
+            .context
+            .provider
+            .join("accounts")
+            .map_err(|_| ProviderPortError::Invalid)?;
+        let response = super::http::post_cbor(&endpoint, invocation)
+            .await
+            .map_err(|_| ProviderPortError::Retry)?;
+        if !matches!(response.status, 200 | 201)
+            || response.body.len() > MAX_PROVIDER_RESPONSE_BYTES
+        {
+            return Err(ProviderPortError::Invalid);
+        }
+        let body: ProviderCreateBody =
+            serde_json::from_slice(&response.body).map_err(|_| ProviderPortError::Invalid)?;
+        if (response.status == 200) != body.reused {
+            return Err(ProviderPortError::Invalid);
+        }
+        Ok(ProviderAcceptance {
+            account_id: body.account_id,
+            descriptor_hex: body.descriptor_hex,
+            create_fingerprint: body.create_fingerprint,
+        })
+    }
+}
+
+fn verify_provider_acceptance(
+    recovery: &ValidatedRecoveryBundle,
+    accepted: ProviderAcceptance,
+) -> Result<String, ()> {
+    if accepted.account_id <= 0
+        || accepted.create_fingerprint != recovery.stored.create_fingerprint
+        || accepted.descriptor_hex != recovery.stored.descriptor_hex
+    {
+        return Err(());
+    }
+    Ok(domain_hash(
+        b"tonk-account-setup-accepted-descriptor-v1",
+        &[recovery.descriptor_bytes()],
+    ))
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+async fn client_is_live(state: &crate::worker::TonkState, client: &str) -> bool {
+    state
+        .clients
+        .read()
+        .await
+        .get(&crate::ClientId(client.to_owned()))
+        .is_some_and(|entry| entry.seen_live)
 }
 
 fn decode_bounded_recovery(
@@ -774,6 +1349,11 @@ fn decode_bounded_recovery(
     let descriptor = decode_hex_field("descriptor", &stored.descriptor_hex, MAX_DESCRIPTOR_BYTES)?;
     let create_invocation =
         decode_hex_field("invocation", &stored.invocation_hex, MAX_INVOCATION_BYTES)?;
+    let replacement_invocation = stored
+        .replacement_invocation_hex
+        .as_deref()
+        .map(|value| decode_hex_field("replacement_invocation", value, MAX_INVOCATION_BYTES))
+        .transpose()?;
     let deposits = stored
         .deposits_hex
         .iter()
@@ -795,6 +1375,7 @@ fn decode_bounded_recovery(
         delegation.len(),
         descriptor.len(),
         create_invocation.len(),
+        replacement_invocation.as_ref().map_or(0, Vec::len),
         consent.len(),
         sealed.len(),
         publish_invocation.len(),
@@ -816,12 +1397,24 @@ fn decode_bounded_recovery(
         delegation,
         descriptor,
         create_invocation,
+        replacement_invocation,
         deposits,
         consent,
         sealed,
         publish_invocation,
         manifest,
     })
+}
+
+fn recovery_hash(stored: &StoredRecoveryBundleV1) -> Result<String, RecoveryValidationError> {
+    // Replacement invocations are deliberately outside the root-signed
+    // manifest and immutable recovery identity. Hash the original bundle so a
+    // freshness repair cannot detach the checkpoint or tombstone from it.
+    let mut original = stored.clone();
+    original.replacement_invocation_hex = None;
+    let record_bytes = encode_recovery(&StoredRecoveryRecord::Bundle(Box::new(original)))
+        .map_err(|_| RecoveryValidationError::Invalid("recovery_record"))?;
+    Ok(blake3::hash(&record_bytes).to_hex().to_string())
 }
 
 fn decode_hex_field(
@@ -969,6 +1562,16 @@ async fn validate_create_invocation(
     passkey: &PasskeyMetadata,
 ) -> Result<InvocationChain<AnySignature>, RecoveryValidationError> {
     let chain = parse_canonical_self_invocation(bytes, root, &["account", "create"], "create")?;
+    validate_create_arguments(&chain, stored, passkey)?;
+    verify_invocation_at(&chain, stored.ceremony_created_at, "create").await?;
+    Ok(chain)
+}
+
+fn validate_create_arguments(
+    chain: &InvocationChain<AnySignature>,
+    stored: &StoredRecoveryBundleV1,
+    passkey: &PasskeyMetadata,
+) -> Result<(), RecoveryValidationError> {
     let arguments = chain.arguments();
     if arguments.len() != 8
         || promised_string(arguments.get("email")) != Some(stored.normalized_email.as_str())
@@ -984,7 +1587,38 @@ async fn validate_create_invocation(
     {
         return Err(RecoveryValidationError::Artifact("create_arguments"));
     }
-    verify_invocation_at(&chain, stored.ceremony_created_at, "create").await?;
+    Ok(())
+}
+
+async fn validate_replacement_invocation(
+    bytes: &[u8],
+    stored: &StoredRecoveryBundleV1,
+    root: &Did,
+    passkey: &PasskeyMetadata,
+    now: u64,
+) -> Result<InvocationChain<AnySignature>, RecoveryValidationError> {
+    let chain = parse_canonical_self_invocation(
+        bytes,
+        root,
+        &["account", "create"],
+        "replacement_invocation",
+    )?;
+    validate_create_arguments(&chain, stored, passkey)?;
+    let expires_at = chain
+        .invocation
+        .expiration()
+        .ok_or(RecoveryValidationError::Artifact("replacement_expiration"))?
+        .to_unix();
+    let min = now
+        .checked_add(CREATE_EXPIRY_MIN_OFFSET)
+        .ok_or(RecoveryValidationError::Timestamp)?;
+    let max = now
+        .checked_add(CREATE_EXPIRY_MAX_OFFSET)
+        .ok_or(RecoveryValidationError::Timestamp)?;
+    if expires_at < min || expires_at > max {
+        return Err(RecoveryValidationError::Artifact("replacement_expiration"));
+    }
+    verify_invocation_exact_at(&chain, now, "replacement_invocation").await?;
     Ok(chain)
 }
 
@@ -1160,6 +1794,14 @@ async fn verify_invocation_at(
     let verify_at = ceremony_created_at
         .checked_add(STAGE_CLOCK_SKEW_SECONDS)
         .ok_or(RecoveryValidationError::Timestamp)?;
+    verify_invocation_exact_at(chain, verify_at, name).await
+}
+
+async fn verify_invocation_exact_at(
+    chain: &InvocationChain<AnySignature>,
+    verify_at: u64,
+    name: &'static str,
+) -> Result<(), RecoveryValidationError> {
     let time = UNIX_EPOCH
         .checked_add(Duration::from_secs(verify_at))
         .ok_or(RecoveryValidationError::Timestamp)?;
@@ -1291,7 +1933,6 @@ enum PrivateNextAction {
     RecordCompletion,
     TombstoneRecovery,
     Acquire,
-    Wait,
     CancelTooLate,
     StartOver,
     Done,
@@ -1718,19 +2359,1595 @@ fn next_action_for_phase(phase: &StoredPhaseV2) -> PrivateNextAction {
     }
 }
 
+fn missing_view() -> AccountSetupView {
+    AccountSetupView {
+        worker_protocol_version: ACCOUNT_SETUP_PROTOCOL_VERSION,
+        operation_id: None,
+        revision: None,
+        progress: None,
+        disposition: AccountSetupDisposition::Missing,
+        next_action: AccountSetupNextAction::Begin,
+        conflict_code: None,
+        stored_version: None,
+    }
+}
+
+fn closed_view(
+    disposition: AccountSetupDisposition,
+    next_action: AccountSetupNextAction,
+    stored_version: Option<u16>,
+) -> AccountSetupView {
+    AccountSetupView {
+        worker_protocol_version: ACCOUNT_SETUP_PROTOCOL_VERSION,
+        operation_id: None,
+        revision: None,
+        progress: None,
+        disposition,
+        next_action,
+        conflict_code: None,
+        stored_version,
+    }
+}
+
+fn checkpoint_view(checkpoint: &ValidatedCheckpoint, owns: bool) -> AccountSetupView {
+    let stored = checkpoint.as_stored();
+    let owned_elsewhere = stored.owner_hash.is_some() && !owns;
+    let (progress, disposition, next_action, conflict_code) = match &stored.phase {
+        StoredPhaseV2::Leased => (
+            AccountSetupProgress::Preparing,
+            if owned_elsewhere {
+                AccountSetupDisposition::InProgressElsewhere
+            } else {
+                AccountSetupDisposition::Ready
+            },
+            if owned_elsewhere {
+                AccountSetupNextAction::Wait
+            } else if stored.owner_hash.is_none() {
+                AccountSetupNextAction::Acquire
+            } else {
+                AccountSetupNextAction::ApprovePasskey
+            },
+            None,
+        ),
+        StoredPhaseV2::Armed => (
+            AccountSetupProgress::PasskeyApproval,
+            if owns {
+                AccountSetupDisposition::Ready
+            } else {
+                AccountSetupDisposition::InProgressElsewhere
+            },
+            AccountSetupNextAction::Wait,
+            None,
+        ),
+        StoredPhaseV2::RecoveryStaged | StoredPhaseV2::RootSaved => (
+            AccountSetupProgress::Recovering,
+            if owned_elsewhere {
+                AccountSetupDisposition::InProgressElsewhere
+            } else {
+                AccountSetupDisposition::Ready
+            },
+            if owned_elsewhere {
+                AccountSetupNextAction::Wait
+            } else if stored.owner_hash.is_none() {
+                AccountSetupNextAction::Acquire
+            } else {
+                AccountSetupNextAction::Continue
+            },
+            None,
+        ),
+        StoredPhaseV2::ProviderAccepted | StoredPhaseV2::Attached => (
+            AccountSetupProgress::ConnectingServices,
+            if owned_elsewhere {
+                AccountSetupDisposition::InProgressElsewhere
+            } else {
+                AccountSetupDisposition::Ready
+            },
+            if owned_elsewhere {
+                AccountSetupNextAction::Wait
+            } else if stored.owner_hash.is_none() {
+                AccountSetupNextAction::Acquire
+            } else {
+                AccountSetupNextAction::Continue
+            },
+            None,
+        ),
+        StoredPhaseV2::CustomerEnrolled | StoredPhaseV2::CustodyQueued => (
+            AccountSetupProgress::Finishing,
+            if owned_elsewhere {
+                AccountSetupDisposition::InProgressElsewhere
+            } else {
+                AccountSetupDisposition::Ready
+            },
+            if owned_elsewhere {
+                AccountSetupNextAction::Wait
+            } else if stored.owner_hash.is_none() {
+                AccountSetupNextAction::Acquire
+            } else {
+                AccountSetupNextAction::Continue
+            },
+            None,
+        ),
+        StoredPhaseV2::Complete => (
+            AccountSetupProgress::Complete,
+            AccountSetupDisposition::Complete,
+            AccountSetupNextAction::None,
+            None,
+        ),
+        StoredPhaseV2::Cancelled => (
+            AccountSetupProgress::Preparing,
+            AccountSetupDisposition::Cancelled,
+            AccountSetupNextAction::Begin,
+            None,
+        ),
+        StoredPhaseV2::InterruptedBeforeRecovery => (
+            AccountSetupProgress::PasskeyApproval,
+            AccountSetupDisposition::InterruptedBeforeRecovery,
+            AccountSetupNextAction::StartOver,
+            None,
+        ),
+        StoredPhaseV2::Conflict { code, .. } => (
+            AccountSetupProgress::Recovering,
+            AccountSetupDisposition::Conflict,
+            AccountSetupNextAction::None,
+            Some(match code {
+                StoredConflictCodeV2::Recovery => AccountSetupConflictCode::RecoveryMismatch,
+                StoredConflictCodeV2::LocalRoot => AccountSetupConflictCode::LocalRootMismatch,
+                StoredConflictCodeV2::Provider => AccountSetupConflictCode::ProviderMismatch,
+                StoredConflictCodeV2::Attachment => AccountSetupConflictCode::AttachmentMismatch,
+            }),
+        ),
+    };
+    AccountSetupView {
+        worker_protocol_version: ACCOUNT_SETUP_PROTOCOL_VERSION,
+        operation_id: Some(stored.operation_id.clone()),
+        revision: Some(stored.revision),
+        progress: Some(progress),
+        disposition,
+        next_action,
+        conflict_code,
+        stored_version: None,
+    }
+}
+
+fn retry_view(checkpoint: &ValidatedCheckpoint) -> AccountSetupView {
+    let mut view = checkpoint_view(checkpoint, true);
+    view.disposition = AccountSetupDisposition::RetryLater;
+    view.next_action = AccountSetupNextAction::Retry;
+    view
+}
+
+fn needs_passkey_response(
+    recovery: &ValidatedRecoveryBundle,
+    view: AccountSetupView,
+) -> AccountSetupResponse {
+    AccountSetupResponse::Protected(AccountSetupProtectedResponse::NeedsPasskey {
+        view,
+        resume: AccountSetupResumeInput {
+            operation_id: recovery.stored.operation_id.clone(),
+            credential_id: recovery.stored.credential_id.clone(),
+            expected_root_did: recovery.stored.root_did.clone(),
+            normalized_email: recovery.stored.normalized_email.clone(),
+            device_did: recovery.stored.device_did.clone(),
+            device_name: recovery.stored.device_name.clone(),
+            delegation_hex: recovery.stored.delegation_hex.clone(),
+            descriptor_hex: recovery.stored.descriptor_hex.clone(),
+            passkey: recovery.stored.passkey.clone(),
+            sealed_hex: recovery.stored.sealed_hex.clone(),
+        },
+    })
+}
+
+fn owns_checkpoint(
+    checkpoint: &ValidatedCheckpoint,
+    owner_token: Option<&str>,
+    client_id: &str,
+) -> bool {
+    let stored = checkpoint.as_stored();
+    let Some(token) = owner_token else {
+        return false;
+    };
+    let Ok(hash) = token_hash(b"tonk-account-setup-owner-v1", &stored.operation_id, token) else {
+        return false;
+    };
+    stored.owner_hash.as_deref() == Some(hash.as_str())
+        && stored.bound_client_id.as_deref() == Some(client_id)
+}
+
+fn mutation_context(
+    mutation: &AccountSetupMutation,
+    checkpoint: &ValidatedCheckpoint,
+    client_id: &str,
+    now: u64,
+) -> Result<MutationContext, ()> {
+    let owner_hash = token_hash(
+        b"tonk-account-setup-owner-v1",
+        &mutation.operation_id,
+        &mutation.owner_token,
+    )?;
+    // The reducer owns the authoritative comparisons; this early check avoids
+    // doing expensive recovery validation for a known stale request.
+    if mutation.operation_id != checkpoint.as_stored().operation_id
+        || mutation.expected_revision != checkpoint.as_stored().revision
+    {
+        return Err(());
+    }
+    Ok(MutationContext {
+        operation_id: mutation.operation_id.clone(),
+        owner_hash,
+        client_id: client_id.to_owned(),
+        expected_revision: mutation.expected_revision,
+        now,
+    })
+}
+
+fn stored_recovery_from_wire(
+    operation_id: String,
+    staged_at: u64,
+    recovery: AccountSetupRecoveryBundle,
+) -> StoredRecoveryBundleV1 {
+    StoredRecoveryBundleV1 {
+        version: recovery.version,
+        operation_id,
+        ceremony_created_at: recovery.ceremony_created_at,
+        staged_at,
+        normalized_email: recovery.normalized_email,
+        provider: recovery.provider,
+        root_did: recovery.root_did,
+        device_did: recovery.device_did,
+        device_name: recovery.device_name,
+        credential_id: recovery.credential_id,
+        delegation_cid: recovery.delegation_cid,
+        delegation_hex: recovery.delegation_hex,
+        passkey: recovery.passkey,
+        encryption_key: recovery.encryption_key,
+        descriptor_hex: recovery.descriptor_hex,
+        create_fingerprint: recovery.create_fingerprint,
+        invocation_hex: recovery.invocation_hex,
+        replacement_invocation_hex: None,
+        deposits_hex: recovery.deposits_hex,
+        custody_did: recovery.custody_did,
+        consent_hex: recovery.consent_hex,
+        sealed_hex: recovery.sealed_hex,
+        publish_invocation_hex: recovery.publish_invocation_hex,
+        recovery_manifest_hex: recovery.recovery_manifest_hex,
+    }
+}
+
+async fn validate_recovery_for_checkpoint(
+    bundle: StoredRecoveryBundleV1,
+    checkpoint: &ValidatedCheckpoint,
+    context: &CanonicalSetupContext,
+    device_did: Did,
+    now: u64,
+) -> Result<ValidatedRecoveryBundle, RecoveryValidationError> {
+    let stored = checkpoint.as_stored();
+    if stored.configuration_hash != context.configuration_hash {
+        return Err(RecoveryValidationError::Trusted("configuration"));
+    }
+    let armed_at = stored.armed_at.ok_or(RecoveryValidationError::Timestamp)?;
+    let recovery = ValidatedRecoveryBundle::new(
+        bundle,
+        &RecoveryTrustContext {
+            operation_id: stored.operation_id.clone(),
+            provider: context.provider.clone(),
+            remote: context.remote.clone(),
+            service_did: context.service_did.clone(),
+            device_did,
+            armed_at,
+            now,
+        },
+    )
+    .await?;
+    if !matches!(stored.phase, StoredPhaseV2::Armed)
+        && (stored.staged_at != Some(recovery.evidence().staged_at)
+            || stored.root_did.as_deref() != Some(recovery.stored.root_did.as_str())
+            || stored.create_fingerprint.as_deref()
+                != Some(recovery.stored.create_fingerprint.as_str())
+            || stored.recovery_hash.as_deref() != Some(recovery.recovery_hash.as_str()))
+    {
+        return Err(RecoveryValidationError::Trusted("checkpoint"));
+    }
+    let has_provider_acceptance = matches!(
+        stored.phase,
+        StoredPhaseV2::ProviderAccepted
+            | StoredPhaseV2::Attached
+            | StoredPhaseV2::CustomerEnrolled
+            | StoredPhaseV2::CustodyQueued
+            | StoredPhaseV2::Complete
+            | StoredPhaseV2::Conflict {
+                last_safe_phase: StoredSafePhaseV2::ProviderAccepted
+                    | StoredSafePhaseV2::Attached
+                    | StoredSafePhaseV2::CustomerEnrolled
+                    | StoredSafePhaseV2::CustodyQueued,
+                ..
+            }
+    );
+    if has_provider_acceptance
+        && stored.accepted_descriptor_hash.as_deref()
+            != Some(
+                domain_hash(
+                    b"tonk-account-setup-accepted-descriptor-v1",
+                    &[recovery.descriptor_bytes()],
+                )
+                .as_str(),
+            )
+    {
+        return Err(RecoveryValidationError::Trusted("checkpoint_acceptance"));
+    }
+    Ok(recovery)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum StagePersistenceError {
+    Unauthorized,
+    Invalid,
+    Store(SetupStoreError),
+}
+
+impl From<SetupStoreError> for StagePersistenceError {
+    fn from(error: SetupStoreError) -> Self {
+        Self::Store(error)
+    }
+}
+
+struct StagePersistenceContext<'a> {
+    checkpoint: &'a ValidatedCheckpoint,
+    mutation: &'a MutationContext,
+    attempt_hash: &'a str,
+    setup: &'a CanonicalSetupContext,
+    device_did: Did,
+    now: u64,
+}
+
+/// Persist protected recovery material and prove it can be read back through
+/// the same validator before the public checkpoint may leave Armed.
+async fn persist_staged_recovery(
+    store: &impl SetupStore,
+    stored: StoredRecoveryBundleV1,
+    context: StagePersistenceContext<'_>,
+) -> Result<ValidatedRecoveryBundle, StagePersistenceError> {
+    if authenticate(context.checkpoint, context.mutation).is_err()
+        || context.checkpoint.as_stored().phase != StoredPhaseV2::Armed
+        || context.checkpoint.as_stored().attempt_hash.as_deref() != Some(context.attempt_hash)
+    {
+        return Err(StagePersistenceError::Unauthorized);
+    }
+    let recovery = validate_recovery_for_checkpoint(
+        stored,
+        context.checkpoint,
+        context.setup,
+        context.device_did.clone(),
+        context.now,
+    )
+    .await
+    .map_err(|_| StagePersistenceError::Invalid)?;
+    save_recovery(
+        store,
+        &StoredRecoveryRecord::Bundle(Box::new(recovery.stored.clone())),
+    )
+    .await?;
+    let RecoveryLoad::Bundle(readback) = load_recovery(store).await? else {
+        return Err(StagePersistenceError::Invalid);
+    };
+    let readback = validate_recovery_for_checkpoint(
+        *readback,
+        context.checkpoint,
+        context.setup,
+        context.device_did,
+        context.now,
+    )
+    .await
+    .map_err(|_| StagePersistenceError::Invalid)?;
+    if readback.recovery_hash != recovery.recovery_hash {
+        return Err(StagePersistenceError::Invalid);
+    }
+    Ok(readback)
+}
+
+async fn recovery_observation(
+    store: &impl SetupStore,
+    checkpoint: &ValidatedCheckpoint,
+    context: &CanonicalSetupContext,
+    device_did: Did,
+    now: u64,
+) -> Result<RecoveryObservation, ()> {
+    match load_recovery(store).await.map_err(|_| ())? {
+        RecoveryLoad::Missing => Ok(RecoveryObservation::Absent),
+        RecoveryLoad::Bundle(bundle) => {
+            validate_recovery_for_checkpoint(*bundle, checkpoint, context, device_did, now)
+                .await
+                .map(|recovery| RecoveryObservation::Staged(recovery.evidence()))
+                .map_err(|_| ())
+        }
+        RecoveryLoad::Tombstone(_) | RecoveryLoad::Corrupt | RecoveryLoad::Unsupported => Err(()),
+    }
+}
+
+async fn persist_reduction(
+    store: &impl SetupStore,
+    reduction: Reduction,
+) -> Result<ValidatedCheckpoint, SetupStoreError> {
+    if reduction.durable_action != DurableAction::None {
+        save_checkpoint(store, &reduction.checkpoint).await?;
+    }
+    Ok(reduction.checkpoint)
+}
+
+async fn persist_conflict(
+    store: &impl SetupStore,
+    checkpoint: ValidatedCheckpoint,
+    mutation: MutationContext,
+    code: StoredConflictCodeV2,
+) -> Result<AccountSetupResponse, SetupStoreError> {
+    let reduction = reduce(checkpoint, ReducerCommand::Conflict { mutation, code })
+        .map_err(|_| SetupStoreError::Write)?;
+    let checkpoint = persist_reduction(store, reduction).await?;
+    Ok(AccountSetupResponse::View(checkpoint_view(
+        &checkpoint,
+        false,
+    )))
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CompletionTombstoneOutcome {
+    AlreadyExact,
+    Repaired,
+    Corrupt,
+    Unsupported,
+}
+
+fn completion_tombstone(
+    checkpoint: &ValidatedCheckpoint,
+    recovery_hash: String,
+) -> RecoveryTombstoneV1 {
+    RecoveryTombstoneV1 {
+        version: RECOVERY_VERSION,
+        operation_id: checkpoint.as_stored().operation_id.clone(),
+        completed_at: checkpoint.as_stored().last_transition_at,
+        recovery_hash,
+    }
+}
+
+async fn repair_completion_tombstone(
+    store: &impl SetupStore,
+    checkpoint: &ValidatedCheckpoint,
+    context: &CanonicalSetupContext,
+    device_did: Did,
+    now: u64,
+) -> Result<CompletionTombstoneOutcome, SetupStoreError> {
+    if checkpoint.as_stored().phase != StoredPhaseV2::Complete {
+        return Ok(CompletionTombstoneOutcome::Corrupt);
+    }
+    match load_recovery(store).await? {
+        RecoveryLoad::Bundle(bundle) => {
+            let Ok(recovery) =
+                validate_recovery_for_checkpoint(*bundle, checkpoint, context, device_did, now)
+                    .await
+            else {
+                return Ok(CompletionTombstoneOutcome::Corrupt);
+            };
+            save_recovery(
+                store,
+                &StoredRecoveryRecord::Tombstone(completion_tombstone(
+                    checkpoint,
+                    recovery.recovery_hash,
+                )),
+            )
+            .await?;
+            Ok(CompletionTombstoneOutcome::Repaired)
+        }
+        RecoveryLoad::Tombstone(tombstone)
+            if tombstone
+                == completion_tombstone(
+                    checkpoint,
+                    checkpoint
+                        .as_stored()
+                        .recovery_hash
+                        .clone()
+                        .unwrap_or_default(),
+                ) =>
+        {
+            Ok(CompletionTombstoneOutcome::AlreadyExact)
+        }
+        RecoveryLoad::Unsupported => Ok(CompletionTombstoneOutcome::Unsupported),
+        RecoveryLoad::Missing | RecoveryLoad::Tombstone(_) | RecoveryLoad::Corrupt => {
+            Ok(CompletionTombstoneOutcome::Corrupt)
+        }
+    }
+}
+
+async fn reconcile_with_provider(
+    state: &crate::worker::TonkState,
+    store: &impl SetupStore,
+    provider: &impl AccountSetupProvider,
+    context: &CanonicalSetupContext,
+    mut checkpoint: ValidatedCheckpoint,
+    owner_hash: String,
+    client_id: &str,
+) -> Result<AccountSetupResponse, SetupStoreError> {
+    loop {
+        let now = now_seconds();
+        if checkpoint.as_stored().phase == StoredPhaseV2::Complete {
+            return match repair_completion_tombstone(
+                store,
+                &checkpoint,
+                context,
+                state.profile.did(),
+                now,
+            )
+            .await?
+            {
+                CompletionTombstoneOutcome::AlreadyExact | CompletionTombstoneOutcome::Repaired => {
+                    Ok(AccountSetupResponse::View(checkpoint_view(
+                        &checkpoint,
+                        false,
+                    )))
+                }
+                CompletionTombstoneOutcome::Corrupt => Ok(AccountSetupResponse::View(closed_view(
+                    AccountSetupDisposition::Corrupt,
+                    AccountSetupNextAction::None,
+                    None,
+                ))),
+                CompletionTombstoneOutcome::Unsupported => {
+                    Ok(AccountSetupResponse::View(closed_view(
+                        AccountSetupDisposition::Unsupported,
+                        AccountSetupNextAction::None,
+                        None,
+                    )))
+                }
+            };
+        }
+        let mutation = MutationContext {
+            operation_id: checkpoint.as_stored().operation_id.clone(),
+            owner_hash: owner_hash.clone(),
+            client_id: client_id.to_owned(),
+            expected_revision: checkpoint.as_stored().revision,
+            now,
+        };
+        if authenticate(&checkpoint, &mutation).is_err() {
+            return Ok(AccountSetupResponse::View(checkpoint_view(
+                &checkpoint,
+                false,
+            )));
+        }
+        let bundle = match load_recovery(store).await? {
+            RecoveryLoad::Bundle(bundle) => *bundle,
+            RecoveryLoad::Unsupported => {
+                return Ok(AccountSetupResponse::View(closed_view(
+                    AccountSetupDisposition::Unsupported,
+                    AccountSetupNextAction::None,
+                    None,
+                )));
+            }
+            RecoveryLoad::Missing | RecoveryLoad::Tombstone(_) | RecoveryLoad::Corrupt => {
+                return persist_conflict(
+                    store,
+                    checkpoint,
+                    mutation,
+                    StoredConflictCodeV2::Recovery,
+                )
+                .await;
+            }
+        };
+        let recovery = match validate_recovery_for_checkpoint(
+            bundle,
+            &checkpoint,
+            context,
+            state.profile.did(),
+            now,
+        )
+        .await
+        {
+            Ok(recovery) => recovery,
+            Err(_) => {
+                return persist_conflict(
+                    store,
+                    checkpoint,
+                    mutation,
+                    StoredConflictCodeV2::Recovery,
+                )
+                .await;
+            }
+        };
+
+        match checkpoint.as_stored().phase {
+            StoredPhaseV2::RecoveryStaged => {
+                let request = SaveRootRequest {
+                    credential_id: recovery.stored.credential_id.clone(),
+                    delegation_hex: recovery.stored.delegation_hex.clone(),
+                    passkey: recovery.stored.passkey.clone(),
+                    encryption_key: recovery.stored.encryption_key.clone(),
+                };
+                match super::identity::observe_root(state, &recovery.stored.root_did, &request)
+                    .await
+                    .map_err(|_| SetupStoreError::Read)?
+                {
+                    super::identity::LocalRootObservation::Missing => {
+                        if super::identity::persist_root(state, request.clone())
+                            .await
+                            .is_err()
+                        {
+                            return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+                        }
+                    }
+                    super::identity::LocalRootObservation::Exact => {}
+                    super::identity::LocalRootObservation::Mismatch => {
+                        return persist_conflict(
+                            store,
+                            checkpoint,
+                            mutation,
+                            StoredConflictCodeV2::LocalRoot,
+                        )
+                        .await;
+                    }
+                }
+                if super::identity::observe_root(state, &recovery.stored.root_did, &request)
+                    .await
+                    .ok()
+                    != Some(super::identity::LocalRootObservation::Exact)
+                {
+                    return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+                }
+                checkpoint = persist_reduction(
+                    store,
+                    reduce(
+                        checkpoint,
+                        ReducerCommand::Observe {
+                            mutation,
+                            evidence: VerifiedEvidence::LocalRootSaved,
+                        },
+                    )
+                    .map_err(|_| SetupStoreError::Write)?,
+                )
+                .await?;
+            }
+            StoredPhaseV2::RootSaved => {
+                let status_invocation =
+                    match tonk_identity::request::build_account_setup_status_invocation(
+                        state.profile.signer().signer().clone(),
+                        recovery.delegation(),
+                        &recovery.stored.create_fingerprint,
+                    )
+                    .await
+                    {
+                        Ok(invocation) => invocation,
+                        Err(_) => return Ok(AccountSetupResponse::View(retry_view(&checkpoint))),
+                    };
+                let create_invocation = recovery
+                    .create_invocation_bytes()
+                    .map_err(|_| SetupStoreError::Read)?;
+                let accepted = match resolve_provider_acceptance(
+                    provider,
+                    &status_invocation,
+                    &create_invocation,
+                    recovery.create_freshness(),
+                )
+                .await
+                {
+                    ProviderResolution::Accepted(accepted) => accepted,
+                    ProviderResolution::Mismatch => {
+                        return persist_conflict(
+                            store,
+                            checkpoint,
+                            mutation,
+                            StoredConflictCodeV2::Provider,
+                        )
+                        .await;
+                    }
+                    ProviderResolution::NeedsPasskey => {
+                        if !client_is_live(state, client_id).await {
+                            return Ok(AccountSetupResponse::View(checkpoint_view(
+                                &checkpoint,
+                                false,
+                            )));
+                        }
+                        let mut view = checkpoint_view(&checkpoint, true);
+                        view.disposition = AccountSetupDisposition::NeedsPasskey;
+                        view.next_action = AccountSetupNextAction::ResumeWithPasskey;
+                        return Ok(needs_passkey_response(&recovery, view));
+                    }
+                    ProviderResolution::Retry => {
+                        return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+                    }
+                };
+                let descriptor_hash = match verify_provider_acceptance(&recovery, accepted) {
+                    Ok(hash) => hash,
+                    Err(()) => {
+                        return persist_conflict(
+                            store,
+                            checkpoint,
+                            mutation,
+                            StoredConflictCodeV2::Provider,
+                        )
+                        .await;
+                    }
+                };
+                checkpoint = persist_reduction(
+                    store,
+                    reduce(
+                        checkpoint,
+                        ReducerCommand::Observe {
+                            mutation,
+                            evidence: VerifiedEvidence::ProviderAccepted { descriptor_hash },
+                        },
+                    )
+                    .map_err(|_| SetupStoreError::Write)?,
+                )
+                .await?;
+            }
+            StoredPhaseV2::ProviderAccepted => {
+                match super::account::observe_attachment(
+                    state,
+                    recovery.root_did(),
+                    context.provider.as_str(),
+                    recovery.descriptor_bytes(),
+                )
+                .await
+                .map_err(|_| SetupStoreError::Read)?
+                {
+                    super::account::AttachmentObservation::Missing => {
+                        let link = AccountLinkRequest {
+                            provider: context.provider.to_string(),
+                            root_did: recovery.stored.root_did.clone(),
+                            credential_id: recovery.stored.credential_id.clone(),
+                            delegation_hex: recovery.stored.delegation_hex.clone(),
+                            descriptor_hex: recovery.stored.descriptor_hex.clone(),
+                            initialize_name: true,
+                        };
+                        if super::account::persist_link(state, &link).await.is_err() {
+                            return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+                        }
+                    }
+                    super::account::AttachmentObservation::Exact => {}
+                    super::account::AttachmentObservation::Mismatch => {
+                        return persist_conflict(
+                            store,
+                            checkpoint,
+                            mutation,
+                            StoredConflictCodeV2::Attachment,
+                        )
+                        .await;
+                    }
+                }
+                if super::account::observe_attachment(
+                    state,
+                    recovery.root_did(),
+                    context.provider.as_str(),
+                    recovery.descriptor_bytes(),
+                )
+                .await
+                .ok()
+                    != Some(super::account::AttachmentObservation::Exact)
+                    || super::account_state::ensure_account_state(state).await
+                        != tonk_account::AccountStateStatus::Ready
+                {
+                    return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+                }
+                checkpoint = persist_reduction(
+                    store,
+                    reduce(
+                        checkpoint,
+                        ReducerCommand::Observe {
+                            mutation,
+                            evidence: VerifiedEvidence::AttachmentSaved,
+                        },
+                    )
+                    .map_err(|_| SetupStoreError::Write)?,
+                )
+                .await?;
+            }
+            StoredPhaseV2::Attached => {
+                match super::customer::observe_customer(
+                    state,
+                    &recovery.stored.root_did,
+                    &recovery.stored.normalized_email,
+                )
+                .await
+                .map_err(|_| SetupStoreError::Read)?
+                {
+                    super::customer::CustomerObservation::Missing => {
+                        if super::customer::enroll_customer(
+                            state,
+                            &context.service_origin,
+                            Some(recovery.stored.normalized_email.clone()),
+                            &recovery.stored.deposits_hex,
+                        )
+                        .await
+                        .is_err()
+                        {
+                            return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+                        }
+                    }
+                    super::customer::CustomerObservation::Exact => {}
+                    super::customer::CustomerObservation::Mismatch => {
+                        return persist_conflict(
+                            store,
+                            checkpoint,
+                            mutation,
+                            StoredConflictCodeV2::Attachment,
+                        )
+                        .await;
+                    }
+                }
+                if super::customer::observe_customer(
+                    state,
+                    &recovery.stored.root_did,
+                    &recovery.stored.normalized_email,
+                )
+                .await
+                .ok()
+                    != Some(super::customer::CustomerObservation::Exact)
+                {
+                    return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+                }
+                checkpoint = persist_reduction(
+                    store,
+                    reduce(
+                        checkpoint,
+                        ReducerCommand::Observe {
+                            mutation,
+                            evidence: VerifiedEvidence::CustomerEnrolled,
+                        },
+                    )
+                    .map_err(|_| SetupStoreError::Write)?,
+                )
+                .await?;
+            }
+            StoredPhaseV2::CustomerEnrolled => {
+                if recovery.publish_freshness() == RecoveryFreshness::NeedsRefresh {
+                    return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+                }
+                if super::customer::persist_custody_setup(
+                    state,
+                    &recovery.stored.custody_did,
+                    &recovery.stored.consent_hex,
+                    &recovery.stored.sealed_hex,
+                    &recovery.stored.publish_invocation_hex,
+                )
+                .await
+                .is_err()
+                {
+                    return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+                }
+                checkpoint = persist_reduction(
+                    store,
+                    reduce(
+                        checkpoint,
+                        ReducerCommand::Observe {
+                            mutation,
+                            evidence: VerifiedEvidence::CustodyQueued,
+                        },
+                    )
+                    .map_err(|_| SetupStoreError::Write)?,
+                )
+                .await?;
+            }
+            StoredPhaseV2::CustodyQueued => {
+                checkpoint = persist_reduction(
+                    store,
+                    reduce(
+                        checkpoint,
+                        ReducerCommand::Observe {
+                            mutation,
+                            evidence: VerifiedEvidence::CompletionRecorded,
+                        },
+                    )
+                    .map_err(|_| SetupStoreError::Write)?,
+                )
+                .await?;
+                let tombstone = StoredRecoveryRecord::Tombstone(completion_tombstone(
+                    &checkpoint,
+                    recovery.recovery_hash.clone(),
+                ));
+                if save_recovery(store, &tombstone).await.is_err() {
+                    return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+                }
+                return Ok(AccountSetupResponse::View(checkpoint_view(
+                    &checkpoint,
+                    false,
+                )));
+            }
+            StoredPhaseV2::Complete => {
+                let tombstone = StoredRecoveryRecord::Tombstone(completion_tombstone(
+                    &checkpoint,
+                    recovery.recovery_hash.clone(),
+                ));
+                if save_recovery(store, &tombstone).await.is_err() {
+                    return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+                }
+                return Ok(AccountSetupResponse::View(checkpoint_view(
+                    &checkpoint,
+                    false,
+                )));
+            }
+            _ => {
+                return Ok(AccountSetupResponse::View(checkpoint_view(
+                    &checkpoint,
+                    true,
+                )));
+            }
+        }
+    }
+}
+
+async fn inspect_response(
+    state: &crate::worker::TonkState,
+    store: &impl SetupStore,
+    origin: &crate::axum::RequestOrigin,
+    owner_token: Option<&str>,
+    client_id: &str,
+) -> Result<AccountSetupResponse, SetupStoreError> {
+    let checkpoint = match load_checkpoint(store).await? {
+        CheckpointLoad::Missing => return Ok(AccountSetupResponse::View(missing_view())),
+        CheckpointLoad::Corrupt => {
+            return Ok(AccountSetupResponse::View(closed_view(
+                AccountSetupDisposition::Corrupt,
+                AccountSetupNextAction::None,
+                None,
+            )));
+        }
+        CheckpointLoad::Unsupported(version) => {
+            return Ok(AccountSetupResponse::View(closed_view(
+                AccountSetupDisposition::Unsupported,
+                AccountSetupNextAction::None,
+                version,
+            )));
+        }
+        CheckpointLoad::Ready(checkpoint) => *checkpoint,
+    };
+    if checkpoint.as_stored().phase == StoredPhaseV2::Complete
+        && let Ok(context) = resolve_setup_context(origin).await
+    {
+        match repair_completion_tombstone(
+            store,
+            &checkpoint,
+            &context,
+            state.profile.did(),
+            now_seconds(),
+        )
+        .await?
+        {
+            CompletionTombstoneOutcome::AlreadyExact | CompletionTombstoneOutcome::Repaired => {}
+            CompletionTombstoneOutcome::Corrupt => {
+                return Ok(AccountSetupResponse::View(closed_view(
+                    AccountSetupDisposition::Corrupt,
+                    AccountSetupNextAction::None,
+                    None,
+                )));
+            }
+            CompletionTombstoneOutcome::Unsupported => {
+                return Ok(AccountSetupResponse::View(closed_view(
+                    AccountSetupDisposition::Unsupported,
+                    AccountSetupNextAction::None,
+                    None,
+                )));
+            }
+        }
+    }
+    let owns = owns_checkpoint(&checkpoint, owner_token, client_id)
+        && client_is_live(state, client_id).await;
+    if owns
+        && matches!(
+            checkpoint.as_stored().phase,
+            StoredPhaseV2::RootSaved
+                | StoredPhaseV2::ProviderAccepted
+                | StoredPhaseV2::Attached
+                | StoredPhaseV2::CustomerEnrolled
+                | StoredPhaseV2::CustodyQueued
+        )
+        && let Ok(context) = resolve_setup_context(origin).await
+        && let Ok(RecoveryLoad::Bundle(bundle)) = load_recovery(store).await
+        && let Ok(recovery) = validate_recovery_for_checkpoint(
+            *bundle,
+            &checkpoint,
+            &context,
+            state.profile.did(),
+            now_seconds(),
+        )
+        .await
+        && recovery.create_freshness() == RecoveryFreshness::NeedsRefresh
+    {
+        let mut view = checkpoint_view(&checkpoint, true);
+        view.disposition = AccountSetupDisposition::NeedsPasskey;
+        view.next_action = AccountSetupNextAction::ResumeWithPasskey;
+        return Ok(needs_passkey_response(&recovery, view));
+    }
+    Ok(AccountSetupResponse::View(checkpoint_view(
+        &checkpoint,
+        owns,
+    )))
+}
+
+async fn handle_locked(
+    state: &crate::worker::TonkState,
+    origin: &crate::axum::RequestOrigin,
+    client_id: &str,
+    request: AccountSetupRequest,
+) -> Result<AccountSetupResponse, SetupStoreError> {
+    let store = CredentialSetupStore { state };
+    match request {
+        AccountSetupRequest::Handshake(handshake) => {
+            if handshake.protocol_version != ACCOUNT_SETUP_PROTOCOL_VERSION {
+                return Ok(AccountSetupResponse::View(closed_view(
+                    AccountSetupDisposition::UpdateRequired,
+                    AccountSetupNextAction::Reload,
+                    None,
+                )));
+            }
+            let Ok(context) = resolve_setup_context(origin).await else {
+                return Ok(AccountSetupResponse::View(closed_view(
+                    AccountSetupDisposition::UpdateRequired,
+                    AccountSetupNextAction::Reload,
+                    None,
+                )));
+            };
+            if !provider_supports_recovery(&context).await {
+                return Ok(AccountSetupResponse::View(closed_view(
+                    AccountSetupDisposition::UpdateRequired,
+                    AccountSetupNextAction::Reload,
+                    None,
+                )));
+            }
+            Ok(AccountSetupResponse::Capabilities(
+                AccountSetupCapabilities {
+                    worker_protocol_version: ACCOUNT_SETUP_PROTOCOL_VERSION,
+                    provider_recovery_version: ACCOUNT_SETUP_PROVIDER_RECOVERY_VERSION,
+                },
+            ))
+        }
+        AccountSetupRequest::Inspect(inspect) => {
+            inspect_response(
+                state,
+                &store,
+                origin,
+                inspect.owner_token.as_deref(),
+                client_id,
+            )
+            .await
+        }
+        AccountSetupRequest::Begin(begin) => {
+            if begin.protocol_version != ACCOUNT_SETUP_PROTOCOL_VERSION {
+                return Ok(AccountSetupResponse::View(closed_view(
+                    AccountSetupDisposition::UpdateRequired,
+                    AccountSetupNextAction::Reload,
+                    None,
+                )));
+            }
+            let Ok(context) = resolve_setup_context(origin).await else {
+                return Ok(AccountSetupResponse::View(closed_view(
+                    AccountSetupDisposition::UpdateRequired,
+                    AccountSetupNextAction::Reload,
+                    None,
+                )));
+            };
+            if !provider_supports_recovery(&context).await {
+                return Ok(AccountSetupResponse::View(closed_view(
+                    AccountSetupDisposition::UpdateRequired,
+                    AccountSetupNextAction::Reload,
+                    None,
+                )));
+            }
+            match load_checkpoint(&store).await? {
+                CheckpointLoad::Ready(existing)
+                    if !matches!(
+                        existing.as_stored().phase,
+                        StoredPhaseV2::Cancelled | StoredPhaseV2::InterruptedBeforeRecovery
+                    ) =>
+                {
+                    return Ok(AccountSetupResponse::View(checkpoint_view(
+                        &existing, false,
+                    )));
+                }
+                CheckpointLoad::Corrupt => {
+                    return Ok(AccountSetupResponse::View(closed_view(
+                        AccountSetupDisposition::Corrupt,
+                        AccountSetupNextAction::None,
+                        None,
+                    )));
+                }
+                CheckpointLoad::Unsupported(version) => {
+                    return Ok(AccountSetupResponse::View(closed_view(
+                        AccountSetupDisposition::Unsupported,
+                        AccountSetupNextAction::None,
+                        version,
+                    )));
+                }
+                _ => {}
+            }
+            let operation_id = hex::encode(rand::random::<[u8; 32]>());
+            let owner_hash = match token_hash(
+                b"tonk-account-setup-owner-v1",
+                &operation_id,
+                &begin.owner_token,
+            ) {
+                Ok(hash) => hash,
+                Err(()) => {
+                    return Ok(AccountSetupResponse::View(closed_view(
+                        AccountSetupDisposition::Conflict,
+                        AccountSetupNextAction::None,
+                        None,
+                    )));
+                }
+            };
+            let now = now_seconds().max(1);
+            let checkpoint = ValidatedCheckpoint::new(StoredCheckpointV2 {
+                version: CHECKPOINT_VERSION,
+                operation_id,
+                revision: 1,
+                owner_hash: Some(owner_hash),
+                bound_client_id: Some(client_id.to_owned()),
+                configuration_hash: context.configuration_hash.clone(),
+                phase: StoredPhaseV2::Leased,
+                armed_at: None,
+                staged_at: None,
+                attempt_hash: None,
+                root_did: None,
+                create_fingerprint: None,
+                recovery_hash: None,
+                accepted_descriptor_hash: None,
+                last_transition_at: now,
+            })
+            .map_err(|_| SetupStoreError::Write)?;
+            save_checkpoint(&store, &checkpoint).await?;
+            Ok(AccountSetupResponse::Lease(AccountSetupLease {
+                view: checkpoint_view(&checkpoint, true),
+                ceremony: context.ceremony(),
+            }))
+        }
+        AccountSetupRequest::Arm(arm) => {
+            let CheckpointLoad::Ready(checkpoint) = load_checkpoint(&store).await? else {
+                return inspect_response(state, &store, origin, None, client_id).await;
+            };
+            let checkpoint = *checkpoint;
+            let Ok(context) = resolve_setup_context(origin).await else {
+                return Ok(AccountSetupResponse::View(closed_view(
+                    AccountSetupDisposition::UpdateRequired,
+                    AccountSetupNextAction::Reload,
+                    None,
+                )));
+            };
+            if !provider_supports_recovery(&context).await {
+                return Ok(AccountSetupResponse::View(closed_view(
+                    AccountSetupDisposition::UpdateRequired,
+                    AccountSetupNextAction::Reload,
+                    None,
+                )));
+            }
+            let Ok(mutation) =
+                mutation_context(&arm.mutation, &checkpoint, client_id, now_seconds())
+            else {
+                return Ok(AccountSetupResponse::View(checkpoint_view(
+                    &checkpoint,
+                    false,
+                )));
+            };
+            let Ok(attempt_hash) = token_hash(
+                b"tonk-account-setup-attempt-v1",
+                &arm.mutation.operation_id,
+                &arm.attempt_token,
+            ) else {
+                return Ok(AccountSetupResponse::View(checkpoint_view(
+                    &checkpoint,
+                    false,
+                )));
+            };
+            let reduction = match reduce(
+                checkpoint.clone(),
+                ReducerCommand::Arm {
+                    mutation,
+                    attempt_hash,
+                    configuration_hash: context.configuration_hash,
+                },
+            ) {
+                Ok(reduction) => reduction,
+                Err(_) => {
+                    return Ok(AccountSetupResponse::View(checkpoint_view(
+                        &checkpoint,
+                        false,
+                    )));
+                }
+            };
+            let checkpoint = persist_reduction(&store, reduction).await?;
+            Ok(AccountSetupResponse::View(checkpoint_view(
+                &checkpoint,
+                true,
+            )))
+        }
+        AccountSetupRequest::Stage(stage) => {
+            let CheckpointLoad::Ready(checkpoint) = load_checkpoint(&store).await? else {
+                return inspect_response(state, &store, origin, None, client_id).await;
+            };
+            let checkpoint = *checkpoint;
+            let Ok(context) = resolve_setup_context(origin).await else {
+                return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+            };
+            let now = now_seconds();
+            let Ok(mutation) = mutation_context(&stage.mutation, &checkpoint, client_id, now)
+            else {
+                return Ok(AccountSetupResponse::View(checkpoint_view(
+                    &checkpoint,
+                    false,
+                )));
+            };
+            let Ok(attempt_hash) = token_hash(
+                b"tonk-account-setup-attempt-v1",
+                &stage.mutation.operation_id,
+                &stage.attempt_token,
+            ) else {
+                return Ok(AccountSetupResponse::View(checkpoint_view(
+                    &checkpoint,
+                    false,
+                )));
+            };
+            let stored =
+                stored_recovery_from_wire(stage.mutation.operation_id.clone(), now, stage.recovery);
+            // The load-bearing ordering: protected recovery first, same-path
+            // readback/validation second, checkpoint phase third, root last.
+            let readback = match persist_staged_recovery(
+                &store,
+                stored,
+                StagePersistenceContext {
+                    checkpoint: &checkpoint,
+                    mutation: &mutation,
+                    attempt_hash: &attempt_hash,
+                    setup: &context,
+                    device_did: state.profile.did(),
+                    now,
+                },
+            )
+            .await
+            {
+                Ok(readback) => readback,
+                Err(StagePersistenceError::Invalid) => {
+                    return Ok(AccountSetupResponse::View(checkpoint_view(
+                        &checkpoint,
+                        true,
+                    )));
+                }
+                Err(StagePersistenceError::Unauthorized) => {
+                    return Ok(AccountSetupResponse::View(checkpoint_view(
+                        &checkpoint,
+                        false,
+                    )));
+                }
+                Err(StagePersistenceError::Store(error)) => return Err(error),
+            };
+            let reduction = reduce(
+                checkpoint,
+                ReducerCommand::Stage {
+                    mutation,
+                    attempt_hash,
+                    evidence: readback.evidence(),
+                },
+            )
+            .map_err(|_| SetupStoreError::Write)?;
+            let checkpoint = persist_reduction(&store, reduction).await?;
+            let owner_hash = checkpoint
+                .as_stored()
+                .owner_hash
+                .clone()
+                .ok_or(SetupStoreError::Read)?;
+            reconcile_with_provider(
+                state,
+                &store,
+                &HttpAccountSetupProvider { context: &context },
+                &context,
+                checkpoint,
+                owner_hash,
+                client_id,
+            )
+            .await
+        }
+        AccountSetupRequest::Continue(mutation_wire) => {
+            let CheckpointLoad::Ready(checkpoint) = load_checkpoint(&store).await? else {
+                return inspect_response(state, &store, origin, None, client_id).await;
+            };
+            let checkpoint = *checkpoint;
+            let Ok(mutation) =
+                mutation_context(&mutation_wire, &checkpoint, client_id, now_seconds())
+            else {
+                return Ok(AccountSetupResponse::View(checkpoint_view(
+                    &checkpoint,
+                    false,
+                )));
+            };
+            if authenticate(&checkpoint, &mutation).is_err() {
+                return Ok(AccountSetupResponse::View(checkpoint_view(
+                    &checkpoint,
+                    false,
+                )));
+            }
+            let Ok(context) = resolve_setup_context(origin).await else {
+                return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+            };
+            reconcile_with_provider(
+                state,
+                &store,
+                &HttpAccountSetupProvider { context: &context },
+                &context,
+                checkpoint,
+                mutation.owner_hash,
+                client_id,
+            )
+            .await
+        }
+        AccountSetupRequest::ReplaceInvocation(replacement) => {
+            let CheckpointLoad::Ready(checkpoint) = load_checkpoint(&store).await? else {
+                return inspect_response(state, &store, origin, None, client_id).await;
+            };
+            let checkpoint = *checkpoint;
+            let Ok(mutation) =
+                mutation_context(&replacement.mutation, &checkpoint, client_id, now_seconds())
+            else {
+                return Ok(AccountSetupResponse::View(checkpoint_view(
+                    &checkpoint,
+                    false,
+                )));
+            };
+            if authenticate(&checkpoint, &mutation).is_err() {
+                return Ok(AccountSetupResponse::View(checkpoint_view(
+                    &checkpoint,
+                    false,
+                )));
+            }
+            let Ok(context) = resolve_setup_context(origin).await else {
+                return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+            };
+            let RecoveryLoad::Bundle(mut bundle) = load_recovery(&store).await? else {
+                return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+            };
+            bundle.replacement_invocation_hex = Some(replacement.invocation_hex);
+            let validated = match validate_recovery_for_checkpoint(
+                *bundle,
+                &checkpoint,
+                &context,
+                state.profile.did(),
+                now_seconds(),
+            )
+            .await
+            {
+                Ok(validated) => validated,
+                Err(_) => return Ok(AccountSetupResponse::View(retry_view(&checkpoint))),
+            };
+            save_recovery(
+                &store,
+                &StoredRecoveryRecord::Bundle(Box::new(validated.stored.clone())),
+            )
+            .await?;
+            reconcile_with_provider(
+                state,
+                &store,
+                &HttpAccountSetupProvider { context: &context },
+                &context,
+                checkpoint,
+                mutation.owner_hash,
+                client_id,
+            )
+            .await
+        }
+        AccountSetupRequest::Cancel(cancel) => {
+            let CheckpointLoad::Ready(checkpoint) = load_checkpoint(&store).await? else {
+                return inspect_response(state, &store, origin, None, client_id).await;
+            };
+            let checkpoint = *checkpoint;
+            let Ok(mutation) = mutation_context(&cancel, &checkpoint, client_id, now_seconds())
+            else {
+                return Ok(AccountSetupResponse::View(checkpoint_view(
+                    &checkpoint,
+                    false,
+                )));
+            };
+            let reduction = match reduce(checkpoint.clone(), ReducerCommand::Cancel { mutation }) {
+                Ok(reduction) => reduction,
+                Err(_) => {
+                    return Ok(AccountSetupResponse::View(checkpoint_view(
+                        &checkpoint,
+                        false,
+                    )));
+                }
+            };
+            let too_late = reduction.next_action == PrivateNextAction::CancelTooLate;
+            let checkpoint = persist_reduction(&store, reduction).await?;
+            let mut view = checkpoint_view(&checkpoint, true);
+            if too_late {
+                view.disposition = AccountSetupDisposition::CancelTooLate;
+                view.next_action = AccountSetupNextAction::Wait;
+            }
+            Ok(AccountSetupResponse::View(view))
+        }
+        AccountSetupRequest::Acquire(acquire) => {
+            let CheckpointLoad::Ready(checkpoint) = load_checkpoint(&store).await? else {
+                return inspect_response(state, &store, origin, None, client_id).await;
+            };
+            let mut checkpoint = *checkpoint;
+            let Ok(context) = resolve_setup_context(origin).await else {
+                return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+            };
+            let now = now_seconds();
+            let mut acquire_revision = acquire.expected_revision;
+            if let Some(bound) = checkpoint.as_stored().bound_client_id.clone() {
+                if client_is_live(state, &bound).await {
+                    return Ok(AccountSetupResponse::View(checkpoint_view(
+                        &checkpoint,
+                        false,
+                    )));
+                }
+                let observation = match recovery_observation(
+                    &store,
+                    &checkpoint,
+                    &context,
+                    state.profile.did(),
+                    now,
+                )
+                .await
+                {
+                    Ok(observation) => observation,
+                    Err(()) => {
+                        return Ok(AccountSetupResponse::View(closed_view(
+                            AccountSetupDisposition::Corrupt,
+                            AccountSetupNextAction::None,
+                            None,
+                        )));
+                    }
+                };
+                let reduction = match reduce(
+                    checkpoint.clone(),
+                    ReducerCommand::OwnerAbsent {
+                        expected_revision: acquire.expected_revision,
+                        observed_client_id: bound,
+                        recovery: observation,
+                        now,
+                    },
+                ) {
+                    Ok(reduction) => reduction,
+                    Err(_) => {
+                        return Ok(AccountSetupResponse::View(checkpoint_view(
+                            &checkpoint,
+                            false,
+                        )));
+                    }
+                };
+                checkpoint = persist_reduction(&store, reduction).await?;
+                acquire_revision = checkpoint.as_stored().revision;
+                if matches!(
+                    checkpoint.as_stored().phase,
+                    StoredPhaseV2::InterruptedBeforeRecovery
+                ) {
+                    return Ok(AccountSetupResponse::View(checkpoint_view(
+                        &checkpoint,
+                        false,
+                    )));
+                }
+            }
+            let observation =
+                recovery_observation(&store, &checkpoint, &context, state.profile.did(), now)
+                    .await
+                    .map_err(|_| SetupStoreError::Read)?;
+            let Ok(owner_hash) = token_hash(
+                b"tonk-account-setup-owner-v1",
+                &acquire.operation_id,
+                &acquire.owner_token,
+            ) else {
+                return Ok(AccountSetupResponse::View(checkpoint_view(
+                    &checkpoint,
+                    false,
+                )));
+            };
+            let reduction = match reduce(
+                checkpoint.clone(),
+                ReducerCommand::Acquire {
+                    operation_id: acquire.operation_id,
+                    new_owner_hash: owner_hash,
+                    new_client_id: client_id.to_owned(),
+                    expected_revision: acquire_revision,
+                    recovery: observation,
+                    now,
+                },
+            ) {
+                Ok(reduction) => reduction,
+                Err(_) => {
+                    return Ok(AccountSetupResponse::View(checkpoint_view(
+                        &checkpoint,
+                        false,
+                    )));
+                }
+            };
+            let checkpoint = persist_reduction(&store, reduction).await?;
+            Ok(AccountSetupResponse::View(checkpoint_view(
+                &checkpoint,
+                true,
+            )))
+        }
+    }
+}
+
+/// Single worker authority for durable account setup. The route never logs its
+/// request or response because later variants contain protected material.
+pub(super) struct AccountSetupJson(AccountSetupResponse);
+
+impl std::fmt::Debug for AccountSetupJson {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("AccountSetupJson(<redacted>)")
+    }
+}
+
+impl IntoResponse for AccountSetupJson {
+    fn into_response(self) -> Response {
+        Json(self.0).into_response()
+    }
+}
+
+#[wasm_compat]
+pub(super) async fn handle(
+    State(state): State<super::AppState>,
+    client: Option<Extension<crate::ClientId>>,
+    origin: Option<Extension<crate::axum::RequestOrigin>>,
+    Json(request): Json<AccountSetupRequest>,
+) -> Result<AccountSetupJson, crate::TonkWorkerError> {
+    let client = client
+        .map(|Extension(client)| client)
+        .filter(|client| valid_identifier(&client.0, 512))
+        .ok_or_else(|| {
+            crate::TonkWorkerError::Router("account setup requires a client id".into())
+        })?;
+    let origin = origin.map(|Extension(origin)| origin).ok_or_else(|| {
+        crate::TonkWorkerError::Router("account setup requires a request origin".into())
+    })?;
+    let lock_name = {
+        let state = state.read().await;
+        format!(
+            "{ACCOUNT_SETUP_LOCK_NAME}:{}",
+            domain_hash(
+                b"tonk/account-setup/web-lock/v1",
+                &[state.profile.did().as_ref().as_bytes()],
+            )
+        )
+    };
+    let _cross_worker = match acquire_cross_worker_setup_lock(&lock_name).await {
+        Ok(guard) => guard,
+        Err(()) => {
+            return Ok(AccountSetupJson(AccountSetupResponse::View(closed_view(
+                AccountSetupDisposition::UpdateRequired,
+                AccountSetupNextAction::Reload,
+                None,
+            ))));
+        }
+    };
+    let local = state.read().await.account_setup_lock.clone();
+    let _local_guard = local.lock().await;
+    let state = state.read().await;
+    mark_request_client_live(&state, &client).await;
+    let response = handle_locked(&state, &origin, &client.0, request)
+        .await
+        .map_err(|error| {
+            crate::TonkWorkerError::Internal(match error {
+                SetupStoreError::Read => "account setup credential read failed".into(),
+                SetupStoreError::Write => "account setup credential write failed".into(),
+            })
+        })?;
+    Ok(AccountSetupJson(response))
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        ACCOUNT_SETUP_CHECKPOINT_SITE, ACCOUNT_SETUP_RECOVERY_SITE, CREATE_EXPIRY_MAX_OFFSET,
-        CREATE_EXPIRY_MIN_OFFSET, DurableAction, MAX_RECOVERY_RECORD_BYTES, MutationContext,
-        PUBLISH_EXPIRY_MAX_OFFSET, PUBLISH_EXPIRY_MIN_OFFSET, PrivateNextAction, RecoveryEvidence,
-        RecoveryFreshness, RecoveryObservation, RecoveryTrustContext, RecoveryValidationError,
-        ReducerCommand, ReductionError, StoredCheckpointV2, StoredConflictCodeV2, StoredPhaseV2,
-        StoredRecoveryBundleV1, StoredRecoveryRecord, StoredSafePhaseV2, StoredSetupError,
-        ValidatedCheckpoint, ValidatedRecoveryBundle, VerifiedEvidence, decode_bounded_recovery,
-        decode_checkpoint, decode_recovery, encode_checkpoint, encode_recovery, reduce,
-        validate_original_expiration, validate_stage_timestamps,
+        ACCOUNT_SETUP_CHECKPOINT_SITE, ACCOUNT_SETUP_RECOVERY_SITE, AccountSetupProvider,
+        CREATE_EXPIRY_MAX_OFFSET, CREATE_EXPIRY_MIN_OFFSET, CanonicalSetupContext, CheckpointLoad,
+        CompletionTombstoneOutcome, DurableAction, MAX_RECOVERY_RECORD_BYTES, MutationContext,
+        PUBLISH_EXPIRY_MAX_OFFSET, PUBLISH_EXPIRY_MIN_OFFSET, PrivateNextAction,
+        ProviderAcceptance, ProviderPortError, ProviderResolution, ProviderSetupStatus,
+        RecoveryEvidence, RecoveryFreshness, RecoveryObservation, RecoveryTrustContext,
+        RecoveryValidationError, ReducerCommand, ReductionError, SetupStore, SetupStoreError,
+        StagePersistenceContext, StagePersistenceError, StoredCheckpointV2, StoredConflictCodeV2,
+        StoredPhaseV2, StoredRecoveryBundleV1, StoredRecoveryRecord, StoredSafePhaseV2,
+        StoredSetupError, ValidatedCheckpoint, ValidatedRecoveryBundle, VerifiedEvidence,
+        decode_bounded_recovery, decode_checkpoint, decode_recovery, domain_hash,
+        encode_checkpoint, encode_recovery, load_checkpoint, persist_reduction,
+        persist_staged_recovery, recovery_observation, reduce, repair_completion_tombstone,
+        resolve_provider_acceptance, supports_provider_capabilities, validate_original_expiration,
+        validate_stage_timestamps,
     };
+    use async_trait::async_trait;
     use dialog_credentials::Ed25519Signer;
     use dialog_ucan_core::time::timestamp::{Duration, Timestamp, UNIX_EPOCH};
     use dialog_varsig::Principal as _;
@@ -1743,8 +3960,254 @@ mod tests {
     use tonk_identity::envelope::{AccountSecret, KekMethod, custody_kek, custody_signer};
     use tonk_worker_api::PasskeyMetadata;
 
+    use std::collections::VecDeque;
+    use std::sync::{
+        Mutex,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    struct ScriptedProvider {
+        statuses: Mutex<VecDeque<Result<ProviderSetupStatus, ProviderPortError>>>,
+        creates: Mutex<VecDeque<Result<ProviderAcceptance, ProviderPortError>>>,
+        calls: Mutex<Vec<(&'static str, Vec<u8>)>>,
+    }
+
+    impl ScriptedProvider {
+        fn new(
+            statuses: impl IntoIterator<Item = Result<ProviderSetupStatus, ProviderPortError>>,
+            creates: impl IntoIterator<Item = Result<ProviderAcceptance, ProviderPortError>>,
+        ) -> Self {
+            Self {
+                statuses: Mutex::new(statuses.into_iter().collect()),
+                creates: Mutex::new(creates.into_iter().collect()),
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn calls(&self) -> Vec<(&'static str, Vec<u8>)> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    impl AccountSetupProvider for ScriptedProvider {
+        async fn status(
+            &self,
+            invocation: &[u8],
+        ) -> Result<ProviderSetupStatus, ProviderPortError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(("status", invocation.to_vec()));
+            self.statuses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("scripted status result")
+        }
+
+        async fn create(&self, invocation: &[u8]) -> Result<ProviderAcceptance, ProviderPortError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(("create", invocation.to_vec()));
+            self.creates
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("scripted create result")
+        }
+    }
+
+    #[derive(Default)]
+    struct MemorySetupStore {
+        checkpoint: Mutex<Option<Vec<u8>>>,
+        recovery: Mutex<Option<Vec<u8>>>,
+        fail_checkpoint_saves: AtomicUsize,
+        fail_recovery_saves: AtomicUsize,
+        events: Mutex<Vec<&'static str>>,
+    }
+
+    impl MemorySetupStore {
+        fn fail_next_recovery_save(&self) {
+            self.fail_recovery_saves.store(1, Ordering::SeqCst);
+        }
+
+        fn fail_next_checkpoint_save(&self) {
+            self.fail_checkpoint_saves.store(1, Ordering::SeqCst);
+        }
+
+        fn recovery_record(&self) -> StoredRecoveryRecord {
+            decode_recovery(
+                self.recovery
+                    .lock()
+                    .unwrap()
+                    .as_deref()
+                    .expect("recovery record"),
+            )
+            .unwrap()
+        }
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    impl SetupStore for MemorySetupStore {
+        async fn load_checkpoint(&self) -> Result<Option<Vec<u8>>, SetupStoreError> {
+            Ok(self.checkpoint.lock().unwrap().clone())
+        }
+
+        async fn save_checkpoint(&self, bytes: Vec<u8>) -> Result<(), SetupStoreError> {
+            self.events.lock().unwrap().push("checkpoint");
+            if self.fail_checkpoint_saves.swap(0, Ordering::SeqCst) != 0 {
+                return Err(SetupStoreError::Write);
+            }
+            *self.checkpoint.lock().unwrap() = Some(bytes);
+            Ok(())
+        }
+
+        async fn load_recovery(&self) -> Result<Option<Vec<u8>>, SetupStoreError> {
+            Ok(self.recovery.lock().unwrap().clone())
+        }
+
+        async fn save_recovery(&self, bytes: Vec<u8>) -> Result<(), SetupStoreError> {
+            self.events.lock().unwrap().push("recovery");
+            if self.fail_recovery_saves.swap(0, Ordering::SeqCst) != 0 {
+                return Err(SetupStoreError::Write);
+            }
+            *self.recovery.lock().unwrap() = Some(bytes);
+            Ok(())
+        }
+    }
+
     fn hash(byte: &str) -> String {
         byte.repeat(32)
+    }
+
+    fn provider_acceptance() -> ProviderAcceptance {
+        ProviderAcceptance {
+            account_id: 7,
+            descriptor_hex: "aabb".to_string(),
+            create_fingerprint: hash("44"),
+        }
+    }
+
+    #[dialog_common::test]
+    fn it_accepts_only_the_exact_provider_recovery_capability_contract() {
+        assert!(supports_provider_capabilities(
+            br#"{"service":"tonk-account-service","capabilities":{"accountSetupRecovery":1}}"#
+        ));
+        for rejected in [
+            br#"{"service":"tonk-account-service","capabilities":{"accountSetupRecovery":0}}"#
+                .as_slice(),
+            br#"{"service":"tonk-account-service","capabilities":{"accountSetupRecovery":2}}"#,
+            br#"{"service":"other","capabilities":{"accountSetupRecovery":1}}"#,
+            br#"{"service":"tonk-account-service","capabilities":{}}"#,
+            br#"{"service":"tonk-account-service","capabilities":{"accountSetupRecovery":1},"unexpected":true}"#,
+            br#"not-json"#,
+        ] {
+            assert!(!supports_provider_capabilities(rejected));
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_queries_status_before_exact_replay_and_recovers_a_lost_create_response() {
+        let accepted = provider_acceptance();
+        let first_create =
+            ScriptedProvider::new([Ok(ProviderSetupStatus::Absent)], [Ok(accepted.clone())]);
+        assert!(matches!(
+            resolve_provider_acceptance(
+                &first_create,
+                b"first-status",
+                b"exact-stored-create",
+                RecoveryFreshness::Usable,
+            )
+            .await,
+            ProviderResolution::Accepted(result) if result == accepted
+        ));
+        assert_eq!(
+            first_create.calls(),
+            vec![
+                ("status", b"first-status".to_vec()),
+                ("create", b"exact-stored-create".to_vec()),
+            ]
+        );
+
+        let provider = ScriptedProvider::new(
+            [
+                Ok(ProviderSetupStatus::Absent),
+                Ok(ProviderSetupStatus::Accepted(accepted.clone())),
+            ],
+            [Err(ProviderPortError::Retry)],
+        );
+        let status_invocation = b"proof-bound-status";
+        let create_invocation = b"exact-stored-create";
+
+        assert!(matches!(
+            resolve_provider_acceptance(
+                &provider,
+                status_invocation,
+                create_invocation,
+                RecoveryFreshness::Usable,
+            )
+            .await,
+            ProviderResolution::Retry
+        ));
+        assert!(matches!(
+            resolve_provider_acceptance(
+                &provider,
+                status_invocation,
+                create_invocation,
+                RecoveryFreshness::Usable,
+            )
+            .await,
+            ProviderResolution::Accepted(result) if result == accepted
+        ));
+        assert_eq!(
+            provider.calls(),
+            vec![
+                ("status", status_invocation.to_vec()),
+                ("create", create_invocation.to_vec()),
+                ("status", status_invocation.to_vec()),
+            ]
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_never_turns_unknown_provider_outcomes_into_absent_or_create() {
+        let cases = [
+            (Err(ProviderPortError::Retry), ProviderResolution::Retry),
+            (Err(ProviderPortError::Invalid), ProviderResolution::Retry),
+            (
+                Ok(ProviderSetupStatus::Mismatch),
+                ProviderResolution::Mismatch,
+            ),
+        ];
+        for (status, expected) in cases {
+            let provider = ScriptedProvider::new([status], []);
+            let result = resolve_provider_acceptance(
+                &provider,
+                b"status",
+                b"create",
+                RecoveryFreshness::Usable,
+            )
+            .await;
+            assert!(std::mem::discriminant(&result) == std::mem::discriminant(&expected));
+            assert_eq!(provider.calls(), vec![("status", b"status".to_vec())]);
+        }
+
+        let provider = ScriptedProvider::new([Ok(ProviderSetupStatus::Absent)], []);
+        assert!(matches!(
+            resolve_provider_acceptance(
+                &provider,
+                b"status",
+                b"expired-create",
+                RecoveryFreshness::NeedsRefresh,
+            )
+            .await,
+            ProviderResolution::NeedsPasskey
+        ));
+        assert_eq!(provider.calls(), vec![("status", b"status".to_vec())]);
     }
 
     fn leased() -> ValidatedCheckpoint {
@@ -1800,6 +4263,7 @@ mod tests {
             descriptor_hex: "eeff".to_string(),
             create_fingerprint: hash("33"),
             invocation_hex: "2233".to_string(),
+            replacement_invocation_hex: None,
             deposits_hex: vec!["4455".to_string()],
             custody_did: "did:key:custody".to_string(),
             consent_hex: "6677".to_string(),
@@ -1957,6 +4421,7 @@ mod tests {
             descriptor_hex,
             create_fingerprint: create_fingerprint.to_hex(),
             invocation_hex: account.invocation_hex,
+            replacement_invocation_hex: None,
             deposits_hex,
             custody_did,
             consent_hex: hex::encode(consent_bytes),
@@ -1974,6 +4439,310 @@ mod tests {
             now: staged_at + 1,
         };
         (bundle, trust)
+    }
+
+    async fn completed_recovery_fixture(
+        seed: u8,
+    ) -> (
+        MemorySetupStore,
+        ValidatedCheckpoint,
+        CanonicalSetupContext,
+        dialog_varsig::Did,
+    ) {
+        let (bundle, trust) = valid_recovery(seed).await;
+        let validated = ValidatedRecoveryBundle::new(bundle.clone(), &trust)
+            .await
+            .unwrap();
+        let checkpoint = ValidatedCheckpoint::new(StoredCheckpointV2 {
+            version: 2,
+            operation_id: bundle.operation_id.clone(),
+            revision: 9,
+            owner_hash: None,
+            bound_client_id: None,
+            configuration_hash: hash("22"),
+            phase: StoredPhaseV2::Complete,
+            armed_at: Some(trust.armed_at),
+            staged_at: Some(bundle.staged_at),
+            attempt_hash: None,
+            root_did: Some(bundle.root_did.clone()),
+            create_fingerprint: Some(bundle.create_fingerprint.clone()),
+            recovery_hash: Some(validated.recovery_hash.clone()),
+            accepted_descriptor_hash: Some(domain_hash(
+                b"tonk-account-setup-accepted-descriptor-v1",
+                &[validated.descriptor_bytes()],
+            )),
+            last_transition_at: bundle.staged_at + 7,
+        })
+        .unwrap();
+        let context = CanonicalSetupContext {
+            service_origin: "https://app.example/".parse().unwrap(),
+            provider: trust.provider,
+            remote: trust.remote,
+            service_did: trust.service_did,
+            configuration_hash: hash("22"),
+        };
+        let store = MemorySetupStore::default();
+        *store.checkpoint.lock().unwrap() = Some(encode_checkpoint(&checkpoint).unwrap());
+        *store.recovery.lock().unwrap() =
+            Some(encode_recovery(&StoredRecoveryRecord::Bundle(Box::new(bundle))).unwrap());
+        (store, checkpoint, context, trust.device_did)
+    }
+
+    async fn armed_recovery_fixture(
+        seed: u8,
+    ) -> (
+        MemorySetupStore,
+        ValidatedCheckpoint,
+        StoredRecoveryBundleV1,
+        CanonicalSetupContext,
+        dialog_varsig::Did,
+        u64,
+    ) {
+        let (bundle, trust) = valid_recovery(seed).await;
+        let checkpoint = ValidatedCheckpoint::new(StoredCheckpointV2 {
+            version: 2,
+            operation_id: bundle.operation_id.clone(),
+            revision: 2,
+            owner_hash: Some(hash("11")),
+            bound_client_id: Some("client-1".to_string()),
+            configuration_hash: hash("22"),
+            phase: StoredPhaseV2::Armed,
+            armed_at: Some(trust.armed_at),
+            staged_at: None,
+            attempt_hash: Some(hash("33")),
+            root_did: None,
+            create_fingerprint: None,
+            recovery_hash: None,
+            accepted_descriptor_hash: None,
+            last_transition_at: trust.armed_at,
+        })
+        .unwrap();
+        let context = CanonicalSetupContext {
+            service_origin: "https://app.example/".parse().unwrap(),
+            provider: trust.provider,
+            remote: trust.remote,
+            service_did: trust.service_did,
+            configuration_hash: hash("22"),
+        };
+        let store = MemorySetupStore::default();
+        *store.checkpoint.lock().unwrap() = Some(encode_checkpoint(&checkpoint).unwrap());
+        (
+            store,
+            checkpoint,
+            bundle,
+            context,
+            trust.device_did,
+            trust.now,
+        )
+    }
+
+    #[dialog_common::test]
+    async fn it_stages_recovery_before_the_checkpoint_and_repairs_a_lost_stage_checkpoint() {
+        let (store, checkpoint, bundle, context, device_did, now) =
+            armed_recovery_fixture(51).await;
+        let mutation = MutationContext {
+            operation_id: checkpoint.as_stored().operation_id.clone(),
+            owner_hash: hash("11"),
+            client_id: "client-1".to_string(),
+            expected_revision: checkpoint.as_stored().revision,
+            now,
+        };
+        let mut unauthorized = mutation.clone();
+        unauthorized.owner_hash = hash("99");
+        let attempt_hash = hash("33");
+        assert!(matches!(
+            persist_staged_recovery(
+                &store,
+                bundle.clone(),
+                StagePersistenceContext {
+                    checkpoint: &checkpoint,
+                    mutation: &unauthorized,
+                    attempt_hash: &attempt_hash,
+                    setup: &context,
+                    device_did: device_did.clone(),
+                    now,
+                },
+            )
+            .await,
+            Err(StagePersistenceError::Unauthorized)
+        ));
+        assert!(store.recovery.lock().unwrap().is_none());
+        assert!(store.events.lock().unwrap().is_empty());
+
+        let mut changed_context = context.clone();
+        changed_context.configuration_hash = hash("99");
+        assert!(matches!(
+            persist_staged_recovery(
+                &store,
+                bundle.clone(),
+                StagePersistenceContext {
+                    checkpoint: &checkpoint,
+                    mutation: &mutation,
+                    attempt_hash: &attempt_hash,
+                    setup: &changed_context,
+                    device_did: device_did.clone(),
+                    now,
+                },
+            )
+            .await,
+            Err(StagePersistenceError::Invalid)
+        ));
+        assert!(store.recovery.lock().unwrap().is_none());
+
+        store.fail_next_recovery_save();
+        assert!(matches!(
+            persist_staged_recovery(
+                &store,
+                bundle.clone(),
+                StagePersistenceContext {
+                    checkpoint: &checkpoint,
+                    mutation: &mutation,
+                    attempt_hash: &attempt_hash,
+                    setup: &context,
+                    device_did: device_did.clone(),
+                    now,
+                },
+            )
+            .await,
+            Err(StagePersistenceError::Store(SetupStoreError::Write))
+        ));
+        assert!(store.recovery.lock().unwrap().is_none());
+        assert!(matches!(
+            load_checkpoint(&store).await.unwrap(),
+            CheckpointLoad::Ready(ref loaded)
+                if loaded.as_stored().phase == StoredPhaseV2::Armed
+        ));
+
+        let recovery = persist_staged_recovery(
+            &store,
+            bundle,
+            StagePersistenceContext {
+                checkpoint: &checkpoint,
+                mutation: &mutation,
+                attempt_hash: &attempt_hash,
+                setup: &context,
+                device_did: device_did.clone(),
+                now,
+            },
+        )
+        .await
+        .unwrap();
+        store.fail_next_checkpoint_save();
+        let reduction = reduce(
+            checkpoint.clone(),
+            ReducerCommand::Stage {
+                mutation,
+                attempt_hash,
+                evidence: recovery.evidence(),
+            },
+        )
+        .unwrap();
+        assert!(matches!(
+            persist_reduction(&store, reduction).await,
+            Err(SetupStoreError::Write)
+        ));
+
+        let CheckpointLoad::Ready(restarted) = load_checkpoint(&store).await.unwrap() else {
+            panic!("armed checkpoint must survive the failed phase write");
+        };
+        let restarted = *restarted;
+        assert_eq!(restarted.as_stored().phase, StoredPhaseV2::Armed);
+        let observation = recovery_observation(&store, &restarted, &context, device_did, now)
+            .await
+            .unwrap();
+        let repaired = reduce(
+            restarted.clone(),
+            ReducerCommand::OwnerAbsent {
+                expected_revision: restarted.as_stored().revision,
+                observed_client_id: "client-1".to_string(),
+                recovery: observation,
+                now,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            repaired.checkpoint.as_stored().phase,
+            StoredPhaseV2::RecoveryStaged
+        );
+        assert!(repaired.checkpoint.as_stored().attempt_hash.is_none());
+    }
+
+    #[dialog_common::test]
+    async fn it_commits_complete_before_tombstoning_and_repairs_a_lost_tombstone_write() {
+        let (store, checkpoint, context, device_did) = completed_recovery_fixture(52).await;
+        store.fail_next_recovery_save();
+
+        assert_eq!(
+            repair_completion_tombstone(
+                &store,
+                &checkpoint,
+                &context,
+                device_did.clone(),
+                checkpoint.as_stored().last_transition_at,
+            )
+            .await,
+            Err(SetupStoreError::Write)
+        );
+        assert!(matches!(
+            decode_checkpoint(store.checkpoint.lock().unwrap().as_deref().unwrap())
+                .unwrap()
+                .as_stored()
+                .phase,
+            StoredPhaseV2::Complete
+        ));
+        assert!(matches!(
+            store.recovery_record(),
+            StoredRecoveryRecord::Bundle(_)
+        ));
+        let mut mixed = checkpoint.as_stored().clone();
+        mixed.accepted_descriptor_hash = Some(hash("99"));
+        let mixed = ValidatedCheckpoint::new(mixed).unwrap();
+        assert_eq!(
+            repair_completion_tombstone(
+                &store,
+                &mixed,
+                &context,
+                device_did.clone(),
+                checkpoint.as_stored().last_transition_at,
+            )
+            .await,
+            Ok(CompletionTombstoneOutcome::Corrupt)
+        );
+
+        assert_eq!(
+            repair_completion_tombstone(
+                &store,
+                &checkpoint,
+                &context,
+                device_did.clone(),
+                checkpoint.as_stored().last_transition_at,
+            )
+            .await,
+            Ok(CompletionTombstoneOutcome::Repaired)
+        );
+        let StoredRecoveryRecord::Tombstone(tombstone) = store.recovery_record() else {
+            panic!("completion must replace the recovery bundle with a tombstone");
+        };
+        assert_eq!(tombstone.operation_id, checkpoint.as_stored().operation_id);
+        assert_eq!(
+            tombstone.completed_at,
+            checkpoint.as_stored().last_transition_at
+        );
+        assert_eq!(
+            Some(tombstone.recovery_hash),
+            checkpoint.as_stored().recovery_hash
+        );
+        assert_eq!(
+            repair_completion_tombstone(
+                &store,
+                &checkpoint,
+                &context,
+                device_did,
+                checkpoint.as_stored().last_transition_at,
+            )
+            .await,
+            Ok(CompletionTombstoneOutcome::AlreadyExact)
+        );
     }
 
     #[dialog_common::test]
@@ -2357,6 +5126,21 @@ mod tests {
         .unwrap()
         .checkpoint;
         assert!(released.as_stored().owner_hash.is_none());
+
+        assert!(matches!(
+            reduce(
+                released.clone(),
+                ReducerCommand::Acquire {
+                    operation_id: "setup-1".to_string(),
+                    new_owner_hash: hash("77"),
+                    new_client_id: "client-2".to_string(),
+                    expected_revision: 1,
+                    recovery: RecoveryObservation::Absent,
+                    now: 1_754_380_802,
+                },
+            ),
+            Err(ReductionError::StaleRevision)
+        ));
 
         assert!(matches!(
             reduce(

--- a/rust/tonk-worker/src/router/account_setup.rs
+++ b/rust/tonk-worker/src/router/account_setup.rs
@@ -187,6 +187,21 @@ impl ValidatedCheckpoint {
 /// schema; Stage performs an explicit conversion before validation/storage.
 /// This type deliberately has no `Debug` implementation.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+enum StoredPendingPublishReplacementV1 {
+    Original,
+    Replacement {
+        created_at: u64,
+        invocation_hex: String,
+    },
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct StoredRecoveryBundleV1 {
     version: u16,
@@ -226,6 +241,10 @@ struct StoredRecoveryBundleV1 {
     replacement_publish_invocation_created_at: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     replacement_publish_invocation_hex: Option<String>,
+    /// Durable intent retained between saving a fresh publish receipt and
+    /// atomically replacing the corresponding pending-queue entry.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pending_publish_replacement_from: Option<StoredPendingPublishReplacementV1>,
     recovery_manifest_hex: String,
 }
 
@@ -525,7 +544,6 @@ struct ValidatedRecoveryBundle {
     delegation: DelegationChain,
     descriptor: AccountRepositoryDescriptorV1,
     create_invocation: InvocationChain<AnySignature>,
-    publish_invocation: InvocationChain<AnySignature>,
     recovery_hash: String,
     #[cfg(test)]
     create_expires_at: u64,
@@ -682,6 +700,45 @@ impl ValidatedRecoveryBundle {
                 ));
             }
         };
+        if let Some(previous) = decoded.pending_publish_replacement_from.as_ref() {
+            let (Some(current_created_at), Some(current_hex)) = (
+                stored.replacement_publish_invocation_created_at,
+                stored.replacement_publish_invocation_hex.as_deref(),
+            ) else {
+                return Err(RecoveryValidationError::Invalid(
+                    "pending_publish_replacement",
+                ));
+            };
+            match (previous, stored.pending_publish_replacement_from.as_ref()) {
+                (
+                    DecodedPendingPublishReplacement::Original,
+                    Some(StoredPendingPublishReplacementV1::Original),
+                ) if current_hex != stored.publish_invocation_hex => {}
+                (
+                    DecodedPendingPublishReplacement::Replacement {
+                        created_at,
+                        invocation,
+                    },
+                    Some(StoredPendingPublishReplacementV1::Replacement { invocation_hex, .. }),
+                ) if *created_at > 0
+                    && *created_at <= current_created_at
+                    && invocation_hex != current_hex =>
+                {
+                    validate_replacement_publish_invocation(
+                        invocation,
+                        &custody_did,
+                        &decoded.sealed,
+                        *created_at,
+                    )
+                    .await?;
+                }
+                _ => {
+                    return Err(RecoveryValidationError::Invalid(
+                        "pending_publish_replacement",
+                    ));
+                }
+            }
+        }
 
         let service_did = trust.service_did.as_ref().map(ToString::to_string);
         AccountSetupRecoveryManifestV1::validate(
@@ -729,7 +786,6 @@ impl ValidatedRecoveryBundle {
             delegation,
             descriptor,
             create_invocation: replacement_invocation.unwrap_or(create_invocation),
-            publish_invocation: replacement_publish_invocation.unwrap_or(publish_invocation),
             recovery_hash,
             #[cfg(test)]
             create_expires_at,
@@ -779,10 +835,22 @@ impl ValidatedRecoveryBundle {
     }
 
     fn publish_invocation_hex(&self) -> Result<String, RecoveryValidationError> {
-        self.publish_invocation
-            .to_bytes()
-            .map(hex::encode)
-            .map_err(|_| RecoveryValidationError::Artifact("publish"))
+        Ok(self
+            .stored
+            .replacement_publish_invocation_hex
+            .clone()
+            .unwrap_or_else(|| self.stored.publish_invocation_hex.clone()))
+    }
+
+    fn pending_publish_replacement_from_hex(&self) -> Option<&str> {
+        match self.stored.pending_publish_replacement_from.as_ref()? {
+            StoredPendingPublishReplacementV1::Original => {
+                Some(self.stored.publish_invocation_hex.as_str())
+            }
+            StoredPendingPublishReplacementV1::Replacement { invocation_hex, .. } => {
+                Some(invocation_hex.as_str())
+            }
+        }
     }
 }
 
@@ -796,7 +864,16 @@ struct DecodedRecovery {
     sealed: Vec<u8>,
     publish_invocation: Vec<u8>,
     replacement_publish_invocation: Option<Vec<u8>>,
+    pending_publish_replacement_from: Option<DecodedPendingPublishReplacement>,
     manifest: Vec<u8>,
+}
+
+enum DecodedPendingPublishReplacement {
+    Original,
+    Replacement {
+        created_at: u64,
+        invocation: Vec<u8>,
+    },
 }
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
@@ -1701,6 +1778,26 @@ fn decode_bounded_recovery(
             )
         })
         .transpose()?;
+    let pending_publish_replacement_from = stored
+        .pending_publish_replacement_from
+        .as_ref()
+        .map(|previous| match previous {
+            StoredPendingPublishReplacementV1::Original => {
+                Ok(DecodedPendingPublishReplacement::Original)
+            }
+            StoredPendingPublishReplacementV1::Replacement {
+                created_at,
+                invocation_hex,
+            } => Ok(DecodedPendingPublishReplacement::Replacement {
+                created_at: *created_at,
+                invocation: decode_hex_field(
+                    "pending_publish_replacement_from",
+                    invocation_hex,
+                    MAX_INVOCATION_BYTES,
+                )?,
+            }),
+        })
+        .transpose()?;
     let manifest = decode_hex_field(
         "recovery_manifest",
         &stored.recovery_manifest_hex,
@@ -1715,6 +1812,14 @@ fn decode_bounded_recovery(
         sealed.len(),
         publish_invocation.len(),
         replacement_publish_invocation.as_ref().map_or(0, Vec::len),
+        pending_publish_replacement_from
+            .as_ref()
+            .map_or(0, |previous| match previous {
+                DecodedPendingPublishReplacement::Original => 0,
+                DecodedPendingPublishReplacement::Replacement { invocation, .. } => {
+                    invocation.len()
+                }
+            }),
         manifest.len(),
     ]
     .into_iter()
@@ -1739,6 +1844,7 @@ fn decode_bounded_recovery(
         sealed,
         publish_invocation,
         replacement_publish_invocation,
+        pending_publish_replacement_from,
         manifest,
     })
 }
@@ -1752,6 +1858,7 @@ fn recovery_hash(stored: &StoredRecoveryBundleV1) -> Result<String, RecoveryVali
     original.replacement_invocation_hex = None;
     original.replacement_publish_invocation_created_at = None;
     original.replacement_publish_invocation_hex = None;
+    original.pending_publish_replacement_from = None;
     let record_bytes = encode_recovery(&StoredRecoveryRecord::Bundle(Box::new(original)))
         .map_err(|_| RecoveryValidationError::Invalid("recovery_record"))?;
     Ok(blake3::hash(&record_bytes).to_hex().to_string())
@@ -3012,6 +3119,7 @@ fn stored_recovery_from_wire(
         publish_invocation_hex: recovery.publish_invocation_hex,
         replacement_publish_invocation_created_at: None,
         replacement_publish_invocation_hex: None,
+        pending_publish_replacement_from: None,
         recovery_manifest_hex: recovery.recovery_manifest_hex,
     }
 }
@@ -3259,6 +3367,56 @@ async fn repair_completion_tombstone(
     }
 }
 
+enum PendingPublishReplacementRepair {
+    Ready(Box<ValidatedRecoveryBundle>),
+    Retry,
+    Mismatch,
+}
+
+/// Finish a recovery-first publish replacement intent. The production queue
+/// mutator accepts either the previous or current exact invocation, making
+/// this safe after a failure before, during, or after its durable write.
+async fn repair_pending_publish_replacement(
+    effects: &impl SetupEffects,
+    store: &impl SetupStore,
+    mut recovery: ValidatedRecoveryBundle,
+) -> Result<PendingPublishReplacementRepair, SetupStoreError> {
+    let Some(previous_invocation_hex) = recovery
+        .pending_publish_replacement_from_hex()
+        .map(str::to_owned)
+    else {
+        return Ok(PendingPublishReplacementRepair::Ready(Box::new(recovery)));
+    };
+    let replacement_invocation_hex = recovery
+        .publish_invocation_hex()
+        .map_err(|_| SetupStoreError::Read)?;
+    match effects
+        .replace_custody_publish(
+            &recovery.stored.custody_did,
+            &recovery.stored.consent_hex,
+            &recovery.stored.sealed_hex,
+            &previous_invocation_hex,
+            &replacement_invocation_hex,
+        )
+        .await
+    {
+        Ok(super::customer::CustodySetupObservation::Pending)
+        | Ok(super::customer::CustodySetupObservation::Complete) => {
+            recovery.stored.pending_publish_replacement_from = None;
+            save_recovery(
+                store,
+                &StoredRecoveryRecord::Bundle(Box::new(recovery.stored.clone())),
+            )
+            .await?;
+            Ok(PendingPublishReplacementRepair::Ready(Box::new(recovery)))
+        }
+        Ok(super::customer::CustodySetupObservation::Mismatch) => {
+            Ok(PendingPublishReplacementRepair::Mismatch)
+        }
+        Err(()) => Ok(PendingPublishReplacementRepair::Retry),
+    }
+}
+
 async fn reconcile_with_provider(
     effects: &impl SetupEffects,
     store: &impl SetupStore,
@@ -3268,6 +3426,13 @@ async fn reconcile_with_provider(
     owner_hash: String,
     client_id: &str,
 ) -> Result<AccountSetupResponse, SetupStoreError> {
+    if checkpoint.as_stored().configuration_hash != context.configuration_hash {
+        return Ok(AccountSetupResponse::View(closed_view(
+            AccountSetupDisposition::UpdateRequired,
+            AccountSetupNextAction::Reload,
+            None,
+        )));
+    }
     loop {
         let now = effects.now_seconds();
         if checkpoint.as_stored().phase == StoredPhaseV2::Complete {
@@ -3343,6 +3508,21 @@ async fn reconcile_with_provider(
         {
             Ok(recovery) => recovery,
             Err(_) => {
+                return persist_conflict(
+                    store,
+                    checkpoint,
+                    mutation,
+                    StoredConflictCodeV2::Recovery,
+                )
+                .await;
+            }
+        };
+        let recovery = match repair_pending_publish_replacement(effects, store, recovery).await? {
+            PendingPublishReplacementRepair::Ready(recovery) => *recovery,
+            PendingPublishReplacementRepair::Retry => {
+                return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+            }
+            PendingPublishReplacementRepair::Mismatch => {
                 return persist_conflict(
                     store,
                     checkpoint,
@@ -3768,13 +3948,23 @@ async fn inspect_response(
         }
         SetupLoad::Ready(checkpoint) => *checkpoint,
     };
+    let context = contexts.resolve(trusted_origin).await.ok();
+    if context.as_ref().is_some_and(|context| {
+        checkpoint.as_stored().configuration_hash != context.configuration_hash
+    }) {
+        return Ok(AccountSetupResponse::View(closed_view(
+            AccountSetupDisposition::UpdateRequired,
+            AccountSetupNextAction::Reload,
+            None,
+        )));
+    }
     if checkpoint.as_stored().phase == StoredPhaseV2::Complete
-        && let Ok(context) = contexts.resolve(trusted_origin).await
+        && let Some(context) = context.as_ref()
     {
         match repair_completion_tombstone(
             store,
             &checkpoint,
-            &context,
+            context,
             effects.device_did(),
             effects.now_seconds(),
         )
@@ -3804,12 +3994,12 @@ async fn inspect_response(
             checkpoint.as_stored().phase,
             StoredPhaseV2::RootSaved | StoredPhaseV2::CustomerEnrolled
         )
-        && let Ok(context) = contexts.resolve(trusted_origin).await
+        && let Some(context) = context.as_ref()
         && let Ok(RecoveryLoad::Bundle(bundle)) = load_recovery(store).await
         && let Ok(recovery) = validate_recovery_for_checkpoint(
             *bundle,
             &checkpoint,
-            &context,
+            context,
             effects.device_did(),
             effects.now_seconds(),
         )
@@ -4256,6 +4446,13 @@ async fn handle_locked(
             let Ok(context) = contexts.resolve(trusted_origin).await else {
                 return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
             };
+            if checkpoint.as_stored().configuration_hash != context.configuration_hash {
+                return Ok(AccountSetupResponse::View(closed_view(
+                    AccountSetupDisposition::UpdateRequired,
+                    AccountSetupNextAction::Reload,
+                    None,
+                )));
+            }
             let RecoveryLoad::Bundle(mut bundle) = load_recovery(store).await? else {
                 return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
             };
@@ -4325,17 +4522,16 @@ async fn handle_locked(
             let Ok(context) = contexts.resolve(trusted_origin).await else {
                 return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
             };
-            let RecoveryLoad::Bundle(mut bundle) = load_recovery(store).await? else {
+            if checkpoint.as_stored().configuration_hash != context.configuration_hash {
+                return Ok(AccountSetupResponse::View(closed_view(
+                    AccountSetupDisposition::UpdateRequired,
+                    AccountSetupNextAction::Reload,
+                    None,
+                )));
+            }
+            let RecoveryLoad::Bundle(bundle) = load_recovery(store).await? else {
                 return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
             };
-            let previous_invocation_hex = bundle
-                .replacement_publish_invocation_hex
-                .clone()
-                .unwrap_or_else(|| bundle.publish_invocation_hex.clone());
-            if previous_invocation_hex != replacement.invocation_hex {
-                bundle.replacement_publish_invocation_created_at = Some(now);
-                bundle.replacement_publish_invocation_hex = Some(replacement.invocation_hex);
-            }
             let validated = match validate_recovery_for_checkpoint(
                 *bundle,
                 &checkpoint,
@@ -4348,32 +4544,87 @@ async fn handle_locked(
                 Ok(validated) => validated,
                 Err(_) => return Ok(AccountSetupResponse::View(retry_view(&checkpoint))),
             };
-            let replacement_invocation_hex = validated
+            let validated =
+                match repair_pending_publish_replacement(effects, store, validated).await? {
+                    PendingPublishReplacementRepair::Ready(validated) => *validated,
+                    PendingPublishReplacementRepair::Retry
+                    | PendingPublishReplacementRepair::Mismatch => {
+                        return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+                    }
+                };
+            let previous_invocation_hex = validated
                 .publish_invocation_hex()
                 .map_err(|_| SetupStoreError::Read)?;
+            let replacing = previous_invocation_hex != replacement.invocation_hex;
+            let mut bundle = validated.stored.clone();
+            if replacing {
+                if checkpoint.as_stored().phase == StoredPhaseV2::CustodyQueued {
+                    bundle.pending_publish_replacement_from = Some(
+                        match (
+                            bundle.replacement_publish_invocation_created_at,
+                            bundle.replacement_publish_invocation_hex.as_ref(),
+                        ) {
+                            (Some(created_at), Some(invocation_hex)) => {
+                                StoredPendingPublishReplacementV1::Replacement {
+                                    created_at,
+                                    invocation_hex: invocation_hex.clone(),
+                                }
+                            }
+                            (None, None) => StoredPendingPublishReplacementV1::Original,
+                            _ => return Ok(AccountSetupResponse::View(retry_view(&checkpoint))),
+                        },
+                    );
+                }
+                bundle.replacement_publish_invocation_created_at = Some(now);
+                bundle.replacement_publish_invocation_hex = Some(replacement.invocation_hex);
+            }
+            let validated = match validate_recovery_for_checkpoint(
+                bundle,
+                &checkpoint,
+                &context,
+                effects.device_did(),
+                now,
+            )
+            .await
+            {
+                Ok(validated) => validated,
+                Err(_) => return Ok(AccountSetupResponse::View(retry_view(&checkpoint))),
+            };
+            if replacing {
+                save_recovery(
+                    store,
+                    &StoredRecoveryRecord::Bundle(Box::new(validated.stored.clone())),
+                )
+                .await?;
+            }
             if checkpoint.as_stored().phase == StoredPhaseV2::CustodyQueued {
-                match effects
-                    .replace_custody_publish(
-                        &validated.stored.custody_did,
-                        &validated.stored.consent_hex,
-                        &validated.stored.sealed_hex,
-                        &previous_invocation_hex,
-                        &replacement_invocation_hex,
-                    )
-                    .await
-                {
-                    Ok(super::customer::CustodySetupObservation::Pending)
-                    | Ok(super::customer::CustodySetupObservation::Complete) => {}
-                    Ok(super::customer::CustodySetupObservation::Mismatch) | Err(()) => {
-                        return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+                if replacing {
+                    match repair_pending_publish_replacement(effects, store, validated).await? {
+                        PendingPublishReplacementRepair::Ready(_) => {}
+                        PendingPublishReplacementRepair::Retry
+                        | PendingPublishReplacementRepair::Mismatch => {
+                            return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+                        }
+                    }
+                } else {
+                    match effects
+                        .replace_custody_publish(
+                            &validated.stored.custody_did,
+                            &validated.stored.consent_hex,
+                            &validated.stored.sealed_hex,
+                            &previous_invocation_hex,
+                            &previous_invocation_hex,
+                        )
+                        .await
+                    {
+                        Ok(super::customer::CustodySetupObservation::Pending)
+                        | Ok(super::customer::CustodySetupObservation::Complete) => {}
+                        Ok(super::customer::CustodySetupObservation::Mismatch) | Err(()) => {
+                            return Ok(AccountSetupResponse::View(retry_view(&checkpoint)));
+                        }
                     }
                 }
             }
-            save_recovery(
-                store,
-                &StoredRecoveryRecord::Bundle(Box::new(validated.stored.clone())),
-            )
-            .await?;
             reconcile_with_provider(
                 effects,
                 store,
@@ -4634,12 +4885,13 @@ mod tests {
         SetupStoreError, StagePersistenceContext, StagePersistenceError, StoredCheckpointV2,
         StoredConflictCodeV2, StoredPhaseV2, StoredRecoveryBundleV1, StoredRecoveryRecord,
         StoredSafePhaseV2, StoredSetupError, ValidatedCheckpoint, ValidatedRecoveryBundle,
-        VerifiedEvidence, classify_provider_create_error, decode_bounded_recovery,
-        decode_checkpoint, decode_recovery, domain_hash, encode_checkpoint, encode_recovery,
-        handle_locked, load_checkpoint, load_setup, persist_reduction, persist_staged_recovery,
-        reconcile_with_provider, recovery_observation, reduce, repair_completion_tombstone,
-        resolve_provider_acceptance, supports_provider_capabilities, token_hash,
-        validate_original_expiration, validate_stage_timestamps,
+        VerifiedEvidence, classify_provider_create_error, configuration_hash,
+        decode_bounded_recovery, decode_checkpoint, decode_recovery, domain_hash,
+        encode_checkpoint, encode_recovery, handle_locked, load_checkpoint, load_setup,
+        persist_reduction, persist_staged_recovery, reconcile_with_provider, recovery_observation,
+        reduce, repair_completion_tombstone, resolve_provider_acceptance,
+        supports_provider_capabilities, token_hash, validate_original_expiration,
+        validate_stage_timestamps,
     };
     use async_trait::async_trait;
     use dialog_credentials::Ed25519Signer;
@@ -4656,8 +4908,8 @@ mod tests {
     use tonk_worker_api::{
         ACCOUNT_SETUP_PROTOCOL_VERSION, AccountLinkRequest, AccountSetupAcquire, AccountSetupBegin,
         AccountSetupDisposition, AccountSetupInspect, AccountSetupInvocation, AccountSetupMutation,
-        AccountSetupProtectedResponse, AccountSetupRequest, AccountSetupResponse,
-        AccountSetupResumeInput, PasskeyMetadata, SaveRootRequest,
+        AccountSetupNextAction, AccountSetupProtectedResponse, AccountSetupRequest,
+        AccountSetupResponse, AccountSetupResumeInput, PasskeyMetadata, SaveRootRequest,
     };
 
     use std::collections::{BTreeSet, VecDeque};
@@ -4853,17 +5105,26 @@ mod tests {
             &self,
             status: tonk_account::customer::CustomerStatus,
             email: &str,
-            _provider: Option<&str>,
+            provider: Option<&str>,
         ) -> Result<(), crate::TonkWorkerError> {
             if self.fail_account_save.load(Ordering::SeqCst) {
                 return Err(crate::TonkWorkerError::Internal(
                     "injected profile-main projection failure".to_string(),
                 ));
             }
+            let customer = self
+                .local
+                .lock()
+                .unwrap()
+                .as_ref()
+                .map(|record| record.customer.clone())
+                .unwrap_or_default();
             *self.account.lock().unwrap() =
                 Some(super::super::customer::AccountCustomerProjection {
+                    customer,
                     status: status.as_str().to_string(),
                     email: email.to_string(),
+                    provider: provider.map(str::to_owned),
                 });
             Ok(())
         }
@@ -4880,9 +5141,11 @@ mod tests {
         fail_root_persist: AtomicBool,
         fail_attachment_persist: AtomicBool,
         fail_custody: AtomicBool,
+        fail_custody_replace: AtomicBool,
         complete_custody_on_drain: AtomicBool,
         replace_custody_calls: AtomicUsize,
         custody: Mutex<super::super::customer::CustodySetupObservation>,
+        custody_invocation: Mutex<Option<String>>,
         events: Mutex<Vec<&'static str>>,
     }
 
@@ -4899,9 +5162,11 @@ mod tests {
                 fail_root_persist: AtomicBool::new(false),
                 fail_attachment_persist: AtomicBool::new(false),
                 fail_custody: AtomicBool::new(false),
+                fail_custody_replace: AtomicBool::new(false),
                 complete_custody_on_drain: AtomicBool::new(true),
                 replace_custody_calls: AtomicUsize::new(0),
                 custody: Mutex::new(super::super::customer::CustodySetupObservation::Pending),
+                custody_invocation: Mutex::new(None),
                 events: Mutex::new(Vec::new()),
             }
         }
@@ -5010,12 +5275,13 @@ mod tests {
             _custody: &str,
             _consent_hex: &str,
             _sealed_hex: &str,
-            _invocation_hex: &str,
+            invocation_hex: &str,
         ) -> Result<(), ()> {
             self.events.lock().unwrap().push("custody");
             if self.fail_custody.load(Ordering::SeqCst) {
                 Err(())
             } else {
+                *self.custody_invocation.lock().unwrap() = Some(invocation_hex.to_owned());
                 *self.custody.lock().unwrap() =
                     super::super::customer::CustodySetupObservation::Pending;
                 Ok(())
@@ -5027,8 +5293,15 @@ mod tests {
             _custody: &str,
             _consent_hex: &str,
             _sealed_hex: &str,
-            _invocation_hex: &str,
+            invocation_hex: &str,
         ) -> Result<super::super::customer::CustodySetupObservation, ()> {
+            if let Some(recorded) = self.custody_invocation.lock().unwrap().as_deref() {
+                return Ok(if recorded == invocation_hex {
+                    super::super::customer::CustodySetupObservation::Pending
+                } else {
+                    super::super::customer::CustodySetupObservation::Mismatch
+                });
+            }
             Ok(*self.custody.lock().unwrap())
         }
 
@@ -5037,15 +5310,31 @@ mod tests {
             _custody: &str,
             _consent_hex: &str,
             _sealed_hex: &str,
-            _previous_invocation_hex: &str,
-            _replacement_invocation_hex: &str,
+            previous_invocation_hex: &str,
+            replacement_invocation_hex: &str,
         ) -> Result<super::super::customer::CustodySetupObservation, ()> {
             self.replace_custody_calls.fetch_add(1, Ordering::SeqCst);
+            if self.fail_custody_replace.swap(false, Ordering::SeqCst) {
+                return Err(());
+            }
+            let mut queued = self.custody_invocation.lock().unwrap();
+            if let Some(recorded) = queued.as_deref() {
+                if recorded == previous_invocation_hex {
+                    *queued = Some(replacement_invocation_hex.to_owned());
+                    return Ok(super::super::customer::CustodySetupObservation::Pending);
+                }
+                return Ok(if recorded == replacement_invocation_hex {
+                    super::super::customer::CustodySetupObservation::Pending
+                } else {
+                    super::super::customer::CustodySetupObservation::Mismatch
+                });
+            }
             Ok(*self.custody.lock().unwrap())
         }
 
         async fn drain_pending_custody(&self) {
             if self.complete_custody_on_drain.load(Ordering::SeqCst) {
+                *self.custody_invocation.lock().unwrap() = None;
                 *self.custody.lock().unwrap() =
                     super::super::customer::CustodySetupObservation::Complete;
             }
@@ -5490,6 +5779,7 @@ mod tests {
             publish_invocation_hex: "aabb".to_string(),
             replacement_publish_invocation_created_at: None,
             replacement_publish_invocation_hex: None,
+            pending_publish_replacement_from: None,
             recovery_manifest_hex: "bbcc".to_string(),
         }
     }
@@ -5651,6 +5941,7 @@ mod tests {
             publish_invocation_hex: hex::encode(publish_invocation),
             replacement_publish_invocation_created_at: None,
             replacement_publish_invocation_hex: None,
+            pending_publish_replacement_from: None,
             recovery_manifest_hex: hex::encode(manifest.bytes()),
         };
         let trust = RecoveryTrustContext {
@@ -5880,6 +6171,192 @@ mod tests {
                 .unwrap()
                 .is_some()
         );
+    }
+
+    #[dialog_common::test]
+    async fn it_advances_when_activation_outpaces_the_local_customer_projection() {
+        let (store, checkpoint, context, device_did) =
+            active_recovery_fixture(76, StoredPhaseV2::Attached).await;
+        let StoredRecoveryRecord::Bundle(bundle) = store.recovery_record() else {
+            panic!("fixture must retain protected recovery");
+        };
+        let effects = TestEffects::new(device_did);
+        effects
+            .complete_custody_on_drain
+            .store(false, Ordering::SeqCst);
+        effects.now.store(
+            checkpoint.as_stored().last_transition_at + 1,
+            Ordering::SeqCst,
+        );
+        effects
+            .live_clients
+            .lock()
+            .unwrap()
+            .insert("client-1".to_string());
+        *effects.customer_projections.local.lock().unwrap() =
+            Some(super::super::customer::CustomerRecord {
+                customer: bundle.root_did.clone(),
+                email: bundle.normalized_email.clone(),
+                status: tonk_account::customer::CustomerStatus::Registered,
+                enrolled_at: bundle.staged_at,
+            });
+        *effects.customer_projections.account.lock().unwrap() =
+            Some(super::super::customer::AccountCustomerProjection {
+                customer: bundle.root_did.clone(),
+                status: "Active".to_string(),
+                email: bundle.normalized_email.clone(),
+                provider: Some("https://accounts.example/".to_string()),
+            });
+        let provider = ScriptedProvider::new(
+            std::iter::empty::<Result<ProviderSetupStatus, ProviderPortError>>(),
+            std::iter::empty::<Result<ProviderAcceptance, ProviderPortError>>(),
+        );
+
+        let response = reconcile_with_provider(
+            &effects,
+            &store,
+            &provider,
+            &context,
+            checkpoint,
+            hash("11"),
+            "client-1",
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            response,
+            AccountSetupResponse::View(view)
+                if view.disposition == AccountSetupDisposition::RetryLater
+        ));
+        let CheckpointLoad::Ready(queued) = load_checkpoint(&store).await.unwrap() else {
+            panic!("an activated customer must advance to durable custody work");
+        };
+        assert_eq!(queued.as_stored().phase, StoredPhaseV2::CustodyQueued);
+        assert_eq!(effects.events.lock().unwrap().as_slice(), ["custody"]);
+    }
+
+    #[dialog_common::test]
+    async fn it_rejects_invalid_customer_projection_identity_and_provider() {
+        let port = MemoryCustomerProjectionPort::default();
+        *port.local.lock().unwrap() = Some(super::super::customer::CustomerRecord {
+            customer: "did:key:zExpected".to_string(),
+            email: "person@example.com".to_string(),
+            status: tonk_account::customer::CustomerStatus::Registered,
+            enrolled_at: 1,
+        });
+        *port.account.lock().unwrap() = Some(super::super::customer::AccountCustomerProjection {
+            customer: "did:key:zOther".to_string(),
+            status: "Registered".to_string(),
+            email: "person@example.com".to_string(),
+            provider: None,
+        });
+
+        assert_eq!(
+            super::super::customer::observe_customer_projections(
+                &port,
+                "did:key:zExpected",
+                "person@example.com",
+            )
+            .await
+            .unwrap(),
+            super::super::customer::CustomerObservation::Mismatch
+        );
+
+        *port.account.lock().unwrap() = Some(super::super::customer::AccountCustomerProjection {
+            customer: "did:key:zExpected".to_string(),
+            status: "Active".to_string(),
+            email: "person@example.com".to_string(),
+            provider: Some("javascript:alert(1)".to_string()),
+        });
+        assert_eq!(
+            super::super::customer::observe_customer_projections(
+                &port,
+                "did:key:zExpected",
+                "person@example.com",
+            )
+            .await
+            .unwrap(),
+            super::super::customer::CustomerObservation::Mismatch
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_reports_post_stage_configuration_drift_without_mutating_recovery() {
+        let (store, checkpoint, mut context, device_did) =
+            active_recovery_fixture(77, StoredPhaseV2::CustodyQueued).await;
+        let owner_token = "owner-token".repeat(4);
+        let mut stored = checkpoint.into_stored();
+        stored.owner_hash = Some(
+            token_hash(
+                b"tonk-account-setup-owner-v1",
+                &stored.operation_id,
+                &owner_token,
+            )
+            .unwrap(),
+        );
+        let checkpoint = ValidatedCheckpoint::new(stored).unwrap();
+        *store.checkpoint.lock().unwrap() = Some(encode_checkpoint(&checkpoint).unwrap());
+        let checkpoint_before = store.checkpoint.lock().unwrap().clone();
+        let recovery_before = store.recovery.lock().unwrap().clone();
+        context.provider = "https://new-accounts.example/".parse().unwrap();
+        context.configuration_hash = configuration_hash(
+            &context.provider,
+            &context.remote,
+            context.service_did.as_ref(),
+        );
+        assert_ne!(
+            checkpoint.as_stored().configuration_hash,
+            context.configuration_hash
+        );
+        let contexts = FixedContextSource::new(context);
+        let effects = TestEffects::new(device_did);
+        effects.now.store(
+            checkpoint.as_stored().last_transition_at + 1,
+            Ordering::SeqCst,
+        );
+        effects
+            .live_clients
+            .lock()
+            .unwrap()
+            .insert("client-1".to_string());
+        let provider = ScriptedProvider::new(
+            std::iter::empty::<Result<ProviderSetupStatus, ProviderPortError>>(),
+            std::iter::empty::<Result<ProviderAcceptance, ProviderPortError>>(),
+        );
+        let origin: url::Url = "https://app.example/".parse().unwrap();
+
+        let response = handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-1"),
+            AccountSetupRequest::Continue(AccountSetupMutation {
+                operation_id: checkpoint.as_stored().operation_id.clone(),
+                owner_token,
+                expected_revision: checkpoint.as_stored().revision,
+            }),
+        )
+        .await
+        .unwrap();
+
+        let AccountSetupResponse::View(view) = response else {
+            panic!("configuration drift must return a redacted view");
+        };
+        assert_eq!(view.disposition, AccountSetupDisposition::UpdateRequired);
+        assert_eq!(view.next_action, AccountSetupNextAction::Reload);
+        assert_eq!(
+            *store.checkpoint.lock().unwrap(),
+            checkpoint_before,
+            "configuration drift must not advance or terminally conflict the checkpoint"
+        );
+        assert_eq!(
+            *store.recovery.lock().unwrap(),
+            recovery_before,
+            "configuration drift must leave protected recovery byte-for-byte intact"
+        );
+        assert!(effects.events.lock().unwrap().is_empty());
     }
 
     #[dialog_common::test]
@@ -6322,6 +6799,298 @@ mod tests {
         assert_eq!(
             replaced.replacement_publish_invocation_created_at,
             Some(next_time)
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_recovers_when_the_publish_replacement_receipt_cannot_be_saved() {
+        let seed = 74;
+        let (store, checkpoint, context, device_did) =
+            active_recovery_fixture(seed, StoredPhaseV2::CustodyQueued).await;
+        let first_owner = "first-owner-token".repeat(3);
+        let mut stored = checkpoint.into_stored();
+        stored.owner_hash = Some(
+            token_hash(
+                b"tonk-account-setup-owner-v1",
+                &stored.operation_id,
+                &first_owner,
+            )
+            .unwrap(),
+        );
+        let checkpoint = ValidatedCheckpoint::new(stored).unwrap();
+        *store.checkpoint.lock().unwrap() = Some(encode_checkpoint(&checkpoint).unwrap());
+        let StoredRecoveryRecord::Bundle(bundle) = store.recovery_record() else {
+            panic!("fixture must retain protected recovery");
+        };
+        let old_publish = bundle.publish_invocation_hex.clone();
+        let first_time = bundle.ceremony_created_at + DEFERRED_PUBLISH_TTL_SECONDS + 1;
+        let first_replacement = fresh_publish_invocation(seed, &bundle, first_time).await;
+        let effects = TestEffects::new(device_did);
+        effects
+            .complete_custody_on_drain
+            .store(false, Ordering::SeqCst);
+        *effects.custody_invocation.lock().unwrap() = Some(old_publish.clone());
+        effects
+            .live_clients
+            .lock()
+            .unwrap()
+            .insert("client-1".to_string());
+        effects.now.store(first_time, Ordering::SeqCst);
+        let contexts = FixedContextSource::new(context);
+        let provider = ScriptedProvider::new(
+            std::iter::empty::<Result<ProviderSetupStatus, ProviderPortError>>(),
+            std::iter::empty::<Result<ProviderAcceptance, ProviderPortError>>(),
+        );
+        let origin: url::Url = "https://app.example/".parse().unwrap();
+        store.fail_next_recovery_save();
+
+        let failed = handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-1"),
+            AccountSetupRequest::ReplacePublishInvocation(AccountSetupInvocation {
+                mutation: AccountSetupMutation {
+                    operation_id: checkpoint.as_stored().operation_id.clone(),
+                    owner_token: first_owner,
+                    expected_revision: checkpoint.as_stored().revision,
+                },
+                invocation_hex: first_replacement,
+            }),
+        )
+        .await;
+        assert!(matches!(failed, Err(SetupStoreError::Write)));
+        assert_eq!(
+            effects.custody_invocation.lock().unwrap().as_deref(),
+            Some(old_publish.as_str()),
+            "the pending queue must not move ahead of its durable replacement receipt"
+        );
+        assert_eq!(effects.replace_custody_calls.load(Ordering::SeqCst), 0);
+
+        let retry_time = first_time + 61;
+        let retry_replacement = fresh_publish_invocation(seed, &bundle, retry_time).await;
+        effects.now.store(retry_time, Ordering::SeqCst);
+        {
+            let mut clients = effects.live_clients.lock().unwrap();
+            clients.remove("client-1");
+            clients.insert("client-2".to_string());
+        }
+        let next_owner = "reloaded-owner-token".repeat(3);
+        let acquired = handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-2"),
+            AccountSetupRequest::Acquire(AccountSetupAcquire {
+                operation_id: checkpoint.as_stored().operation_id.clone(),
+                owner_token: next_owner.clone(),
+                expected_revision: checkpoint.as_stored().revision,
+            }),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            acquired,
+            AccountSetupResponse::View(view)
+                if view.disposition == AccountSetupDisposition::Ready
+                    && view.next_action == AccountSetupNextAction::Continue
+        ));
+        let CheckpointLoad::Ready(acquired_checkpoint) = load_checkpoint(&store).await.unwrap()
+        else {
+            panic!("reload must acquire the queued custody checkpoint");
+        };
+
+        let resumed = handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-2"),
+            AccountSetupRequest::ReplacePublishInvocation(AccountSetupInvocation {
+                mutation: AccountSetupMutation {
+                    operation_id: acquired_checkpoint.as_stored().operation_id.clone(),
+                    owner_token: next_owner,
+                    expected_revision: acquired_checkpoint.as_stored().revision,
+                },
+                invocation_hex: retry_replacement.clone(),
+            }),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            resumed,
+            AccountSetupResponse::View(view)
+                if view.disposition == AccountSetupDisposition::RetryLater
+        ));
+        assert_eq!(
+            effects.custody_invocation.lock().unwrap().as_deref(),
+            Some(retry_replacement.as_str())
+        );
+        let StoredRecoveryRecord::Bundle(saved) = store.recovery_record() else {
+            panic!("reloaded replacement must retain protected recovery");
+        };
+        assert_eq!(
+            saved.replacement_publish_invocation_created_at,
+            Some(retry_time)
+        );
+        assert_eq!(
+            saved.replacement_publish_invocation_hex.as_deref(),
+            Some(retry_replacement.as_str())
+        );
+    }
+
+    #[dialog_common::test]
+    async fn it_repairs_a_saved_publish_replacement_after_the_queue_write_fails() {
+        let seed = 75;
+        let (store, checkpoint, context, device_did) =
+            active_recovery_fixture(seed, StoredPhaseV2::CustodyQueued).await;
+        let first_owner = "first-owner-token".repeat(3);
+        let mut stored = checkpoint.into_stored();
+        stored.owner_hash = Some(
+            token_hash(
+                b"tonk-account-setup-owner-v1",
+                &stored.operation_id,
+                &first_owner,
+            )
+            .unwrap(),
+        );
+        let checkpoint = ValidatedCheckpoint::new(stored).unwrap();
+        *store.checkpoint.lock().unwrap() = Some(encode_checkpoint(&checkpoint).unwrap());
+        let StoredRecoveryRecord::Bundle(bundle) = store.recovery_record() else {
+            panic!("fixture must retain protected recovery");
+        };
+        let old_publish = bundle.publish_invocation_hex.clone();
+        let receipt_time = bundle.ceremony_created_at + DEFERRED_PUBLISH_TTL_SECONDS + 1;
+        let replacement = fresh_publish_invocation(seed, &bundle, receipt_time).await;
+        let effects = TestEffects::new(device_did);
+        effects
+            .complete_custody_on_drain
+            .store(false, Ordering::SeqCst);
+        effects.fail_custody_replace.store(true, Ordering::SeqCst);
+        *effects.custody_invocation.lock().unwrap() = Some(old_publish.clone());
+        effects
+            .live_clients
+            .lock()
+            .unwrap()
+            .insert("client-1".to_string());
+        effects.now.store(receipt_time, Ordering::SeqCst);
+        let contexts = FixedContextSource::new(context);
+        let provider = ScriptedProvider::new(
+            std::iter::empty::<Result<ProviderSetupStatus, ProviderPortError>>(),
+            std::iter::empty::<Result<ProviderAcceptance, ProviderPortError>>(),
+        );
+        let origin: url::Url = "https://app.example/".parse().unwrap();
+
+        let interrupted = handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-1"),
+            AccountSetupRequest::ReplacePublishInvocation(AccountSetupInvocation {
+                mutation: AccountSetupMutation {
+                    operation_id: checkpoint.as_stored().operation_id.clone(),
+                    owner_token: first_owner,
+                    expected_revision: checkpoint.as_stored().revision,
+                },
+                invocation_hex: replacement.clone(),
+            }),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            interrupted,
+            AccountSetupResponse::View(view)
+                if view.disposition == AccountSetupDisposition::RetryLater
+        ));
+        assert_eq!(
+            effects.custody_invocation.lock().unwrap().as_deref(),
+            Some(old_publish.as_str()),
+            "the injected queue failure must leave the previous authorization intact"
+        );
+        let StoredRecoveryRecord::Bundle(saved) = store.recovery_record() else {
+            panic!("the replacement receipt must survive the interrupted queue write");
+        };
+        assert_eq!(
+            saved.replacement_publish_invocation_created_at,
+            Some(receipt_time)
+        );
+        assert_eq!(
+            saved.replacement_publish_invocation_hex.as_deref(),
+            Some(replacement.as_str())
+        );
+
+        {
+            let mut clients = effects.live_clients.lock().unwrap();
+            clients.remove("client-1");
+            clients.insert("client-2".to_string());
+        }
+        let next_owner = "reloaded-owner-token".repeat(3);
+        let acquired = handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-2"),
+            AccountSetupRequest::Acquire(AccountSetupAcquire {
+                operation_id: checkpoint.as_stored().operation_id.clone(),
+                owner_token: next_owner.clone(),
+                expected_revision: checkpoint.as_stored().revision,
+            }),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            acquired,
+            AccountSetupResponse::View(view)
+                if view.disposition == AccountSetupDisposition::Ready
+                    && view.next_action == AccountSetupNextAction::Continue
+        ));
+
+        let repaired = handle_locked(
+            &effects,
+            &store,
+            &contexts,
+            &provider,
+            request_scope(&origin, "client-2"),
+            AccountSetupRequest::Inspect(AccountSetupInspect {
+                owner_token: Some(next_owner),
+            }),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            repaired,
+            AccountSetupResponse::View(view)
+                if view.disposition == AccountSetupDisposition::RetryLater
+        ));
+        assert_eq!(
+            effects.custody_invocation.lock().unwrap().as_deref(),
+            Some(replacement.as_str()),
+            "reload must finish the durable replacement intent before observing custody"
+        );
+        let CheckpointLoad::Ready(repaired_checkpoint) = load_checkpoint(&store).await.unwrap()
+        else {
+            panic!("the repaired setup must retain its queued checkpoint");
+        };
+        assert_eq!(
+            repaired_checkpoint.as_stored().phase,
+            StoredPhaseV2::CustodyQueued
+        );
+        let StoredRecoveryRecord::Bundle(repaired_recovery) = store.recovery_record() else {
+            panic!("the repaired queue must retain protected recovery");
+        };
+        assert_eq!(
+            repaired_recovery.replacement_publish_invocation_created_at,
+            Some(receipt_time)
+        );
+        assert_eq!(
+            repaired_recovery
+                .replacement_publish_invocation_hex
+                .as_deref(),
+            Some(replacement.as_str())
         );
     }
 

--- a/rust/tonk-worker/src/router/account_state.rs
+++ b/rust/tonk-worker/src/router/account_state.rs
@@ -1771,6 +1771,7 @@ mod tests {
             sync_queue: Default::default(),
             commands: crate::router::command_registry(),
             clients: Default::default(),
+            account_setup_lock: Default::default(),
             account_keys: Default::default(),
             registry: crate::device::Registry {
                 profile: name.clone(),

--- a/rust/tonk-worker/src/router/account_state.rs
+++ b/rust/tonk-worker/src/router/account_state.rs
@@ -1765,6 +1765,7 @@ mod tests {
             storage,
             session_expires_at: session.expires_at,
             profile_name: name.clone(),
+            service_origin: None,
             reactor,
             view_bindings: Default::default(),
             bridges: Default::default(),
@@ -1772,6 +1773,7 @@ mod tests {
             commands: crate::router::command_registry(),
             clients: Default::default(),
             account_setup_lock: Default::default(),
+            pending_work_lock: Default::default(),
             account_keys: Default::default(),
             registry: crate::device::Registry {
                 profile: name.clone(),

--- a/rust/tonk-worker/src/router/browser_lock.rs
+++ b/rust/tonk-worker/src/router/browser_lock.rs
@@ -1,0 +1,59 @@
+//! Profile-scoped browser serialization shared by durable worker effects.
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) struct CrossWorkerGuard(Option<tokio::sync::oneshot::Sender<()>>);
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+pub(crate) struct CrossWorkerGuard;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+impl Drop for CrossWorkerGuard {
+    fn drop(&mut self) {
+        if let Some(release) = self.0.take() {
+            let _ = release.send(());
+        }
+    }
+}
+
+/// Acquire an exact named browser Web Lock.
+///
+/// Callers intentionally fail closed if this is unavailable: a local mutex
+/// cannot serialize two concurrently alive service-worker generations.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) async fn acquire(lock_name: &str) -> Result<CrossWorkerGuard, ()> {
+    use wasm_bindgen::{JsCast as _, JsValue, closure::Closure};
+    use wasm_bindgen_futures::{JsFuture, future_to_promise, spawn_local};
+
+    let global = js_sys::global();
+    let navigator =
+        js_sys::Reflect::get(&global, &JsValue::from_str("navigator")).map_err(|_| ())?;
+    let locks = js_sys::Reflect::get(&navigator, &JsValue::from_str("locks")).map_err(|_| ())?;
+    let request: js_sys::Function = js_sys::Reflect::get(&locks, &JsValue::from_str("request"))
+        .map_err(|_| ())?
+        .dyn_into()
+        .map_err(|_| ())?;
+    let (acquired_tx, acquired_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    let callback = Closure::once_into_js(move |_lock: JsValue| -> js_sys::Promise {
+        let _ = acquired_tx.send(());
+        future_to_promise(async move {
+            let _ = release_rx.await;
+            Ok(JsValue::UNDEFINED)
+        })
+    });
+    let request_promise: js_sys::Promise = request
+        .call2(&locks, &JsValue::from_str(lock_name), &callback)
+        .map_err(|_| ())?
+        .dyn_into()
+        .map_err(|_| ())?;
+    spawn_local(async move {
+        let _ = JsFuture::from(request_promise).await;
+    });
+    acquired_rx.await.map_err(|_| ())?;
+    Ok(CrossWorkerGuard(Some(release_tx)))
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+pub(crate) async fn acquire(_lock_name: &str) -> Result<CrossWorkerGuard, ()> {
+    Ok(CrossWorkerGuard)
+}

--- a/rust/tonk-worker/src/router/browser_lock.rs
+++ b/rust/tonk-worker/src/router/browser_lock.rs
@@ -3,8 +3,13 @@
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) struct CrossWorkerGuard(Option<tokio::sync::oneshot::Sender<()>>);
 
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+#[cfg(all(not(all(target_arch = "wasm32", target_os = "unknown")), not(test)))]
 pub(crate) struct CrossWorkerGuard;
+
+#[cfg(all(not(all(target_arch = "wasm32", target_os = "unknown")), test))]
+pub(crate) struct CrossWorkerGuard {
+    _guard: tokio::sync::OwnedMutexGuard<()>,
+}
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl Drop for CrossWorkerGuard {
@@ -53,7 +58,33 @@ pub(crate) async fn acquire(lock_name: &str) -> Result<CrossWorkerGuard, ()> {
     Ok(CrossWorkerGuard(Some(release_tx)))
 }
 
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+#[cfg(all(not(all(target_arch = "wasm32", target_os = "unknown")), not(test)))]
 pub(crate) async fn acquire(_lock_name: &str) -> Result<CrossWorkerGuard, ()> {
     Ok(CrossWorkerGuard)
+}
+
+/// Native unit tests model the browser's named-lock registry so tests can use
+/// the exact production acquisition wrapper with distinct per-worker mutexes.
+#[cfg(all(not(all(target_arch = "wasm32", target_os = "unknown")), test))]
+pub(crate) async fn acquire(lock_name: &str) -> Result<CrossWorkerGuard, ()> {
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock, Weak};
+
+    static LOCKS: OnceLock<Mutex<HashMap<String, Weak<tokio::sync::Mutex<()>>>>> = OnceLock::new();
+    let lock = {
+        let mut locks = LOCKS
+            .get_or_init(|| Mutex::new(HashMap::new()))
+            .lock()
+            .map_err(|_| ())?;
+        if let Some(lock) = locks.get(lock_name).and_then(Weak::upgrade) {
+            lock
+        } else {
+            let lock = std::sync::Arc::new(tokio::sync::Mutex::new(()));
+            locks.insert(lock_name.to_owned(), std::sync::Arc::downgrade(&lock));
+            lock
+        }
+    };
+    Ok(CrossWorkerGuard {
+        _guard: lock.lock_owned().await,
+    })
 }

--- a/rust/tonk-worker/src/router/customer.rs
+++ b/rust/tonk-worker/src/router/customer.rs
@@ -689,8 +689,10 @@ pub(crate) enum CustomerRecordProjection {
 
 #[derive(Clone)]
 pub(crate) struct AccountCustomerProjection {
+    pub(crate) customer: String,
     pub(crate) status: String,
     pub(crate) email: String,
+    pub(crate) provider: Option<String>,
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -744,12 +746,15 @@ impl CustomerProjectionPort for WorkerCustomerProjectionPort<'_> {
     async fn load_account_customer(
         &self,
     ) -> Result<Option<AccountCustomerProjection>, TonkWorkerError> {
-        Ok(load_account_customer(self.0)
-            .await?
-            .map(|record| AccountCustomerProjection {
+        Ok(load_account_customer(self.0).await?.map(|record| {
+            let provider = record.provider().map(str::to_owned);
+            AccountCustomerProjection {
+                customer: record.this.to_string(),
                 status: record.status.0,
                 email: record.email.0,
-            }))
+                provider,
+            }
+        }))
     }
 
     async fn save_customer_record(&self, record: &CustomerRecord) -> Result<(), TonkWorkerError> {
@@ -779,6 +784,30 @@ pub(crate) async fn persist_customer_projections(
         .await
 }
 
+fn valid_account_customer_projection(
+    projected: &AccountCustomerProjection,
+    expected_root: &str,
+    expected_email: &str,
+) -> bool {
+    if projected.customer != expected_root
+        || projected.email != expected_email
+        || CustomerStatus::parse(&projected.status).is_err()
+    {
+        return false;
+    }
+    projected.provider.as_deref().is_none_or(|provider| {
+        Url::parse(provider).is_ok_and(|url| {
+            matches!(url.scheme(), "http" | "https")
+                && !url.cannot_be_a_base()
+                && url.host_str().is_some()
+                && url.username().is_empty()
+                && url.password().is_none()
+                && url.query().is_none()
+                && url.fragment().is_none()
+        })
+    })
+}
+
 pub(crate) async fn observe_customer_projections(
     port: &impl CustomerProjectionPort,
     expected_root: &str,
@@ -792,15 +821,14 @@ pub(crate) async fn observe_customer_projections(
         (CustomerRecordProjection::Present(local), Some(projected))
             if local.customer == expected_root
                 && local.email == expected_email
-                && projected.email == expected_email
-                && projected.status == local.status.as_str() =>
+                && valid_account_customer_projection(&projected, expected_root, expected_email) =>
         {
             Ok(CustomerObservation::Exact)
         }
         // One projection can survive a crash between the two writes. Replay
         // the idempotent enrollment so both become durable before advancing.
         (CustomerRecordProjection::Missing, Some(projected))
-            if projected.email == expected_email =>
+            if valid_account_customer_projection(&projected, expected_root, expected_email) =>
         {
             Ok(CustomerObservation::Missing)
         }
@@ -1649,6 +1677,27 @@ mod tests {
         assert!(
             entries == first_then_second || entries == second_then_first,
             "both ordered Provision+Publish pairs must survive either lock acquisition order"
+        );
+    }
+
+    #[dialog_common::test]
+    async fn production_append_repairs_a_partially_drained_custody_batch() {
+        let batch = custody_batch("01");
+        let store = MemoryPendingQueueStore(Mutex::new(PendingQueue(vec![batch[1].clone()])));
+        let scope = PendingMutationScope::new(
+            b"did:key:zAccountProfile",
+            Arc::new(tokio::sync::Mutex::new(())),
+        );
+
+        append_to_pending_store(&scope, &store, batch.clone())
+            .await
+            .unwrap();
+
+        let queue = store.load_queue().await.unwrap();
+        assert_eq!(
+            queue.entries(),
+            batch.as_slice(),
+            "a checkpoint-loss retry must restore Provision ahead of the surviving Publish"
         );
     }
 

--- a/rust/tonk-worker/src/router/customer.rs
+++ b/rust/tonk-worker/src/router/customer.rs
@@ -140,17 +140,18 @@ pub(crate) async fn enroll_customer(
         }
         Err(error) => return Err(error.into()),
     };
+    if receipt.customer != root_did {
+        return Err(TonkWorkerError::Internal(
+            "enrollment receipt named a different account".to_string(),
+        ));
+    }
 
-    save_customer(
-        state,
-        &CustomerRecord {
-            customer: receipt.customer.to_string(),
-            email: email.clone(),
-            status: receipt.status,
-            enrolled_at: Timestamp::now().to_unix(),
-        },
-    )
-    .await?;
+    let record = CustomerRecord {
+        customer: receipt.customer.to_string(),
+        email: email.clone(),
+        status: receipt.status,
+        enrolled_at: Timestamp::now().to_unix(),
+    };
     // The same answer as a fact on profile main, so every device on this
     // account reads the registration state by query rather than by
     // probing the service itself.
@@ -160,7 +161,12 @@ pub(crate) async fn enroll_customer(
     // deriving an address from whichever origin it happened to reach.
     // An older service that answers no remote leaves whatever was
     // recorded before in place.
-    record_customer_status(state, receipt.status, &email, receipt.provider.as_deref()).await?;
+    persist_customer_projections(
+        &WorkerCustomerProjectionPort(state),
+        &record,
+        receipt.provider.as_deref(),
+    )
+    .await?;
     Ok(receipt)
 }
 
@@ -473,9 +479,8 @@ pub(crate) async fn persist_custody_setup(
     sealed_hex: &str,
     invocation_hex: &str,
 ) -> Result<(), TonkWorkerError> {
-    let _mutation = acquire_pending_mutation(state).await?;
     record_custody_cell(state, custody, sealed_hex).await?;
-    append_pending_locked(
+    append_pending(
         state,
         [
             PendingWork::Provision {
@@ -491,7 +496,7 @@ pub(crate) async fn persist_custody_setup(
         ],
     )
     .await?;
-    drain_pending_locked(state).await;
+    drain_pending(state).await;
     Ok(())
 }
 
@@ -675,54 +680,150 @@ pub(crate) enum CustomerObservation {
     Mismatch,
 }
 
+#[derive(Clone)]
+pub(crate) enum CustomerRecordProjection {
+    Missing,
+    Present(CustomerRecord),
+    Corrupt,
+}
+
+#[derive(Clone)]
+pub(crate) struct AccountCustomerProjection {
+    pub(crate) status: String,
+    pub(crate) email: String,
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+pub(crate) trait CustomerProjectionPort {
+    async fn load_customer_record(&self) -> Result<CustomerRecordProjection, TonkWorkerError>;
+    async fn load_account_customer(
+        &self,
+    ) -> Result<Option<AccountCustomerProjection>, TonkWorkerError>;
+    async fn save_customer_record(&self, record: &CustomerRecord) -> Result<(), TonkWorkerError>;
+    async fn save_account_customer(
+        &self,
+        status: CustomerStatus,
+        email: &str,
+        provider: Option<&str>,
+    ) -> Result<(), TonkWorkerError>;
+}
+
+struct WorkerCustomerProjectionPort<'a>(&'a crate::worker::TonkState);
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl CustomerProjectionPort for WorkerCustomerProjectionPort<'_> {
+    async fn load_customer_record(&self) -> Result<CustomerRecordProjection, TonkWorkerError> {
+        let bytes = match self
+            .0
+            .profile
+            .credential()
+            .site(CUSTOMER_CREDENTIAL_SITE)
+            .load::<Vec<u8>>()
+            .perform(&self.0.operator)
+            .await
+        {
+            Ok(bytes) if bytes.is_empty() => return Ok(CustomerRecordProjection::Missing),
+            Ok(bytes) => bytes,
+            Err(error) if crate::credential::is_missing(&error) => {
+                return Ok(CustomerRecordProjection::Missing);
+            }
+            Err(error) => {
+                return Err(TonkWorkerError::Internal(format!(
+                    "failed to load the customer record: {error}"
+                )));
+            }
+        };
+        Ok(match serde_json::from_slice(&bytes) {
+            Ok(record) => CustomerRecordProjection::Present(record),
+            Err(_) => CustomerRecordProjection::Corrupt,
+        })
+    }
+
+    async fn load_account_customer(
+        &self,
+    ) -> Result<Option<AccountCustomerProjection>, TonkWorkerError> {
+        Ok(load_account_customer(self.0)
+            .await?
+            .map(|record| AccountCustomerProjection {
+                status: record.status.0,
+                email: record.email.0,
+            }))
+    }
+
+    async fn save_customer_record(&self, record: &CustomerRecord) -> Result<(), TonkWorkerError> {
+        save_customer(self.0, record).await
+    }
+
+    async fn save_account_customer(
+        &self,
+        status: CustomerStatus,
+        email: &str,
+        provider: Option<&str>,
+    ) -> Result<(), TonkWorkerError> {
+        record_customer_status(self.0, status, email, provider).await
+    }
+}
+
+/// Persist the device-local enrollment record before the shared profile-main
+/// projection. A retry repeats both idempotent writes; advancing the setup saga
+/// is left to an exact observation after both have succeeded.
+pub(crate) async fn persist_customer_projections(
+    port: &impl CustomerProjectionPort,
+    record: &CustomerRecord,
+    provider: Option<&str>,
+) -> Result<(), TonkWorkerError> {
+    port.save_customer_record(record).await?;
+    port.save_account_customer(record.status, &record.email, provider)
+        .await
+}
+
+pub(crate) async fn observe_customer_projections(
+    port: &impl CustomerProjectionPort,
+    expected_root: &str,
+    expected_email: &str,
+) -> Result<CustomerObservation, TonkWorkerError> {
+    let local = port.load_customer_record().await?;
+    let projected = port.load_account_customer().await?;
+    match (local, projected) {
+        (CustomerRecordProjection::Missing, None) => Ok(CustomerObservation::Missing),
+        (CustomerRecordProjection::Corrupt, _) => Ok(CustomerObservation::Mismatch),
+        (CustomerRecordProjection::Present(local), Some(projected))
+            if local.customer == expected_root
+                && local.email == expected_email
+                && projected.email == expected_email
+                && projected.status == local.status.as_str() =>
+        {
+            Ok(CustomerObservation::Exact)
+        }
+        // One projection can survive a crash between the two writes. Replay
+        // the idempotent enrollment so both become durable before advancing.
+        (CustomerRecordProjection::Missing, Some(projected))
+            if projected.email == expected_email =>
+        {
+            Ok(CustomerObservation::Missing)
+        }
+        (CustomerRecordProjection::Present(local), None)
+            if local.customer == expected_root && local.email == expected_email =>
+        {
+            Ok(CustomerObservation::Missing)
+        }
+        _ => Ok(CustomerObservation::Mismatch),
+    }
+}
+
 pub(crate) async fn observe_customer(
     state: &crate::worker::TonkState,
     expected_root: &str,
     expected_email: &str,
 ) -> Result<CustomerObservation, TonkWorkerError> {
-    let local = match state
-        .profile
-        .credential()
-        .site(CUSTOMER_CREDENTIAL_SITE)
-        .load::<Vec<u8>>()
-        .perform(&state.operator)
-        .await
-    {
-        Ok(bytes) if bytes.is_empty() => None,
-        Ok(bytes) => match serde_json::from_slice::<CustomerRecord>(&bytes) {
-            Ok(record) => Some(record),
-            Err(_) => return Ok(CustomerObservation::Mismatch),
-        },
-        Err(error) if crate::credential::is_missing(&error) => None,
-        Err(error) => {
-            return Err(TonkWorkerError::Internal(format!(
-                "failed to load the customer record: {error}"
-            )));
-        }
-    };
-    let projected = load_account_customer(state).await?;
-    match (local, projected) {
-        (None, None) => Ok(CustomerObservation::Missing),
-        (Some(local), Some(projected))
-            if local.customer == expected_root
-                && local.email == expected_email
-                && projected.email.0 == expected_email
-                && projected.status.0 == local.status.as_str() =>
-        {
-            // `load_account_customer` queries this exact root, so a row
-            // reaching here also proves the authoritative subject.
-            Ok(CustomerObservation::Exact)
-        }
-        // One projection can survive a crash between the two writes. Replay
-        // the idempotent enrollment so both become durable before advancing.
-        (None, Some(projected)) if projected.email.0 == expected_email => {
-            Ok(CustomerObservation::Missing)
-        }
-        (Some(local), None) if local.customer == expected_root && local.email == expected_email => {
-            Ok(CustomerObservation::Missing)
-        }
-        _ => Ok(CustomerObservation::Mismatch),
-    }
+    observe_customer_projections(
+        &WorkerCustomerProjectionPort(state),
+        expected_root,
+        expected_email,
+    )
+    .await
 }
 
 /// Whether a provider actually serves this account — the precondition
@@ -953,17 +1054,13 @@ async fn load_pending(state: &crate::worker::TonkState) -> Result<PendingQueue, 
     if bytes.is_empty() {
         return Ok(PendingQueue::default());
     }
-    match serde_json::from_slice(&bytes) {
-        Ok(queue) => Ok(queue),
-        Err(error) => {
-            // An unreadable queue would otherwise wedge every later
-            // append. The work it held is recoverable — re-running the
-            // ceremony re-queues it — where a permanently poisoned site
-            // is not.
-            log!("stored pending work is unreadable, starting a fresh queue: {error}");
-            Ok(PendingQueue::default())
-        }
-    }
+    serde_json::from_slice(&bytes).map_err(|error| {
+        // Pending custody work is the only durable copy of a bounded publish
+        // authorization after the passkey ceremony. Treat unreadable bytes as
+        // an ambiguity to preserve, never as an empty queue that is safe to
+        // overwrite.
+        TonkWorkerError::Internal(format!("stored pending work is unreadable: {error}"))
+    })
 }
 
 async fn save_pending(
@@ -990,6 +1087,116 @@ trait PendingQueueStore {
     async fn save_queue(&self, queue: &PendingQueue) -> Result<(), TonkWorkerError>;
 }
 
+/// Exact status of the account-setup custody pair in the durable pending queue.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CustodySetupObservation {
+    /// Provision and/or publish is still recorded in a valid replay order.
+    Pending,
+    /// No entry for this custody subject remains after it was durably queued.
+    Complete,
+    /// Entries for the subject exist but do not reproduce the staged pair.
+    Mismatch,
+}
+
+fn observe_custody_queue(
+    queue: &PendingQueue,
+    custody: &str,
+    consent_hex: &str,
+    sealed_hex: &str,
+    invocation_hex: &str,
+) -> CustodySetupObservation {
+    let mut provision_at = None;
+    let mut publish_at = None;
+    for (index, work) in queue.entries().iter().enumerate() {
+        match work {
+            PendingWork::Provision {
+                consumer,
+                consent_hex: recorded_consent,
+                consumer_kind,
+            } if consumer == custody => {
+                if provision_at.is_some()
+                    || recorded_consent != consent_hex
+                    || consumer_kind.as_deref() != Some("custody")
+                {
+                    return CustodySetupObservation::Mismatch;
+                }
+                provision_at = Some(index);
+            }
+            PendingWork::PublishCustody {
+                custody: recorded_custody,
+                sealed_hex: recorded_sealed,
+                invocation_hex: recorded_invocation,
+            } if recorded_custody == custody => {
+                if publish_at.is_some()
+                    || recorded_sealed != sealed_hex
+                    || recorded_invocation != invocation_hex
+                {
+                    return CustodySetupObservation::Mismatch;
+                }
+                publish_at = Some(index);
+            }
+            _ => {}
+        }
+    }
+
+    match (provision_at, publish_at) {
+        (None, None) => CustodySetupObservation::Complete,
+        (None, Some(_)) => CustodySetupObservation::Pending,
+        (Some(provision), Some(publish)) if provision < publish => CustodySetupObservation::Pending,
+        (Some(_), None) | (Some(_), Some(_)) => CustodySetupObservation::Mismatch,
+    }
+}
+
+fn replace_custody_publish_in_queue(
+    queue: &mut PendingQueue,
+    custody: &str,
+    consent_hex: &str,
+    sealed_hex: &str,
+    previous_invocation_hex: &str,
+    replacement_invocation_hex: &str,
+) -> (CustodySetupObservation, bool) {
+    let mut replacement_at = None;
+    for (index, work) in queue.0.iter().enumerate() {
+        if let PendingWork::PublishCustody {
+            custody: recorded_custody,
+            sealed_hex: recorded_sealed,
+            invocation_hex,
+        } = work
+            && recorded_custody == custody
+            && recorded_sealed == sealed_hex
+            && (invocation_hex == previous_invocation_hex
+                || invocation_hex == replacement_invocation_hex)
+        {
+            if replacement_at.is_some() {
+                return (CustodySetupObservation::Mismatch, false);
+            }
+            replacement_at = Some(index);
+        }
+    }
+
+    let mut changed = false;
+    if let Some(index) = replacement_at {
+        let PendingWork::PublishCustody { invocation_hex, .. } = &mut queue.0[index] else {
+            unreachable!("the selected entry was a custody publish")
+        };
+        if invocation_hex == previous_invocation_hex && invocation_hex != replacement_invocation_hex
+        {
+            *invocation_hex = replacement_invocation_hex.to_owned();
+            changed = true;
+        }
+    }
+    (
+        observe_custody_queue(
+            queue,
+            custody,
+            consent_hex,
+            sealed_hex,
+            replacement_invocation_hex,
+        ),
+        changed,
+    )
+}
+
 struct WorkerPendingQueueStore<'a>(&'a crate::worker::TonkState);
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -1004,7 +1211,7 @@ impl PendingQueueStore for WorkerPendingQueueStore<'_> {
     }
 }
 
-async fn append_to_pending_store(
+async fn append_to_pending_store_locked(
     store: &impl PendingQueueStore,
     work: impl IntoIterator<Item = PendingWork>,
 ) -> Result<(), TonkWorkerError> {
@@ -1018,23 +1225,105 @@ struct PendingMutationGuard {
     _local: tokio::sync::OwnedMutexGuard<()>,
 }
 
+#[derive(Clone)]
+struct PendingMutationScope {
+    lock_name: String,
+    local: std::sync::Arc<tokio::sync::Mutex<()>>,
+}
+
+impl PendingMutationScope {
+    fn new(profile_did: &[u8], local: std::sync::Arc<tokio::sync::Mutex<()>>) -> Self {
+        let profile_hash = blake3::hash(profile_did);
+        Self {
+            lock_name: format!("tonk-pending-effects-v1:{profile_hash}"),
+            local,
+        }
+    }
+
+    fn for_state(state: &crate::worker::TonkState) -> Self {
+        Self::new(
+            state.profile.did().as_ref().as_bytes(),
+            state.pending_work_lock.clone(),
+        )
+    }
+
+    async fn acquire(&self) -> Result<PendingMutationGuard, TonkWorkerError> {
+        let cross_worker = super::browser_lock::acquire(&self.lock_name)
+            .await
+            .map_err(|()| {
+                TonkWorkerError::Internal(
+                    "pending effects require cross-worker serialization; reload and retry"
+                        .to_string(),
+                )
+            })?;
+        let local = self.local.clone().lock_owned().await;
+        Ok(PendingMutationGuard {
+            _cross_worker: cross_worker,
+            _local: local,
+        })
+    }
+}
+
 async fn acquire_pending_mutation(
     state: &crate::worker::TonkState,
 ) -> Result<PendingMutationGuard, TonkWorkerError> {
-    let profile_hash = blake3::hash(state.profile.did().as_ref().as_bytes());
-    let lock_name = format!("tonk-pending-effects-v1:{profile_hash}");
-    let cross_worker = super::browser_lock::acquire(&lock_name)
-        .await
-        .map_err(|()| {
-            TonkWorkerError::Internal(
-                "pending effects require cross-worker serialization; reload and retry".to_string(),
-            )
-        })?;
-    let local = state.pending_work_lock.clone().lock_owned().await;
-    Ok(PendingMutationGuard {
-        _cross_worker: cross_worker,
-        _local: local,
-    })
+    PendingMutationScope::for_state(state).acquire().await
+}
+
+/// The sole append seam for the durable pending queue. Both lock layers are
+/// acquired here, so production routes and concurrency tests cannot provide a
+/// test-only mutex around an otherwise racy load/append/save sequence.
+async fn append_to_pending_store(
+    scope: &PendingMutationScope,
+    store: &impl PendingQueueStore,
+    work: impl IntoIterator<Item = PendingWork>,
+) -> Result<(), TonkWorkerError> {
+    let _mutation = scope.acquire().await?;
+    append_to_pending_store_locked(store, work).await
+}
+
+async fn observe_custody_in_pending_store(
+    scope: &PendingMutationScope,
+    store: &impl PendingQueueStore,
+    custody: &str,
+    consent_hex: &str,
+    sealed_hex: &str,
+    invocation_hex: &str,
+) -> Result<CustodySetupObservation, TonkWorkerError> {
+    let _mutation = scope.acquire().await?;
+    let queue = store.load_queue().await?;
+    Ok(observe_custody_queue(
+        &queue,
+        custody,
+        consent_hex,
+        sealed_hex,
+        invocation_hex,
+    ))
+}
+
+async fn replace_custody_publish_in_pending_store(
+    scope: &PendingMutationScope,
+    store: &impl PendingQueueStore,
+    custody: &str,
+    consent_hex: &str,
+    sealed_hex: &str,
+    previous_invocation_hex: &str,
+    replacement_invocation_hex: &str,
+) -> Result<CustodySetupObservation, TonkWorkerError> {
+    let _mutation = scope.acquire().await?;
+    let mut queue = store.load_queue().await?;
+    let (observation, changed) = replace_custody_publish_in_queue(
+        &mut queue,
+        custody,
+        consent_hex,
+        sealed_hex,
+        previous_invocation_hex,
+        replacement_invocation_hex,
+    );
+    if changed {
+        store.save_queue(&queue).await?;
+    }
+    Ok(observation)
 }
 
 /// Record `work` for replay once the account confirms its email, then
@@ -1044,17 +1333,65 @@ pub(crate) async fn defer(
     state: &crate::worker::TonkState,
     work: PendingWork,
 ) -> Result<(), TonkWorkerError> {
-    let _mutation = acquire_pending_mutation(state).await?;
-    append_pending_locked(state, [work]).await?;
-    drain_pending_locked(state).await;
+    append_pending(state, [work]).await?;
+    drain_pending(state).await;
     Ok(())
 }
 
-async fn append_pending_locked(
+/// Observe an already-queued account-setup custody pair under the same lock
+/// used by every append and drain. Absence is meaningful only after the saga's
+/// `CustodyQueued` checkpoint proves the pair was saved successfully.
+pub(crate) async fn observe_custody_setup(
+    state: &crate::worker::TonkState,
+    custody: &str,
+    consent_hex: &str,
+    sealed_hex: &str,
+    invocation_hex: &str,
+) -> Result<CustodySetupObservation, TonkWorkerError> {
+    observe_custody_in_pending_store(
+        &PendingMutationScope::for_state(state),
+        &WorkerPendingQueueStore(state),
+        custody,
+        consent_hex,
+        sealed_hex,
+        invocation_hex,
+    )
+    .await
+}
+
+/// Replace only the matching queued custody publish authorization, retaining
+/// its position behind Provision. If activation already drained the pair,
+/// absence remains Complete and the replacement is not re-queued.
+pub(crate) async fn replace_custody_publish(
+    state: &crate::worker::TonkState,
+    custody: &str,
+    consent_hex: &str,
+    sealed_hex: &str,
+    previous_invocation_hex: &str,
+    replacement_invocation_hex: &str,
+) -> Result<CustodySetupObservation, TonkWorkerError> {
+    replace_custody_publish_in_pending_store(
+        &PendingMutationScope::for_state(state),
+        &WorkerPendingQueueStore(state),
+        custody,
+        consent_hex,
+        sealed_hex,
+        previous_invocation_hex,
+        replacement_invocation_hex,
+    )
+    .await
+}
+
+async fn append_pending(
     state: &crate::worker::TonkState,
     work: impl IntoIterator<Item = PendingWork>,
 ) -> Result<(), TonkWorkerError> {
-    append_to_pending_store(&WorkerPendingQueueStore(state), work).await
+    append_to_pending_store(
+        &PendingMutationScope::for_state(state),
+        &WorkerPendingQueueStore(state),
+        work,
+    )
+    .await
 }
 
 /// Replay queued work in the order it was recorded, stopping at the
@@ -1239,12 +1576,16 @@ mod tests {
     use async_trait::async_trait;
     use tonk_account::pending::{PendingQueue, PendingWork};
 
-    use super::{PendingQueueStore, append_to_pending_store};
+    use super::{
+        CustodySetupObservation, PendingMutationScope, PendingQueueStore, append_to_pending_store,
+        observe_custody_in_pending_store, replace_custody_publish_in_pending_store,
+    };
 
     #[derive(Default)]
     struct MemoryPendingQueueStore(Mutex<PendingQueue>);
 
-    #[async_trait]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     impl PendingQueueStore for MemoryPendingQueueStore {
         async fn load_queue(&self) -> Result<PendingQueue, crate::TonkWorkerError> {
             let queue = self.0.lock().unwrap().clone();
@@ -1275,21 +1616,25 @@ mod tests {
     }
 
     #[dialog_common::test]
-    async fn concurrent_custody_appends_never_lose_or_cross_the_ordered_pair() {
+    async fn production_lock_wrapper_keeps_concurrent_custody_batches_ordered() {
         let store = Arc::new(MemoryPendingQueueStore::default());
-        let mutation_lock = Arc::new(tokio::sync::Mutex::new(()));
+        // Distinct local mutexes model two live worker generations. Only the
+        // canonical named-lock half of the production wrapper can serialize
+        // them; a test-only shared mutex would hide the race under review.
+        let left_scope = PendingMutationScope::new(
+            b"did:key:zAccountProfile",
+            Arc::new(tokio::sync::Mutex::new(())),
+        );
+        let right_scope = PendingMutationScope::new(
+            b"did:key:zAccountProfile",
+            Arc::new(tokio::sync::Mutex::new(())),
+        );
         let first = custody_batch("01");
         let second = custody_batch("02");
 
         let (left, right) = tokio::join!(
-            async {
-                let _guard = mutation_lock.lock().await;
-                append_to_pending_store(store.as_ref(), first.clone()).await
-            },
-            async {
-                let _guard = mutation_lock.lock().await;
-                append_to_pending_store(store.as_ref(), second.clone()).await
-            },
+            append_to_pending_store(&left_scope, store.as_ref(), first.clone()),
+            append_to_pending_store(&right_scope, store.as_ref(), second.clone()),
         );
         left.unwrap();
         right.unwrap();
@@ -1305,5 +1650,70 @@ mod tests {
             entries == first_then_second || entries == second_then_first,
             "both ordered Provision+Publish pairs must survive either lock acquisition order"
         );
+    }
+
+    #[dialog_common::test]
+    async fn production_mutator_replaces_publish_without_moving_it_ahead_of_provision() {
+        let store = MemoryPendingQueueStore::default();
+        let scope = PendingMutationScope::new(
+            b"did:key:zAccountProfile",
+            Arc::new(tokio::sync::Mutex::new(())),
+        );
+        append_to_pending_store(&scope, &store, custody_batch("01"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            replace_custody_publish_in_pending_store(
+                &scope,
+                &store,
+                "invalid-custody-01",
+                "aa01",
+                "bb01",
+                "cc01",
+                "fresh01",
+            )
+            .await
+            .unwrap(),
+            CustodySetupObservation::Pending
+        );
+        // A lost response repeats the same mutation without a second entry or
+        // a second receipt-worthy queue change.
+        assert_eq!(
+            replace_custody_publish_in_pending_store(
+                &scope,
+                &store,
+                "invalid-custody-01",
+                "aa01",
+                "bb01",
+                "cc01",
+                "fresh01",
+            )
+            .await
+            .unwrap(),
+            CustodySetupObservation::Pending
+        );
+        assert_eq!(
+            observe_custody_in_pending_store(
+                &scope,
+                &store,
+                "invalid-custody-01",
+                "aa01",
+                "bb01",
+                "fresh01",
+            )
+            .await
+            .unwrap(),
+            CustodySetupObservation::Pending
+        );
+
+        let queue = store.load_queue().await.unwrap();
+        assert_eq!(queue.len(), 2);
+        assert!(matches!(queue.entries()[0], PendingWork::Provision { .. }));
+        assert!(matches!(
+            &queue.entries()[1],
+            PendingWork::PublishCustody { invocation_hex, .. }
+                if invocation_hex == "fresh01"
+        ));
     }
 }

--- a/rust/tonk-worker/src/router/customer.rs
+++ b/rust/tonk-worker/src/router/customer.rs
@@ -462,6 +462,39 @@ async fn record_custody_cell(
     Ok(())
 }
 
+/// Persist the complete first-custody handoff in recovery-safe order.
+///
+/// The local sealed cell is written first. The provision and publish entries
+/// are then appended to one queue value in that exact order and saved once,
+/// after which draining is best effort. Repeating the operation is safe:
+/// branch assertions are idempotent and [`PendingQueue::push_all`] suppresses
+/// exact duplicates without changing order.
+pub(crate) async fn persist_custody_setup(
+    state: &crate::worker::TonkState,
+    custody: &str,
+    consent_hex: &str,
+    sealed_hex: &str,
+    invocation_hex: &str,
+) -> Result<(), TonkWorkerError> {
+    record_custody_cell(state, custody, sealed_hex).await?;
+    let mut queue = load_pending(state).await?;
+    queue.push_all([
+        PendingWork::Provision {
+            consumer: custody.to_owned(),
+            consent_hex: consent_hex.to_owned(),
+            consumer_kind: Some("custody".to_owned()),
+        },
+        PendingWork::PublishCustody {
+            custody: custody.to_owned(),
+            sealed_hex: sealed_hex.to_owned(),
+            invocation_hex: invocation_hex.to_owned(),
+        },
+    ]);
+    save_pending(state, &queue).await?;
+    drain_pending(state).await;
+    Ok(())
+}
+
 /// Provision `consumer`, or queue it when the account has not yet
 /// confirmed its email.
 ///
@@ -630,6 +663,53 @@ async fn load_customer(
             Ok(None)
         }
     }
+}
+
+/// Exact local enrollment observation used before replaying an at-least-once
+/// enrollment effect. An unreadable record is a mismatch here, never absence:
+/// the recovery saga must not erase ambiguity by resubmitting authority.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CustomerObservation {
+    Missing,
+    Exact,
+    Mismatch,
+}
+
+pub(crate) async fn observe_customer(
+    state: &crate::worker::TonkState,
+    expected_root: &str,
+    expected_email: &str,
+) -> Result<CustomerObservation, TonkWorkerError> {
+    let bytes = match state
+        .profile
+        .credential()
+        .site(CUSTOMER_CREDENTIAL_SITE)
+        .load::<Vec<u8>>()
+        .perform(&state.operator)
+        .await
+    {
+        Ok(bytes) if bytes.is_empty() => return Ok(CustomerObservation::Missing),
+        Ok(bytes) => bytes,
+        Err(error) if crate::credential::is_missing(&error) => {
+            return Ok(CustomerObservation::Missing);
+        }
+        Err(error) => {
+            return Err(TonkWorkerError::Internal(format!(
+                "failed to load the customer record: {error}"
+            )));
+        }
+    };
+    let record: CustomerRecord = match serde_json::from_slice(&bytes) {
+        Ok(record) => record,
+        Err(_) => return Ok(CustomerObservation::Mismatch),
+    };
+    Ok(
+        if record.customer == expected_root && record.email == expected_email {
+            CustomerObservation::Exact
+        } else {
+            CustomerObservation::Mismatch
+        },
+    )
 }
 
 /// Whether a provider actually serves this account — the precondition

--- a/rust/tonk-worker/src/router/customer.rs
+++ b/rust/tonk-worker/src/router/customer.rs
@@ -8,6 +8,7 @@
 //! deployment serving this page — so endpoints derive from the request
 //! origin and the service DID comes from `/.well-known/tonk`.
 
+use async_trait::async_trait;
 use axum::{
     Json,
     extract::{Extension, State},
@@ -159,11 +160,7 @@ pub(crate) async fn enroll_customer(
     // deriving an address from whichever origin it happened to reach.
     // An older service that answers no remote leaves whatever was
     // recorded before in place.
-    if let Err(error) =
-        record_customer_status(state, receipt.status, &email, receipt.provider.as_deref()).await
-    {
-        log!("account customer status not recorded: {error}");
-    }
+    record_customer_status(state, receipt.status, &email, receipt.provider.as_deref()).await?;
     Ok(receipt)
 }
 
@@ -476,22 +473,25 @@ pub(crate) async fn persist_custody_setup(
     sealed_hex: &str,
     invocation_hex: &str,
 ) -> Result<(), TonkWorkerError> {
+    let _mutation = acquire_pending_mutation(state).await?;
     record_custody_cell(state, custody, sealed_hex).await?;
-    let mut queue = load_pending(state).await?;
-    queue.push_all([
-        PendingWork::Provision {
-            consumer: custody.to_owned(),
-            consent_hex: consent_hex.to_owned(),
-            consumer_kind: Some("custody".to_owned()),
-        },
-        PendingWork::PublishCustody {
-            custody: custody.to_owned(),
-            sealed_hex: sealed_hex.to_owned(),
-            invocation_hex: invocation_hex.to_owned(),
-        },
-    ]);
-    save_pending(state, &queue).await?;
-    drain_pending(state).await;
+    append_pending_locked(
+        state,
+        [
+            PendingWork::Provision {
+                consumer: custody.to_owned(),
+                consent_hex: consent_hex.to_owned(),
+                consumer_kind: Some("custody".to_owned()),
+            },
+            PendingWork::PublishCustody {
+                custody: custody.to_owned(),
+                sealed_hex: sealed_hex.to_owned(),
+                invocation_hex: invocation_hex.to_owned(),
+            },
+        ],
+    )
+    .await?;
+    drain_pending_locked(state).await;
     Ok(())
 }
 
@@ -680,7 +680,7 @@ pub(crate) async fn observe_customer(
     expected_root: &str,
     expected_email: &str,
 ) -> Result<CustomerObservation, TonkWorkerError> {
-    let bytes = match state
+    let local = match state
         .profile
         .credential()
         .site(CUSTOMER_CREDENTIAL_SITE)
@@ -688,28 +688,41 @@ pub(crate) async fn observe_customer(
         .perform(&state.operator)
         .await
     {
-        Ok(bytes) if bytes.is_empty() => return Ok(CustomerObservation::Missing),
-        Ok(bytes) => bytes,
-        Err(error) if crate::credential::is_missing(&error) => {
-            return Ok(CustomerObservation::Missing);
-        }
+        Ok(bytes) if bytes.is_empty() => None,
+        Ok(bytes) => match serde_json::from_slice::<CustomerRecord>(&bytes) {
+            Ok(record) => Some(record),
+            Err(_) => return Ok(CustomerObservation::Mismatch),
+        },
+        Err(error) if crate::credential::is_missing(&error) => None,
         Err(error) => {
             return Err(TonkWorkerError::Internal(format!(
                 "failed to load the customer record: {error}"
             )));
         }
     };
-    let record: CustomerRecord = match serde_json::from_slice(&bytes) {
-        Ok(record) => record,
-        Err(_) => return Ok(CustomerObservation::Mismatch),
-    };
-    Ok(
-        if record.customer == expected_root && record.email == expected_email {
-            CustomerObservation::Exact
-        } else {
-            CustomerObservation::Mismatch
-        },
-    )
+    let projected = load_account_customer(state).await?;
+    match (local, projected) {
+        (None, None) => Ok(CustomerObservation::Missing),
+        (Some(local), Some(projected))
+            if local.customer == expected_root
+                && local.email == expected_email
+                && projected.email.0 == expected_email
+                && projected.status.0 == local.status.as_str() =>
+        {
+            // `load_account_customer` queries this exact root, so a row
+            // reaching here also proves the authoritative subject.
+            Ok(CustomerObservation::Exact)
+        }
+        // One projection can survive a crash between the two writes. Replay
+        // the idempotent enrollment so both become durable before advancing.
+        (None, Some(projected)) if projected.email.0 == expected_email => {
+            Ok(CustomerObservation::Missing)
+        }
+        (Some(local), None) if local.customer == expected_root && local.email == expected_email => {
+            Ok(CustomerObservation::Missing)
+        }
+        _ => Ok(CustomerObservation::Mismatch),
+    }
 }
 
 /// Whether a provider actually serves this account — the precondition
@@ -807,17 +820,23 @@ pub(crate) async fn registration(state: &crate::worker::TonkState) -> Registrati
 pub(crate) async fn account_customer(
     state: &crate::worker::TonkState,
 ) -> Option<tonk_schema::AccountCustomer> {
+    load_account_customer(state).await.ok().flatten()
+}
+
+async fn load_account_customer(
+    state: &crate::worker::TonkState,
+) -> Result<Option<tonk_schema::AccountCustomer>, TonkWorkerError> {
     use dialog_query::{Output as _, Query, Term};
     use tonk_schema::{AccountCustomer, prelude::DidExt as _};
 
-    let account = super::identity::root_did(state).await.ok()?;
+    let account = super::identity::root_did(state).await?;
     let branch = state
         .reactor
         .profile_repository()
         .branch(tonk_account::MAIN_BRANCH)
         .acquire(&state.operator)
         .await
-        .ok()?;
+        .map_err(|error| TonkWorkerError::Internal(format!("acquire account branch: {error}")))?;
     let rows: Vec<AccountCustomer> = branch
         .handle()
         .query()
@@ -830,8 +849,8 @@ pub(crate) async fn account_customer(
         .perform(&state.operator)
         .try_vec()
         .await
-        .ok()?;
-    rows.into_iter().next()
+        .map_err(|error| TonkWorkerError::Internal(format!("query account customer: {error}")))?;
+    Ok(rows.into_iter().next())
 }
 
 /// Record the account's registration state as a fact on profile main,
@@ -964,6 +983,60 @@ async fn save_pending(
         .map_err(|error| TonkWorkerError::Internal(format!("failed to save pending work: {error}")))
 }
 
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+trait PendingQueueStore {
+    async fn load_queue(&self) -> Result<PendingQueue, TonkWorkerError>;
+    async fn save_queue(&self, queue: &PendingQueue) -> Result<(), TonkWorkerError>;
+}
+
+struct WorkerPendingQueueStore<'a>(&'a crate::worker::TonkState);
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl PendingQueueStore for WorkerPendingQueueStore<'_> {
+    async fn load_queue(&self) -> Result<PendingQueue, TonkWorkerError> {
+        load_pending(self.0).await
+    }
+
+    async fn save_queue(&self, queue: &PendingQueue) -> Result<(), TonkWorkerError> {
+        save_pending(self.0, queue).await
+    }
+}
+
+async fn append_to_pending_store(
+    store: &impl PendingQueueStore,
+    work: impl IntoIterator<Item = PendingWork>,
+) -> Result<(), TonkWorkerError> {
+    let mut queue = store.load_queue().await?;
+    queue.push_all(work);
+    store.save_queue(&queue).await
+}
+
+struct PendingMutationGuard {
+    _cross_worker: super::browser_lock::CrossWorkerGuard,
+    _local: tokio::sync::OwnedMutexGuard<()>,
+}
+
+async fn acquire_pending_mutation(
+    state: &crate::worker::TonkState,
+) -> Result<PendingMutationGuard, TonkWorkerError> {
+    let profile_hash = blake3::hash(state.profile.did().as_ref().as_bytes());
+    let lock_name = format!("tonk-pending-effects-v1:{profile_hash}");
+    let cross_worker = super::browser_lock::acquire(&lock_name)
+        .await
+        .map_err(|()| {
+            TonkWorkerError::Internal(
+                "pending effects require cross-worker serialization; reload and retry".to_string(),
+            )
+        })?;
+    let local = state.pending_work_lock.clone().lock_owned().await;
+    Ok(PendingMutationGuard {
+        _cross_worker: cross_worker,
+        _local: local,
+    })
+}
+
 /// Record `work` for replay once the account confirms its email, then
 /// try to drain immediately — an already-active customer must not wait
 /// for the next status probe.
@@ -971,11 +1044,17 @@ pub(crate) async fn defer(
     state: &crate::worker::TonkState,
     work: PendingWork,
 ) -> Result<(), TonkWorkerError> {
-    let mut queue = load_pending(state).await?;
-    queue.push(work);
-    save_pending(state, &queue).await?;
-    drain_pending(state).await;
+    let _mutation = acquire_pending_mutation(state).await?;
+    append_pending_locked(state, [work]).await?;
+    drain_pending_locked(state).await;
     Ok(())
+}
+
+async fn append_pending_locked(
+    state: &crate::worker::TonkState,
+    work: impl IntoIterator<Item = PendingWork>,
+) -> Result<(), TonkWorkerError> {
+    append_to_pending_store(&WorkerPendingQueueStore(state), work).await
 }
 
 /// Replay queued work in the order it was recorded, stopping at the
@@ -987,6 +1066,14 @@ pub(crate) async fn defer(
 /// design — a drain that cannot run leaves the queue exactly as it was,
 /// and the next probe tries again.
 pub(crate) async fn drain_pending(state: &crate::worker::TonkState) {
+    let _mutation = match acquire_pending_mutation(state).await {
+        Ok(guard) => guard,
+        Err(error) => return log!("pending work lock unavailable: {error}"),
+    };
+    drain_pending_locked(state).await;
+}
+
+async fn drain_pending_locked(state: &crate::worker::TonkState) {
     let mut queue = match load_pending(state).await {
         Ok(queue) => queue,
         Err(error) => return log!("pending work unreadable: {error}"),
@@ -1018,10 +1105,10 @@ pub(crate) async fn drain_pending(state: &crate::worker::TonkState) {
 
 /// Perform one queued entry.
 ///
-/// A custody publish needs the PRF-derived custody key, which only a
-/// page holding a fresh passkey assertion has, so the worker cannot run
-/// one and reports it as still waiting. That halts the drain by design:
-/// the publish must not be overtaken by entries recorded after it.
+/// A custody publish uses the bounded pre-signed invocation captured while
+/// the page held the PRF-derived custody key. That lets the worker replay it
+/// later without reopening the key. A failed provision or publish still
+/// halts the drain so no later entry can overtake the custody pair.
 async fn run_pending(
     state: &crate::worker::TonkState,
     work: &PendingWork,
@@ -1143,4 +1230,80 @@ pub(crate) async fn clear_customer(
         .map_err(|error| {
             TonkWorkerError::Internal(format!("failed to clear the customer record: {error}"))
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+    use tonk_account::pending::{PendingQueue, PendingWork};
+
+    use super::{PendingQueueStore, append_to_pending_store};
+
+    #[derive(Default)]
+    struct MemoryPendingQueueStore(Mutex<PendingQueue>);
+
+    #[async_trait]
+    impl PendingQueueStore for MemoryPendingQueueStore {
+        async fn load_queue(&self) -> Result<PendingQueue, crate::TonkWorkerError> {
+            let queue = self.0.lock().unwrap().clone();
+            tokio::task::yield_now().await;
+            Ok(queue)
+        }
+
+        async fn save_queue(&self, queue: &PendingQueue) -> Result<(), crate::TonkWorkerError> {
+            tokio::task::yield_now().await;
+            *self.0.lock().unwrap() = queue.clone();
+            Ok(())
+        }
+    }
+
+    fn custody_batch(label: &str) -> [PendingWork; 2] {
+        [
+            PendingWork::Provision {
+                consumer: format!("invalid-custody-{label}"),
+                consent_hex: format!("aa{label}"),
+                consumer_kind: Some("custody".to_string()),
+            },
+            PendingWork::PublishCustody {
+                custody: format!("invalid-custody-{label}"),
+                sealed_hex: format!("bb{label}"),
+                invocation_hex: format!("cc{label}"),
+            },
+        ]
+    }
+
+    #[dialog_common::test]
+    async fn concurrent_custody_appends_never_lose_or_cross_the_ordered_pair() {
+        let store = Arc::new(MemoryPendingQueueStore::default());
+        let mutation_lock = Arc::new(tokio::sync::Mutex::new(()));
+        let first = custody_batch("01");
+        let second = custody_batch("02");
+
+        let (left, right) = tokio::join!(
+            async {
+                let _guard = mutation_lock.lock().await;
+                append_to_pending_store(store.as_ref(), first.clone()).await
+            },
+            async {
+                let _guard = mutation_lock.lock().await;
+                append_to_pending_store(store.as_ref(), second.clone()).await
+            },
+        );
+        left.unwrap();
+        right.unwrap();
+
+        let queue = store.load_queue().await.unwrap();
+        let entries = queue.entries();
+        let first_then_second = first.into_iter().chain(second.clone()).collect::<Vec<_>>();
+        let second_then_first = second
+            .into_iter()
+            .chain(custody_batch("01"))
+            .collect::<Vec<_>>();
+        assert!(
+            entries == first_then_second || entries == second_then_first,
+            "both ordered Provision+Publish pairs must survive either lock acquisition order"
+        );
+    }
 }

--- a/rust/tonk-worker/src/router/identity.rs
+++ b/rust/tonk-worker/src/router/identity.rs
@@ -47,6 +47,46 @@ pub(crate) struct LocalRoot {
     pub encryption_key: Option<dialog_varsig::Did>,
 }
 
+/// Exact observation used by the account-setup saga. A mismatch is distinct
+/// from absence so recovery never replaces authority that belongs to another
+/// ceremony.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum LocalRootObservation {
+    Missing,
+    Exact,
+    Mismatch,
+}
+
+pub(crate) async fn observe_root(
+    state: &TonkState,
+    expected_root_did: &str,
+    expected: &SaveRootRequest,
+) -> Result<LocalRootObservation, TonkWorkerError> {
+    let actual = match local_root(state).await {
+        Ok(actual) => actual,
+        Err(TonkWorkerError::RootRequired) => return Ok(LocalRootObservation::Missing),
+        Err(error) => return Err(error),
+    };
+    let expected_encryption = expected
+        .encryption_key
+        .as_deref()
+        .map(parse_encryption_key)
+        .transpose()?;
+    let expected_delegation = hex::decode(&expected.delegation_hex)
+        .map_err(|error| TonkWorkerError::Router(format!("invalid delegation hex: {error}")))?;
+    let exact = actual.root_did.to_string() == expected_root_did
+        && actual.device_did == state.profile.did()
+        && actual.credential_id == expected.credential_id
+        && actual.bytes == expected_delegation
+        && actual.passkey == expected.passkey
+        && actual.encryption_key == expected_encryption;
+    Ok(if exact {
+        LocalRootObservation::Exact
+    } else {
+        LocalRootObservation::Mismatch
+    })
+}
+
 pub(crate) async fn validate_grant(
     bytes: Vec<u8>,
     device_did: &dialog_varsig::Did,

--- a/rust/tonk-worker/src/router/profile_name.rs
+++ b/rust/tonk-worker/src/router/profile_name.rs
@@ -287,6 +287,7 @@ mod tests {
             storage,
             session_expires_at: session.expires_at,
             profile_name: name.to_string(),
+            service_origin: None,
             reactor,
             view_bindings: Default::default(),
             bridges: Default::default(),
@@ -294,6 +295,7 @@ mod tests {
             commands: crate::router::command_registry(),
             clients: Default::default(),
             account_setup_lock: Default::default(),
+            pending_work_lock: Default::default(),
             account_keys: Default::default(),
             registry: crate::device::Registry {
                 profile: name.to_string(),

--- a/rust/tonk-worker/src/router/profile_name.rs
+++ b/rust/tonk-worker/src/router/profile_name.rs
@@ -293,6 +293,7 @@ mod tests {
             sync_queue: Default::default(),
             commands: crate::router::command_registry(),
             clients: Default::default(),
+            account_setup_lock: Default::default(),
             account_keys: Default::default(),
             registry: crate::device::Registry {
                 profile: name.to_string(),

--- a/rust/tonk-worker/src/router/route_table.rs
+++ b/rust/tonk-worker/src/router/route_table.rs
@@ -23,6 +23,7 @@ const ROUTES: &[&str] = &[
     "/api/account/devices/register",
     "/api/account/devices/revoke",
     "/api/account/display-name",
+    "/api/account/setup",
     "/api/account/spaces/delete",
     "/api/account/summary",
     "/api/custody/provision",

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -350,6 +350,25 @@ pub type DefaultSpace = dialog_storage::provider::storage::NativeSpace;
 /// Concrete operator type for the default storage backend.
 pub type DefaultOperator = Operator<DefaultSpace>;
 
+fn worker_service_origin() -> Option<url::Url> {
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    {
+        use wasm_bindgen::JsCast as _;
+
+        let origin = js_sys::global()
+            .dyn_into::<web_sys::ServiceWorkerGlobalScope>()
+            .ok()?
+            .location()
+            .origin();
+        if origin.is_empty() {
+            return None;
+        }
+        return format!("{origin}/").parse().ok();
+    }
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    None
+}
+
 /// Application state containing the profile and operator.
 pub struct TonkState {
     /// The user's persistent profile.
@@ -372,6 +391,10 @@ pub struct TonkState {
     /// not retain this internally, so we carry it here for routes
     /// that report it back to the UI (e.g. `GET /api/profile`).
     pub profile_name: String,
+    /// Exact origin captured from the service-worker global, never from an
+    /// intercepted request. Security-sensitive same-origin setup flows derive
+    /// deployment configuration only from this value.
+    pub service_origin: Option<url::Url>,
     /// Reactive layer: cached repository/branch handles and the
     /// query subscriptions registered against them. Routes that
     /// mutate a branch flow through `reactor.repository(r).branch(b)`
@@ -402,6 +425,10 @@ pub struct TonkState {
     /// production pairs it with a profile-scoped Web Lock; native tests use
     /// this deterministic mutex directly.
     pub account_setup_lock: Arc<tokio::sync::Mutex<()>>,
+    /// Per-worker half of the pending-effect queue serialization fence. Every
+    /// load/append/drain/save mutation also holds the matching profile-scoped
+    /// browser Web Lock so old and new workers cannot lose each other's work.
+    pub pending_work_lock: Arc<tokio::sync::Mutex<()>>,
     /// Routing keys the hidden account repository answers to, resolved lazily.
     /// Consulted by the middleware that keeps that repository off the generic
     /// HTTP surface, so it sits on the hot path for every repository request.
@@ -1741,6 +1768,7 @@ pub(crate) async fn boot_state(
         storage,
         session_expires_at: session.expires_at,
         profile_name,
+        service_origin: worker_service_origin(),
         reactor,
         view_bindings: Default::default(),
         bridges: Default::default(),
@@ -1748,6 +1776,7 @@ pub(crate) async fn boot_state(
         sync_queue: Default::default(),
         clients: Default::default(),
         account_setup_lock: Default::default(),
+        pending_work_lock: Default::default(),
         account_keys: Default::default(),
         registry,
     };

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -398,6 +398,10 @@ pub struct TonkState {
     /// whether we have observed it alive. The stale-client sweep reaps
     /// born-then-died clients from here. See [`crate::router::ClientRegistry`].
     pub clients: crate::router::ClientRegistry,
+    /// Per-worker half of the account-setup serialization fence. Browser
+    /// production pairs it with a profile-scoped Web Lock; native tests use
+    /// this deterministic mutex directly.
+    pub account_setup_lock: Arc<tokio::sync::Mutex<()>>,
     /// Routing keys the hidden account repository answers to, resolved lazily.
     /// Consulted by the middleware that keeps that repository off the generic
     /// HTTP surface, so it sits on the hot path for every repository request.
@@ -1743,6 +1747,7 @@ pub(crate) async fn boot_state(
         commands: crate::router::command_registry(),
         sync_queue: Default::default(),
         clients: Default::default(),
+        account_setup_lock: Default::default(),
         account_keys: Default::default(),
         registry,
     };


### PR DESCRIPTION
## Summary

- wire the versioned account-setup recovery protocol through the production worker route
- stage protected recovery before saving the root or contacting the provider
- reconcile exact provider replay, both customer projections, and the ordered custody queue
- retain recovery until custody work is observably drained, including crash-safe publish replacement
- fail closed on ownership, revision, origin, configuration, identity, and artifact mismatches

This backend slice is intentionally not invoked by the current UI. A stacked UI follow-up will add the WebAuthn adapter, reload recovery surface, stale-worker refusal, browser journeys, and Storybook behavior.

## Stack

- base: #836
- this PR: durable worker saga and production seams
- next: top-document UI and WebAuthn orchestration

## Verification

- account setup saga: 37 passed
- customer production seams: 3 passed
- pending queue: 4 passed
- all-target tonk-worker Clippy: passed
- wasm32 tonk-worker check: passed
- cargo fmt and diff checks: passed
- two independent post-implementation reviews: no remaining blocker

## Recovery contracts

- no account secret, PRF result, KEK, private key, owner token, or attempt token is persisted or logged
- partially drained custody batches preserve Provision before PublishCustody
- publish replacement converges across recovery-store and queue-write uncertainty
- valid customer lifecycle divergence advances only with exact root and email identity
- post-stage deployment drift returns non-mutating UpdateRequired

## Residual validation

Real two-service-worker Web Lock behavior, virtual-authenticator reload journeys, stale-worker UI copy, and the irreducible crash interval after authenticator creation but before sealed recovery commit belong to the stacked UI/browser slice.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the account setup process in the `tonk-worker` by introducing new features for managing account setups, improving the handling of pending work, and ensuring proper serialization and observation of custody processes.

### Detailed summary
- Added `ClientQueryOptions` to `Cargo.toml`.
- Introduced new API routes for account setup and spaces deletion.
- Added `service_origin` and locks in `account_state.rs` and `profile_name.rs`.
- Implemented `AttachmentObservation` and `LocalRootObservation` enums for status tracking.
- Enhanced `load_provider` function's visibility to `pub(crate)`.
- Refined `observe_attachment` logic for attachment reconciliation.
- Expanded `AccountCeremony` struct to include `delegation_cid` and `create_fingerprint`.
- Added `persist_custody_setup` function for managing custody handoff.
- Introduced `PendingMutationScope` for managing pending work with proper locking.
- Implemented tests for custody handling and pending work management.
- Updated error handling and observation logic for pending work and custody processes.

> The following files were skipped due to too many changes: `plan/audit-account-setup-recovery.md`, `rust/tonk-worker/src/router/account_setup.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->