### PR TITLE
Read space provisioning from the account db, not per share

### DIFF
--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -63,6 +63,20 @@ concept!: &space
       the: xyz.tonk.space/local
       cardinality: one
       as: boolean
+    provider:
+      description: >
+        The account providing this space with the access service. Its
+        presence records that the space is provisioned (its remote is
+        served): `/provider/add` runs when the upstream is attached,
+        never per share, and this fact is what a share consults. The
+        sync engine retracts it when the service answers that the
+        subject is no longer served, returning the space to local-only.
+        The value is the providing account's DID entity — identical
+        from every replica, so the record converges where per-device
+        timestamps would not.
+      the: xyz.tonk.space/provider
+      cardinality: one
+      as: entity
 
 # The Add Space command. Asserted by the Hub's two create forms (the bar's
 # `new space` rung and the stack's ghost) and by the FAB's `new` row; the

--- a/rust/tonk-schema/src/domain.rs
+++ b/rust/tonk-schema/src/domain.rs
@@ -82,6 +82,18 @@ pub mod space {
     #[cardinality(one)]
     pub struct Local(pub bool);
 
+    /// The account providing this space with the access service. Its
+    /// PRESENCE is the record that the space is provisioned; the sync
+    /// engine retracts it when the service answers that the subject is
+    /// no longer served, returning the row to local-only. The value is
+    /// the providing account's DID entity — stable across replicas, so
+    /// every device asserts the identical fact and the record converges
+    /// (a timestamp here would give each writer its own value).
+    #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    #[domain("xyz.tonk.space")]
+    #[cardinality(one)]
+    pub struct Provider(pub Entity);
+
     /// The space's display name, mirrored into the account directory
     /// (the content-branch copy stays the editable source of truth) so
     /// every device can label a space it has not replicated yet.

--- a/rust/tonk-schema/src/replica.rs
+++ b/rust/tonk-schema/src/replica.rs
@@ -165,6 +165,37 @@ impl SpaceName {
     }
 }
 
+/// The account currently providing this space with the access
+/// service, on the directory entity.
+///
+/// Its presence IS the provisioned state: `/provider/add` succeeded
+/// for this subject, so its remote is served and a share can skip the
+/// provisioning ceremony. The sync engine retracts it when the gate
+/// answers that the subject is no longer served (a `Declined` refusal
+/// retrying cannot clear), which returns the space to local-only.
+///
+/// The value is the providing ACCOUNT's DID entity rather than a
+/// timestamp: every replica that observes the provisioning asserts the
+/// identical fact, so the record converges, where per-writer
+/// timestamps would give each device its own value.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SpaceProvider {
+    /// The repository's own entity — the directory entity.
+    pub this: Entity,
+    /// The account (customer) whose registration serves this space.
+    pub provider: crate::domain::space::Provider,
+}
+
+impl SpaceProvider {
+    /// Record that `provider` provides `subject`.
+    pub fn new(subject: &Did, provider: &Did) -> Self {
+        Self {
+            this: subject.this(),
+            provider: crate::domain::space::Provider(provider.this()),
+        }
+    }
+}
+
 /// Who founded a space and when, on the directory entity.
 ///
 /// Founding is distinct from mounting: [`record_space_mount`] runs for
