### PR TITLE
ci(e2e): run the suite from a cachix-cached archive, quarantine the broken account flows

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,3 +6,13 @@ serial-integration = { max-threads = 1 }
 [[profile.default.overrides]]
 filter = 'test(/^.*integration_tests::/)'
 test-group = 'serial-integration'
+
+# The profile `test:e2e` runs the tonk-ui real-browser suite under, from
+# the prebuilt `tests-e2e` archive.
+[profile.e2e]
+# Every test stands up its own access service + Caddy + Chrome; two at
+# once fight over the machine, so the whole suite stays serialized.
+test-threads = 1
+# Report every failure: a fail-fast pass over an hour-long suite hides
+# everything after the first broken test.
+fail-fast = false

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -16,3 +16,29 @@ test-threads = 1
 # Report every failure: a fail-fast pass over an hour-long suite hides
 # everything after the first broken test.
 fail-fast = false
+# QUARANTINE — these account flows fail deterministically on every
+# branch since the 2026-09-01 staging merges; the extra failure waits
+# pushed the e2e job past its 60-minute timeout, so runs were killed
+# before reporting at all. Tracked in
+# https://github.com/tonk-labs/tonk/issues/852 — fix and remove; new
+# entries need a linked issue.
+default-filter = """
+not (
+    test(=account_flow::tests::it_adds_a_second_account_and_switches_between_disjoint_space_lists)
+  | test(=account_flow::tests::it_asks_the_page_for_a_passkey_assertion_when_custody_needs_the_key)
+  | test(=account_flow::tests::it_backs_up_a_claimed_space_for_another_account_device)
+  | test(=account_flow::tests::it_deletes_the_account_and_releases_its_email_and_profile)
+  | test(=account_flow::tests::it_explains_email_verification_before_account_sync)
+  | test(=account_flow::tests::it_finishes_both_waiting_devices_when_a_third_confirms)
+  | test(=account_flow::tests::it_links_the_cli_through_the_browser_callback)
+  | test(=account_flow::tests::it_links_without_being_told_the_account_service)
+  | test(=account_flow::tests::it_names_pending_activation_consistently_in_a_space)
+  | test(=account_flow::tests::it_offers_the_copy_row_once_an_account_exists)
+  | test(=account_flow::tests::it_registers_before_linking_a_cli_from_a_fresh_browser)
+  | test(=account_flow::tests::it_revokes_the_cli_device_from_the_browser)
+  | test(=account_flow::tests::it_signs_back_into_the_same_account_after_signing_out)
+  | test(=account_flow::tests::it_signs_up_through_the_account_panels)
+  | test(=account_flow::tests::it_syncs_a_local_only_space_once_sync_is_enabled)
+  | test(=account_flow::tests::it_waits_for_the_email_when_a_second_device_signs_in)
+)
+"""

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,9 +41,10 @@ jobs:
     name: 'End-to-end account tests'
     needs: ['lints']
     runs-on: 'ubuntu-latest'
-    # A cold Nix build can take ~20 minutes before the ~30-minute suite starts.
-    # Keep a bound for wedged WebDriver or network calls while leaving headroom
-    # for runner variance.
+    # A cold build of the tests-e2e archive can take ~20 minutes before the
+    # suite starts; a warm cachix hit cuts that to a download. Keep a bound
+    # for wedged WebDriver or network calls while leaving headroom for
+    # runner variance.
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/flake.nix
+++ b/flake.nix
@@ -331,8 +331,28 @@
           "test:e2e" = {
             description = "Run serialized real-browser account integration tests";
             command = ''
-              cargo build -p tonk-cli &&
-              cargo test -p tonk-ui --features integration-tests -- --test-threads=1
+              # Both installables come from the Nix store, so cachix serves
+              # them warm; rebuilding them in-place with cargo cost every CI
+              # run a from-scratch compile, since runners keep no cargo
+              # target directory between runs.
+              nix build .#tonk-cli .#tests-e2e
+
+              TONK_BIN="$(nix eval .#tonk-cli.outPath --raw)/bin/tonk"
+              export TONK_BIN
+              # The store-built CLI bakes in the release PostHog key; the
+              # debug build the suite spawned before had none. Keep test
+              # runs out of the analytics.
+              export DO_NOT_TRACK=1
+
+              TESTS_PATH="$(nix eval .#tests-e2e.outPath --raw)"
+
+              # The `e2e` profile (.config/nextest.toml) serializes the
+              # suite and holds the quarantine list of known-broken tests.
+              cargo nextest run \
+                --profile e2e \
+                --workspace-remap ./ \
+                --archive-file "$TESTS_PATH/tests-e2e.tar.zst" \
+                "$@"
             '';
           };
 
