### PR TITLE
fix(account): keep custody setup in one pending batch

### DIFF
--- a/rust/tonk-account/src/pending.rs
+++ b/rust/tonk-account/src/pending.rs
@@ -99,6 +99,27 @@ impl PendingQueue {
         }
     }
 
+    /// Append a related batch in its supplied order, suppressing exact work
+    /// already present without allowing a missing prerequisite to land behind
+    /// a surviving later entry. Callers serialize the queue once afterwards.
+    pub fn push_all(&mut self, work: impl IntoIterator<Item = PendingWork>) {
+        let batch = work.into_iter().collect::<Vec<_>>();
+        for (index, entry) in batch.iter().cloned().enumerate() {
+            if self.0.contains(&entry) {
+                continue;
+            }
+            let insert_at = batch[index + 1..]
+                .iter()
+                .filter_map(|later| self.0.iter().position(|queued| queued == later))
+                .min();
+            if let Some(insert_at) = insert_at {
+                self.0.insert(insert_at, entry);
+            } else {
+                self.0.push(entry);
+            }
+        }
+    }
+
     /// The entries in replay order.
     pub fn entries(&self) -> &[PendingWork] {
         &self.0
@@ -139,6 +160,22 @@ mod tests {
             matches!(queue.entries()[1], PendingWork::PublishCustody { .. }),
             "the publish must stay behind the provision that makes it servable"
         );
+    }
+
+    #[test]
+    fn it_repairs_a_surviving_publish_when_the_complete_batch_is_replayed() {
+        let provision = provision("did:key:zCustody");
+        let publish = PendingWork::PublishCustody {
+            custody: "did:key:zCustody".to_string(),
+            sealed_hex: "bb".to_string(),
+            invocation_hex: "c0de".to_string(),
+        };
+        let mut queue = PendingQueue(vec![publish.clone()]);
+
+        queue.push_all([provision.clone(), publish.clone()]);
+        queue.push_all([provision.clone(), publish.clone()]);
+
+        assert_eq!(queue.entries(), &[provision, publish]);
     }
 
     #[test]

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -2093,8 +2093,9 @@ pub(crate) async fn run_account_ceremony(
 
     // Neither of these can land before the emailed link is clicked: the
     // service provisions nothing, and serves nothing, for a customer
-    // that has not confirmed its email. Both queue instead, and replay
-    // on activation.
+    // that has not confirmed its email. Keep the direct provision call for
+    // pages still controlled by an older worker; the queue request below is
+    // the durable, ordered provision-and-publish handoff in current workers.
     if let Err(error) =
         crate::api::provision_custody(&created.custody_did, &created.consent_hex).await
     {
@@ -2102,6 +2103,7 @@ pub(crate) async fn run_account_ceremony(
     }
     if let Err(error) = crate::api::queue_custody_publish(
         &created.custody_did,
+        &created.consent_hex,
         &created.sealed_hex,
         &created.publish_invocation_hex,
     )
@@ -2200,6 +2202,7 @@ async fn complete_remote(
         }
         if let Err(error) = crate::api::queue_custody_publish(
             &custody.custody_did,
+            &custody.consent_hex,
             &custody.sealed_hex,
             &custody.publish_invocation_hex,
         )
@@ -2641,6 +2644,7 @@ fn bind(host: &HtmlElement) {
                 // the provisioning deposit lands.
                 if let Err(error) = crate::api::queue_custody_publish(
                     &enrolled.custody_did,
+                    &enrolled.consent_hex,
                     &enrolled.sealed_hex,
                     enrolled.publish_invocation_hex.as_deref().unwrap_or(""),
                 )

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -752,10 +752,11 @@ pub async fn pending_work() -> Result<tonk_account::pending::PendingQueue, TonkU
     }
 }
 
-/// Queue a custody cell that could not be published yet, so it is
-/// republished once provisioning and email activation let it through.
+/// Record the complete custody handoff. The worker queues provisioning before
+/// any deferred publish in one durable write, then drains both in order.
 pub async fn queue_custody_publish(
     custody: &str,
+    consent_hex: &str,
     sealed_hex: &str,
     invocation_hex: &str,
 ) -> Result<(), TonkUiError> {
@@ -764,6 +765,7 @@ pub async fn queue_custody_publish(
         .post(format!("{}/api/custody/queue", origin()))
         .json(&serde_json::json!({
             "custody": custody,
+            "consentHex": consent_hex,
             "sealedHex": sealed_hex,
             "invocationHex": invocation_hex,
         }))

--- a/rust/tonk-worker/src/router/customer.rs
+++ b/rust/tonk-worker/src/router/customer.rs
@@ -364,6 +364,15 @@ pub struct ProvisionCustodyRequest {
     pub consent_hex: String,
 }
 
+fn decode_custody_consent(
+    consent_hex: &str,
+) -> Result<dialog_ucan_core::DelegationChain, TonkWorkerError> {
+    let bytes = hex::decode(consent_hex)
+        .map_err(|error| TonkWorkerError::Router(format!("consent is not hex: {error}")))?;
+    dialog_ucan_core::DelegationChain::try_from(bytes.as_slice())
+        .map_err(|error| TonkWorkerError::Router(format!("consent does not decode: {error}")))
+}
+
 /// POST `/api/custody/provision` → provision a custody space under
 /// this profile's account. The page runs the enrollment ceremony and
 /// hands the consent here; the call is idempotent, and retryable — the
@@ -378,10 +387,7 @@ pub async fn provision_custody(
         .custody
         .parse()
         .map_err(|error| TonkWorkerError::Router(format!("invalid custody DID: {error:?}")))?;
-    let bytes = hex::decode(&request.consent_hex)
-        .map_err(|error| TonkWorkerError::Router(format!("consent is not hex: {error}")))?;
-    let consent = dialog_ucan_core::DelegationChain::try_from(bytes.as_slice())
-        .map_err(|error| TonkWorkerError::Router(format!("consent does not decode: {error}")))?;
+    let consent = decode_custody_consent(&request.consent_hex)?;
     provision_or_defer(&state, &custody, &consent, Some("custody")).await?;
     Ok(Json(()))
 }
@@ -393,11 +399,34 @@ pub async fn provision_custody(
 pub struct QueueCustodyRequest {
     /// The custody space whose cell is waiting.
     pub custody: String,
+    /// Consent for provisioning this custody space. Optional only so a page
+    /// loaded before this worker version can finish its already-started flow.
+    #[serde(default)]
+    pub consent_hex: Option<String>,
     /// Hex-encoded sealed envelope to publish.
     pub sealed_hex: String,
     /// Hex-encoded pre-signed publish invocation, minted by the
     /// ceremony that sealed the envelope.
     pub invocation_hex: String,
+}
+
+fn custody_pending_batch(request: &QueueCustodyRequest) -> Vec<PendingWork> {
+    let mut work = Vec::with_capacity(2);
+    if let Some(consent_hex) = &request.consent_hex {
+        work.push(PendingWork::Provision {
+            consumer: request.custody.clone(),
+            consent_hex: consent_hex.clone(),
+            consumer_kind: Some("custody".to_owned()),
+        });
+    }
+    if !request.invocation_hex.is_empty() {
+        work.push(PendingWork::PublishCustody {
+            custody: request.custody.clone(),
+            sealed_hex: request.sealed_hex.clone(),
+            invocation_hex: request.invocation_hex.clone(),
+        });
+    }
+    work
 }
 
 /// POST `/api/custody/queue` → record a custody cell for publication
@@ -412,23 +441,18 @@ pub async fn queue_custody(
     Json(request): Json<QueueCustodyRequest>,
 ) -> Result<Json<()>, TonkWorkerError> {
     let state = state.read().await;
+    if let Some(consent_hex) = &request.consent_hex {
+        // Reject malformed recovery material before it can poison the durable
+        // queue. The access service still verifies its authority on replay.
+        decode_custody_consent(consent_hex)?;
+    }
     record_custody_cell(&state, &request.custody, &request.sealed_hex).await?;
-    // An empty invocation means the ceremony already published the cell
-    // (a passkey enrolled on an active account): the record above is
-    // all that was left to do.
-    if !request.invocation_hex.is_empty() {
-        defer(
-            &state,
-            PendingWork::PublishCustody {
-                custody: request.custody,
-                sealed_hex: request.sealed_hex,
-                invocation_hex: request.invocation_hex,
-            },
-        )
-        .await?;
-        // Nothing may be waiting on activation at all: a provisioning
-        // deposit queued just ahead of this can land right away.
-        drain_pending(&state).await;
+    let work = custody_pending_batch(&request);
+    if !work.is_empty() {
+        // Provision and publish are one durable ordered batch. Replaying this
+        // request also restores a missing provision ahead of a surviving
+        // publish from an interrupted earlier attempt.
+        defer_all(&state, work).await?;
     }
     Ok(Json(()))
 }
@@ -891,11 +915,36 @@ pub(crate) async fn defer(
     state: &crate::worker::TonkState,
     work: PendingWork,
 ) -> Result<(), TonkWorkerError> {
+    defer_all(state, vec![work]).await
+}
+
+async fn defer_all(
+    state: &crate::worker::TonkState,
+    work: Vec<PendingWork>,
+) -> Result<(), TonkWorkerError> {
     let mut queue = load_pending(state).await?;
-    queue.push(work);
+    queue.push_all(work);
     save_pending(state, &queue).await?;
     drain_pending(state).await;
     Ok(())
+}
+
+/// The next independently removable prefix. A custody provision immediately
+/// followed by its publish stays one replay unit: if publishing fails after
+/// provisioning succeeds, retaining both preserves the consent needed to try
+/// the complete handoff again.
+fn pending_replay_batch(work: &[PendingWork], start: usize) -> &[PendingWork] {
+    let Some(first) = work.get(start) else {
+        return &work[work.len()..];
+    };
+    let width = match (first, work.get(start + 1)) {
+        (
+            PendingWork::Provision { consumer, .. },
+            Some(PendingWork::PublishCustody { custody, .. }),
+        ) if consumer == custody => 2,
+        _ => 1,
+    };
+    &work[start..start + width]
 }
 
 /// Replay queued work in the order it was recorded, stopping at the
@@ -916,14 +965,15 @@ pub(crate) async fn drain_pending(state: &crate::worker::TonkState) {
     }
 
     let mut completed = 0;
-    for work in queue.entries() {
-        match run_pending(state, work).await {
-            Ok(()) => completed += 1,
-            Err(error) => {
+    'queue: while completed < queue.len() {
+        let batch = pending_replay_batch(queue.entries(), completed);
+        for work in batch {
+            if let Err(error) = run_pending(state, work).await {
                 log!("pending work for {} still waiting: {error}", work.subject());
-                break;
+                break 'queue;
             }
         }
+        completed += batch.len();
     }
     if completed == 0 {
         return;
@@ -955,13 +1005,8 @@ async fn run_pending(
             let consumer: dialog_varsig::Did = consumer.parse().map_err(|error| {
                 TonkWorkerError::Router(format!("queued consumer DID is invalid: {error:?}"))
             })?;
-            let bytes = hex::decode(consent_hex).map_err(|error| {
-                TonkWorkerError::Router(format!("queued consent is not hex: {error}"))
-            })?;
-            let consent =
-                dialog_ucan_core::DelegationChain::try_from(bytes.as_slice()).map_err(|error| {
-                    TonkWorkerError::Router(format!("queued consent does not decode: {error}"))
-                })?;
+            let consent = decode_custody_consent(consent_hex)
+                .map_err(|error| TonkWorkerError::Router(format!("queued custody {error}")))?;
             provision_consumer(state, &consumer, &consent, consumer_kind.as_deref()).await
         }
         PendingWork::PublishCustody {
@@ -1063,4 +1108,75 @@ pub(crate) async fn clear_customer(
         .map_err(|error| {
             TonkWorkerError::Internal(format!("failed to clear the customer record: {error}"))
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn custody_queue_carries_an_ordered_repair_batch_and_accepts_legacy_requests() {
+        let request = QueueCustodyRequest {
+            custody: "did:key:zCustody".to_owned(),
+            consent_hex: Some("aa".to_owned()),
+            sealed_hex: "bb".to_owned(),
+            invocation_hex: "c0de".to_owned(),
+        };
+        assert_eq!(
+            custody_pending_batch(&request),
+            vec![
+                PendingWork::Provision {
+                    consumer: "did:key:zCustody".to_owned(),
+                    consent_hex: "aa".to_owned(),
+                    consumer_kind: Some("custody".to_owned()),
+                },
+                PendingWork::PublishCustody {
+                    custody: "did:key:zCustody".to_owned(),
+                    sealed_hex: "bb".to_owned(),
+                    invocation_hex: "c0de".to_owned(),
+                },
+            ]
+        );
+
+        let legacy: QueueCustodyRequest = serde_json::from_value(serde_json::json!({
+            "custody": "did:key:zCustody",
+            "sealedHex": "bb",
+            "invocationHex": "c0de"
+        }))
+        .unwrap();
+        assert_eq!(
+            custody_pending_batch(&legacy),
+            vec![PendingWork::PublishCustody {
+                custody: "did:key:zCustody".to_owned(),
+                sealed_hex: "bb".to_owned(),
+                invocation_hex: "c0de".to_owned(),
+            }]
+        );
+    }
+
+    #[test]
+    fn custody_replay_keeps_a_matching_provision_and_publish_in_one_batch() {
+        let matching = QueueCustodyRequest {
+            custody: "did:key:zCustody".to_owned(),
+            consent_hex: Some("aa".to_owned()),
+            sealed_hex: "bb".to_owned(),
+            invocation_hex: "c0de".to_owned(),
+        };
+        let matching = custody_pending_batch(&matching);
+        assert_eq!(pending_replay_batch(&matching, 0), matching.as_slice());
+
+        let unrelated = vec![
+            PendingWork::Provision {
+                consumer: "did:key:zOne".to_owned(),
+                consent_hex: "aa".to_owned(),
+                consumer_kind: Some("custody".to_owned()),
+            },
+            PendingWork::PublishCustody {
+                custody: "did:key:zTwo".to_owned(),
+                sealed_hex: "bb".to_owned(),
+                invocation_hex: "c0de".to_owned(),
+            },
+        ];
+        assert_eq!(pending_replay_batch(&unrelated, 0), &unrelated[..1]);
+    }
 }


### PR DESCRIPTION
## Summary

- carry custody consent with a queued publish and persist provision plus publish as one ordered batch
- retain the pair until both operations succeed, so a failed publish cannot discard the provision needed for retry
- repair a surviving publish when a complete batch is replayed, while accepting legacy queue requests

## Context

The reported account had a durable PublishCustody entry but no preceding Provision entry. Its retries therefore reached the access service as an unknown custody subject and failed permanently with subject is not provisioned.

This is deliberately scoped to the worker and UI queue boundary on current staging. It has no dependency on the broader custody/account saga in #820.

## Tests

- cargo test -p tonk-account pending::tests --target aarch64-apple-darwin -- --nocapture
- cargo test -p tonk-worker --lib router::customer::tests --target aarch64-apple-darwin -- --nocapture
- cargo check -p tonk-worker -p tonk-ui --target wasm32-unknown-unknown
- cargo fmt --all -- --check
- git diff --check

A live WebAuthn recovery was not run because it requires the affected passkey and account state.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the custody publishing process by introducing new features for handling consent and improving the durability of queued operations. It refines the `queue_custody_publish` function and related logic for better order and reliability during custody handoff.

### Detailed summary
- Updated documentation for `queue_custody_publish` to clarify its purpose.
- Added `consent_hex` parameter to `queue_custody_publish`.
- Improved the handling of custody consent decoding with a new function `decode_custody_consent`.
- Refactored `queue_custody` to create a batch of work, ensuring ordered execution.
- Introduced `push_all` method in `PendingQueue` for batch insertion.
- Added tests to verify the behavior of custody queue and replay mechanisms.
- Enhanced error handling for malformed consent in the queue process.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->