@@ -517,6 +548,14 @@ impl Replica {
     /// The `status` value for a temporarily unavailable service.
     pub fn unavailable_status() -> SyncStatusAttr {
         SyncStatusAttr(Self::UNAVAILABLE.parse().expect("sync:unavailable parses"))
+    }
+
+    /// The `status` value for a local-only space. Also published when
+    /// the service answers that the subject is no longer served — a
+    /// remote nothing will serve is a remote in name only, and `local`
+    /// is what drives the connect affordance that re-provisions it.
+    pub fn local_status() -> SyncStatusAttr {
+        SyncStatusAttr(Self::LOCAL.parse().expect("sync:local parses"))
     }
 
     /// Map a head-comparison [`SyncState`](crate::SyncState) to the

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -3280,32 +3280,45 @@ mod tests {
 
     /// Type into the row named `noun` and commit it with Enter.
     async fn type_into_settled_row(driver: &WebDriver, noun: &str, value: &str) -> Result<()> {
-        let outcome = driver
-            .execute_async(
-                r##"
-                const done = arguments[arguments.length - 1];
-                const [noun, value] = [arguments[0], arguments[1]];
-                for (const row of document.querySelectorAll("#tonk-register .orow")) {
-                    const k = row.querySelector(".k");
-                    if (!k || k.textContent.trim() !== noun) continue;
-                    const input = row.querySelector("input");
-                    if (!input) return done({ error: noun + " row takes no input" });
-                    input.focus();
-                    input.value = value;
-                    input.dispatchEvent(new Event("input", { bubbles: true }));
-                    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
-                    return done({ ok: true });
+        // The row unfolds a beat after the step before it settles — the
+        // ceremony reads the account summary between "email · verified"
+        // and asking for a name — so an absent row is waited out rather
+        // than failed on the first look.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        loop {
+            let outcome = driver
+                .execute_async(
+                    r##"
+                    const done = arguments[arguments.length - 1];
+                    const [noun, value] = [arguments[0], arguments[1]];
+                    for (const row of document.querySelectorAll("#tonk-register .orow")) {
+                        const k = row.querySelector(".k");
+                        if (!k || k.textContent.trim() !== noun) continue;
+                        const input = row.querySelector("input");
+                        if (!input) return done({ error: noun + " row takes no input" });
+                        input.focus();
+                        input.value = value;
+                        input.dispatchEvent(new Event("input", { bubbles: true }));
+                        input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+                        return done({ ok: true });
+                    }
+                    done({ error: "no row named " + noun });
+                    "##,
+                    vec![serde_json::json!(noun), serde_json::json!(value)],
+                )
+                .await?;
+            let outcome = outcome.json().clone();
+            match outcome.get("error").and_then(|error| error.as_str()) {
+                None => return Ok(()),
+                Some(error) if error.starts_with("no row named") => {
+                    if tokio::time::Instant::now() >= deadline {
+                        return Err(anyhow!("could not fill the {noun:?} row: {error}"));
+                    }
+                    tokio::time::sleep(Duration::from_millis(250)).await;
                 }
-                done({ error: "no row named " + noun });
-                "##,
-                vec![serde_json::json!(noun), serde_json::json!(value)],
-            )
-            .await?;
-        let outcome = outcome.json().clone();
-        if let Some(error) = outcome.get("error").and_then(|error| error.as_str()) {
-            return Err(anyhow!("could not fill the {noun:?} row: {error}"));
+                Some(error) => return Err(anyhow!("could not fill the {noun:?} row: {error}")),
+            }
         }
-        Ok(())
     }
 
     /// Wait for the narrator to say something containing `fragment`.

--- a/rust/tonk-worker/src/router/account_state.rs
+++ b/rust/tonk-worker/src/router/account_state.rs
@@ -2079,6 +2079,81 @@ mod tests {
         discard(state, &ready.key);
     }
 
+    /// The account db's record of a provisioned space, round-tripped:
+    /// recording a provider makes the `SpaceProvider` fact present —
+    /// what lets a share skip `/provider/add` — and retraction (what
+    /// the sync engine does when the gate stops serving the subject)
+    /// returns the space to local-only. Both write the ACCOUNT's did as
+    /// the value, so every replica asserts the identical fact.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[dialog_common::test]
+    async fn it_records_and_retracts_the_space_provider() {
+        use tonk_schema::SpaceProvider;
+
+        let (state, service, _root, _remote) = ready_account_state(None).await;
+        assert_eq!(
+            ensure_account_state(&state).await,
+            AccountStateStatus::Ready
+        );
+        let ready = require_ready_account_state(&state).await.unwrap();
+        let account = super::super::identity::root_did(&state).await.unwrap();
+        let space: dialog_varsig::Did = "did:key:z6MknYwGXCDLuJnBUR4bbWFPiD2Saos16CHQQ2ex6U1Ti2t"
+            .parse()
+            .unwrap();
+
+        async fn recorded(
+            state: &crate::worker::TonkState,
+            space: &dialog_varsig::Did,
+        ) -> Vec<SpaceProvider> {
+            let branch = state
+                .reactor
+                .profile_repository()
+                .branch(tonk_account::MAIN_BRANCH)
+                .acquire(&state.operator)
+                .await
+                .unwrap();
+            branch
+                .handle()
+                .query()
+                .select(Query::<SpaceProvider> {
+                    this: Term::from(space.this()),
+                    provider: Term::var("provider"),
+                })
+                .perform(&state.operator)
+                .try_vec()
+                .await
+                .unwrap()
+        }
+
+        assert!(
+            recorded(&state, &space).await.is_empty(),
+            "a fresh space records no provider"
+        );
+
+        super::super::customer::record_space_provider(&state, &space).await;
+        let rows = recorded(&state, &space).await;
+        assert_eq!(rows.len(), 1, "provisioning records the provider");
+        assert_eq!(
+            rows[0].provider.0,
+            account.this(),
+            "the value is the providing account"
+        );
+
+        // Re-recording converges rather than accumulating: the value is
+        // the account did, identical from every writer.
+        super::super::customer::record_space_provider(&state, &space).await;
+        assert_eq!(recorded(&state, &space).await.len(), 1);
+
+        super::super::customer::retract_space_provider(&state, &space).await;
+        assert!(
+            recorded(&state, &space).await.is_empty(),
+            "retraction returns the space to local-only"
+        );
+
+        service.stop().await.unwrap();
+        discard(state, &ready.key);
+    }
+
     /// The registering browser's whole wait, end to end: enrolled and
     /// refused, activated somewhere else, noticed at the FIRST sweep the
     /// gate serves. Every other test here starts `Active` with the

--- a/rust/tonk-worker/src/router/customer.rs
+++ b/rust/tonk-worker/src/router/customer.rs
@@ -675,14 +675,148 @@ pub(crate) async fn provision_consumer(
         })?;
     let origin = service_origin()?;
     match post_cbor(&ucan_endpoint(&origin)?, &body).await {
-        Ok(_) => Ok(()),
+        Ok(_) => {
+            record_space_provider(state, consumer).await;
+            Ok(())
+        }
         Err(HttpError::Upstream(failure))
             if failure.code.as_deref() == Some("ConsumerProvided") =>
         {
+            // Another customer provides it — the space is served, but
+            // not under this account, so there is nothing to record.
             log!("consumer {consumer} already has a provider; leaving it");
             Ok(())
         }
         Err(error) => Err(error.into()),
+    }
+}
+
+/// Record that this account provides `consumer`, on the space's
+/// directory entity in the account db. The write side of the fact
+/// [`space_provider_recorded`] reads: its presence is what lets a share
+/// skip the `/provider/add` ceremony. Best-effort — provisioning stands
+/// in D1 whether or not the fact records it, and the next share heals a
+/// missing row by provisioning again.
+pub(crate) async fn record_space_provider(
+    state: &crate::worker::TonkState,
+    consumer: &dialog_varsig::Did,
+) {
+    use tonk_schema::SpaceProvider;
+
+    let Ok(account) = super::identity::root_did(state).await else {
+        return;
+    };
+    if let Err(error) = state
+        .reactor
+        .profile_repository()
+        .branch(tonk_account::MAIN_BRANCH)
+        .transaction()
+        .assert(SpaceProvider::new(consumer, &account))
+        .commit()
+        .perform(&state.operator)
+        .await
+    {
+        log!("space provider for {consumer} not recorded: {error}");
+    }
+}
+
+/// Drop the record that this account provides `consumer` — the space is
+/// back to local-only. Called when deprovisioning succeeds and when the
+/// sync engine observes the gate refusing the subject with a denial
+/// retrying cannot clear. Best-effort, like the record.
+pub(crate) async fn retract_space_provider(
+    state: &crate::worker::TonkState,
+    consumer: &dialog_varsig::Did,
+) {
+    use dialog_query::{Output as _, Query, Term};
+    use tonk_schema::{SpaceProvider, prelude::DidExt as _};
+
+    let branch = match state
+        .reactor
+        .profile_repository()
+        .branch(tonk_account::MAIN_BRANCH)
+        .acquire(&state.operator)
+        .await
+    {
+        Ok(branch) => branch,
+        Err(error) => {
+            log!("space provider for {consumer} not read: {error}");
+            return;
+        }
+    };
+    let recorded: Vec<SpaceProvider> = match branch
+        .handle()
+        .query()
+        .select(Query::<SpaceProvider> {
+            this: Term::from(consumer.this()),
+            provider: Term::var("provider"),
+        })
+        .perform(&state.operator)
+        .try_vec()
+        .await
+    {
+        Ok(rows) => rows,
+        Err(error) => {
+            log!("space provider for {consumer} not read: {error}");
+            return;
+        }
+    };
+    for row in recorded {
+        if let Err(error) = branch
+            .handle()
+            .transaction()
+            .retract(row)
+            .commit()
+            .perform(&state.operator)
+            .await
+        {
+            log!("space provider for {consumer} not retracted: {error}");
+        }
+    }
+}
+
+/// Whether the account db records a provider for `consumer` — the read
+/// a share consults instead of running `/provider/add` per click.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) async fn space_provider_recorded(
+    state: &crate::worker::TonkState,
+    consumer: &dialog_varsig::Did,
+) -> bool {
+    use dialog_query::{Output as _, Query, Term};
+    use tonk_schema::{SpaceProvider, prelude::DidExt as _};
+
+    let branch = match state
+        .reactor
+        .profile_repository()
+        .branch(tonk_account::MAIN_BRANCH)
+        .acquire(&state.operator)
+        .await
+    {
+        Ok(branch) => branch,
+        Err(error) => {
+            log!("space provider for {consumer} not read: {error}");
+            return false;
+        }
+    };
+    match branch
+        .handle()
+        .query()
+        .select(Query::<SpaceProvider> {
+            this: Term::from(consumer.this()),
+            provider: Term::var("provider"),
+        })
+        .perform(&state.operator)
+        .try_vec()
+        .await
+    {
+        Ok(rows) => {
+            let rows: Vec<SpaceProvider> = rows;
+            !rows.is_empty()
+        }
+        Err(error) => {
+            log!("space provider for {consumer} not read: {error}");
+            false
+        }
     }
 }
 
