### PR TITLE
feat(access): style account activation email

### DIFF
--- a/rust/tonk-access-service/src/email.rs
+++ b/rust/tonk-access-service/src/email.rs
@@ -73,19 +73,109 @@ impl Resend {
     }
 }
 
+#[cfg(any(target_arch = "wasm32", test))]
+fn activation_email_html(link: &str) -> String {
+    let link = link
+        .replace('&', "&amp;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;");
+
+    format!(
+        r#"<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Activate your tonk account</title>
+  </head>
+  <body style="margin:0;background:#e8e6e4;color:#38182a;font-family:'Arial Narrow','Helvetica Neue',Arial,sans-serif;-webkit-font-smoothing:antialiased;">
+    <div style="display:none;max-height:0;overflow:hidden;opacity:0;">Verify your email address to activate syncing for your tonk account.</div>
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;background:#e8e6e4;">
+      <tr>
+        <td align="center" style="padding:48px 16px 64px;">
+          <table role="presentation" width="432" cellpadding="0" cellspacing="0" style="width:100%;max-width:432px;border-collapse:separate;border-spacing:0;">
+            <tr>
+              <td align="center" style="padding:0 0 40px;">
+                <img src="https://tonk.network/images/tonk-wordmark.svg" width="132" height="44" alt="tonk" style="display:block;width:132px;max-width:100%;height:auto;border:0;outline:none;text-decoration:none;color:#38182a;font-size:20px;font-weight:800;line-height:44px;text-align:center;">
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:15px 16px 10px;background:#f7f6f5;border:1px solid #38182a;font-size:13px;font-weight:700;line-height:1;letter-spacing:.02em;text-transform:lowercase;">activate your account</td>
+            </tr>
+            <tr>
+              <td style="padding-top:7px;">
+                <a href="{link}" style="display:block;box-sizing:border-box;min-height:44px;padding:15px 24px 13px;background:#38182a;color:#f7f6f5;font-size:13px;font-weight:700;line-height:16px;letter-spacing:.02em;text-align:right;text-decoration:none;text-transform:lowercase;">verify email</a>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding-top:7px;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;background:#f7f6f5;">
+                  <tr>
+                    <td style="padding:14px 16px 15px;font-family:'Helvetica Neue',Arial,sans-serif;font-size:13px;line-height:1.5;color:#38182a;">Confirm your email address to activate syncing for your tonk account. The button opens Tonk so you can review and complete activation.</td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:18px 16px 0;font-family:'Helvetica Neue',Arial,sans-serif;font-size:12px;line-height:1.5;color:#5b4953;">If you did not request this, you can safely ignore this email.</td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>"#
+    )
+}
+
 #[cfg(target_arch = "wasm32")]
 #[async_trait(?Send)]
 impl EmailSender for Resend {
     async fn send_activation(&self, email: &str, link: &str) -> Result<(), EmailError> {
         self.0
-            .send(
+            .send_html(
                 email,
                 "Activate your tonk account",
                 &format!(
                     "Confirm your email address and accept the terms of service to activate your tonk account:\n\n{link}\n\nIf you did not request this, ignore this message."
                 ),
+                &activation_email_html(link),
             )
             .await
             .map_err(|err| EmailError::Send(err.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::activation_email_html;
+
+    #[test]
+    fn activation_email_uses_a_styled_verification_button() {
+        let html = activation_email_html("https://tonk.network/activate?token=abc");
+
+        assert!(html.contains("background:#e8e6e4"));
+        assert!(html.contains("background:#38182a"));
+        assert!(html.contains(
+            r#"<img src="https://tonk.network/images/tonk-wordmark.svg" width="132" height="44" alt="tonk""#
+        ));
+        assert!(
+            html.contains(r#"href="https://tonk.network/activate?token=abc" style="display:block"#)
+        );
+        assert!(html.contains(">verify email</a>"));
+    }
+
+    #[test]
+    fn activation_email_escapes_the_link_for_an_html_attribute() {
+        let html = activation_email_html(
+            "https://tonk.network/activate?one=1&two=\"quoted\"&three=<value>",
+        );
+
+        assert!(html.contains(
+            r#"href="https://tonk.network/activate?one=1&amp;two=&quot;quoted&quot;&amp;three=&lt;value&gt;""#
+        ));
+        assert!(!html.contains(r#"href="https://tonk.network/activate?one=1&two="#));
     }
 }

--- a/rust/tonk-email/src/resend.rs
+++ b/rust/tonk-email/src/resend.rs
@@ -6,7 +6,7 @@ use worker::{Fetch, Headers, Method, Request, RequestInit};
 
 use crate::EmailError;
 
-/// A Resend client that sends plain-text messages.
+/// A Resend client that sends text and HTML messages.
 pub struct Resend {
     /// Resend API key, sent as a bearer token.
     api_key: String,
@@ -20,7 +20,10 @@ struct SendRequest<'a> {
     from: &'a str,
     to: [&'a str; 1],
     subject: &'a str,
-    text: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    text: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    html: Option<&'a str>,
 }
 
 impl Resend {
@@ -32,11 +35,33 @@ impl Resend {
 
     /// Send a plain-text message.
     pub async fn send(&self, to: &str, subject: &str, text: &str) -> Result<(), EmailError> {
+        self.send_message(to, subject, Some(text), None).await
+    }
+
+    /// Send an HTML message with a plain-text fallback.
+    pub async fn send_html(
+        &self,
+        to: &str,
+        subject: &str,
+        text: &str,
+        html: &str,
+    ) -> Result<(), EmailError> {
+        self.send_message(to, subject, Some(text), Some(html)).await
+    }
+
+    async fn send_message(
+        &self,
+        to: &str,
+        subject: &str,
+        text: Option<&str>,
+        html: Option<&str>,
+    ) -> Result<(), EmailError> {
         let body = SendRequest {
             from: &self.from,
             to: [to],
             subject,
             text,
+            html,
         };
         let body_json =
             serde_json::to_string(&body).map_err(|err| EmailError::Send(err.to_string()))?;


### PR DESCRIPTION
## Summary

- send a Tonk-styled HTML activation email with the canonical wordmark and a clickable verification button
- retain a plain-text fallback and escape activation URLs before interpolating them into HTML
- extend the shared Resend transport to support HTML without changing existing text-only callers

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p tonk-access-service --target aarch64-apple-darwin --features integration-tests --lib email`
- `cargo check -p tonk-access-service --target wasm32-unknown-unknown`
- isolated headless Chrome preview: wordmark HTTP 200, correct intrinsic dimensions, and no horizontal overflow

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `Resend` client to support sending both text and HTML messages. It introduces a new function for sending HTML emails and modifies the existing plain-text sending functionality. Additionally, it adds a new HTML template for activation emails and corresponding tests.

### Detailed summary
- Updated the `Resend` struct documentation to indicate support for HTML messages.
- Changed the `text` field in `SendRequest` to be an `Option`.
- Added a new `send_html` function for sending HTML emails.
- Introduced a private `send_message` function to handle both text and HTML.
- Added an `activation_email_html` function to generate HTML for activation emails.
- Updated the `send_activation` method to use `send_html`.
- Added tests for HTML email generation and link escaping.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->