### PR TITLE
Cache servability verdicts so presign stops querying D1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -151,10 +151,12 @@ jobs:
           control="tonk-access-control-pr-${{ github.event.pull_request.number }}"
           ingest="tonk-access-ingest-pr-${{ github.event.pull_request.number }}"
           revocations="tonk-access-revocations-pr-${{ github.event.pull_request.number }}"
+          servability="tonk-access-servability-pr-${{ github.event.pull_request.number }}"
           config="$PWD/wrangler.preview.toml"
           control_id="$(resolve "$control" "rust/tonk-access-service/migrations")"
           ingest_id="$(resolve "$ingest" "rust/tonk-access-service/migrations-ingest")"
           revocations_id="$(resolve_kv "$revocations")"
+          servability_id="$(resolve_kv "$servability")"
           cp wrangler.toml "$config"
           sed -i \
             -e "s/database_name = \"tonk-access-control-preview\"/database_name = \"$control\"/" \
@@ -162,12 +164,14 @@ jobs:
             -e "s/database_name = \"tonk-access-ingest-preview\"/database_name = \"$ingest\"/" \
             -e "s/database_id = \"INGEST-REPLACED-PER-PULL-REQUEST\"/database_id = \"$ingest_id\"/" \
             -e "s/id = \"REPLACED-PER-PULL-REQUEST\"/id = \"$revocations_id\"/" \
+            -e "s/id = \"SERVABILITY-REPLACED-PER-PULL-REQUEST\"/id = \"$servability_id\"/" \
             "$config"
           if ! grep -Fq "database_name = \"$control\"" "$config" \
             || ! grep -Fq "database_id = \"$control_id\"" "$config" \
             || ! grep -Fq "database_name = \"$ingest\"" "$config" \
             || ! grep -Fq "database_id = \"$ingest_id\"" "$config" \
-            || ! grep -Fq "id = \"$revocations_id\"" "$config"; then
+            || ! grep -Fq "id = \"$revocations_id\"" "$config" \
+            || ! grep -Fq "id = \"$servability_id\"" "$config"; then
             echo "::error::Could not bind the access preview config to $control/$ingest/$revocations"
             exit 1
           fi

--- a/docs/access-control-schema.md
+++ b/docs/access-control-schema.md
@@ -118,13 +118,14 @@ provider's `customer`. Read in three separate steps it could see a customer that
 activates between the first and the last, and it would cost three round
 trips on a path that runs before every presign.
 
-It still reaches D1 directly, every time. `plan/Access metering.md` §11
-specifies a read through an isolate cache, then KV, and D1 only on a
-miss — but the consumer-state KV namespace does not exist yet, and
-`REVOCATIONS_KV` is the only one bound. The value KV is meant to serve
-is derived from sponsorships, usage, and plan rates (§11.1), so that
-tier belongs with the increment that brings those tables. The join does
-not have to wait for it.
+On the worker the query runs behind the cache tier `plan/Access
+metering.md` §11 specifies: an isolate cache, then `SERVABILITY_KV`,
+and D1 only on a miss, with the derived verdict written back under an
+absolute `not_after` (generous for a permit, short for a denial). The
+registration commands write the fresh verdict through after their D1
+commit, and deprovisioning deletes the key. The funding axes (§11.1 —
+sponsorships, usage, plan rates) still await the increment that brings
+those tables; the cached value is today's verdict, no more.
 
 Because the gate is subject-level, it cannot serve a read while refusing
 a write. Anything needing that distinction has to come from the

--- a/rust/tonk-access-service/src/handlers/deletion.rs
+++ b/rust/tonk-access-service/src/handlers/deletion.rs
@@ -1,12 +1,31 @@
 //! Worker adapter for hosted-space deletion.
 
