### PR TITLE
Serve the customer probe and email lookup from KV

### DIFF
--- a/rust/tonk-access-service/src/handlers/deletion.rs
+++ b/rust/tonk-access-service/src/handlers/deletion.rs
@@ -47,6 +47,12 @@ pub async fn handle_customer(body: &[u8], env: &worker::Env) -> worker::Result<w
         match crate::deletion::delete_customer(&store, &purger, body, now).await {
             Ok(receipt) => {
                 forget_verdict(&receipt.customer, env).await;
+                // The customer-row replica goes with it; the address
+                // key is unreachable from the DID once the row is gone
+                // and rides out its own validity instead.
+                if let Some(kv) = crate::handlers::ucan::servability_kv(env) {
+                    crate::store::replica::forget(&kv, &receipt.customer).await;
+                }
                 Ok(serde_json::to_value(receipt).expect("receipt serializes"))
             }
             Err(error) => Err(error),

--- a/rust/tonk-access-service/src/handlers/lookup.rs
+++ b/rust/tonk-access-service/src/handlers/lookup.rs
@@ -49,8 +49,9 @@ pub async fn handle(_req: Request, _ctx: RouteContext<()>) -> worker::Result<Res
 /// twin above, and the helpers server for the native implementation).
 #[cfg(target_arch = "wasm32")]
 pub async fn handle(req: Request, ctx: RouteContext<()>) -> worker::Result<Response> {
-    use crate::lookup::{address_from_segments, customer_did, resolve};
+    use crate::lookup::{address_from_segments, customer_did, found_of};
     use crate::store::d1::D1Store;
+    use crate::store::{Store, replica};
     use worker::Cache;
 
     // A cached answer skips both the limiter and D1. That is the right
@@ -92,14 +93,6 @@ pub async fn handle(req: Request, ctx: RouteContext<()>) -> worker::Result<Respo
         return not_found();
     };
 
-    let store = match ctx.env.d1("CONTROL") {
-        Ok(database) => D1Store::new(database),
-        Err(err) => {
-            worker::console_error!("email lookup unavailable, no CONTROL binding: {err}");
-            return with_cors(Response::error("Customer registry is not configured", 500));
-        }
-    };
-
     let url = req.url()?;
     let host = url.host_str().map(ToString::to_string).unwrap_or_default();
     let origin = url.origin().ascii_serialization();
@@ -107,8 +100,45 @@ pub async fn handle(req: Request, ctx: RouteContext<()>) -> worker::Result<Respo
         return not_found();
     };
 