@@ -706,6 +840,7 @@ pub(crate) async fn deprovision_consumer(
             TonkWorkerError::Internal(format!("failed to build the remove invocation: {error}"))
         })?;
     post_cbor(&ucan_endpoint(origin)?, &body).await?;
+    retract_space_provider(state, consumer).await;
     Ok(())
 }
 

--- a/rust/tonk-worker/src/router/customer.rs
+++ b/rust/tonk-worker/src/router/customer.rs
@@ -676,7 +676,13 @@ pub(crate) async fn provision_consumer(
     let origin = service_origin()?;
     match post_cbor(&ucan_endpoint(&origin)?, &body).await {
         Ok(_) => {
-            record_space_provider(state, consumer).await;
+            // Only a SPACE lands in the directory. A custody namespace
+            // is provisioned through the same command, but it is not a
+            // directory row, and stamping one would hang provider facts
+            // on an entity nothing lists.
+            if matches!(kind, None | Some("space")) {
+                record_space_provider(state, consumer).await;
+            }
             Ok(())
         }
         Err(HttpError::Upstream(failure))

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -1074,14 +1074,22 @@ async fn run_invite(
     // A share is a promise the recipient can actually pull, and an
     // upstream can outlive its provisioning (a space created before the
     // account had an active customer keeps its remote while the service
-    // refuses every presign). Ensure the consumer row exists before any
-    // key material is minted: `/provider/add` is idempotent — an already
-    // provided consumer answers `ConsumerProvided`, treated as success —
-    // so every share self-heals that half-state. Best effort like the
-    // enable-sync attach: a foreign remote (self-hosted, a test server)
-    // is not our access service, and refusing the mint over it would
-    // make those unshareable.
-    match provision_space_consumer(&tonk, &repository.did()).await {
+    // refuses every presign). Whether the consumer row exists is read
+    // from the account db first: the `SpaceProvider` fact is written
+    // when `/provider/add` succeeds and retracted when the gate stops
+    // serving the subject, so a provisioned space mints its link with
+    // no registration call at all. Only a space with no record runs the
+    // ceremony — a legacy space provisioned before the fact existed, or
+    // one whose earlier attempt failed — and success records the fact,
+    // so it runs once, not per share. Best effort like the enable-sync
+    // attach: a foreign remote (self-hosted, a test server) is not our
+    // access service, and refusing the mint over it would make those
+    // unshareable.
+    match if super::customer::space_provider_recorded(&tonk, &repository.did()).await {
+        Ok(())
+    } else {
+        provision_space_consumer(&tonk, &repository.did()).await
+    } {
         Ok(()) => {}
         // Our own service said no, and waiting will not change the
         // answer. A link minted anyway points at a space the service

--- a/rust/tonk-worker/src/router/sync.rs
+++ b/rust/tonk-worker/src/router/sync.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 
 use ::axum::{Json, extract::Path, extract::State};
 use axum_wasm_macros::wasm_compat;
-use dialog_capability::access::AuthorizeError;
+use dialog_capability::access::{AuthorizeError, Recourse};
 use dialog_effects::Rejection;
 use dialog_repository::{PublishError, PullError, Revision};
 use serde::Deserialize;
@@ -258,8 +258,17 @@ async fn publish_settled_status(tonk: &crate::worker::TonkState, repo: &str, bra
         Ok(remote) => remote,
         Err(e) => {
             log!("publish_settled_status: fetch {repo}/{branch} failed: {e}");
-            publish_sync_status_attr(tonk, repo, branch, tonk_schema::Replica::offline_status())
-                .await;
+            // An unserved subject is not offline: the service answered,
+            // and said no. Settle on `local` — the same status the
+            // failure path stamps — or the chip would flap between the
+            // two on every sweep.
+            let status = match classified_service_failure(&e) {
+                Some(TonkWorkerError::Upstream {
+                    code: Some(code), ..
+                }) if code == "NOT_PROVISIONED" => tonk_schema::Replica::local_status(),
+                _ => tonk_schema::Replica::offline_status(),
+            };
+            publish_sync_status_attr(tonk, repo, branch, status).await;
             return;
         }
     };
@@ -364,6 +373,24 @@ fn classified_service_failure(
                     message: "synchronization is temporarily unavailable".to_string(),
                 }
             }
+            // The gate's own policy refusal. Retry means the condition
+            // clears by itself (an activation email waiting to be
+            // opened), so it reads as ordinary unavailability. None
+            // means the service stopped serving this subject — nothing
+            // this client can wait out — which is what lets the sync
+            // engine return the space to local-only.
+            AuthorizeError::Declined { recourse, .. } => match recourse {
+                Recourse::Retry => TonkWorkerError::Upstream {
+                    status: 503,
+                    code: Some("SYNC_UNAVAILABLE".to_string()),
+                    message: "synchronization is temporarily unavailable".to_string(),
+                },
+                Recourse::None => TonkWorkerError::Upstream {
+                    status: 403,
+                    code: Some("NOT_PROVISIONED".to_string()),
+                    message: "the service no longer serves this space".to_string(),
+                },
+            },
             _ => TonkWorkerError::Upstream {
                 status: 502,
                 code: Some("UPSTREAM_ERROR".to_string()),
@@ -424,9 +451,44 @@ async fn publish_failure_status(
         TonkWorkerError::Upstream {
             code: Some(code), ..
         } if code == "SYNC_CONFLICT" => tonk_schema::Replica::conflict_status(),
+        TonkWorkerError::Upstream {
+            code: Some(code), ..
+        } if code == "NOT_PROVISIONED" => {
+            // The service stopped serving this subject, and waiting will
+            // not bring it back: drop the account-db provider record so
+            // the directory reads the space as local-only again, and
+            // stamp `local` — the status that drives the connect
+            // affordance whose enable-sync is the re-provisioning path.
+            forget_space_provider(tonk, repo, branch).await;
+            tonk_schema::Replica::local_status()
+        }
         _ => tonk_schema::Replica::unavailable_status(),
     };
     publish_sync_status_attr(tonk, repo, branch, status).await;
+}
+
+/// Retract the account-db [`SpaceProvider`](tonk_schema::SpaceProvider)
+/// record for the subject `repo`/`branch` belongs to — the "update the
+/// record" half of observing a deprovisioned space. Best-effort: a
+/// record that outlives its provisioning only costs the next share one
+/// refused mint.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn forget_space_provider(tonk: &crate::worker::TonkState, repo: &str, branch: &str) {
+    let session = match tonk
+        .reactor
+        .repository(repo)
+        .branch(branch)
+        .acquire(&tonk.operator)
+        .await
+    {
+        Ok(session) => session,
+        Err(e) => {
+            log!("forget_space_provider: failed to acquire {repo}/{branch}: {e}");
+            return;
+        }
+    };
+    let subject = session.handle().of().clone();
+    super::customer::retract_space_provider(tonk, &subject).await;
 }
 
 /// Branch names in `branches` that have an upstream, sorted for a


### PR DESCRIPTION
Stacked on #853. Every copy-link click ran `/provider/add` as idempotent self-healing insurance, putting a registration ceremony (and its D1 write) on a user-frequency button — the click that surfaced the D1 overload in the first place. The premise this replaces is that the client cannot know whether a space is provisioned; now it can, from the account db.

Provisioning becomes a recorded fact. When `/provider/add` succeeds — from `enable_sync_inner` attaching the upstream, from creation's active-customer path, or from the deferred pending-work queue, all of which funnel through `provision_consumer` — a `SpaceProvider` fact lands on the space's directory entity in the account db. The value is the providing account's DID rather than a timestamp: every replica that observes the provisioning asserts the identical fact, so the record converges where per-writer timestamps would give each device its own value. The share path consults the fact and mints its link with no registration call at all; only a space with no record (a legacy space provisioned before the fact existed, or one whose earlier attempt failed) runs the ceremony, once, and the success records it. Local-only spaces keep their existing flow — sharing one still attaches the upstream via enable-sync, which is where `/provider/add` now lives.

The reverse transition closes the loop. A deprovisioned space's D1 status change reaches KV (#851 writes the verdict through, deletion drops the key), surfaces on `/ucan/` as the gate's `Declined` refusal, and the sync engine now classifies that: a refusal retrying can clear (awaiting activation) stays `SYNC_UNAVAILABLE`, while one it cannot (`Recourse::None` — deprovisioned, suspended, archived) becomes `NOT_PROVISIONED`, which retracts the `SpaceProvider` fact and settles the status chip on `sync:local`. Both the failure path and the routine status sweep classify it, so the chip reads local-only steadily instead of flapping to `offline`. `sync:local` is also what drives the FAB's "connect this space" banner, whose enable-sync is exactly the re-provisioning path — so the recovery affordance appears by itself.

The `xyz.tonk.space/provider` attribute is declared on the `tonk:space` concept in profile.yaml per schema-first, and the round trip (record → present → converge on re-record → retract → absent) is pinned by a test against the account-state fixture.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the handling of space provisioning within the system. It introduces a new `Provider` struct and modifies related functions to manage the relationship between accounts and spaces more effectively, ensuring proper state management when services are provisioned or deprovisioned.

### Detailed summary
- Added `provider` field in `profile.yaml` with detailed description.
- Introduced `Provider` struct in `domain.rs` to represent the account providing access.
- Updated logic in `repository.rs` to check if a space is provisioned before minting keys.
- Enhanced `SpaceProvider` struct in `replica.rs` to track provisioning status.
- Implemented `record_space_provider` and `retract_space_provider` functions for managing provider records.
- Modified error handling in `sync.rs` to differentiate between service availability and provisioning status.
- Updated UI interaction logic in `account_flow.rs` to improve user experience during account setup.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->