### PR TITLE
fix(access): drop the child before the parent in the account-db rebuild

### DIFF
--- a/rust/tonk-access-service/migrations/0006_account_schema.sql
+++ b/rust/tonk-access-service/migrations/0006_account_schema.sql
@@ -7,12 +7,14 @@
 --
 -- Both tables change constraints (the primary key renames, `provider`
 -- becomes NOT NULL), which SQLite cannot ALTER in place, so each is
--- rebuilt and the rows carried over. Foreign keys are deferred to the
--- commit: `consumer` still references the old `customer` while the
--- tables swap, and by commit both sides of every reference are the new
--- tables.
-PRAGMA defer_foreign_keys = true;
-
+-- rebuilt and the rows carried over. The order matters: `consumer`
+-- references `customer`, so dropping `customer` while `consumer` rows
+-- still point at it counts every row as a foreign-key violation — a
+-- violation that survives to the end of the batch and makes D1 roll the
+-- whole migration back, even though `consumer` itself is dropped later.
+-- Instead the rows `consumer` contributes are parked in a keyless seed
+-- table first, the child is dropped before its parent, and
+-- `subscription` is built once the new `customer` it references exists.
 CREATE TABLE customer_next (
   account           TEXT PRIMARY KEY, -- the account DID this subscribes
   email             TEXT NOT NULL,
@@ -39,6 +41,34 @@ SELECT did, email, verified, terms_version, terms_accepted_at, status,
        stripe_customer
   FROM customer;
 
+-- `provider` was nullable and meant "not servable"; the new shape has
+-- no unservable subscription, so those rows do not carry over. Neither
+-- do rows whose deletion already finished — the new model records a
+-- finished deletion by the row's absence.
+CREATE TABLE subscription_seed (
+  consumer        TEXT,
+  provider        TEXT,
+  registered_at      INTEGER,
+  archived_at     INTEGER,
+  suspend_code    TEXT,
+  suspend_message TEXT,
+  suspend_until_at   INTEGER,
+  size            INTEGER,
+  measured_at     INTEGER,
+  deleted_at      INTEGER,
+  kind            TEXT
+);
+
+INSERT INTO subscription_seed (consumer, provider, registered_at, archived_at,
+                               suspend_code, suspend_message, suspend_until_at,
+                               size, measured_at, deleted_at, kind)
+SELECT did, provider, registered, archived_at, suspend_code,
+       suspend_message, suspend_until, size, measured_at, deleted_at, kind
+  FROM consumer
+ WHERE provider IS NOT NULL
+   AND deletion_state != 'deleted';
+
+DROP TABLE consumer;
 DROP TABLE customer;
 ALTER TABLE customer_next RENAME TO customer;
 CREATE UNIQUE INDEX customer_email ON customer(email);
@@ -58,18 +88,12 @@ CREATE TABLE subscription (
   expires_at      INTEGER            -- when this subscription lapses; null never expires
 );
 
--- `provider` was nullable and meant "not servable"; the new shape has
--- no unservable subscription, so those rows do not carry over. Neither
--- do rows whose deletion already finished — the new model records a
--- finished deletion by the row's absence.
 INSERT INTO subscription (consumer, provider, registered_at, archived_at,
                           suspend_code, suspend_message, suspend_until_at,
                           size, measured_at, deleted_at, kind)
-SELECT did, provider, registered, archived_at, suspend_code,
-       suspend_message, suspend_until, size, measured_at, deleted_at, kind
-  FROM consumer
- WHERE provider IS NOT NULL
-   AND deletion_state != 'deleted';
+SELECT consumer, provider, registered_at, archived_at, suspend_code,
+       suspend_message, suspend_until_at, size, measured_at, deleted_at, kind
+  FROM subscription_seed;
 
-DROP TABLE consumer;
+DROP TABLE subscription_seed;
 CREATE INDEX subscription_provider ON subscription(provider);


### PR DESCRIPTION
## What changed

The staging Cloudflare deploy ([Deploy run 2305](https://github.com/tonk-labs/tonk/actions/runs/33490386546)) failed applying `0006_account_schema.sql` to `tonk-access-control-staging` with `FOREIGN KEY constraint failed [code: 7500]`, and D1 rolled the migration back — staging has been undeployable since #820 landed.

The cause is mechanical, not bad staging data: the migration dropped the old `customer` table while `consumer` rows still referenced it. Under `PRAGMA defer_foreign_keys`, each such row counts as a violation, and the later `DROP TABLE consumer` never clears the count — after the rename, its foreign key resolves against the new `customer`, which has no `did` column. The check at the end of the batch fails and D1 rolls everything back. Tests never caught it because they apply migrations to an empty database, where dropping `customer` violates nothing.

This reworks the ordering so no constraint is ever violated: the rows `consumer` contributes are parked in a keyless `subscription_seed` table, the child is dropped before its parent, and `subscription` is built once the new `customer` it references exists. The final schema is unchanged, and no deferral is needed, so the migration behaves the same under D1's batch mode and rusqlite's autocommit `execute_batch` (where the deferral pragma silently resets after one statement anyway). The migration was never recorded as applied in any environment — the failed run rolled back — so editing it in place is safe.

## Verification

- Reproduced the original failure locally in SQLite (`foreign_keys=ON`, single deferred transaction, one valid `customer` + `consumer` row): `FOREIGN KEY constraint failed` at commit, exactly matching the wrangler error.
- Ran the fixed migration in three modes — D1-style single transaction, autocommit per statement, and empty database — with populated data covering active/registered customers, custody and space consumers, suspended, unservable (`provider IS NULL`) and finished-deletion rows: clean `PRAGMA foreign_key_check`, correct carry-over, no leftover `*_seed`/`*_next` tables.
- `cargo test -p tonk-access-service --features integration-tests --test schema_doc` — 3 passed (final schema unchanged, so `docs/access-control-schema.md` needs no update).
- `cargo test -p tonk-access-service --features integration-tests --lib` — 65 passed.

## Storybook impact

- [x] No user-visible contract changed because: this only reorders the internal statements of an unapplied D1 migration; the resulting schema is identical and no browser or CLI behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011P6pRbkMqWfZiP2Yoo1bqM

---
_Generated by [Claude Code](https://claude.ai/code/session_011P6pRbkMqWfZiP2Yoo1bqM)_

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the database schema by renaming primary keys and enforcing NOT NULL constraints. It involves rebuilding tables to accommodate these changes while managing foreign key references correctly during the migration process.

### Detailed summary
- Renamed primary key in the `customer` table.
- Changed `provider` column to NOT NULL in the new schema.
- Created a new `subscription_seed` table to temporarily hold data.
- Dropped the old `consumer` table before renaming `customer_next`.
- Updated data insertion into the `subscription` table from `subscription_seed`.
- Dropped the `subscription_seed` table after migration.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->