-    match resolve(&store, &did, &address, &origin).await {
-        Ok(Some(found)) => {
+    // The replica answers the poll phases HTTP caching cannot hold —
+    // an address not yet registered, a registration awaiting its email
+    // — so waiting on either stops being a D1 read per poll. A fresh
+    // record, present or recorded-absent, is the answer; anything else
+    // falls through to D1 and backfills.
+    let now = worker::Date::now().as_millis() / 1_000;
+    let kv = crate::handlers::ucan::servability_kv(&ctx.env);
+    let cached = match &kv {
+        Some(kv) => replica::load(kv, &replica::email_key(&address), now).await,
+        None => None,
+    };
+    let customer = match cached {
+        Some(cached) => cached.customer,
+        None => {
+            let store = match ctx.env.d1("CONTROL") {
+                Ok(database) => D1Store::new(database),
+                Err(err) => {
+                    worker::console_error!("email lookup unavailable, no CONTROL binding: {err}");
+                    return with_cors(Response::error("Customer registry is not configured", 500));
+                }
+            };
+            match store.customer_by_email(&address).await {
+                Ok(row) => {
+                    if let Some(kv) = &kv {
+                        replica::backfill(kv, &replica::email_key(&address), row.clone(), now)
+                            .await;
+                    }
+                    row
+                }
+                Err(err) => {
+                    worker::console_error!("email lookup failed: {err}");
+                    return with_cors(Response::error("Customer registry is unavailable", 500));
+                }
+            }
+        }
+    };
+
+    match customer.map(|customer| found_of(&did, &customer, &origin)) {
+        Some(found) => {
             let body = serde_json::to_string_pretty(&found.document)
                 .map_err(|error| worker::Error::RustError(error.to_string()))?;
             let response = Response::ok(body)?.with_status(found.status).with_headers({
@@ -132,11 +162,7 @@ pub async fn handle(req: Request, ctx: RouteContext<()>) -> worker::Result<Respo
             }
             Ok(response)
         }
-        Ok(None) => not_found(),
-        Err(err) => {
-            worker::console_error!("email lookup failed: {err}");
-            with_cors(Response::error("Customer registry is unavailable", 500))
-        }
+        None => not_found(),
     }
 }
 

--- a/rust/tonk-access-service/src/handlers/registration.rs
+++ b/rust/tonk-access-service/src/handlers/registration.rs
@@ -94,26 +94,42 @@ async fn replicate_verdicts(answer: &crate::registration::Answer, env: &Env) {
         // out the cached verdict's validity instead.
         Answer::Done => return,
     };
-    let mut subjects = vec![customer.clone()];
-    match env.d1("CONTROL") {
-        Ok(control) => match D1Store::new(control)
-            .subscriptions_by_provider(&customer)
-            .await
-        {
-            Ok(subscriptions) => subjects.extend(
-                subscriptions
-                    .into_iter()
-                    .map(|subscription| subscription.consumer)
-                    .filter(|consumer| *consumer != customer),
-            ),
-            Err(err) => {
-                worker::console_error!("verdicts for {customer}'s consumers not refreshed: {err}");
-            }
-        },
-        Err(err) => worker::console_error!("verdicts not refreshed, no CONTROL binding: {err}"),
-    }
     let kv = servability_kv(env);
     let now = Date::now().as_millis() / 1_000;
+    let mut subjects = vec![customer.clone()];
+    match env.d1("CONTROL") {
+        Ok(control) => {
+            let store = D1Store::new(control);
+            match store.subscriptions_by_provider(&customer).await {
+                Ok(subscriptions) => subjects.extend(
+                    subscriptions
+                        .into_iter()
+                        .map(|subscription| subscription.consumer)
+                        .filter(|consumer| *consumer != customer),
+                ),
+                Err(err) => {
+                    worker::console_error!(
+                        "verdicts for {customer}'s consumers not refreshed: {err}"
+                    );
+                }
+            }
+            // The row itself, for the probe and the email lookup: both
+            // poll it, and the write-through is how a poll notices the
+            // enrollment or activation that just happened.
+            if let Some(kv) = &kv {
+                match store.customer(&customer).await {
+                    Ok(Some(row)) => crate::store::replica::replicate(kv, &row, now).await,
+                    Ok(None) => {}
+                    Err(err) => {
+                        worker::console_error!(
+                            "customer replica for {customer} not written: {err}"
+                        );
+                    }
+                }
+            }
+        }
+        Err(err) => worker::console_error!("verdicts not refreshed, no CONTROL binding: {err}"),
+    }
     for subject in subjects {
         let _ = derive_verdict(&subject, now, env, kv.as_ref()).await;
     }
@@ -229,14 +245,26 @@ pub async fn handle_customer(_req: Request, _ctx: RouteContext<()>) -> worker::R
 /// body; see the native twin above).
 #[cfg(target_arch = "wasm32")]
 pub async fn handle_customer(req: Request, ctx: RouteContext<()>) -> worker::Result<Response> {
-    use tonk_account::customer::{CustomerStatus, Receipt};
-
     use crate::store::Store;
     use crate::store::d1::D1Store;
+    use crate::store::replica;
 
     let Some(did) = ctx.param("did") else {
         return Response::error("Not Found", 404);
     };
+
+    // This is a poll — the enrolling client watches it for activation —
+    // so it reads the KV replica first and reaches D1 only on a miss,
+    // backfilling what it finds. Enrollment and activation write the
+    // replica through, which is how the poll notices them.
+    let now = worker::Date::now().as_millis() / 1_000;
+    let kv = super::ucan::servability_kv(&ctx.env);
+    if let Some(kv) = &kv
+        && let Some(cached) = replica::load(kv, &replica::did_key(did), now).await
+    {
+        return answer_probe(cached.customer, &req);
+    }
+
     let store = match ctx.env.d1("CONTROL") {
         Ok(database) => D1Store::new(database),
         Err(err) => {
@@ -245,7 +273,29 @@ pub async fn handle_customer(req: Request, ctx: RouteContext<()>) -> worker::Res
         }
     };
     match store.customer(did).await {
-        Ok(Some(customer)) => {
+        Ok(row) => {
+            if let Some(kv) = &kv {
+                replica::backfill(kv, &replica::did_key(did), row.clone(), now).await;
+            }
+            answer_probe(row, &req)
+        }
+        Err(err) => {
+            worker::console_error!("customer probe failed: {err}");
+            Response::error("Customer registry is unavailable", 500)
+        }
+    }
+}
+
+/// The probe's answer for a customer row, or for its absence.
+#[cfg(target_arch = "wasm32")]
+fn answer_probe(
+    customer: Option<crate::store::Customer>,
+    req: &Request,
+) -> worker::Result<Response> {
+    use tonk_account::customer::{CustomerStatus, Receipt};
+
+    match customer {
+        Some(customer) => {
             let receipt = Receipt {
                 customer: customer.account.parse().map_err(|err| {
                     worker::Error::RustError(format!("stored customer did is malformed: {err:?}"))
@@ -267,14 +317,10 @@ pub async fn handle_customer(req: Request, ctx: RouteContext<()>) -> worker::Res
             };
             Response::from_json(&receipt)
         }
-        Ok(None) => {
+        None => {
             let refusal = RegistrationError::UnknownCustomer;
             let response = Response::from_json(&serde_json::json!({ "error": refusal }))?;
             Ok(response.with_status(refusal.status()))
-        }
-        Err(err) => {
-            worker::console_error!("customer probe failed: {err}");
-            Response::error("Customer registry is unavailable", 500)
         }
     }
 }

--- a/rust/tonk-access-service/src/lookup.rs
+++ b/rust/tonk-access-service/src/lookup.rs
@@ -134,6 +134,17 @@ pub struct Found {
     pub status: u16,
 }
 
+/// The answer for a customer row, whichever store it was read from:
+/// the document built for `did` at `origin`, with the status its state
+/// fixes.
+pub fn found_of(did: &str, customer: &crate::store::Customer, origin: &str) -> Found {
+    let suspended = customer.status == CustomerStatus::Suspended;
+    Found {
+        document: customer_document(did, customer, suspended, origin),
+        status: status_of(customer.status),
+    }
+}
+
 /// Resolve `address` against `store`, building the document for `did`.
 ///
 /// `Ok(None)` when no customer holds the address, which the caller
@@ -148,11 +159,7 @@ pub async fn resolve<S: Store>(
     let Some(customer) = store.customer_by_email(address).await? else {
         return Ok(None);
     };
-    let suspended = customer.status == CustomerStatus::Suspended;
-    Ok(Some(Found {
-        document: customer_document(did, &customer, suspended, origin),
-        status: status_of(customer.status),
-    }))
+    Ok(Some(found_of(did, &customer, origin)))
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]

--- a/rust/tonk-access-service/src/store.rs
+++ b/rust/tonk-access-service/src/store.rs
@@ -41,7 +41,11 @@ pub fn parse_status(value: &str) -> Result<CustomerStatus, StoreError> {
 
 /// A billable party, keyed by the DID that also names its account
 /// consumer.
-#[derive(Debug, Clone)]
+///
+/// Serde is for the KV replica ([`replica`]): the row travels there as
+/// itself, so the probe and the email lookup answer from KV exactly
+/// what D1 would have said.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Customer {
     /// The account this subscription is for.
     pub account: String,
@@ -565,6 +569,8 @@ DELETE FROM customer
 "#;
 
 pub mod ingest;
+
+pub mod replica;
 
 #[cfg(all(feature = "helpers", not(target_arch = "wasm32")))]
 pub mod sqlite;

--- a/rust/tonk-access-service/src/store/replica.rs
+++ b/rust/tonk-access-service/src/store/replica.rs
@@ -1,0 +1,246 @@
+//! KV replica of the customer row, so the registration probe and the
+//! email lookup answer without reading control D1 per request.
+//!
+//! Both endpoints answer from the same fact — the `customer` row — read
+//! by account DID (`GET /customer/:did`) or by address
+//! (`GET /customer/:domain/:local/did.json`), and both are polled: an
+//! enrolling client watches the probe for activation, an invite flow
+//! watches the lookup for the address it just invited. Neither answer
+//! is HTTP-cacheable while it is the one being waited on, so before
+//! this replica every poll was a D1 read.
+//!
+//! The row is replicated under both access paths at the same points
+//! that commit it to D1 — enrollment and activation write it through,
+//! customer deletion drops the DID key — and the read path backfills on
+//! a miss. The record rarely changes once activated, so an `Active` row
+//! carries generous validity; a `Registered` row is exactly what a
+//! poller is waiting to see change, and an absent row is what an invite
+//! flow polls through, so both stay short. `not_after` is absolute and
+//! inside the value, like the servability verdicts': KV's own expiry
+//! (minimum 60 seconds) is only garbage collection.
+
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+use serde::{Deserialize, Serialize};
+use tonk_account::customer::CustomerStatus;
+
+use crate::email::normalize_email;
+use crate::store::Customer;
+
+/// The value shape this build writes and accepts; any other version
+/// reads as a miss.
+const VERSION: u32 = 1;
+
+/// How long an `Active` (or `Suspended`) row stands, in seconds. These
+/// change through commands that rewrite the replica, so validity only
+/// bounds how long a write this service never saw — a manual D1 edit, a
+/// missed write-through — goes unnoticed.
+const SETTLED_VALIDITY: u64 = 300;
+
+/// How long a `Registered` row or a known-absent answer stands, in
+/// seconds. Both are the states polls wait through: activation and
+/// enrollment rewrite the replica when they land, but only in the colo
+/// that served them, so a short validity caps how stale another colo
+/// can stay.
+const UNSETTLED_VALIDITY: u64 = 30;
+
+/// A remembered customer-row read: the row, or its recorded absence.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CachedCustomer {
+    /// Value-shape version; see [`VERSION`].
+    pub v: u32,
+    /// Absolute expiry: a reader at or past this moment revalidates.
+    pub not_after: u64,
+    /// The row as D1 answered it; `None` records that no customer
+    /// holds the asked-for key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub customer: Option<Customer>,
+}
+
+impl CachedCustomer {
+    /// Record a row read at `now`, with validity for its state.
+    pub fn record(customer: Option<Customer>, seed: &str, now: u64) -> Self {
+        let base = match &customer {
+            Some(customer) if customer.status != CustomerStatus::Registered => SETTLED_VALIDITY,
+            _ => UNSETTLED_VALIDITY,
+        };
+        Self {
+            v: VERSION,
+            not_after: now + base + jitter(seed, now, base / 5),
+            customer,
+        }
+    }
+
+    /// Whether this record may still be used at `now`.
+    pub fn fresh(&self, now: u64) -> bool {
+        now < self.not_after
+    }
+
+    /// The record as its stored JSON.
+    pub fn encode(&self) -> String {
+        serde_json::to_string(self).expect("customer record serializes")
+    }
+
+    /// Read a stored value back; `None` — a miss — for anything this
+    /// build does not recognize.
+    pub fn decode(text: &str) -> Option<Self> {
+        serde_json::from_str::<Self>(text)
+            .ok()
+            .filter(|cached| cached.v == VERSION)
+    }
+
+    /// Seconds the backing store should retain this value. At least
+    /// KV's 60-second minimum; `not_after` inside the value governs.
+    pub fn retention(&self, now: u64) -> u64 {
+        (self.not_after.saturating_sub(now)).max(60)
+    }
+}
+
+/// The KV key for the row read by account DID.
+pub fn did_key(did: &str) -> String {
+    format!("customer/{did}")
+}
+
+/// The KV key for the row read by email address, normalized so two
+/// spellings of one address share an entry.
+pub fn email_key(address: &str) -> String {
+    format!("address/{}", normalize_email(address))
+}
+
+/// Read a fresh record from KV. `None` on a miss, a stale or
+/// unrecognized value, or a read error — all of which the caller
+/// answers by falling through to D1, exactly as it did before the
+/// replica existed.
+#[cfg(target_arch = "wasm32")]
+pub async fn load(kv: &worker::kv::KvStore, key: &str, now: u64) -> Option<CachedCustomer> {
+    match kv.get(key).text().await {
+        Ok(Some(text)) => CachedCustomer::decode(&text).filter(|cached| cached.fresh(now)),
+        Ok(None) => None,
+        Err(err) => {
+            worker::console_error!("customer replica unreadable at {key}: {err}");
+            None
+        }
+    }
+}
+
+/// Record what D1 answered for the asked-for key. A present row is
+/// written under both its access paths — the probe's DID key and the
+/// lookup's address key — so either endpoint warms the other; a
+/// recorded absence is a fact only about the key that was asked.
+/// Best-effort: a failed write costs at most one more D1 read.
+#[cfg(target_arch = "wasm32")]
+pub async fn backfill(kv: &worker::kv::KvStore, asked: &str, customer: Option<Customer>, now: u64) {
+    match customer {
+        Some(customer) => replicate(kv, &customer, now).await,
+        None => {
+            let record = CachedCustomer::record(None, asked, now);
+            save(kv, asked, &record, now).await;
+        }
+    }
+}
+
+/// Write the row through under both its keys. Called by the read path
+/// on a backfill and by the registration commands after their D1
+/// commit, so a state change propagates as itself.
+#[cfg(target_arch = "wasm32")]
+pub async fn replicate(kv: &worker::kv::KvStore, customer: &Customer, now: u64) {
+    let record = CachedCustomer::record(Some(customer.clone()), &customer.account, now);
+    save(kv, &did_key(&customer.account), &record, now).await;
+    save(kv, &email_key(&customer.email), &record, now).await;
+}
+
+/// Drop the DID key, forcing the next probe through authoritative D1.
+/// The address key is not reachable from a DID alone once the row is
+/// gone; it rides out its own validity instead.
+#[cfg(target_arch = "wasm32")]
+pub async fn forget(kv: &worker::kv::KvStore, did: &str) {
+    if let Err(err) = kv.delete(&did_key(did)).await {
+        worker::console_error!("customer replica for {did} not dropped: {err}");
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn save(kv: &worker::kv::KvStore, key: &str, record: &CachedCustomer, now: u64) {
+    let write = kv
+        .put(key, record.encode())
+        .map(|put| put.expiration_ttl(record.retention(now)));
+    let written = match write {
+        Ok(put) => put.execute().await.map_err(|err| err.to_string()),
+        Err(err) => Err(err.to_string()),
+    };
+    if let Err(err) = written {
+        worker::console_error!("customer replica at {key} not written: {err}");
+    }
+}
+
+/// Deterministic spread in `0..=range`, so records written together do
+/// not all expire together.
+fn jitter(seed: &str, now: u64, range: u64) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    seed.hash(&mut hasher);
+    now.hash(&mut hasher);
+    match range {
+        0 => 0,
+        range => hasher.finish() % (range + 1),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn customer(status: CustomerStatus) -> Customer {
+        Customer {
+            account: "did:key:zAlice".into(),
+            email: "alice@example.com".into(),
+            ledger: None,
+            status,
+            plan: "trial".into(),
+            verified_at: 7,
+            terms_version: Some("1".into()),
+        }
+    }
+
+    #[test]
+    fn it_round_trips_a_row_and_its_absence() {
+        let present = CachedCustomer::record(Some(customer(CustomerStatus::Active)), "k", 1_000);
+        assert_eq!(CachedCustomer::decode(&present.encode()), Some(present));
+        let absent = CachedCustomer::record(None, "k", 1_000);
+        let decoded = CachedCustomer::decode(&absent.encode()).expect("decodes");
+        assert_eq!(decoded.customer, None);
+    }
+
+    #[test]
+    fn it_keeps_unsettled_states_short() {
+        let active = CachedCustomer::record(Some(customer(CustomerStatus::Active)), "k", 1_000);
+        let registered =
+            CachedCustomer::record(Some(customer(CustomerStatus::Registered)), "k", 1_000);
+        let absent = CachedCustomer::record(None, "k", 1_000);
+        assert!(registered.not_after < active.not_after);
+        assert!(absent.not_after < active.not_after);
+        assert!(!registered.fresh(1_000 + UNSETTLED_VALIDITY + UNSETTLED_VALIDITY / 5 + 1));
+        assert!(active.fresh(1_000 + UNSETTLED_VALIDITY + UNSETTLED_VALIDITY / 5 + 1));
+    }
+
+    #[test]
+    fn it_treats_an_unknown_version_as_a_miss() {
+        let mut recorded = CachedCustomer::record(None, "k", 1_000);
+        recorded.v = VERSION + 1;
+        assert_eq!(CachedCustomer::decode(&recorded.encode()), None);
+        assert_eq!(CachedCustomer::decode("not json"), None);
+    }
+
+    #[test]
+    fn it_normalizes_the_address_key() {
+        assert_eq!(
+            email_key("Alice@Example.COM"),
+            email_key("alice@example.com")
+        );
+    }
+
+    #[test]
+    fn it_retains_at_least_the_kv_minimum() {
+        let absent = CachedCustomer::record(None, "k", 1_000);
+        assert!(absent.retention(1_000) >= 60);
+    }
+}


### PR DESCRIPTION
Stacked on #851. The verdict cache took the gate off D1, but the registration polls still hit it per request: an enrolling client watches `GET /customer/:did` for activation, and the invite flow polls the email `did.json` — and both answers are deliberately `no-store` while they are the one being waited on, because the change is what the caller is waiting for. HTTP caching can never absorb that phase, so it was a D1 read per poll.

The record itself rarely changes once created and activated, so this replicates the customer row into `SERVABILITY_KV` under both of its access paths — `customer/{did}` for the probe, `address/{email}` for the lookup — at the same points that commit it to D1: enrollment and activation write it through (the write-through is precisely how a poll notices them), reads backfill on a miss and warm both keys from either, and customer deletion drops the DID key. Validity is asymmetric like the verdicts': an `Active` row stands 5 minutes, while a `Registered` row and a recorded absence stay at 30 seconds, since those are exactly the states polls wait to see change and the write-through only lands instantly in the colo that served the command.

Both handlers fall through to D1 exactly as before on a KV miss, a stale or unrecognized value, a read error, or a missing binding.