@@ -446,6 +466,15 @@
             name = "web-release";
             target = "wasm32-unknown-unknown";
             args = "--workspace --exclude tonk-cli --release";
+          };
+
+          # The real-browser suite `test:e2e` runs. Its `integration-tests`
+          # feature pulls the WebDriver stack the shared workspace artifacts
+          # never compile, hence its own dependency-only build.
+          tests-e2e = buildTestArchive {
+            name = "e2e";
+            args = "--package tonk-ui --features integration-tests";
+            depsExtraArgs = "--package tonk-ui --features integration-tests";
           };
 
           tests = pkgs.runCommand "tests-all" { } ''

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -170,11 +170,29 @@ let
       name,
       args ? "",
       target ? null,
+      # Extra cargo args for a dedicated dependency-only build. An archive
+      # whose feature set pulls dependencies the shared workspace artifacts
+      # never compile (e.g. tonk-ui's `integration-tests` WebDriver stack)
+      # names them here so they are cached across source changes instead of
+      # rebuilt inside every archive derivation.
+      depsExtraArgs ? null,
     }:
     let
       targetAttributes = if target == "wasm32-unknown-unknown" then wasmAttributes else commonAttributes;
 
-      targetArtifacts = if target == "wasm32-unknown-unknown" then wasmArtifacts else nativeArtifacts;
+      sharedArtifacts = if target == "wasm32-unknown-unknown" then wasmArtifacts else nativeArtifacts;
+
+      targetArtifacts =
+        if depsExtraArgs == null then
+          sharedArtifacts
+        else
+          craneLib.buildDepsOnly (
+            targetAttributes
+            // {
+              pname = "tonk-workspace-${name}-deps";
+              cargoExtraArgs = depsExtraArgs;
+            }
+          );
     in
     craneLib.mkCargoDerivation (
       targetAttributes

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -1874,7 +1874,11 @@ mod tests {
         let path = std::env::var_os("TONK_BIN")
             .map(PathBuf::from)
             .unwrap_or_else(|| {
-                PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                // Runtime variable first: under the `tests-e2e` archive
+                // the compile-time path names the Nix build sandbox.
+                let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+                    .unwrap_or_else(|_| env!("CARGO_MANIFEST_DIR").to_string());
+                PathBuf::from(manifest_dir)
                     .join("../..")
                     .join("target/debug/tonk")
             });

--- a/rust/tonk-ui/src/helpers.rs
+++ b/rust/tonk-ui/src/helpers.rs
@@ -260,7 +260,14 @@ mod native {
                 .ok_or_else(|| anyhow!("Access service URL has no port"))?;
             let caddy_data = std::env::temp_dir().join(format!("tonk-e2e-caddy-{web_port}"));
             std::fs::create_dir_all(&caddy_data)?;
-            let workspace = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            // The runner's variable wins over the compile-time constant:
+            // a binary out of the `tests-e2e` archive was compiled in the
+            // Nix sandbox, whose source path no longer exists, while
+            // `cargo nextest run --workspace-remap` points the runtime
+            // variable at the live checkout.
+            let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+                .unwrap_or_else(|_| env!("CARGO_MANIFEST_DIR").to_string());
+            let workspace = std::path::Path::new(&manifest_dir)
                 .parent()
                 .and_then(std::path::Path::parent)
                 .ok_or_else(|| anyhow!("tonk-ui manifest has no workspace root"))?;


### PR DESCRIPTION
## What changed

The e2e job has been flirting with its 60-minute timeout and dying there: ~18 minutes of from-scratch cargo compile (runners keep no target dir) + a 34-minute serialized suite + ~10 minutes of stacked poll-deadline waits from 16 account-flow tests that fail deterministically on every branch since the 2026-09-01 staging merges. Three staging runs in a row ([2257](https://github.com/tonk-labs/tonk/actions/runs/33490386593), [2263](https://github.com/tonk-labs/tonk/actions/runs/33527518855), [2265](https://github.com/tonk-labs/tonk/actions/runs/33533988429)) were killed at the limit and reported nothing — which is how the regression merged and stayed invisible.

Two changes, one commit each:

1. **The e2e suite now rides the same crane/nextest-archive machinery as every other test job.** A new `tests-e2e` package builds the `tonk-ui --features integration-tests` test binary in the Nix store (with its own dependency-only artifact set, since the WebDriver stack isn't in the shared workspace deps), and `test:e2e` runs it via `cargo nextest run --archive-file` under a dedicated `e2e` profile (serialized, no fail-fast — matching the old `--test-threads=1` behavior). The CLI the tests spawn comes from the cached `tonk-cli` package via `TONK_BIN`, with `DO_NOT_TRACK=1` since the store-built binary bakes in the release PostHog key the old debug build never had. cachix serves both warm, so re-runs and staging-merge runs of an already-built tree download instead of recompiling. Archived binaries carry the sandbox's compile-time `CARGO_MANIFEST_DIR`, so the harness's workspace lookup and the CLI fallback path now prefer the runtime variable nextest sets (remapped to the live checkout by `--workspace-remap`); plain `cargo test` runs are unchanged.

2. **The 16 broken tests are quarantined** via the `e2e` profile's `default-filter`, each listed exactly in `.config/nextest.toml`, so the remaining 53 tests report again instead of pushing every run past the timeout. Fixing and re-enabling them is tracked in #852 (investigation, suspect window #820/#842/#800, repro command, per-test checklist). The quarantine is its own commit so it reverts cleanly as tests get fixed. To be clear about the trade-off: this restores CI signal, it does not fix the broken account flows — #852 is the follow-up that does.

## Verification

- `cargo check -p tonk-ui --tests --features integration-tests` — passes
- `cargo fmt -p tonk-ui --check` — clean
- `.config/nextest.toml` parses under cargo-nextest 0.9.143 with `--profile e2e` (and a deliberately corrupted filter fails to parse, so the check is meaningful)
- `flake.nix` and `nix/rust.nix` pass a nix syntax parse; `nix flake check`/nixfmt could not be run in this environment — the Lints job on this PR is the authoritative check for formatting
- The full archive-path run needs a CI runner (chromedriver + Caddy + the nix store build); this PR's own e2e job exercises it end to end

## Storybook impact

- [x] No user-visible contract changed because: this touches only CI/test infrastructure (nix build packaging, the nextest profile, and test-harness path resolution); no product code path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuH1TzUwQiar2362kTvMoq

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuH1TzUwQiar2362kTvMoq)_

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `tonk` project by improving the handling of paths in the Rust code, optimizing CI configurations, and refining the test suite for integration tests. It emphasizes runtime variables and caching to improve performance.

### Detailed summary
- Updated path handling in `rust/tonk-ui/src/account_flow.rs` to prioritize runtime variables.
- Improved directory management in `rust/tonk-ui/src/helpers.rs` for workspace paths.
- Enhanced comments in `.github/workflows/test.yml` regarding build times and caching.
- Added support for dependency-only builds in `nix/rust.nix`.
- Modified the `flake.nix` to use Nix store for building and testing.
- Introduced a dedicated `tests-e2e` build for integration tests in `flake.nix`.
- Updated `.config/nextest.toml` with new test profiling and quarantine settings for known failures.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->