+/// Deprovisioning deletes the cached servability verdict rather than
+/// writing a negative one, forcing the next presign through
+/// authoritative D1 while the purge is in flight. Best-effort: a
+/// missed delete rides out the verdict's own validity.
+#[cfg(target_arch = "wasm32")]
+async fn forget_verdict(subject: &str, env: &worker::Env) {
+    use crate::provisioning::cache;
+
+    cache::isolate_forget(subject);
+    if let Some(kv) = crate::handlers::ucan::servability_kv(env)
+        && let Err(err) = kv.delete(&cache::key(subject)).await
+    {
+        worker::console_error!("cached verdict for {subject} not dropped: {err}");
+    }
+}
+
 #[cfg(target_arch = "wasm32")]
 pub async fn handle(body: &[u8], env: &worker::Env) -> worker::Result<worker::Response> {
     let store = crate::store::d1::D1Store::new(env.d1("CONTROL")?);
     let purger = crate::deletion::R2SpacePurger::new(env.bucket("BUCKET")?);
     let now = worker::Date::now().as_millis() / 1_000;
     match crate::deletion::delete(&store, &purger, body, now).await {
-        Ok(receipt) => worker::Response::from_json(&receipt),
+        Ok(receipt) => {
+            forget_verdict(receipt.space.as_str(), env).await;
+            worker::Response::from_json(&receipt)
+        }
         Err(error) => worker::Response::from_json(&serde_json::json!({ "error": error }))
             .map(|response| response.with_status(error.status())),
     }
@@ -25,9 +44,13 @@ pub async fn handle_customer(body: &[u8], env: &worker::Env) -> worker::Result<w
             .await
             .map(|plan| serde_json::to_value(plan).expect("plan serializes"))
     } else {
-        crate::deletion::delete_customer(&store, &purger, body, now)
-            .await
-            .map(|receipt| serde_json::to_value(receipt).expect("receipt serializes"))
+        match crate::deletion::delete_customer(&store, &purger, body, now).await {
+            Ok(receipt) => {
+                forget_verdict(&receipt.customer, env).await;
+                Ok(serde_json::to_value(receipt).expect("receipt serializes"))
+            }
+            Err(error) => Err(error),
+        }
     };
     match result {
         Ok(receipt) => worker::Response::from_json(&receipt),

--- a/rust/tonk-access-service/src/handlers/registration.rs
+++ b/rust/tonk-access-service/src/handlers/registration.rs
@@ -50,11 +50,72 @@ impl crate::email::EmailSender for MaybeEmail {
 #[cfg(target_arch = "wasm32")]
 pub async fn handle(body: &[u8], req: &Request, env: &Env) -> worker::Result<Response> {
     match handle_inner(body, req, env).await {
-        Ok(receipt) => Response::from_json(&receipt),
+        Ok(receipt) => {
+            replicate_verdicts(&receipt, env).await;
+            Response::from_json(&receipt)
+        }
         Err(err) => {
             let response = Response::from_json(&serde_json::json!({ "error": err }))?;
             Ok(response.with_status(err.status()))
         }
+    }
+}
+
+/// Write the fresh servability verdicts for every subject a completed
+/// registration command changed, so the change propagates to the
+/// presign path as itself rather than waiting out a cached entry's
+/// validity. `/provider/add` touches the provisioned consumer;
+/// `/customer/enroll` and `/customer/activate` touch the customer and
+/// every consumer it funds. Best-effort: a failed write costs at most
+/// one stale validity window, which the verdicts are sized for.
+#[cfg(target_arch = "wasm32")]
+async fn replicate_verdicts(answer: &crate::registration::Answer, env: &Env) {
+    use worker::Date;
+
+    use crate::handlers::ucan::{derive_verdict, servability_kv};
+    use crate::registration::Answer;
+    use crate::store::Store;
+    use crate::store::d1::D1Store;
+
+    let customer = match answer {
+        Answer::Subscription(receipt) => {
+            let now = Date::now().as_millis() / 1_000;
+            let _ = derive_verdict(
+                receipt.consumer.as_str(),
+                now,
+                env,
+                servability_kv(env).as_ref(),
+            )
+            .await;
+            return;
+        }
+        Answer::Customer(receipt) => receipt.customer.as_str().to_string(),
+        // The operator commands answer nothing; their consumer rides
+        // out the cached verdict's validity instead.
+        Answer::Done => return,
+    };
+    let mut subjects = vec![customer.clone()];
+    match env.d1("CONTROL") {
+        Ok(control) => match D1Store::new(control)
+            .subscriptions_by_provider(&customer)
+            .await
+        {
+            Ok(subscriptions) => subjects.extend(
+                subscriptions
+                    .into_iter()
+                    .map(|subscription| subscription.consumer)
+                    .filter(|consumer| *consumer != customer),
+            ),
+            Err(err) => {
+                worker::console_error!("verdicts for {customer}'s consumers not refreshed: {err}");
+            }
+        },
+        Err(err) => worker::console_error!("verdicts not refreshed, no CONTROL binding: {err}"),
+    }
+    let kv = servability_kv(env);
+    let now = Date::now().as_millis() / 1_000;
+    for subject in subjects {
+        let _ = derive_verdict(&subject, now, env, kv.as_ref()).await;
     }
 }
 

--- a/rust/tonk-access-service/src/handlers/ucan.rs
+++ b/rust/tonk-access-service/src/handlers/ucan.rs
@@ -241,10 +241,15 @@ async fn presign(body_bytes: &[u8], env: &Env) -> std::result::Result<(Response,
 /// never reach here — `serve` answers them before the presign path —
 /// so enrolling and activating stay possible while the gate denies the
 /// data plane.
+///
+/// The verdict resolves per plan/Access metering.md §11.3: isolate
+/// cache, then KV, then control D1 on a miss, writing the derived
+/// verdict back. D1 is the authority; the caches only remember its
+/// answers until their `not_after`.
 #[cfg(target_arch = "wasm32")]
 async fn screen_provisioning(body_bytes: &[u8], env: &Env) -> std::result::Result<(), Refusal> {
-    use crate::provisioning::{container_subject, screen};
-    use crate::store::d1::D1Store;
+    use crate::provisioning::cache::{self, CachedVerdict};
+    use crate::provisioning::container_subject;
 
     let Some(subject) = container_subject(body_bytes) else {
         // The authorizer accepted these bytes, so a subject we cannot
@@ -253,15 +258,99 @@ async fn screen_provisioning(body_bytes: &[u8], env: &Env) -> std::result::Resul
         console_error!("provisioning screen unavailable, container has no readable subject");
         return Err(provisioning_unavailable());
     };
+    let now = Date::now().as_millis() / 1_000;
+
+    if let Some(cached) = cache::isolate_lookup(&subject, now) {
+        return cached.verdict().map_err(Into::into);
+    }
+
+    let kv = servability_kv(env);
+    if let Some(kv) = &kv {
+        match kv.get(&cache::key(&subject)).text().await {
+            Ok(Some(text)) => {
+                if let Some(cached) = CachedVerdict::decode(&text).filter(|c| c.fresh(now)) {
+                    cache::isolate_store(&subject, cached.clone(), now);
+                    return cached.verdict().map_err(Into::into);
+                }
+            }
+            // A miss is not an answer — KV is eventually consistent —
+            // so it falls through to authoritative D1.
+            Ok(None) => {}
+            Err(err) => {
+                // A KV read error is served, per the plan: the gate
+                // exists for billing, and its cache being unreachable
+                // is the service's own trouble, not the caller's.
+                console_error!("servability cache unreadable, serving {subject} unscreened: {err}");
+                return Ok(());
+            }
+        }
+    }
+
+    let outcome = derive_verdict(&subject, now, env, kv.as_ref()).await?;
+    match outcome {
+        Ok(()) => Ok(()),
+        Err(reason) => {
+            worker::console_log!("presign rejected: {subject} is not servable ({reason})");
+            Err(reason.into())
+        }
+    }
+}
+
+/// The verdict-cache KV namespace, if this deployment has one. Serving
+/// degrades to per-request D1 reads without it rather than refusing.
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn servability_kv(env: &Env) -> Option<worker::kv::KvStore> {
+    use crate::provisioning::cache;
+
+    match env.kv(cache::BINDING) {
+        Ok(kv) => Some(kv),
+        Err(err) => {
+            console_error!(
+                "servability cache absent, no {} binding: {err}",
+                cache::BINDING
+            );
+            None
+        }
+    }
+}
+
+/// Derive `subject`'s verdict from control D1 and remember it in the
+/// isolate cache and KV. The single write path for cached verdicts:
+/// the presign path calls it on a cache miss, the registration and
+/// deletion handlers after a state change, so a change propagates as
+/// itself rather than waiting out a stale entry's validity.
+#[cfg(target_arch = "wasm32")]
+pub(crate) async fn derive_verdict(
+    subject: &str,
+    now: u64,
+    env: &Env,
+    kv: Option<&worker::kv::KvStore>,
+) -> std::result::Result<std::result::Result<(), AuthorizeError>, Refusal> {
+    use crate::provisioning::cache::{self, CachedVerdict};
+    use crate::provisioning::screen;
+    use crate::store::d1::D1Store;
+
     let store = D1Store::new(env.d1("CONTROL").map_err(|err| {
         console_error!("provisioning screen unavailable, no CONTROL binding: {err}");
         provisioning_unavailable()
     })?);
-    match screen(&store, &subject, Date::now().as_millis() / 1_000).await {
-        Ok(Ok(())) => Ok(()),
-        Ok(Err(reason)) => {
-            worker::console_log!("presign rejected: {subject} is not servable ({reason})");
-            Err(reason.into())
+    match screen(&store, subject, now).await {
+        Ok(outcome) => {
+            let cached = CachedVerdict::record(&outcome, subject, now);
+            cache::isolate_store(subject, cached.clone(), now);
+            if let Some(kv) = kv {
+                let write = kv
+                    .put(&cache::key(subject), cached.encode())
+                    .map(|put| put.expiration_ttl(cached.retention(now)));
+                let written = match write {
+                    Ok(put) => put.execute().await.map_err(|err| err.to_string()),
+                    Err(err) => Err(err.to_string()),
+                };
+                if let Err(err) = written {
+                    console_error!("servability verdict for {subject} not cached: {err}");
+                }
+            }
+            Ok(outcome)
         }
         Err(err) => {
             // The gate fails closed, but a store failure is the

--- a/rust/tonk-access-service/src/provisioning.rs
+++ b/rust/tonk-access-service/src/provisioning.rs
@@ -21,6 +21,8 @@
 //! `AwaitingActivation` learns it is confirmed when the same sync
 //! succeeds, with no separate probe.
 
+pub mod cache;
+
 use dialog_capability::access::{AuthorizeError, Recourse};
 use dialog_ucan_core::{Container, Invocation};
 use dialog_varsig::AnySignature;

--- a/rust/tonk-access-service/src/provisioning/cache.rs
+++ b/rust/tonk-access-service/src/provisioning/cache.rs
@@ -1,0 +1,229 @@
+//! Cached servability verdicts, so the presign hot path does not read
+//! control D1 per request.
+//!
+//! plan/Access metering.md §7 and §11 specify the resolution order this
+//! implements: isolate cache, then KV, then control D1 on a miss, with
+//! the derived verdict written back. The gate's authority stays in
+//! [`screen`](crate::provisioning::screen); this module only remembers
+//! its answers for a bounded time.
+//!
+//! Staleness is asymmetric, per the plan: a stale permit costs a
+//! handful of operations, a stale denial costs a paying customer
+//! service. So a serving verdict lives [`OK_VALIDITY`] and a denial
+//! only [`DENY_VALIDITY`], and validity carries jitter so expiry does
+//! not cluster into a synchronised read storm against D1.
+//!
+//! `not_after` is an absolute timestamp inside the value rather than a
+//! store TTL: the isolate copy ages after it is read, and KV's own
+//! expiry (minimum 60 seconds) is only garbage collection.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+use dialog_capability::access::AuthorizeError;
+use serde::{Deserialize, Serialize};
+
+/// The KV namespace binding holding cached verdicts.
+pub const BINDING: &str = "SERVABILITY_KV";
+
+/// The value shape this build writes and accepts. A stale isolate can
+/// hold a shape written by a previous deploy, so a value declaring any
+/// other version reads as a miss rather than as garbage.
+const VERSION: u32 = 1;
+
+/// How long a serving verdict stands before revalidation, in seconds.
+const OK_VALIDITY: u64 = 300;
+
+/// How long a denial stands, in seconds. Short, because the states it
+/// caches clear by someone acting — provisioning, activation — and the
+/// person who acted is usually watching the retry.
+const DENY_VALIDITY: u64 = 30;
+
+/// Entries kept in the isolate cache before it is pruned.
+const ISOLATE_CAPACITY: usize = 1024;
+
+/// A remembered gate verdict: serving when `deny` is absent, refused
+/// with exactly the recorded error otherwise.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CachedVerdict {
+    /// Value-shape version; see [`VERSION`].
+    pub v: u32,
+    /// Absolute expiry: a reader at or past this moment revalidates.
+    pub not_after: u64,
+    /// The refusal, when the verdict is a refusal.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deny: Option<AuthorizeError>,
+}
+
+impl CachedVerdict {
+    /// Record `outcome` as a verdict valid from `now`, with per-variant
+    /// validity and jitter keyed off the subject.
+    pub fn record(outcome: &Result<(), AuthorizeError>, subject: &str, now: u64) -> Self {
+        let base = match outcome {
+            Ok(()) => OK_VALIDITY,
+            Err(_) => DENY_VALIDITY,
+        };
+        Self {
+            v: VERSION,
+            not_after: now + base + jitter(subject, now, base / 5),
+            deny: outcome.as_ref().err().cloned(),
+        }
+    }
+
+    /// Whether this verdict may still be used at `now`.
+    pub fn fresh(&self, now: u64) -> bool {
+        now < self.not_after
+    }
+
+    /// The gate outcome this verdict remembers.
+    pub fn verdict(&self) -> Result<(), AuthorizeError> {
+        match &self.deny {
+            None => Ok(()),
+            Some(deny) => Err(deny.clone()),
+        }
+    }
+
+    /// The verdict as its stored JSON.
+    pub fn encode(&self) -> String {
+        serde_json::to_string(self).expect("verdict serializes")
+    }
+
+    /// Read a stored value back; `None` — a miss — for anything this
+    /// build does not recognize.
+    pub fn decode(text: &str) -> Option<Self> {
+        serde_json::from_str::<Self>(text)
+            .ok()
+            .filter(|cached| cached.v == VERSION)
+    }
+
+    /// Seconds the backing store should retain this value. At least
+    /// KV's 60-second minimum; `not_after` inside the value is what
+    /// governs validity.
+    pub fn retention(&self, now: u64) -> u64 {
+        (self.not_after.saturating_sub(now)).max(60)
+    }
+}
+
+/// The KV key for a subject's verdict.
+pub fn key(subject: &str) -> String {
+    format!("servability/{subject}")
+}
+
+/// Deterministic spread in `0..=range`, so verdicts recorded together
+/// do not all expire together.
+fn jitter(subject: &str, now: u64, range: u64) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    subject.hash(&mut hasher);
+    now.hash(&mut hasher);
+    match range {
+        0 => 0,
+        range => hasher.finish() % (range + 1),
+    }
+}
+
+thread_local! {
+    /// This isolate's own verdicts. Workers isolates are single
+    /// threaded, so thread local is isolate local.
+    static ISOLATE: RefCell<HashMap<String, CachedVerdict>> = RefCell::new(HashMap::new());
+}
+
+/// The isolate's fresh verdict for `subject`, if it holds one.
+pub fn isolate_lookup(subject: &str, now: u64) -> Option<CachedVerdict> {
+    ISOLATE.with(|cell| {
+        cell.borrow()
+            .get(subject)
+            .filter(|cached| cached.fresh(now))
+            .cloned()
+    })
+}
+
+/// Remember `verdict` in this isolate. At capacity the expired entries
+/// are pruned first; a cache still full of fresh entries is cleared —
+/// correctness never depends on retention.
+pub fn isolate_store(subject: &str, verdict: CachedVerdict, now: u64) {
+    ISOLATE.with(|cell| {
+        let mut entries = cell.borrow_mut();
+        if entries.len() >= ISOLATE_CAPACITY {
+            entries.retain(|_, cached| cached.fresh(now));
+        }
+        if entries.len() >= ISOLATE_CAPACITY {
+            entries.clear();
+        }
+        entries.insert(subject.to_string(), verdict);
+    });
+}
+
+/// Drop this isolate's verdict for `subject`, so a state change made
+/// here is visible here immediately. Other isolates converge by
+/// `not_after`.
+pub fn isolate_forget(subject: &str) {
+    ISOLATE.with(|cell| {
+        cell.borrow_mut().remove(subject);
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use dialog_capability::access::Recourse;
+
+    use super::*;
+
+    fn denial() -> AuthorizeError {
+        AuthorizeError::Declined {
+            recourse: Recourse::Retry,
+            reason: "the subject's own registration awaits email activation".into(),
+        }
+    }
+
+    #[test]
+    fn it_round_trips_a_serving_verdict() {
+        let recorded = CachedVerdict::record(&Ok(()), "did:key:zAlice", 1_000);
+        let decoded = CachedVerdict::decode(&recorded.encode()).expect("decodes");
+        assert_eq!(decoded, recorded);
+        assert!(decoded.verdict().is_ok());
+    }
+
+    #[test]
+    fn it_round_trips_a_denial_with_its_recourse() {
+        let recorded = CachedVerdict::record(&Err(denial()), "did:key:zAlice", 1_000);
+        let decoded = CachedVerdict::decode(&recorded.encode()).expect("decodes");
+        assert_eq!(decoded.verdict(), Err(denial()));
+    }
+
+    #[test]
+    fn it_gives_denials_shorter_validity_than_permits() {
+        let ok = CachedVerdict::record(&Ok(()), "did:key:zAlice", 1_000);
+        let deny = CachedVerdict::record(&Err(denial()), "did:key:zAlice", 1_000);
+        assert!(deny.not_after < ok.not_after);
+        assert!(deny.fresh(1_000 + DENY_VALIDITY - 1));
+        assert!(!deny.fresh(1_000 + DENY_VALIDITY + DENY_VALIDITY / 5 + 1));
+        assert!(!ok.fresh(1_000 + OK_VALIDITY + OK_VALIDITY / 5 + 1));
+    }
+
+    #[test]
+    fn it_treats_an_unknown_version_as_a_miss() {
+        let mut recorded = CachedVerdict::record(&Ok(()), "did:key:zAlice", 1_000);
+        recorded.v = VERSION + 1;
+        assert_eq!(CachedVerdict::decode(&recorded.encode()), None);
+        assert_eq!(CachedVerdict::decode("not json"), None);
+    }
+
+    #[test]
+    fn it_retains_at_least_the_kv_minimum() {
+        let deny = CachedVerdict::record(&Err(denial()), "did:key:zAlice", 1_000);
+        assert!(deny.retention(1_000) >= 60);
+        let ok = CachedVerdict::record(&Ok(()), "did:key:zAlice", 1_000);
+        assert!(ok.retention(1_000) >= OK_VALIDITY);
+    }
+
+    #[test]
+    fn it_serves_from_the_isolate_until_expiry_and_forgets_on_demand() {
+        let recorded = CachedVerdict::record(&Ok(()), "did:key:zIsolate", 1_000);
+        isolate_store("did:key:zIsolate", recorded.clone(), 1_000);
+        assert_eq!(isolate_lookup("did:key:zIsolate", 1_000), Some(recorded));
+        assert_eq!(isolate_lookup("did:key:zIsolate", u64::MAX), None);
+        isolate_forget("did:key:zIsolate");
+        assert_eq!(isolate_lookup("did:key:zIsolate", 1_000), None);
+    }
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -28,7 +28,7 @@ bucket_name = "tonk-spaces"
 
 # Control state for customer registration: customers, consumers, and
 # plans. Registration commands answer 500 while this binding is absent or
-# empty; the presign path never touches it.
+# empty; the presign path reads it only on a servability-cache miss.
 #
 # Ships empty: the id is minted once at bootstrap via `wrangler d1 create
 # tonk-access-control` and filled in here. Wrangler refuses to deploy
@@ -62,6 +62,15 @@ migrations_dir = "rust/tonk-access-service/migrations-ingest"
 [[kv_namespaces]]
 binding = "REVOCATIONS_KV"
 id = "04f72780ec4541318e768ec26d9cc5e4"
+
+# Servability verdicts derived from control, read on the presign hot
+# path so it does not query D1 per request (plan/Access metering.md
+# §11). Registration commands write the fresh verdict through after
+# their D1 commit. A missing binding degrades to per-request D1 reads
+# rather than refusing.
+[[kv_namespaces]]
+binding = "SERVABILITY_KV"
+id = "a4904c12fa6e4090870a5dab61898e58"
 
 # Lookup rate limit: the email lookup answers an unauthenticated GET, and
 # the address it resolves is in the URL, so the endpoint is a registration
@@ -110,6 +119,10 @@ migrations_dir = "rust/tonk-access-service/migrations-ingest"
 [[env.staging.kv_namespaces]]
 binding = "REVOCATIONS_KV"
 id = "02b830113c7f47879b3a839a52f643df"
+
+[[env.staging.kv_namespaces]]
+binding = "SERVABILITY_KV"
+id = "480460e06995424e8122b774cdcac697"
 
 [[env.staging.ratelimits]]
 name = "LOOKUP_LIMITER"
@@ -165,6 +178,10 @@ migrations_dir = "rust/tonk-access-service/migrations-ingest"
 [[env.preview.kv_namespaces]]
 binding = "REVOCATIONS_KV"
 id = "REPLACED-PER-PULL-REQUEST"
+
+[[env.preview.kv_namespaces]]
+binding = "SERVABILITY_KV"
+id = "SERVABILITY-REPLACED-PER-PULL-REQUEST"
 
 [[env.preview.ratelimits]]
 name = "LOOKUP_LIMITER"


### PR DESCRIPTION
Staging began answering `/ucan/` with `D1 DB is overloaded. Requests queued for too long` under ordinary sync traffic, and every `/provider/add` failed with it — so a shared space was never provisioned, its sync was refused with `not provisioned`, and the person following the invite hit "you do not have access to this space". The cause is that the provisioning gate queries control D1 on **every** presign: ~2,300 metered invocations in one staging hour, peaking at 37/sec, each one a `SELECT_SERVABILITY` — against a database whose own config still promises "the presign path never touches it".

`plan/Access metering.md` §11 always specified the missing tier, so this builds it: the gate resolves through an isolate cache, then a new `SERVABILITY_KV` namespace, and reaches D1 only on a miss, writing the derived verdict back under an absolute `not_after` — generous for a serving verdict (5 min), short for a denial (30 s), jittered so expiry doesn't cluster into a synchronized D1 read storm. A KV read *error* serves rather than refuses, per the plan; a *miss* is not an answer (KV is eventually consistent) and falls through to authoritative D1.

Rather than invalidating by deletion and eating a D1 read, the registration commands propagate their own effect: after the D1 commit, `/provider/add` writes the consumer's fresh verdict, and `/customer/enroll` / `/customer/activate` write the customer's and every consumer it funds. The KV race this invites — a slow stale write landing over a fresh one — is bounded by the short denial validity, which is the plan's own mitigation. Deprovisioning deletes the key instead, forcing the next presign through D1 while the purge is in flight. The operator commands (suspend/resume/archive) don't name their consumer in the answer and ride out the validity window.

The staging and production namespaces are minted and bound; previews mint `tonk-access-servability-pr-N` the same way revocations are. A deployment without the binding degrades to today's per-request D1 reads rather than refusing.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a caching mechanism for servability verdicts in the `tonk-access-service`, enhancing performance by reducing the number of direct queries to the control database. It implements an isolate cache and modifies various handlers to utilize this caching.

### Detailed summary
- Added `cache` module for caching servability verdicts.
- Updated `provisioning.rs` to implement cache logic for querying verdicts.
- Modified `deletion.rs` and `registration.rs` to handle verdict replication and deletion.
- Enhanced `ucan.rs` with caching logic for verdicts and added error handling.
- Updated configuration files to include new `SERVABILITY_KV` binding.
- Introduced `CachedVerdict` struct for managing cached verdicts with validity and jitter.
- Implemented tests for caching behavior and verdict handling in `cache.rs`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->