### PR TITLE
feat: add account observability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4722,6 +4722,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "thiserror 2.0.18",
  "tokio",
  "wasm-bindgen",
  "wasm-bindgen-test",

--- a/docs/account-observability.md
+++ b/docs/account-observability.md
@@ -1,0 +1,75 @@
+# Account observability runbook
+
+Account health uses the typed `account_event` stream in PostHog and structured
+access-service failures in Cloudflare Workers Logs. They are deliberately not
+joinable per user. Browser and CLI handoff attempts also have separate random
+attempt IDs.
+
+## PostHog dashboard
+
+The saved [Account health dashboard](https://eu.posthog.com/project/70116/dashboard/928106)
+uses only `account_event`. Its aggregate HogQL insights were executed once
+while the event stream was still empty, proving their query shapes without
+introducing test account data. It contains:
+
+1. starts and unique profiles by surface and action;
+2. terminal results, separating success, degraded success, cancellation,
+   blocks, hard failures, and unknown commits;
+3. hard-failure rate (`retryable_failure + terminal_failure + unknown_commit`
+   divided by `started`) and degraded-success rate, annotated only after 20
+   starts;
+4. failures by `failure_kind`, then `stage`;
+5. degraded successes by `degradation_kind`, then `stage`;
+6. impacted unique profiles by environment, version, surface, browser, and OS
+   (native browser dimensions are “not applicable”);
+7. p50/p95 terminal duration by action and surface;
+8. exact attempt-level journey progression using the documented starts,
+   checkpoints, and terminals; and
+9. release regressions for `failure_kind=unknown`, 5xx, `panic`, and
+   `$exception` (the latter remains empty while exception capture is disabled).
+
+Never combine `cli_command_run` with `account_event` attempt counts. The
+generic CLI record answers adoption and exit questions; account health uses the
+typed stream, including degraded zero-exit commands.
+
+Two saved alerts cover any unknown/5xx/panic/exception and a 15-minute
+hard-failure rate above 10 percent after 20 starts. They are deliberately
+disabled until staging proves the stream and production rollout is approved.
+The project plan does not include the add-on required for 15-minute evaluation,
+so PostHog accepted an hourly evaluation cadence over the exact trailing
+15-minute query windows. Enabling them or adding another notification
+integration requires rollout approval.
+
+## Worker queries
+
+Save access Worker queries grouped by `operation`, `failure_kind`, and `site`,
+split into 4xx and 5xx status classes and compared by version/environment.
+Record the retention displayed by the live Cloudflare account at rollout time;
+do not assume it matches PostHog retention.
+
+## Investigation order
+
+1. Find the leading PostHog surface/action/stage/failure or degradation.
+2. Split by environment and version, then by browser/OS only where relevant.
+3. Reproduce the corresponding typed branch without using captured content.
+4. For access-service stages, inspect matching-time aggregate Worker logs.
+
+There is no per-user bridge between the systems. Exact local diagnostics are
+used during reproduction, not copied into either remote system. An `unknown`
+classification is fixed by deepening the upstream typed error; it is not fixed
+by adding error text or fingerprints.
+
+## Ownership and rollout
+
+Product code owners approve enum additions; privacy review approves new
+properties. Web owns passkey, PRF, consent, and callback-delivery stages. CLI
+owns listener bind, browser open, callback wait, grant validation, and local
+convergence. The access Worker owns request-handler failures.
+
+Before production, compare staging web and CLI exports against the property
+allowlist and privacy sentinels, confirm starts and terminals balance except for
+abandoned navigation, and verify automatic polls do not dominate. Confirm a
+controlled Worker 4xx and 5xx contain no URL/query, email, DID, subject,
+invocation, credential, or raw error. Generic exception capture stays disabled
+until an exact outbound-payload test and non-public source-map staging proof
+both pass.

--- a/docs/storybook/accounts/authority-and-deletion.md
+++ b/docs/storybook/accounts/authority-and-deletion.md
@@ -190,7 +190,11 @@ semantics. CLI device JSON and exit codes must not depend on TTY rendering.
 
 **Privacy and telemetry.** Verified email is used for arming but must not enter
 telemetry. Passkey, deletion authorization, device grants, and owned-space plans
-are sensitive.
+are sensitive. Destructive actions emit only their closed action, stage, result,
+and failure classification. A response lost after dispatch is
+`unknown_commit`; no target ID, inventory count, plan, response body, or raw
+diagnostic accompanies it. Access Worker failure logs likewise contain no
+subject or profile identity.
 
 ## Edge cases
 

--- a/docs/storybook/accounts/lifecycle.md
+++ b/docs/storybook/accounts/lifecycle.md
@@ -294,8 +294,13 @@ submit/cancel must match pointer behavior. CLI JSON state and exit codes must be
 stable and diagnostics must stay on stderr.
 
 **Privacy and telemetry.** Account email, passkey material, callbacks, UCANs,
-and argument values must not enter telemetry. Approval links contain authority
-context and should not be logged beyond what the user explicitly sees.
+and argument values must not enter telemetry. The browser and CLI emit the same
+closed `account_event` journey vocabulary, but own separate random attempt IDs;
+the callback protocol carries no analytics identifier. Cancellation, activation
+waits, unknown commits, and degraded CLI success remain distinct outcomes.
+Approval links contain authority context and are never logged or captured.
+Access-service failures use content-free aggregate Worker logs with no profile
+identity or stable join key to PostHog.
 
 ## Edge cases
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -6,9 +6,12 @@ complete inventory of what is sent and how to turn it off.
 
 ## What is never sent
 
-Notation documents, entity names or values, attribute values, file
-paths, remote URLs, and raw DIDs. Identifiers that appear in event
-properties are SHA-256 hashes.
+Notation documents, entity names or values, attribute values, email addresses,
+account or device IDs, credential IDs, passkey labels/providers, callback or
+remote URLs, route parameters, query strings, UCANs/delegations, invocation or
+receipt bytes, HTTP bodies, local paths, and raw error messages. The existing
+profile identity is a SHA-256 hash; account events add no identifier derived
+from account data.
 
 ## Identity
 
@@ -23,6 +26,7 @@ before a profile exists report as `tonk:anonymous`.
 | Event | Properties |
 |---|---|
 | `cli_command_run` | `command`, `subcommand`, `success`, `exit` (success / parse-error / analyze-error / commit-error / io-error), `duration_ms`, `version`, `os`, `arch`, `environment` (constant `"cli"`), ``$lib`` (constant `"tonk-analytics"`); eval adds `source` (inline / file / stdin), `format`, `dry_run`, `quiet` |
+| `account_event` | The closed account journey schema below. Account commands emit this lifecycle in addition to one `cli_command_run`; never add the two event types together when counting account attempts. |
 
 ### Web app
 
@@ -32,7 +36,62 @@ before a profile exists report as `tonk:anonymous`.
 | `$pageview` | `route` — the path with every non-literal segment replaced by a hash (e.g. `/space/1a2b3c4d5e6f7a8b/view/9c8d7e6f5a4b3c2d`); ``$current_url`` carries the same normalized value |
 | `commit` | `branch` (`main` / `meta`; anything else reports as `other`) — fired on the worker's `tonk:local-commit` broadcast for every durable transact/evaluate commit; only the visible tab records it |
 | `sheet_activated` | none |
-| `panic` | `message` (first line of the panic message) |
+| `panic` | `type` (constant `wasm_panic`), repository-relative `location`, and a fingerprint derived only from those static values; the panic message stays in the local console |
+| `account_event` | The same closed account journey schema emitted by the CLI. |
+
+### Account journey schema
+
+`account_event` has `schema_version=1` and only these properties:
+
+- `journey`: `onboarding`, `login`, `activation`, `passkey`,
+  `account_management`, `cli_handoff`, or `account_deletion`;
+- `action`: a reviewed account operation from
+  `open_registration`, `load_account`, `load_registration`, `check_email`,
+  `create_account`, `login`, `add_passkey`, `change_display_name`,
+  `resend_activation`, `load_devices`, `load_profiles`, `link_cli`,
+  `switch_profile`, `sign_out`, `load_deletion_plan`, `delete_account`,
+  `delete_space`, `revoke_device`, `finish_account_backup`,
+  `activate_account`, `watch_activation`, `save_initial_display_name`,
+  `copy_invite`, `finish_previous_action`, `settle_account`,
+  `load_account_spaces`, `pull_account_space`, `open_account_deletion`,
+  `open_space_deletion`, or `sync_account`;
+- `phase`: `started`, `checkpoint`, or `finished`; `stage` is a reviewed
+  lifecycle boundary: `input`, `email_lookup`, `local_preflight`,
+  `passkey_create`, `passkey_assert`, `prf`, `worker_handoff`,
+  `access_service`, `local_commit`, `remote_commit`, `activation_wait`,
+  `callback_bind`, `browser_open`, `callback_wait`, `callback_delivery`,
+  `delegation_validate`, `activation_stage`, `account_sync`,
+  `content_discovery`, `custody_rotation`, `account_load`, or `complete`;
+- `result` on terminal events: `success`, `degraded_success`, `cancelled`,
+  `blocked`, `retryable_failure`, `terminal_failure`, or `unknown_commit`;
+- `failure_kind` on non-success terminal events: `invalid_input`, `cancelled`,
+  `timeout`, `credential_exists`, `passkey_unsupported`, `prf_unsupported`,
+  `security_context`, `awaiting_activation`, `suspended`, `not_provisioned`,
+  `access_denied`, `conflict`, `not_found`, `rate_limited`, `network`,
+  `service_unavailable`, `invalid_response`, `local_state`, `callback`, or
+  `unknown`;
+- `degradation_kind` only on degraded successes: `browser_open`,
+  `account_sync`, `content_discovery`, `custody_rotation`, or
+  `space_rotation`;
+- `surface` (`registration_dialog`, `settings`, `activation_page`,
+  `custody_consent`, `hub`, `cli_callback`, or `native_cli`), `trigger`
+  (`user`, `automatic`, or `recovery`), `account_state` (`none`, `onboarding`,
+  `pending_activation`, `registered_unready`, `ready`, or `unknown`), and a random per-attempt
+  `attempt_id` (not an account identifier and not a dashboard breakdown);
+- terminal `duration_ms`, capped at ten minutes; optional status class (`4xx`
+  or `5xx`) and an allowlisted service code (`root_required`,
+  `credential_revoked`, `upstream_timeout`, `upstream_unavailable`,
+  `account_state_unavailable`, `invalid`, `unauthorized`, `forbidden`,
+  `unknown_customer`, `unknown_consumer`, `customer_active`,
+  `customer_inactive`, `customer_suspended`, `address_taken`,
+  `consumer_provided`, `internal`, or `unknown`); and
+- transport context: `version`, `environment`, and the native library/OS/arch
+  fields where applicable.
+
+Cancellation, activation waits, and suspension are outcomes, not uncaught
+exceptions. A response lost after a possible mutation is `unknown_commit`.
+Automatic probes suppress repeated equal failures until a successful recovery.
+The account capture entry point accepts no arbitrary JSON properties.
 
 Every web event additionally carries an `environment` super property
 derived from the hostname: `production` (tonk.network), `staging`
@@ -44,11 +103,28 @@ Autocapture and session recording are disabled. PostHog runs
 cookieless (`persistence: "memory"`); no third-party script is loaded
 (the bundle is self-hosted).
 
+Browser exception capture and console-error capture are disabled. A project
+setting cannot override that client configuration. Handled account failures
+are represented only by `account_event`; exact diagnostics remain local.
+
 The web shell also listens for a generic `tonk:analytics` DOM event
 (`detail: { name, props }`) so future components can emit events
 without new dependencies. Nothing dispatches it today; any future
 dispatcher is responsible for keeping its payload content-free
 (hashes and counts only), like every event above.
+The bridge cannot emit `account_event`; that name is reserved for the typed,
+validated account capture interface.
+
+## Operational logs
+
+The access Worker writes failed account requests to Cloudflare Workers Logs,
+not PostHog. Each structured object contains only schema version,
+`system=access_worker`, a closed operation/outcome/failure/site, status class,
+retryability, and release version. It contains no request URL, query, subject,
+profile identity, or diagnostic. Invocation logs are disabled for production,
+staging, and preview, so request URLs and their query strings are not ingested;
+the explicit application records contain no URL field. These short-lived
+infrastructure records deliberately have no stable join key to PostHog.
 
 ## Turning it off
 

--- a/flake.lock
+++ b/flake.lock
@@ -32,27 +32,6 @@
         "type": "github"
       }
     },
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "wrangler-flake",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1782949081,
-        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -167,17 +146,16 @@
     },
     "wrangler-flake": {
       "inputs": {
-        "flake-parts": "flake-parts",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1783662463,
-        "narHash": "sha256-GNn1oN8+/OhL8k6sxo1o2OS/ySUp+drFSzKBoFwDPPQ=",
+        "lastModified": 1788291525,
+        "narHash": "sha256-Od9X5EAWOKjy1+VgQPkwk/moqCI6kadEo7WtZJ54BTI=",
         "owner": "emrldnix",
         "repo": "wrangler",
-        "rev": "ee83f56e7f1752d74e8fb06d33816ce946237a6c",
+        "rev": "d95149fd0ce607837da05c2245df3fbdbc9d5dfd",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -88,7 +88,10 @@
             hash = posthogCliRelease.hash;
           };
           nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.autoPatchelfHook ];
-          buildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.stdenv.cc.cc.lib ];
+          buildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [
+            pkgs.stdenv.cc.cc.lib
+            pkgs.zlib
+          ];
           installPhase = ''
             runHook preInstall
             install -Dm755 posthog-cli $out/bin/posthog-cli

--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,50 @@
         # the latest release
         wrangler = wrangler-flake.packages.${system}.wrangler;
 
+        # The official PostHog CLI moves faster than nixpkgs. Pin its release
+        # archives directly so `posthog-cli login` and the API client are
+        # reproducible on every system this flake supports.
+        posthogCliVersion = "0.16.0";
+        posthogCliRelease =
+          {
+            x86_64-linux = {
+              target = "x86_64-unknown-linux-gnu";
+              hash = "sha256-9ucLvHdq8B6UxLEy7BDDtlljY/UBrR+pSx/qgjNlg1w=";
+            };
+            aarch64-linux = {
+              target = "aarch64-unknown-linux-gnu";
+              hash = "sha256-zgSh26cn4Ty7IZ1Ua/yKO2JGrAk2Lmywu4VTJ03Sjgg=";
+            };
+            x86_64-darwin = {
+              target = "x86_64-apple-darwin";
+              hash = "sha256-lfG8QsSq+ywwMUkQEeUMsUbo5cKCnIr6K3obsQrKa1k=";
+            };
+            aarch64-darwin = {
+              target = "aarch64-apple-darwin";
+              hash = "sha256-J4rAW5COg4jXbvPjnEcipYN7Rc0mXEmgVURj36DqVnI=";
+            };
+          }
+          .${system};
+        posthogCli = pkgs.stdenvNoCC.mkDerivation {
+          pname = "posthog-cli";
+          version = posthogCliVersion;
+          src = pkgs.fetchurl {
+            url = "https://github.com/PostHog/posthog/releases/download/posthog-cli%2Fv${posthogCliVersion}/posthog-cli-${posthogCliRelease.target}.tar.gz";
+            hash = posthogCliRelease.hash;
+          };
+          nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.autoPatchelfHook ];
+          buildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.stdenv.cc.cc.lib ];
+          installPhase = ''
+            runHook preInstall
+            install -Dm755 posthog-cli $out/bin/posthog-cli
+            mkdir -p $out/lib
+            cp -R lib/. $out/lib/
+            install -Dm644 LICENSE $out/share/licenses/posthog-cli/LICENSE
+            runHook postInstall
+          '';
+          dontStrip = true;
+        };
+
         chromedriverDarwin = nixpkgs-chromedriver.legacyPackages.${system}.chromedriver;
 
         # Common build inputs for all dev shells
@@ -141,6 +185,8 @@
           # for every crate derivation, so a release tool in there would
           # change 34 hashes and force a cold cache rebuild.
           pkgs.cargo-release
+          pkgs.nodejs
+          posthogCli
           wrangler
           rustToolchain
           wasm-bindgen-cli

--- a/plan/account-observability.md
+++ b/plan/account-observability.md
@@ -1,0 +1,912 @@
+# Account and passkey observability implementation plan
+
+**Goal:** Make onboarding, login, activation, account-management, and passkey
+failure rates measurable and make the common failures diagnosable without
+sending account content, authority material, or raw diagnostics to PostHog.
+
+**Approach:** Put the canonical account event vocabulary, validation, and
+privacy allowlist in `tonk-analytics`, then implement one deep attempt recorder
+per execution interface: web in `tonk-ui` and native in `tonk-cli`. Both client
+adapters emit the same `account_event`; the existing `cli_command_run` remains
+the generic CLI-invocation event and is not a second account taxonomy. PostHog
+holds privacy-safe journey analytics; unexpected browser exceptions use
+PostHog Error Tracking only after payload redaction is proven; the access
+Worker maps the same stable failure concepts into short-lived structured
+Cloudflare logs rather than product analytics.
+
+**Source audit:** `feat/log-account-errors` at
+`c518c1ba49c06b9e637d9f29506ada2ff2e2ef26` on 2026-09-01, equal to
+`origin/staging` when this plan was written.
+
+**Top recommendation:** Ship the typed `account_event` journey stream and its
+dashboard before enabling generic exception collection. Typed events provide
+the denominator, stage, outcome, and recovery classification needed to
+prioritize account work; generic console capture would collect more bytes but
+less trustworthy information and would leak diagnostics that the UI
+deliberately keeps out of user-facing and analytics payloads.
+
+## Implementation status (2026-09-01)
+
+Implemented in this worktree:
+
+- the shared, privacy-validated `account_event` schema and native/web capture
+  adapters;
+- typed passkey, account API, UI recovery, CLI callback, and account-command
+  failure evidence;
+- web and CLI attempt recorders, including automatic-failure suppression,
+  unknown-commit handling, and degraded CLI success;
+- account UI, registration, activation, custody, destructive-action, and CLI
+  instrumentation at their existing control seams;
+- privacy-safe access Worker log records plus explicit production, staging,
+  and preview Workers Logs configuration;
+- telemetry inventory, investigation runbook, Storybook observability notes,
+  schema/unit/integration coverage, and an in-browser PostHog capture fixture.
+
+Still outstanding:
+
+- complete the plan's exhaustive browser assertions for the second-device,
+  failed-ceremony, revoke, and deletion journeys. The focused ordered signup
+  telemetry journey passes in the real Chrome harness. The older full signup
+  journey still times out waiting for its post-activation passkey-device label
+  before reaching the added telemetry assertions;
+- prove release source-map upload and outbound exception redaction before
+  enabling generic PostHog exception collection. Generic exception capture
+  intentionally remains disabled;
+- deploy to staging, exercise controlled 4xx/5xx cases, and verify the saved
+  Cloudflare queries and retention in the account-owning environment;
+- enable the saved PostHog alerts after staging proves the stream and production
+  rollout is approved. The Account health dashboard and its nine validated
+  aggregate insights are saved and linked from `docs/account-observability.md`;
+  the two alerts remain disabled so pre-rollout configuration cannot notify;
+
+No production or staging deployment is implied by the local configuration
+changes. Wrangler 4.128 accepts the checked-in staging observability and query
+redaction fields and enters the custom build without configuration warnings.
+The full cold Nix build remains incomplete because the local disk had about
+6 GB free; an attempted Wrangler derivation failed while unpacking dependencies
+with `No space left on device`, so this is configuration evidence rather than a
+completed deployment dry run.
+
+The architecture rule is **account totality at the schema seam, interface
+locality at the recorder seam**. `tonk-analytics::account` owns what an account
+event means; the web, CLI, and Worker adapters own when their runtime has enough
+evidence to emit one. This keeps one dashboard vocabulary without forcing DOM,
+polling, loopback-listener, process-flush, and Worker-log behavior into one
+shallow cross-platform module.
+
+## Constraints
+
+- Keep PostHog cookieless, preserve the existing web/CLI opt-outs, and make all
+  capture best-effort. Telemetry failure must never alter, delay, retry, or
+  claim success for an account operation.
+- Never send email addresses, raw DIDs, DID-derived event properties, account
+  or device IDs, credential IDs, passkey labels/providers, callback URLs, route
+  parameters, query strings, remote URLs, UCANs/delegations, invocation or
+  receipt bytes, HTTP bodies, entity/space names, local paths, or raw error
+  messages. Preserve the existing `tonk:<sha256(profile DID)>` PostHog distinct
+  identity; do not add a second account identifier.
+- Do not enable `capture_console_errors`. Account code intentionally writes
+  exact diagnostics to `console.error`; PostHog documents console capture as a
+  separate option, and enabling it would bypass the allowlisted event schema.
+- Treat cancellation, timeout, validation refusal, awaiting activation, and a
+  suspended account as outcomes, not product exceptions. Reserve PostHog Error
+  Tracking for uncaught faults and Wasm panics.
+- Classify from `CeremonyRefusal`, `CustodyDenial`, HTTP status, and structured
+  error codes. Human-readable error matching may remain only as a compatibility
+  fallback and must produce `unknown`, never a new analytics value.
+- Every event property is a closed enum, boolean, bounded number, semantic
+  version, or random per-attempt token. No caller may append arbitrary JSON.
+- Web and CLI account adapters must emit the shared `account_event` schema.
+  They may not introduce interface-local spellings for a shared journey,
+  action, stage, result, or failure. Interface-specific mechanics belong in
+  additional closed `stage`, `surface`, or degradation values in that schema.
+- Retain one `cli_command_run` per CLI invocation for overall CLI adoption and
+  exit analysis. An account command additionally emits `account_event`; account
+  health insights use only `account_event`, so the two records are never added
+  together as account attempts.
+- An operation that might have committed before its response failed must use
+  `unknown_commit`; it must not be counted as an ordinary failure or retried by
+  telemetry code.
+- A CLI command that established the account but failed a non-transactional
+  follow-up such as hydration, content-endpoint discovery, or custody rotation
+  must use `degraded_success` with a closed `degradation_kind`. It must not be
+  flattened to either full success or failure merely because the process exits
+  zero and prints a warning.
+- Background probes and activation polling must not inflate failure counts.
+  Emit the first failure in a streak, suppress identical repeats until a
+  success/recovery event closes the streak, and then permit a later failure.
+- Keep client analytics and server operational logs separate. PostHog honors
+  the user's telemetry choice and supports aggregate product decisions;
+  Cloudflare Workers Logs support short-lived infrastructure diagnosis. Do not
+  create a stable identifier joining the two systems or log a profile identity
+  server-side.
+- Do not propagate `attempt_id` through a CLI callback URL in version 1. The
+  browser ceremony and native command are separate attempts with explicit
+  `surface` ownership. Exact browser-to-process correlation would change the
+  handoff protocol and requires a separate privacy and threat-model review.
+- Retain the current `autocapture: false`, session-recording, performance,
+  dead-click, and heatmap settings. Any future change to those is a separate
+  privacy review.
+- Do not add source-map upload credentials to the repository or expose source
+  maps as public deployed assets. A release job may upload them directly and
+  then omit them from `tonk-ui` artifacts.
+- Preserve the existing user-facing recovery contract in
+  `rust/tonk-ui/src/user_error.rs` and all account lifecycle semantics. This
+  plan observes behavior; it does not change authority, storage, passkey, or
+  retry behavior.
+- Update `docs/telemetry.md`, which declares itself the complete event
+  inventory, in the same commit that adds or changes any captured property.
+
+## Current and proposed seams
+
+```text
+Current
+browser account/passkey error -> console + safe UI message -> no remote signal
+CLI account command           -> cli_command_run with only coarse exit status
+access Worker failure         -> inconsistent console diagnostics
+
+Proposed
+tonk_analytics::account
+  -> canonical AccountEvent schema + privacy validation
+     -> tonk_ui::account_observability
+        -> web attempt/checkpoint lifecycle -> account_event -> PostHog
+     -> tonk_cli::account_observability
+        -> command/handoff lifecycle -> account_event -> PostHog
+        -> generic invocation summary -> cli_command_run -> PostHog
+     -> access-service observability adapter
+        -> content-free failure projection -> Cloudflare Workers Logs
+```
+
+The shared module has one small interface: construct and validate a closed
+`AccountEvent`, then hand it to a target-specific transport. It owns no clock,
+randomness, polling state, callback listener, process lifetime, or retry logic.
+
+Each client recorder exposes the same conceptual lifecycle while retaining
+runtime-local mechanics:
+
+```rust
+// tonk-ui: browser randomness, automatic-failure streak suppression,
+// page-local lifetime, and the PostHog web adapter.
+let mut attempt = WebAccountAttempt::start(action, surface, trigger, account_state);
+attempt.checkpoint(stage);
+attempt.finish(AccountOutcome::success(stage));
+// or
+attempt.finish(AccountOutcome::from_problem(stage, &problem));
+
+// tonk-cli: process-local randomness, command stages, zero-exit degradations,
+// and queuing into the existing bounded native telemetry flush.
+let mut attempt = CliAccountAttempt::start(action, account_state);
+attempt.checkpoint(stage);
+attempt.finish(AccountOutcome::degraded(stage, degradation_kind));
+```
+
+Both adapters hide duration, attempt IDs, terminal deduplication, PostHog
+availability, and transport details. Only the web adapter owns automatic-load
+failure-streak suppression; only the CLI adapter owns command finalization and
+the 300 ms native flush. Serialization and the privacy allowlist remain
+canonical in `tonk-analytics::account`.
+
+## Event contract
+
+Use one event name, `account_event`, with `schema_version = 1`. A single event
+keeps trends and funnels composable while the closed properties keep cardinality
+and privacy review tractable.
+
+| Property | Required | Allowed values / rule |
+| --- | --- | --- |
+| `schema_version` | yes | integer `1` |
+| `journey` | yes | `onboarding`, `login`, `activation`, `passkey`, `account_management`, `cli_handoff`, `account_deletion` |
+| `action` | yes | closed snake-case account operation from the list below; semantically equal web and CLI operations use the same value |
+| `phase` | yes | `started`, `checkpoint`, `finished` |
+| `stage` | yes | `input`, `email_lookup`, `local_preflight`, `passkey_create`, `passkey_assert`, `prf`, `worker_handoff`, `access_service`, `local_commit`, `remote_commit`, `activation_wait`, `callback_bind`, `browser_open`, `callback_wait`, `callback_delivery`, `delegation_validate`, `activation_stage`, `account_sync`, `content_discovery`, `custody_rotation`, `account_load`, `complete` |
+| `result` | terminal only | `success`, `degraded_success`, `cancelled`, `blocked`, `retryable_failure`, `terminal_failure`, `unknown_commit` |
+| `failure_kind` | non-success terminals only | table below; absent on starts and successes |
+| `degradation_kind` | degraded-success terminals only | `browser_open`, `account_sync`, `content_discovery`, `custody_rotation`, `space_rotation`; when more than one occurs, emit the earliest incomplete stage as the primary degradation and retain every exact diagnostic locally |
+| `surface` | yes | `registration_dialog`, `settings`, `activation_page`, `custody_consent`, `hub`, `cli_callback`, `native_cli` |
+| `trigger` | yes | `user`, `automatic`, `recovery` |
+| `account_state` | yes | `none`, `onboarding`, `pending_activation`, `registered_unready`, `ready`, `unknown` |
+| `attempt_id` | yes | random/opaque per attempt; never derived from account data and never used as a dashboard breakdown |
+| `duration_ms` | terminal only | non-negative integer, capped at 10 minutes |
+| `http_status_class` | optional | `4xx`, `5xx`; never the response body or URL |
+| `service_code` | optional | allowlisted stable code already parsed from a response; unrecognized values become `unknown` |
+| `version` | yes | `CARGO_PKG_VERSION`; web registers it as a super property and the native client adds it to every queued event |
+| `environment` | yes after transport context | `production`, `staging`, `dev`, `cli`; web registers the deployment value and native account capture supplies `cli` |
+
+The initial closed `action` values are `open_registration`, `load_account`,
+`load_registration`, `check_email`, `create_account`, `login`, `add_passkey`,
+`change_display_name`, `resend_activation`, `load_devices`, `load_profiles`,
+`link_cli`, `switch_profile`, `sign_out`, `load_deletion_plan`,
+`delete_account`, `delete_space`, `revoke_device`, `finish_account_backup`,
+`activate_account`, `watch_activation`, `save_initial_display_name`,
+`copy_invite`, `finish_previous_action`, `settle_account`,
+`load_account_spaces`, `pull_account_space`, `open_account_deletion`,
+`open_space_deletion`, and `sync_account`. CLI `status`, `login`, `logout`,
+`delete`, `space-list`, `space-pull`, `space-delete`, `sync`, `devices`, and
+`revoke` map respectively to `load_account`, `login`, `sign_out`,
+`open_account_deletion`, `load_account_spaces`, `pull_account_space`,
+`open_space_deletion`, `sync_account`, `load_devices`, and `revoke_device`.
+This mapping is exhaustive and compile-tested; an interface does not create a
+synonym merely to identify itself because `surface` already does that.
+
+The failure vocabulary is deliberately smaller than the diagnostic vocabulary:
+
+| `failure_kind` | Source evidence | Meaning in analysis |
+| --- | --- | --- |
+| `invalid_input` | local validation | User could not begin the action; break down separately from product faults. |
+| `cancelled` | `CeremonyRefusal::NotAllowed` before the deadline | User dismissed the passkey prompt. |
+| `timeout` | typed ceremony/worker timeout | Prompt or worker handoff did not finish in time. |
+| `credential_exists` | `CeremonyRefusal::InvalidState` | Authenticator refused duplicate creation. |
+| `passkey_unsupported` | `CeremonyRefusal::NotSupported` | Browser/authenticator lacks required WebAuthn behavior. |
+| `prf_unsupported` | `CeremonyRefusal::NoPrf` | Passkey cannot provide Tonk's custody PRF outputs. |
+| `security_context` | `CeremonyRefusal::Security` | RP/origin/secure-context failure. |
+| `awaiting_activation` | `CustodyDenial::AwaitingActivation` | Expected account gate; result is `blocked`, not failure. |
+| `suspended` | `CustodyDenial::Suspended` | Account policy gate; result is `blocked`. Do not capture its reason. |
+| `not_provisioned` | `CustodyDenial::NotProvisioned` | Custody/account setup incomplete. Do not capture its reason. |
+| `access_denied` | other typed service denial or 401/403 | Authorization refusal without the response text. |
+| `conflict` | stable service code or HTTP 409 | State conflict, including wrong-account passkey when typed. |
+| `not_found` | stable service code or HTTP 404 | Expected object/registration absent at the current stage. |
+| `rate_limited` | HTTP 429 | Retry after service throttling. |
+| `network` | client network error without response | Web or CLI could not reach its local worker, account service, or remote. |
+| `service_unavailable` | HTTP 5xx or typed unavailable code | Local worker/access service failed. |
+| `invalid_response` | typed decode/wire-shape error | A response arrived but violated its interface. |
+| `local_state` | typed local profile/root/repository/storage error | Client-local state could not satisfy the action. |
+| `callback` | typed callback bind/wait/delivery error | The CLI could not listen or wait, or the browser could not notify it. `stage` identifies the owning interface. |
+| `unknown` | no typed evidence | Classification gap; alert on it and deepen the upstream error interface. |
+
+The initial `service_code` allowlist is `root_required`,
+`credential_revoked`, `upstream_timeout`, `upstream_unavailable`,
+`account_state_unavailable`, `invalid`, `unauthorized`, `forbidden`,
+`unknown_customer`, `unknown_consumer`, `customer_active`,
+`customer_inactive`, `customer_suspended`, `address_taken`,
+`consumer_provided`, and `internal`. These are normalized spellings of existing
+worker/registration variants; they are never copied directly from an
+unrecognized response. Adding a value requires updating the schema test and
+telemetry inventory.
+
+Do not add a raw-message fingerprint in version 1. It would be high-cardinality,
+could encode user data even when hashed, and would not explain the fault. The
+action/stage/failure/version/browser dimensions are sufficient to rank common
+failures; `unknown` is a prompt to introduce a stable typed code at its source.
+
+## File map
+
+- `rust/tonk-analytics/src/account.rs`: Closed event vocabulary, property
+  serialization, validation, and privacy-focused unit tests shared by every
+  client interface.
+- `rust/tonk-analytics/src/lib.rs`: Export the account schema and declare the
+  `account_event` event constant.
+- `rust/tonk-analytics/src/web.rs`: Typed web capture interface, version super
+  property, optional redacted exception adapter, and capture-fixture hooks.
+- `rust/tonk-analytics/src/native.rs`: Typed native account capture into the
+  existing in-memory batch; no second transport or flush.
+- `rust/tonk-identity/src/passkey.rs`: Reusable typed mapping from DOM exception
+  name to `CeremonyRefusal`; no analytics dependency.
+- `rust/tonk-ui/src/error.rs`: Structured account transport/response error
+  information alongside the local diagnostic string.
+- `rust/tonk-ui/src/api.rs`: Preserve network, HTTP class, service code, and
+  decode kind for account endpoints instead of flattening them into prose.
+- `rust/tonk-ui/src/user_error.rs`: Produce one `AccountProblem` containing
+  both safe recovery text and the closed failure classification.
+- `rust/tonk-ui/src/account_observability.rs`: Deep web
+  attempt/checkpoint/outcome adapter, PostHog adapter, in-memory test adapter,
+  duration, terminal guard, and automatic failure-streak suppression.
+- `rust/tonk-ui/src/lib.rs`: Register the new module.
+- `rust/tonk-ui/src/account.rs`: Instrument settings, login, account management,
+  passkey addition, profile/device management, sign-out, revocation, and
+  deletion actions at their existing error/presentation seam.
+- `rust/tonk-ui/src/register_dialog.rs`: Instrument registration dialog views,
+  email lookup, create/login, pending activation, initial name, clipboard, and
+  recovery outcomes.
+- `rust/tonk-ui/src/custody_relay.rs`: Preserve typed ceremony refusal and emit
+  custody-consent/handoff stages without recording raw thrown values.
+- `rust/tonk-ui/src/activate.rs`: Instrument activation-link validation,
+  submission, expiry, service refusal, and completion.
+- `rust/tonk-ui/src/analytics.rs`: Safe panic/exception capture and web-level
+  standard context.
+- `rust/tonk-ui/src/account_flow.rs`: Browser integration coverage for exact
+  account event sequences and negative privacy assertions.
+- `rust/tonk-cli/src/account_observability.rs`: Deep native command-attempt
+  adapter, process-local event buffer, terminal guard, and typed CLI outcome and
+  degradation classification.
+- `rust/tonk-cli/src/lib.rs`: Export the native account-observability module.
+- `rust/tonk-cli/src/callback.rs`: Preserve a closed callback failure kind
+  (`bind`, `closed`, `server`, or `timeout`) alongside the existing local
+  diagnostic so native classification never parses display text.
+- `rust/tonk-cli/src/bin/tonk.rs`: Instrument account command and browser-handoff
+  stages before errors are flattened to `ExitCode`; keep local diagnostic text
+  out of both event streams.
+- `rust/tonk-cli/src/telemetry.rs`: Queue shared `AccountEvent` values beside
+  the generic `cli_command_run` record and send both in the existing bounded
+  native batch flush.
+- `rust/tonk-cli/tests/telemetry.rs`: Wire-shape, event-ownership, degradation,
+  privacy, and opt-out coverage for account commands.
+- `rust/tonk-access-service/src/observability.rs`: Structured, content-free
+  Worker operational log records.
+- `rust/tonk-access-service/src/lib.rs`: Request-level operational context and
+  failure logging at the Worker entry seam.
+- `rust/tonk-access-service/src/handlers/registration.rs`: Registration,
+  activation, resend, and customer-probe outcome codes.
+- `rust/tonk-access-service/src/handlers/lookup.rs`: Email-lookup operational
+  outcomes without the queried address.
+- `rust/tonk-access-service/src/handlers/ucan.rs`: Authorization/provisioning
+  failure outcomes without subject, invocation, or reason text.
+- `wrangler.toml`: Explicit production/staging Workers Logs settings with query
+  redaction and invocation-log suppression.
+- `.github/workflows/publish.yml`: Gated source-map upload before deployment if
+  the exception-capture proof establishes useful stack resolution.
+- `docs/telemetry.md`: Complete public inventory, opt-out behavior, retention
+  distinction, and privacy contract.
+- `docs/account-observability.md`: Internal PostHog/Cloudflare dashboard,
+  investigation, alert, and rollout runbook.
+
+## Task dependencies
+
+- Task 1 establishes the canonical schema and blocks Tasks 3, 4, 5, 6, and 7.
+- Task 2 establishes typed web failure evidence and blocks Tasks 3 through 5.
+- Task 3 establishes the web adapter and blocks Tasks 4 and 5.
+- Task 7 depends only on Task 1 and may proceed independently of the web
+  instrumentation; it must consume the same schema rather than copying Task 3.
+- Task 8 may proceed independently after its failure names are checked against
+  Task 1; it emits a distinct operational-log shape, not `AccountEvent`.
+- Task 9 follows the final schemas and staging payloads from Tasks 1 through 8.
+
+### Task 1: Define and enforce the account event schema
+
+**Files:**
+- Create: `rust/tonk-analytics/src/account.rs`
+- Modify: `rust/tonk-analytics/src/lib.rs:event`
+- Modify: `rust/tonk-analytics/src/web.rs:ph_init, capture`
+- Modify: `rust/tonk-analytics/src/native.rs:Client`
+- Test: `rust/tonk-analytics/src/account.rs`
+- Test: inline transport tests in `rust/tonk-analytics/src/web.rs` and
+  `rust/tonk-analytics/src/native.rs`
+
+**Interfaces:**
+- Consumes: the existing guarded `tonk_analytics::web::capture` and
+  `tonk_analytics::native::Client::capture` transports.
+- Produces: `AccountEvent`, the closed enums in the event-contract tables, and
+  `AccountOutcome`, `web::capture_account(&AccountEvent)` plus
+  `native::Client::capture_account(&AccountEvent)`; target adapters cannot pass
+  arbitrary properties through either account entry point.
+
+- [ ] Add `it_serializes_only_the_account_event_allowlist`, constructing one
+      start, checkpoint, success, cancellation, blocked activation, 5xx, and
+      unknown-commit event. Assert exact keys and snake-case values and assert
+      terminal-only fields are absent from starts.
+- [ ] Add `it_rejects_invalid_account_event_shapes`: no terminal result on a
+      start, failure without `failure_kind`, success with a failure kind,
+      degraded success without `degradation_kind`, degradation on another
+      result, duration over 600,000 ms, unrecognized service code, and a
+      non-terminal phase with `duration_ms` must fail validation rather than be
+      captured.
+- [ ] Add `web_and_native_capture_the_same_account_event_shape`: feed one
+      `AccountEvent` to both target adapters and assert the account-owned keys
+      and values are identical. Permit only transport-owned standard context
+      such as `environment`, `$lib`, OS, and architecture to differ. Implement
+      this as paired native and Wasm golden-payload tests because the two
+      transports are target-gated and cannot be linked into one test binary.
+- [ ] Add a sentinel privacy test containing `person@example.com`,
+      `did:key:zSensitive`, a credential ID, an activation URL with `ucan=`, a
+      callback URL, and an HTTP body in nearby source inputs. Serialize the
+      resulting typed event and assert none of the sentinel substrings occur.
+- [ ] Run `cargo test -p tonk-analytics`; expect the new tests to fail because
+      the account schema and capture entry point do not exist.
+- [ ] Implement the enums and a private `validated_properties()` serializer.
+      Keep arbitrary maps out of the public interface; `capture_account` is the
+      only account-event path on both targets. Keep clocks, attempt generation,
+      failure-streak state, callback handling, and flushing out of this module.
+- [ ] Register `version` beside `environment` in `ph_init`, and set
+      `capture_exceptions: false` explicitly so a PostHog project-side toggle
+      cannot silently start collecting console/browser errors before Task 6.
+- [ ] Make native `capture_account` add `environment=cli` through transport
+      context before queuing; do not make each CLI call site supply it. Preserve
+      the existing generic command event's identical environment value.
+- [ ] Run `cargo test -p tonk-analytics` and
+      `cargo test -p tonk-analytics --target wasm32-unknown-unknown`; expect all
+      native and Wasm schema tests to pass.
+
+### Task 2: Preserve typed failure evidence through the UI
+
+**Files:**
+- Modify: `rust/tonk-identity/src/passkey.rs:CeremonyRefusal, ceremony_error`
+- Modify: `rust/tonk-ui/src/custody_relay.rs:CeremonyError::thrown`
+- Modify: `rust/tonk-ui/src/error.rs:TonkUiError`
+- Modify: `rust/tonk-ui/src/api.rs:account endpoint helpers`
+- Modify: `rust/tonk-ui/src/user_error.rs:diagnostic, ceremony, api`
+- Test: the inline test modules in those files
+
+**Interfaces:**
+- Consumes: `CeremonyRefusal`, `CustodyDenial`, structured worker `ErrorBody`,
+  `reqwest::StatusCode`, and the current exact local diagnostic.
+- Produces: `AccountProblem { message, failure_kind, result,
+  http_status_class, service_code }`; presentation and telemetry consume the
+  same value.
+
+- [ ] Add a table-driven `CeremonyRefusal::from_name` test for
+      `NotAllowedError`, `InvalidStateError`, `NotSupportedError`,
+      `SecurityError`, `NoPrfError`, and an unknown name. Run
+      `cargo test -p tonk-identity --target wasm32-unknown-unknown`; expect
+      failure because callers cannot yet recover the typed name.
+- [ ] Extend UI `CeremonyError` with `refusal: Option<CeremonyRefusal>` and read
+      it from the rejected object's `name`; retain `denial` independently so a
+      service refusal and browser refusal cannot overwrite one another.
+- [ ] Introduce a structured account API error variant carrying only
+      `transport_kind` (`network`, `http`, `decode`, `local`), optional status,
+      optional already-allowlisted service code, and the existing diagnostic.
+      Convert account functions from `account_status` through hosted-space
+      deletion; leave unrelated editor/repository functions unchanged.
+- [ ] Refactor `user_error` classification to return `AccountProblem`, and keep
+      the existing string-returning helpers as thin compatibility wrappers
+      during call-site migration. Typed evidence wins; compatibility prose
+      matching must report `failure_kind=unknown`; deepen a typed source instead
+      of promoting matched prose into an analytics classification.
+- [ ] Extend current user-error tests to assert both recovery copy and
+      `failure_kind/result`, including cancellation, timeout, duplicate
+      credential, missing PRF, unsupported browser, awaiting activation,
+      suspended, not provisioned, 401/403, 404, 409, 429, 5xx, network, decode,
+      local state, and unknown commit.
+- [ ] Assert a suspension reason, access-service reason, response body, email,
+      DID, credential ID, and browser exception detail appear only in the local
+      diagnostic and never in `AccountProblem`'s analytics fields or message.
+- [ ] Run `cargo test -p tonk-ui --lib` and
+      `cargo check -p tonk-ui --target wasm32-unknown-unknown`; expect success
+      with no new prose-matching call sites.
+
+### Task 3: Add the deep web account-attempt adapter
+
+**Files:**
+- Create: `rust/tonk-ui/src/account_observability.rs`
+- Modify: `rust/tonk-ui/src/lib.rs`
+- Test: `rust/tonk-ui/src/account_observability.rs`
+
+**Interfaces:**
+- Consumes: `AccountAction`, `AccountProblem`, and the typed
+  `tonk_analytics::account` vocabulary.
+- Produces: `WebAccountAttempt::start`, `checkpoint`, and `finish`; production
+  `PostHogRecorder` and test `MemoryRecorder` adapters at one web-recorder seam.
+
+- [ ] Add `it_records_one_start_and_one_terminal_outcome` with a fake monotonic
+      clock. Assert a repeated `finish` and checkpoints after finish are no-ops,
+      and duration is capped at 600,000 ms.
+- [ ] Add `it_gives_each_attempt_an_opaque_non_content_id`; assert IDs differ,
+      are bounded to 36 ASCII characters, and contain none of the action,
+      account state, or supplied diagnostic.
+- [ ] Add `it_reports_one_automatic_failure_per_streak`: three equal load
+      failures yield one terminal event, a success yields a recovery event, and
+      a later equal failure begins a new streak. User-triggered attempts remain
+      unsuppressed.
+- [ ] Add `it_keeps_expected_blocks_out_of_failure_totals`: cancellation,
+      awaiting activation, and suspension retain their distinct result/failure
+      properties rather than becoming `retryable_failure`.
+- [ ] Run `cargo test -p tonk-ui --lib account_observability`; expect failure
+      because the recorder module is absent.
+- [ ] Implement the recorder behind the three-method interface. Use a random
+      opaque attempt token from browser randomness; when randomness is
+      unavailable, use a page-local monotonic token rather than account data.
+      Never persist an attempt token to local storage. Keep browser-only clocks,
+      failure-streak suppression, and page lifetime here rather than adding
+      them to `tonk-analytics::account`.
+- [ ] Make PostHog-disabled capture a no-op while still allowing UI logic to
+      finish. Do not log analytics delivery errors to the account UI or retry
+      them through an account operation.
+- [ ] Run the focused module tests, `cargo test -p tonk-ui --lib`, and the
+      target-specific check; expect success.
+
+### Task 4: Instrument onboarding, login, activation, and passkeys
+
+**Files:**
+- Modify: `rust/tonk-ui/src/register_dialog.rs`
+- Modify: `rust/tonk-ui/src/account.rs:create/login/add-passkey handlers`
+- Modify: `rust/tonk-ui/src/custody_relay.rs`
+- Modify: `rust/tonk-ui/src/activate.rs`
+- Modify: `rust/tonk-ui/src/account_flow.rs`
+
+**Interfaces:**
+- Consumes: the Task 3 `WebAccountAttempt` interface and Task 2 problems.
+- Produces: complete, correlation-safe event sequences for the four critical
+  journeys, with no change to their durable state or recovery behavior.
+
+- [ ] Add a browser capture fixture that replaces `window.posthog` with an
+      in-memory stub before `analytics::install`, then exposes captured event
+      JSON to `account_flow` assertions. It must exercise the real
+      `before_send` function, not a second Rust-only serializer.
+- [ ] Extend `it_signs_up_through_the_account_panels` to require:
+      registration viewed; create started; email lookup checkpoint; passkey
+      create checkpoint; terminal `blocked/awaiting_activation`; activation
+      started and succeeded; settle started and succeeded. Assert one terminal
+      event per attempt and ordered timestamps.
+- [ ] Extend `it_waits_for_the_email_when_a_second_device_signs_in` to require
+      login `blocked/awaiting_activation`, followed by a recovery settle event
+      after activation; awaiting activation must not increment the product
+      failure series.
+- [ ] Extend `it_retries_the_committed_address_after_a_failed_passkey_ceremony`
+      to distinguish a cancelled ceremony from an unknown-commit recovery and
+      assert that retry creates a new attempt ID.
+- [ ] Add focused stub cases for `InvalidStateError`, `NotSupportedError`,
+      `SecurityError`, no PRF, worker-handoff timeout, typed service denial, and
+      a 5xx. Assert their exact action, stage, result, and failure kind.
+- [ ] Add a negative capture assertion over every event in those journeys for
+      the actual test email, root DID, credential bytes, account endpoint,
+      activation URL/UCAN, service refusal text, and callback URL.
+- [ ] Run each named browser test against the baseline event code; expect it to
+      fail because no `account_event` records exist.
+- [ ] Instrument at the existing user-gesture and error-presentation seams.
+      Define create completion as “registered and waiting for activation,”
+      activation completion as successful consumption of the emailed link,
+      and login completion as the account dashboard becoming ready. Do not call
+      `mediate_now` success full login success when later local attachment can
+      still fail.
+- [ ] Record validation failures only after submission; never record field
+      contents, keystrokes, or dialog focus/hover activity.
+- [ ] Run the focused browser tests serially with
+      `cargo test -p tonk-ui --features integration-tests -- <test-name>
+      --test-threads=1`, then run `cargo test -p tonk-ui --lib` and the Wasm
+      check. Expect all to pass.
+
+### Task 5: Instrument account management and destructive recovery
+
+**Files:**
+- Modify: `rust/tonk-ui/src/account.rs`
+- Modify: `rust/tonk-ui/src/register_dialog.rs`
+- Modify: `rust/tonk-ui/src/custody_relay.rs`
+- Modify: `rust/tonk-ui/src/account_flow.rs`
+
+**Interfaces:**
+- Consumes: the same recorder; no new event names or free-form properties.
+- Produces: start/terminal coverage for every remaining `AccountAction` and
+  failure-streak coverage for automatic account loads.
+
+- [ ] Add a compile-time/table test mapping every `AccountAction` to exactly
+      one stable `journey`, `action`, and default stage. Adding an enum variant
+      without telemetry classification must fail the test/build.
+- [ ] Cover automatic settings/account/registration/device/profile loads.
+      Assert repeated polling failures collapse to one streak, successful
+      reload emits recovery, and a new failure after recovery is visible.
+- [ ] Cover display-name change, activation resend, add/switch profile, link
+      CLI, copy callback/invite, sign out, load deletion plan, revoke device,
+      delete hosted space, and delete account. Each user gesture gets a start
+      and exactly one result.
+- [ ] For revoke/delete, assert pre-dispatch cancellation is `cancelled`, a
+      rejected mutation is `terminal_failure` when the server proves no commit,
+      a lost/undecodable response after dispatch is `unknown_commit`, and a
+      partial deletion result records `unknown_commit` without target IDs or
+      counts that reveal account inventory.
+- [ ] Extend `it_revokes_the_cli_device_from_the_browser` and
+      `it_deletes_the_account_and_releases_its_email_and_profile` to inspect the
+      captured sequences while retaining their existing durable-state
+      assertions.
+- [ ] Add a failure case for clipboard/callback delivery that proves the
+      account/passkey success remains success while the separate callback
+      action ends with `failure_kind=callback`.
+- [ ] Run focused browser tests, `cargo test -p tonk-ui --lib`,
+      `cargo check -p tonk-ui --target wasm32-unknown-unknown`, and
+      `cargo fmt --all -- --check`; expect success.
+
+### Task 6: Add safe runtime exception and panic diagnostics
+
+**Files:**
+- Modify: `rust/tonk-analytics/src/web.rs:ph_init, before_send`
+- Modify: `rust/tonk-ui/src/analytics.rs:install_panic_hook`
+- Modify: `rust/tonk-ui/src/account_flow.rs`
+- Conditional modify: `.github/workflows/publish.yml`
+- Conditional modify: `flake.nix:tonk-ui`
+
+**Interfaces:**
+- Consumes: PostHog's `$exception`/`captureException` interface and the existing
+  normalized-route/privacy rules.
+- Produces: useful uncaught exception issues tagged with environment/version;
+  handled account outcomes remain only `account_event` records.
+
+- [ ] First add a browser payload test for an uncaught `Error`, an unhandled
+      rejection, a cross-origin/extension-shaped error, and a Wasm panic whose
+      message contains every privacy sentinel from Task 1. Inspect the exact
+      outbound payload, not only the PostHog stub call.
+- [ ] Configure `capture_exceptions` with unhandled errors/rejections enabled
+      and console errors disabled. Drop cross-origin/extension-only exceptions.
+      In `before_send`, normalize/remove current/referrer URLs and query/hash,
+      remove code-variable payloads, and replace exception values with a closed
+      type plus safe static location. Preserve same-origin stack frames only.
+- [ ] Replace the current raw first-line `panic.message` property. Capture a
+      static panic type, `PanicHookInfo::location()` reduced to repository-
+      relative file/line when available, and a fingerprint derived only from
+      type + static location. Never hash or send the panic message itself.
+- [ ] Assert handled `AccountProblem`s and all `console.error` calls generate
+      zero `$exception` events. Assert opt-out and missing-key builds generate
+      no account or exception request.
+- [ ] Build a release-shaped UI and determine whether PostHog resolves its JS
+      and Wasm stack locations with an uploaded, non-public source map. Add a
+      publish upload step only if the built artifact contains useful maps and a
+      staging exception resolves to repository source; otherwise document the
+      limit and retain static panic location plus release version.
+- [ ] If uploading, use a dedicated CI secret, associate the release with the
+      Tonk version and commit SHA, upload before `wrangler deploy`, and verify
+      the deployed asset directory contains no `.map` files.
+- [ ] Run the browser payload tests, `nix build .#tonk-ui`, and a staging-only
+      synthetic exception. Confirm one redacted issue in PostHog Error Tracking
+      with environment/version and no sentinel data before enabling production.
+
+### Task 7: Add the deep native CLI account-attempt adapter
+
+**Files:**
+- Create: `rust/tonk-cli/src/account_observability.rs`
+- Modify: `rust/tonk-cli/src/lib.rs`
+- Modify: `rust/tonk-cli/src/bin/tonk.rs:account_op and command dispatch`
+- Modify: `rust/tonk-cli/src/account.rs:link_with_operator, link_via_callback, LinkOutcome`
+- Modify: `rust/tonk-cli/src/callback.rs:Callback::bind, Callback::receive`
+- Modify: `rust/tonk-cli/src/telemetry.rs:Recorder`
+- Modify: `rust/tonk-cli/tests/telemetry.rs`
+
+**Interfaces:**
+- Consumes: `tonk_analytics::account::{AccountEvent, AccountOutcome, Action,
+  Stage, FailureKind, DegradationKind}`, the static `AccountCommand` descriptor,
+  `callback::CallbackFailureKind`, and typed evidence at each CLI account stage
+  before it becomes `anyhow` prose or `ExitCode`.
+- Produces: `CliAccountAttempt::start`, `checkpoint`, `finish`, and
+  `into_events`; `Recorder::account_events` queues those validated events beside
+  one unchanged `cli_command_run`, and `Recorder::finish` sends the single
+  existing native batch within 300 ms. `CliAccountObserver` exposes only
+  `checkpoint(Stage)` and `degraded(DegradationKind)` to the account link path;
+  `CliAccountAttempt` and `NoopAccountObserver` are its two adapters.
+
+- [ ] Add `it_records_native_account_start_checkpoints_and_one_terminal` with a
+      fake monotonic clock. Cover repeated `finish`, checkpoints after finish,
+      a 300-second browser wait, and the shared 600,000 ms duration cap. Assert
+      `surface=native_cli` and an opaque process-local attempt ID.
+- [ ] Add a table test mapping every `AccountCommand` descriptor (`status`,
+      `login`, `logout`, `delete`, `space-list`, `space-pull`, `space-delete`,
+      `sync`, `devices`, and `revoke`) to one shared `journey`, `action`, and
+      initial stage using the event-contract mapping above. A new account
+      subcommand without a mapping must fail.
+- [ ] Add focused login tests for these exact terminal classifications:
+      already signed in -> `blocked/conflict` at `local_preflight`; loopback
+      bind failure -> `retryable_failure/callback` at `callback_bind`;
+      callback timeout -> `retryable_failure/timeout` at `callback_wait`;
+      browser denial -> `blocked/access_denied` at `callback_wait`; malformed or
+      invalid grant -> `terminal_failure/invalid_response` at
+      `delegation_validate`; and durable-state write failure ->
+      `unknown_commit/local_state` at `activation_stage` when commitment cannot
+      be disproved. Classify from the branch and typed source, never from the
+      rendered error.
+- [ ] Replace callback prose-only errors with
+      `CallbackFailureKind::{Bind, Closed, Server, Timeout}` and a
+      `CallbackFailure::kind()` accessor while preserving the current `Display`
+      text and available source chain. Make `Callback::bind` and
+      `Callback::receive` return the typed error. Add callback unit tests for
+      each kind; the observer maps `Timeout` to `failure_kind=timeout` and the
+      other callback transport failures to `failure_kind=callback`.
+- [ ] Add zero-exit login fixtures for failed automatic browser opening followed
+      by a successful manual handoff, an unhydrated `LinkOutcome::warning`,
+      failed content-endpoint discovery, failed onboarding-custody rotation, and
+      failed local-space rotation. Assert terminal `result=degraded_success`
+      with `degradation_kind=browser_open`, `account_sync`,
+      `content_discovery`, `custody_rotation`, or `space_rotation` respectively,
+      while `cli_command_run.success=true`. When several occur, record the
+      earliest incomplete stage as the primary degradation and retain all exact
+      warning text only on local stderr.
+- [ ] Add a native wire-shape test asserting one account invocation produces
+      one `cli_command_run` plus the expected `account_event` sequence in the
+      same `/batch` payload. Assert the generic event retains only its existing
+      command/subcommand/exit/duration properties and does not acquire account
+      `stage`, `result`, or `failure_kind` fields.
+- [ ] Add a negative assertion over both event types for the fixture's email,
+      callback and remote URLs, root/device DIDs, delegation, credential ID,
+      local paths, argv values, warning text, and stderr error. Add opt-out
+      coverage for the same failed command and assert no request arrives.
+- [ ] Run `cargo test -p tonk-cli --test telemetry`; expect the account-event
+      sequence and degradation assertions to fail because only the coarse
+      `cli_command_run` record exists.
+- [ ] Implement `CliAccountAttempt` as a process-local buffer of shared typed
+      events. It may own a clock and random attempt token, but no PostHog client;
+      `Recorder::account_events` validates and queues its events into the
+      recorder's existing `tonk_analytics::native::Client`. Do not create a
+      second HTTP client, request, flush timeout, opt-out decision, or account
+      property map.
+- [ ] Preserve typed stage outcomes through `account_op`, `link_account`, and
+      the observed link path until the attempt is finished. Existing public
+      account entry points that do not record telemetry call the observed form
+      with `NoopAccountObserver`; do not duplicate the link algorithm.
+      Keep browser/passkey stages owned by the web adapter: the CLI records
+      `callback_bind`, `browser_open`, `callback_wait`, `delegation_validate`,
+      `activation_stage`, `account_sync`, `content_discovery`, and
+      `custody_rotation`; the browser records passkey, consent, and
+      `callback_delivery`. Neither side emits the callback address or shares an
+      attempt ID through it.
+- [ ] Run `cargo test -p tonk-cli --test telemetry`, focused callback/account
+      tests, `cargo test -p tonk-cli --lib`, and
+      `cargo fmt --all -- --check`; expect success.
+
+### Task 8: Add privacy-safe access Worker operational logs
+
+**Files:**
+- Create: `rust/tonk-access-service/src/observability.rs`
+- Modify: `rust/tonk-access-service/src/lib.rs`
+- Modify: `rust/tonk-access-service/src/handlers/registration.rs`
+- Modify: `rust/tonk-access-service/src/handlers/lookup.rs`
+- Modify: `rust/tonk-access-service/src/handlers/ucan.rs`
+- Modify: `wrangler.toml`
+- Test: inline module tests plus existing access-service integration tests
+
+**Interfaces:**
+- Consumes: stable handler operation, status, typed registration/provisioning
+  refusal, deployment name, and whether a retry is safe.
+- Produces: one structured JSON log for each failed account-related Worker
+  request; no success/request-body logging and no user/profile identifier.
+
+- [ ] Add serializer tests for `AccessFailureLog` with exact keys:
+      `schema_version`, `system=access_worker`, `operation`, `outcome`,
+      `failure_kind`, `status_class`, `retryable`, and `version`. Test
+      enrollment, activation, resend, lookup, customer probe, authorization,
+      and provisioning failure variants.
+- [ ] Feed the serializer an email, DID, subject, R2 key, invocation, activation
+      URL, and internal error. Assert none can enter serialized properties; an
+      unknown internal failure becomes only `failure_kind=internal` plus a
+      static `site` enum.
+- [ ] Run `cargo test -p tonk-access-service --lib`; expect failure because the
+      observability module does not exist.
+- [ ] Emit structured objects at the HTTP response seam. Use `console_warn` for
+      expected 4xx refusals and `console_error` for unexpected/unavailable 5xx.
+      Never write exact internal diagnostics from the deployed Worker adapter;
+      native helper/local-server stderr remains the detailed development sink.
+- [ ] Replace account-related Worker logs that currently interpolate a subject,
+      DID, or raw error with the structured adapter. Do not broaden this change
+      to ordinary storage/metering logs in the same commit.
+- [ ] Configure production and staging Workers Logs explicitly with logs
+      enabled, `head_sampling_rate = 1`, `invocation_logs = false`, and query
+      string redaction. The worker also serves static assets, so disabling
+      invocation logs avoids recording every asset request while preserving
+      every explicit account failure log. Configure preview identically so QA
+      evidence has the same shape as staging and production.
+- [ ] Run access-service library and registration/lookup/UCAN integration tests,
+      `nix build .#tonk-access-service`, and `wrangler deploy --dry-run` for the
+      checked-in configuration. Expect structured failure records and no
+      request URL/query in the inspected output.
+- [ ] After staging deployment, trigger one typed 4xx and one controlled 5xx;
+      verify both appear under Workers & Pages -> tonk-access-service ->
+      Observability with searchable closed fields and no user/account data.
+
+### Task 9: Document dashboards, alerts, retention, and investigation
+
+**Files:**
+- Modify: `docs/telemetry.md`
+- Create: `docs/account-observability.md`
+- Modify: `docs/storybook/accounts/lifecycle.md:Privacy and telemetry`
+- Modify: `docs/storybook/accounts/authority-and-deletion.md:Privacy and telemetry`
+- Modify: generated Storybook data through the repository build script if the
+  source changes affect its inventory
+
+**Interfaces:**
+- Consumes: the final event/log schemas and actual staging field names.
+- Produces: reproducible PostHog insights, Cloudflare saved queries, alert
+  definitions, and a privacy/audit runbook.
+
+- [ ] Expand the complete telemetry inventory with `account_event`, every
+      property/value family, the difference between analytics and operational
+      logs, exception capture, opt-out behavior, and the explicit never-sent
+      list. State that both web and native CLI adapters emit this event, while
+      `cli_command_run` remains a separate invocation metric and must not be
+      added to account-attempt counts.
+- [ ] Create a PostHog “Account health” dashboard, filtered to
+      `environment in (production, staging, cli)` with dashboard-level
+      environment and `surface` selectors, containing only `account_event` for
+      attempt/outcome insights:
+      1. attempts and unique profiles by `surface`, then `action`;
+      2. terminal success, degraded success, cancelled, blocked, failure, and
+         unknown-commit counts;
+      3. hard-failure rate (`retryable_failure + terminal_failure +
+         unknown_commit` divided by `started`) plus degraded-success rate
+         (`degraded_success` divided by `started`), each with a minimum-attempt
+         annotation;
+      4. failures broken down by `failure_kind`, then `stage`;
+      5. degraded successes by `degradation_kind`, then `stage`, with CLI
+         account-sync, discovery, and custody warnings visible independently of
+         process exit status;
+      6. impacted unique profiles by browser, OS, version, environment, and
+         surface; browser-only dimensions must show “not applicable” rather
+         than excluding native events;
+      7. p50/p95 `duration_ms` by action and surface for terminal events;
+      8. onboarding funnel: registration viewed -> create started -> pending
+         activation -> activation success -> settle success;
+      9. web login funnel: login started -> passkey assert -> login success, with
+         cancellation and activation blocks visible as exclusions;
+      10. native login funnel: login started -> callback bound -> callback
+          received -> delegation validated -> activation staged -> account
+          ready/degraded, without claiming exact correlation to the separate
+          browser attempt;
+      11. passkey-add and destructive-action outcomes by surface; and
+      12. `unknown`, 5xx, panic, and `$exception` events as a release-regression
+          panel.
+- [ ] Save alerts for any production-web or native-CLI
+      `failure_kind=unknown`, for a panic or `$exception` burst, and for a
+      15-minute account hard-failure rate above 10% only when at least 20
+      attempts exist. Route alerts through the team's existing PostHog
+      notification destination; do not add a new external integration without
+      approval.
+- [ ] Save Cloudflare queries grouped by `operation/failure_kind/site` for
+      access Worker 4xx and 5xx, plus a version/environment comparison. Record
+      the Workers Logs retention shown by the live account rather than assuming
+      it equals PostHog retention.
+- [ ] Write the investigation order: identify the top PostHog
+      `surface/action/stage/failure_kind` or `degradation_kind`; split by
+      environment/version and then interface-relevant browser/OS dimensions;
+      reproduce that typed branch; then consult matching-time Cloudflare
+      aggregate logs for access-service failures. State that browser and CLI
+      attempts deliberately have separate attempt IDs and that PostHog and
+      Cloudflare deliberately have no stable per-user join key.
+- [ ] Document event ownership: product code owners approve enum additions,
+      privacy review approves new properties, and `unknown` classifications are
+      fixed by deepening typed upstream errors rather than adding raw strings.
+      Document the stage split: web owns passkey/PRF/consent/callback delivery;
+      CLI owns listener/browser-open/wait/grant-validation/local-convergence;
+      access Worker owns request-handler failures.
+- [ ] Run `python3 scripts/build.py --check` from `docs/storybook` when its
+      sources are modified, `python3 scripts/check-links.py .`,
+      `cargo fmt --all -- --check`, and `git diff --check`; expect success.
+
+## Rollout and completion gate
+
+1. Deploy schema and instrumentation to staging with the PostHog capture
+   fixture, native batch fixture, and both interface opt-out tests green.
+2. Exercise one success and every safe synthetic failure family. Compare the
+   web and CLI PostHog event exports against the same allowlist and privacy
+   sentinels before opening production ingestion. Confirm one CLI account
+   invocation batches one generic `cli_command_run` plus its `account_event`
+   sequence without creating a second request.
+3. Run staging for at least one normal QA cycle. Confirm starts and terminal
+   outcomes balance except for demonstrably abandoned navigation, automatic
+   polls do not dominate counts, CLI zero-exit warnings appear as degraded
+   successes, and `unknown` is not the leading category on either surface.
+4. Enable production account events. Keep generic exception capture disabled
+   until Task 6's exact outbound-payload and source-location checks pass.
+5. Enable structured access Worker logs only after `wrangler` dry-run confirms
+   query redaction and invocation-log suppression for production and staging.
+6. Review the dashboard after the first meaningful production sample. Rank
+   fixes by impacted unique profiles and failure rate, not raw event count; use
+   cancellation and awaiting activation as journey friction, not reliability
+   defects.
+
+Completion requires fresh evidence after the final change:
+
+- all native and Wasm analytics/UI unit tests pass;
+- the named account browser journeys pass serially with exact event sequences;
+- the CLI telemetry integration tests contain the shared schema plus the
+  unchanged generic command event in one batch, and opt-out sends nothing;
+- access-service focused integration tests and Nix builds pass;
+- a staging PostHog export contains every expected event and no sentinel;
+- staging Error Tracking contains only deliberately triggered, redacted
+  unhandled exceptions if Task 6 is enabled;
+- staging Workers Logs contain the controlled 4xx/5xx structured records and no
+  URL query, email, DID, subject, invocation, credential, or raw error;
+- the saved dashboard, funnels, alerts, and operational queries match the
+  documented field names; and
+- `cargo fmt --all -- --check`, documentation build/link checks, and
+  `git diff --check` pass.
+
+## Explicit non-goals
+
+- Recording page contents, keystrokes, session replays, heatmaps, or arbitrary
+  console/network logs.
+- Identifying the passkey manager or collecting authenticator/credential
+  material. Browser and OS properties already supplied by PostHog are enough
+  for platform comparisons.
+- Sending server operational logs to PostHog or bypassing a user's telemetry
+  opt-out with server-side product analytics.
+- Changing account lifecycle, activation, retry, deletion, authority, or
+  storage semantics while adding instrumentation.
+- Building one cross-platform recorder containing DOM, polling, callback,
+  process-flush, and Worker concerns; only the event contract is shared.
+- Correlating an individual browser ceremony to an individual CLI process by
+  adding an identifier to the callback protocol in version 1.
+- Using telemetry as proof that a mutation committed. Durable state and typed
+  service receipts remain canonical; telemetry is a projection for diagnosis.
+
+## External interface references checked for this plan
+
+- PostHog exception capture and redaction:
+  <https://posthog.com/docs/error-tracking/capture>
+- PostHog trends/funnels:
+  <https://posthog.com/docs/product-analytics/trends/overview> and
+  <https://posthog.com/docs/product-analytics/funnels>
+- Cloudflare Workers structured logs and sampling:
+  <https://developers.cloudflare.com/workers/observability/logs/workers-logs/>
+- Cloudflare observability query builder:
+  <https://developers.cloudflare.com/workers/observability/query-builder/>

--- a/rust/tonk-access-service/src/handlers/lookup.rs
+++ b/rust/tonk-access-service/src/handlers/lookup.rs
@@ -79,7 +79,11 @@ pub async fn handle(req: Request, ctx: RouteContext<()>) -> worker::Result<Respo
             // A limiter that cannot answer must not take the endpoint
             // down with it; the lookup discloses nothing a caller could
             // not reach through the registration probe anyway.
-            Err(err) => worker::console_error!("lookup rate limit unavailable: {err}"),
+            // This endpoint deliberately fails open when the limiter is
+            // unavailable. Do not emit a failed-request record for a request
+            // that can still succeed; the response seam below owns the one
+            // terminal record if the lookup itself fails.
+            Err(_) => {}
         }
     }
 
@@ -116,8 +120,16 @@ pub async fn handle(req: Request, ctx: RouteContext<()>) -> worker::Result<Respo
         None => {
             let store = match ctx.env.d1("CONTROL") {
                 Ok(database) => D1Store::new(database),
-                Err(err) => {
-                    worker::console_error!("email lookup unavailable, no CONTROL binding: {err}");
+                Err(_) => {
+                    crate::observability::AccessFailureLog::new(
+                        crate::observability::AccessOperation::Lookup,
+                        crate::observability::AccessOutcome::Unavailable,
+                        crate::observability::AccessFailureKind::Unavailable,
+                        500,
+                        true,
+                        crate::observability::AccessSite::ControlStore,
+                    )
+                    .emit();
                     return with_cors(Response::error("Customer registry is not configured", 500));
                 }
             };
@@ -129,8 +141,16 @@ pub async fn handle(req: Request, ctx: RouteContext<()>) -> worker::Result<Respo
                     }
                     row
                 }
-                Err(err) => {
-                    worker::console_error!("email lookup failed: {err}");
+                Err(_) => {
+                    crate::observability::AccessFailureLog::new(
+                        crate::observability::AccessOperation::Lookup,
+                        crate::observability::AccessOutcome::Unavailable,
+                        crate::observability::AccessFailureKind::Unavailable,
+                        500,
+                        true,
+                        crate::observability::AccessSite::ControlStore,
+                    )
+                    .emit();
                     return with_cors(Response::error("Customer registry is unavailable", 500));
                 }
             }

--- a/rust/tonk-access-service/src/handlers/registration.rs
+++ b/rust/tonk-access-service/src/handlers/registration.rs
@@ -6,7 +6,7 @@
 
 use dialog_credentials::Ed25519Signer;
 use tonk_account::customer::RegistrationError;
-use worker::{Env, Request, Response, RouteContext, console_error};
+use worker::{Env, Request, Response, RouteContext};
 
 use crate::service::{did_document, signer_from_hex};
 
@@ -55,6 +55,44 @@ pub async fn handle(body: &[u8], req: &Request, env: &Env) -> worker::Result<Res
             Response::from_json(&receipt)
         }
         Err(err) => {
+            use crate::observability::{
+                AccessFailureKind, AccessFailureLog, AccessOperation, AccessOutcome, AccessSite,
+            };
+            use crate::registration::RegistrationCommand;
+            let operation = match crate::registration::registration_command(body) {
+                Some(RegistrationCommand::Enroll) => AccessOperation::Enrollment,
+                Some(RegistrationCommand::Activate) => AccessOperation::Activation,
+                Some(RegistrationCommand::Resend) => AccessOperation::Resend,
+                Some(
+                    RegistrationCommand::ProviderAdd
+                    | RegistrationCommand::Suspend
+                    | RegistrationCommand::Resume
+                    | RegistrationCommand::Archive,
+                )
+                | None => AccessOperation::Provisioning,
+            };
+            let status = err.status();
+            let failure_kind = match status {
+                401 | 403 => AccessFailureKind::AccessDenied,
+                404 => AccessFailureKind::NotFound,
+                409 => AccessFailureKind::Conflict,
+                429 => AccessFailureKind::RateLimited,
+                500..=599 => AccessFailureKind::Unavailable,
+                _ => AccessFailureKind::Invalid,
+            };
+            AccessFailureLog::new(
+                operation,
+                if status >= 500 {
+                    AccessOutcome::Unavailable
+                } else {
+                    AccessOutcome::Refused
+                },
+                failure_kind,
+                status,
+                status >= 500 || status == 429,
+                AccessSite::Registration,
+            )
+            .emit();
             let response = Response::from_json(&serde_json::json!({ "error": err }))?;
             Ok(response.with_status(err.status()))
         }
@@ -107,11 +145,7 @@ async fn replicate_verdicts(answer: &crate::registration::Answer, env: &Env) {
                         .map(|subscription| subscription.consumer)
                         .filter(|consumer| *consumer != customer),
                 ),
-                Err(err) => {
-                    worker::console_error!(
-                        "verdicts for {customer}'s consumers not refreshed: {err}"
-                    );
-                }
+                Err(_) => worker::console_error!("consumer verdicts were not refreshed"),
             }
             // The row itself, for the probe and the email lookup: both
             // poll it, and the write-through is how a poll notices the
@@ -120,15 +154,11 @@ async fn replicate_verdicts(answer: &crate::registration::Answer, env: &Env) {
                 match store.customer(&customer).await {
                     Ok(Some(row)) => crate::store::replica::replicate(kv, &row, now).await,
                     Ok(None) => {}
-                    Err(err) => {
-                        worker::console_error!(
-                            "customer replica for {customer} not written: {err}"
-                        );
-                    }
+                    Err(_) => worker::console_error!("customer replica was not written"),
                 }
             }
         }
-        Err(err) => worker::console_error!("verdicts not refreshed, no CONTROL binding: {err}"),
+        Err(_) => worker::console_error!("verdicts were not refreshed: CONTROL is unavailable"),
     }
     for subject in subjects {
         let _ = derive_verdict(&subject, now, env, kv.as_ref()).await;
@@ -267,8 +297,16 @@ pub async fn handle_customer(req: Request, ctx: RouteContext<()>) -> worker::Res
 
     let store = match ctx.env.d1("CONTROL") {
         Ok(database) => D1Store::new(database),
-        Err(err) => {
-            worker::console_error!("customer probe unavailable, no CONTROL binding: {err}");
+        Err(_) => {
+            crate::observability::AccessFailureLog::new(
+                crate::observability::AccessOperation::CustomerProbe,
+                crate::observability::AccessOutcome::Unavailable,
+                crate::observability::AccessFailureKind::Unavailable,
+                500,
+                true,
+                crate::observability::AccessSite::ControlStore,
+            )
+            .emit();
             return Response::error("Customer registry is not configured", 500);
         }
     };
@@ -279,8 +317,16 @@ pub async fn handle_customer(req: Request, ctx: RouteContext<()>) -> worker::Res
             }
             answer_probe(row, &req)
         }
-        Err(err) => {
-            worker::console_error!("customer probe failed: {err}");
+        Err(_) => {
+            crate::observability::AccessFailureLog::new(
+                crate::observability::AccessOperation::CustomerProbe,
+                crate::observability::AccessOutcome::Unavailable,
+                crate::observability::AccessFailureKind::Unavailable,
+                500,
+                true,
+                crate::observability::AccessSite::ControlStore,
+            )
+            .emit();
             Response::error("Customer registry is unavailable", 500)
         }
     }
@@ -297,8 +343,8 @@ fn answer_probe(
     match customer {
         Some(customer) => {
             let receipt = Receipt {
-                customer: customer.account.parse().map_err(|err| {
-                    worker::Error::RustError(format!("stored customer did is malformed: {err:?}"))
+                customer: customer.account.parse().map_err(|_| {
+                    worker::Error::RustError("stored customer DID is malformed".to_owned())
                 })?,
                 status: customer.status,
                 ledger: None,
@@ -329,8 +375,16 @@ fn answer_probe(
 pub async fn handle_did_document(req: Request, ctx: RouteContext<()>) -> worker::Result<Response> {
     let signer = match service_signer(&ctx.env) {
         Ok(signer) => signer,
-        Err(err) => {
-            console_error!("did document unavailable: {err}");
+        Err(_) => {
+            crate::observability::AccessFailureLog::new(
+                crate::observability::AccessOperation::Provisioning,
+                crate::observability::AccessOutcome::Unavailable,
+                crate::observability::AccessFailureKind::Unavailable,
+                404,
+                false,
+                crate::observability::AccessSite::Entry,
+            )
+            .emit();
             return Response::error("Service identity is not configured", 404);
         }
     };

--- a/rust/tonk-access-service/src/handlers/ucan.rs
+++ b/rust/tonk-access-service/src/handlers/ucan.rs
@@ -19,6 +19,65 @@ use dialog_remote_s3::{Address, S3Error, s3::S3Credential};
 use dialog_remote_ucan_s3::UcanAuthorizer;
 use worker::*;
 
+struct PresignFailure {
+    refusal: Refusal,
+    operation: crate::observability::AccessOperation,
+    failure_kind: crate::observability::AccessFailureKind,
+    retryable: bool,
+    site: crate::observability::AccessSite,
+}
+
+impl PresignFailure {
+    fn authorization(refusal: Refusal) -> Self {
+        let status = refusal.status();
+        Self {
+            refusal,
+            operation: crate::observability::AccessOperation::Authorization,
+            failure_kind: match status {
+                401 | 403 => crate::observability::AccessFailureKind::AccessDenied,
+                503 => crate::observability::AccessFailureKind::Unavailable,
+                500..=599 => crate::observability::AccessFailureKind::Internal,
+                _ => crate::observability::AccessFailureKind::Invalid,
+            },
+            retryable: status >= 500,
+            site: crate::observability::AccessSite::Ucan,
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn provisioning(
+        refusal: Refusal,
+        failure_kind: crate::observability::AccessFailureKind,
+        retryable: bool,
+        site: crate::observability::AccessSite,
+    ) -> Self {
+        Self {
+            refusal,
+            operation: crate::observability::AccessOperation::Provisioning,
+            failure_kind,
+            retryable,
+            site,
+        }
+    }
+
+    fn emit(&self) {
+        let status = self.refusal.status();
+        crate::observability::AccessFailureLog::new(
+            self.operation,
+            if status >= 500 {
+                crate::observability::AccessOutcome::Unavailable
+            } else {
+                crate::observability::AccessOutcome::Refused
+            },
+            self.failure_kind,
+            status,
+            self.retryable,
+            self.site,
+        )
+        .emit();
+    }
+}
+
 /// Add CORS headers to a response for WASM compatibility.
 fn with_cors_headers(response: Response) -> Response {
     let headers = response.headers().clone();
@@ -138,7 +197,9 @@ pub async fn serve(mut req: Request, env: Env, ctx: Context) -> Result<Response>
 
     let (response, metered) = match presign(&body_bytes, &env).await {
         Ok((response, bytes)) => (response, Some(("ok", None, bytes))),
-        Err(refusal) => {
+        Err(failure) => {
+            failure.emit();
+            let refusal = failure.refusal;
             // Denials are recorded — a client retrying against a blocked
             // consumer still costs invocations — but only attributable
             // ones: infra failures and malformed containers are the
@@ -189,8 +250,11 @@ fn record_invocation(
 
 /// Authorize the container and answer the presigned request, together
 /// with the declared write bytes when the permit carries them.
-async fn presign(body_bytes: &[u8], env: &Env) -> std::result::Result<(Response, u64), Refusal> {
-    let authorizer = create_authorizer(env)?;
+async fn presign(
+    body_bytes: &[u8],
+    env: &Env,
+) -> std::result::Result<(Response, u64), PresignFailure> {
+    let authorizer = create_authorizer(env).map_err(PresignFailure::authorization)?;
 
     // Revocation is checked inside the chain walk rather than after it,
     // so every proof is measured against the principals entitled to
@@ -201,17 +265,17 @@ async fn presign(body_bytes: &[u8], env: &Env) -> std::result::Result<(Response,
     let authorizer = {
         use crate::revocation::{checker::IndexedRevocations, index::kv::KvRevocationIndex};
 
-        let store = env.kv("REVOCATIONS_KV").map_err(|err| {
-            console_error!("revocation check unavailable, no REVOCATIONS_KV binding: {err}");
-            unavailable()
-        })?;
+        let store = env
+            .kv("REVOCATIONS_KV")
+            .map_err(|_| PresignFailure::authorization(unavailable()))?;
         authorizer.with_revocations(IndexedRevocations(KvRevocationIndex::new(store)))
     };
 
     let authorized_request = authorizer
         .authorize(body_bytes)
         .await
-        .map_err(map_access_error)?;
+        .map_err(map_access_error)
+        .map_err(PresignFailure::authorization)?;
 
     #[cfg(target_arch = "wasm32")]
     screen_provisioning(body_bytes, env).await?;
@@ -226,7 +290,8 @@ async fn presign(body_bytes: &[u8], env: &Env) -> std::result::Result<(Response,
         .unwrap_or(0);
 
     let cbor_bytes = serde_ipld_dagcbor::to_vec(&authorized_request)
-        .map_err(|e| Refusal::unclassified(format!("failed to serialize response: {e}")))?;
+        .map_err(|e| Refusal::unclassified(format!("failed to serialize response: {e}")))
+        .map_err(PresignFailure::authorization)?;
     Response::from_bytes(cbor_bytes)
         .map(|r| {
             let headers = Headers::new();
@@ -234,6 +299,7 @@ async fn presign(body_bytes: &[u8], env: &Env) -> std::result::Result<(Response,
             (r.with_headers(headers), bytes)
         })
         .map_err(|e| Refusal::unclassified(format!("response error: {e}")))
+        .map_err(PresignFailure::authorization)
 }
 
 /// Screen the subject against the provisioning gate: a space is served
@@ -247,7 +313,10 @@ async fn presign(body_bytes: &[u8], env: &Env) -> std::result::Result<(Response,
 /// verdict back. D1 is the authority; the caches only remember its
 /// answers until their `not_after`.
 #[cfg(target_arch = "wasm32")]
-async fn screen_provisioning(body_bytes: &[u8], env: &Env) -> std::result::Result<(), Refusal> {
+async fn screen_provisioning(
+    body_bytes: &[u8],
+    env: &Env,
+) -> std::result::Result<(), PresignFailure> {
     use crate::provisioning::cache::{self, CachedVerdict};
     use crate::provisioning::container_subject;
 
@@ -255,13 +324,24 @@ async fn screen_provisioning(body_bytes: &[u8], env: &Env) -> std::result::Resul
         // The authorizer accepted these bytes, so a subject we cannot
         // read is shape drift between two parsers rather than a caller
         // error. There is nothing to screen against, so it cannot clear.
-        console_error!("provisioning screen unavailable, container has no readable subject");
-        return Err(provisioning_unavailable());
+        return Err(PresignFailure::provisioning(
+            provisioning_unavailable(),
+            crate::observability::AccessFailureKind::Internal,
+            false,
+            crate::observability::AccessSite::Provisioning,
+        ));
     };
     let now = Date::now().as_millis() / 1_000;
 
     if let Some(cached) = cache::isolate_lookup(&subject, now) {
-        return cached.verdict().map_err(Into::into);
+        return cached.verdict().map_err(|reason| {
+            PresignFailure::provisioning(
+                reason.into(),
+                crate::observability::AccessFailureKind::NotProvisioned,
+                false,
+                crate::observability::AccessSite::Provisioning,
+            )
+        });
     }
 
     let kv = servability_kv(env);
@@ -270,29 +350,47 @@ async fn screen_provisioning(body_bytes: &[u8], env: &Env) -> std::result::Resul
             Ok(Some(text)) => {
                 if let Some(cached) = CachedVerdict::decode(&text).filter(|c| c.fresh(now)) {
                     cache::isolate_store(&subject, cached.clone(), now);
-                    return cached.verdict().map_err(Into::into);
+                    return cached.verdict().map_err(|reason| {
+                        PresignFailure::provisioning(
+                            reason.into(),
+                            crate::observability::AccessFailureKind::NotProvisioned,
+                            false,
+                            crate::observability::AccessSite::Provisioning,
+                        )
+                    });
                 }
             }
             // A miss is not an answer — KV is eventually consistent —
             // so it falls through to authoritative D1.
             Ok(None) => {}
-            Err(err) => {
+            Err(_) => {
                 // A KV read error is served, per the plan: the gate
                 // exists for billing, and its cache being unreachable
                 // is the service's own trouble, not the caller's.
-                console_error!("servability cache unreadable, serving {subject} unscreened: {err}");
+                console_error!("servability cache unreadable; serving request unscreened");
                 return Ok(());
             }
         }
     }
 
-    let outcome = derive_verdict(&subject, now, env, kv.as_ref()).await?;
+    let outcome = derive_verdict(&subject, now, env, kv.as_ref())
+        .await
+        .map_err(|_| {
+            PresignFailure::provisioning(
+                provisioning_unavailable(),
+                crate::observability::AccessFailureKind::Unavailable,
+                true,
+                crate::observability::AccessSite::ControlStore,
+            )
+        })?;
     match outcome {
         Ok(()) => Ok(()),
-        Err(reason) => {
-            worker::console_log!("presign rejected: {subject} is not servable ({reason})");
-            Err(reason.into())
-        }
+        Err(reason) => Err(PresignFailure::provisioning(
+            reason.into(),
+            crate::observability::AccessFailureKind::NotProvisioned,
+            false,
+            crate::observability::AccessSite::Provisioning,
+        )),
     }
 }
 
@@ -304,11 +402,8 @@ pub(crate) fn servability_kv(env: &Env) -> Option<worker::kv::KvStore> {
 
     match env.kv(cache::BINDING) {
         Ok(kv) => Some(kv),
-        Err(err) => {
-            console_error!(
-                "servability cache absent, no {} binding: {err}",
-                cache::BINDING
-            );
+        Err(_) => {
+            console_error!("servability cache binding is absent");
             None
         }
     }
@@ -330,10 +425,7 @@ pub(crate) async fn derive_verdict(
     use crate::provisioning::screen;
     use crate::store::d1::D1Store;
 
-    let store = D1Store::new(env.d1("CONTROL").map_err(|err| {
-        console_error!("provisioning screen unavailable, no CONTROL binding: {err}");
-        provisioning_unavailable()
-    })?);
+    let store = D1Store::new(env.d1("CONTROL").map_err(|_| provisioning_unavailable())?);
     match screen(&store, subject, now).await {
         Ok(outcome) => {
             let cached = CachedVerdict::record(&outcome, subject, now);
@@ -346,16 +438,15 @@ pub(crate) async fn derive_verdict(
                     Ok(put) => put.execute().await.map_err(|err| err.to_string()),
                     Err(err) => Err(err.to_string()),
                 };
-                if let Err(err) = written {
-                    console_error!("servability verdict for {subject} not cached: {err}");
+                if written.is_err() {
+                    console_error!("servability verdict was not cached");
                 }
             }
             Ok(outcome)
         }
-        Err(err) => {
+        Err(_) => {
             // The gate fails closed, but a store failure is the
             // service's own unavailability, not a denial to bill.
-            console_error!("presign refused, control store unreachable: {err}");
             Err(provisioning_unavailable())
         }
     }

--- a/rust/tonk-access-service/src/lib.rs
+++ b/rust/tonk-access-service/src/lib.rs
@@ -48,6 +48,7 @@ mod error;
 mod handlers;
 pub mod lookup;
 pub mod metering;
+pub mod observability;
 pub mod provisioning;
 pub mod registration;
 pub mod revocation;

--- a/rust/tonk-access-service/src/observability.rs
+++ b/rust/tonk-access-service/src/observability.rs
@@ -1,0 +1,215 @@
+//! Content-free account failure records for Cloudflare Workers Logs.
+
+use serde::Serialize;
+
+/// Account-related Worker operation.
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AccessOperation {
+    /// Customer enrollment.
+    Enrollment,
+    /// Email-link activation.
+    Activation,
+    /// Activation email resend.
+    Resend,
+    /// Address lookup.
+    Lookup,
+    /// Customer state probe.
+    CustomerProbe,
+    /// UCAN authorization.
+    Authorization,
+    /// Customer provisioning gate.
+    Provisioning,
+}
+
+/// Coarse operational outcome.
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AccessOutcome {
+    /// Caller or policy refusal.
+    Refused,
+    /// Dependency unavailable; retry may be safe.
+    Unavailable,
+    /// Unexpected internal failure.
+    Failed,
+}
+
+/// Closed infrastructure failure family.
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AccessFailureKind {
+    /// Invalid request shape.
+    Invalid,
+    /// Authentication or authorization refusal.
+    AccessDenied,
+    /// Requested record was absent.
+    NotFound,
+    /// State conflict.
+    Conflict,
+    /// Request throttled.
+    RateLimited,
+    /// A required binding or upstream dependency was unavailable.
+    Unavailable,
+    /// Provisioning policy refused service.
+    NotProvisioned,
+    /// Unexpected internal failure.
+    Internal,
+}
+
+/// Static source location for otherwise unknown internal failures.
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AccessSite {
+    /// Worker request entrypoint.
+    Entry,
+    /// Control D1 access.
+    ControlStore,
+    /// Lookup rate limiter.
+    LookupLimiter,
+    /// UCAN parsing or authorization.
+    Ucan,
+    /// Provisioning screen.
+    Provisioning,
+    /// Registration command handler.
+    Registration,
+}
+
+/// Exact JSON object written for one failed account request.
+#[derive(Debug, Serialize)]
+pub struct AccessFailureLog {
+    schema_version: u8,
+    system: &'static str,
+    operation: AccessOperation,
+    outcome: AccessOutcome,
+    failure_kind: AccessFailureKind,
+    status_class: &'static str,
+    retryable: bool,
+    version: &'static str,
+    site: AccessSite,
+}
+
+impl AccessFailureLog {
+    /// Construct a record exclusively from closed, content-free values.
+    pub const fn new(
+        operation: AccessOperation,
+        outcome: AccessOutcome,
+        failure_kind: AccessFailureKind,
+        status: u16,
+        retryable: bool,
+        site: AccessSite,
+    ) -> Self {
+        Self {
+            schema_version: 1,
+            system: "access_worker",
+            operation,
+            outcome,
+            failure_kind,
+            status_class: if status >= 500 { "5xx" } else { "4xx" },
+            retryable,
+            version: env!("CARGO_PKG_VERSION"),
+            site,
+        }
+    }
+
+    /// Serialize for Workers Logs. This cannot fail for the closed schema.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(self).expect("closed access log serializes")
+    }
+
+    /// Write at a severity matching the HTTP status class.
+    #[cfg(target_arch = "wasm32")]
+    pub fn emit(&self) {
+        let json = self.to_json();
+        if self.status_class == "5xx" {
+            worker::console_error!("{json}");
+        } else {
+            worker::console_warn!("{json}");
+        }
+    }
+
+    /// Native builds retain the schema for tests but have no deployed log sink.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn emit(&self) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_serializes_the_exact_content_free_shape() {
+        let log = AccessFailureLog::new(
+            AccessOperation::Lookup,
+            AccessOutcome::Unavailable,
+            AccessFailureKind::Unavailable,
+            503,
+            true,
+            AccessSite::ControlStore,
+        );
+        let value: serde_json::Value = serde_json::from_str(&log.to_json()).unwrap();
+        let mut keys = value
+            .as_object()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        keys.sort();
+        assert_eq!(
+            keys,
+            [
+                "failure_kind",
+                "operation",
+                "outcome",
+                "retryable",
+                "schema_version",
+                "site",
+                "status_class",
+                "system",
+                "version"
+            ]
+        );
+        assert_eq!(value["operation"], "lookup");
+        assert_eq!(value["status_class"], "5xx");
+    }
+
+    #[test]
+    fn sensitive_inputs_cannot_enter_the_log() {
+        let nearby = "person@example.com did:key:zSensitive r2/key invocation activation?ucan=x database-exploded-secret";
+        let json = AccessFailureLog::new(
+            AccessOperation::Authorization,
+            AccessOutcome::Failed,
+            AccessFailureKind::Internal,
+            500,
+            false,
+            AccessSite::Ucan,
+        )
+        .to_json();
+        for sentinel in nearby.split_whitespace() {
+            assert!(!json.contains(sentinel));
+        }
+    }
+
+    #[test]
+    fn every_account_operation_has_a_stable_value() {
+        for operation in [
+            AccessOperation::Enrollment,
+            AccessOperation::Activation,
+            AccessOperation::Resend,
+            AccessOperation::Lookup,
+            AccessOperation::CustomerProbe,
+            AccessOperation::Authorization,
+            AccessOperation::Provisioning,
+        ] {
+            let json = AccessFailureLog::new(
+                operation,
+                AccessOutcome::Refused,
+                AccessFailureKind::Invalid,
+                400,
+                false,
+                AccessSite::Entry,
+            )
+            .to_json();
+            assert!(json.contains("\"operation\":"));
+        }
+    }
+}

--- a/rust/tonk-analytics/Cargo.toml
+++ b/rust/tonk-analytics/Cargo.toml
@@ -11,6 +11,7 @@ hex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2_0_10 = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 dialog-common = { workspace = true, features = ["helpers"] }

--- a/rust/tonk-analytics/src/account.rs
+++ b/rust/tonk-analytics/src/account.rs
@@ -1,0 +1,554 @@
+//! Privacy-safe, cross-interface account journey events.
+//!
+//! The public constructors accept only closed vocabulary. Callers cannot add
+//! arbitrary properties, which keeps account content and diagnostics out of
+//! analytics by construction.
+
+use serde::Serialize;
+use serde_json::{Map, Value};
+use thiserror::Error;
+
+/// Current account event schema.
+pub const SCHEMA_VERSION: u8 = 1;
+/// Longest duration retained in analytics (ten minutes).
+pub const MAX_DURATION_MS: u64 = 600_000;
+
+macro_rules! closed_enum {
+    ($(#[$meta:meta])* $name:ident { $($(#[$variant_meta:meta])* $variant:ident),+ $(,)? }) => {
+        $(#[$meta])*
+        #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Serialize)]
+        #[allow(missing_docs)]
+        #[serde(rename_all = "snake_case")]
+        pub enum $name {
+            $($(#[$variant_meta])* $variant),+
+        }
+    };
+}
+
+closed_enum! {
+    /// Account journey used for funnel grouping.
+    Journey { Onboarding, Login, Activation, Passkey, AccountManagement, CliHandoff, AccountDeletion }
+}
+
+closed_enum! {
+    /// Stable account operation shared by web and CLI.
+    AccountAction {
+        OpenRegistration, LoadAccount, LoadRegistration, CheckEmail, CreateAccount, Login,
+        AddPasskey, ChangeDisplayName, ResendActivation, LoadDevices, LoadProfiles, LinkCli,
+        SwitchProfile, SignOut, LoadDeletionPlan, DeleteAccount, DeleteSpace, RevokeDevice,
+        FinishAccountBackup, ActivateAccount, WatchActivation, SaveInitialDisplayName,
+        CopyInvite, FinishPreviousAction, SettleAccount, LoadAccountSpaces, PullAccountSpace,
+        OpenAccountDeletion, OpenSpaceDeletion, SyncAccount
+    }
+}
+
+closed_enum! {
+    /// Position reached by an account attempt.
+    Stage {
+        Input, EmailLookup, LocalPreflight, PasskeyCreate, PasskeyAssert, Prf, WorkerHandoff,
+        AccessService, LocalCommit, RemoteCommit, ActivationWait, CallbackBind, BrowserOpen,
+        CallbackWait, CallbackDelivery, DelegationValidate, ActivationStage, AccountSync,
+        ContentDiscovery, CustodyRotation, AccountLoad, Complete
+    }
+}
+
+closed_enum! {
+    /// Interface on which this attempt is owned.
+    Surface { RegistrationDialog, Settings, ActivationPage, CustodyConsent, Hub, CliCallback, NativeCli }
+}
+
+closed_enum! {
+    /// What initiated an attempt.
+    Trigger { User, Automatic, Recovery }
+}
+
+closed_enum! {
+    /// Coarse account readiness at attempt start.
+    AccountState { None, Onboarding, PendingActivation, RegisteredUnready, Ready, Unknown }
+}
+
+closed_enum! {
+    /// Terminal result. Expected friction remains distinct from reliability failures.
+    AccountResult { Success, DegradedSuccess, Cancelled, Blocked, RetryableFailure, TerminalFailure, UnknownCommit }
+}
+
+closed_enum! {
+    /// Privacy-safe reason a non-success terminal event ended.
+    FailureKind {
+        InvalidInput, Cancelled, Timeout, CredentialExists, PasskeyUnsupported, PrfUnsupported,
+        SecurityContext, AwaitingActivation, Suspended, NotProvisioned, AccessDenied, Conflict,
+        NotFound, RateLimited, Network, ServiceUnavailable, InvalidResponse, LocalState,
+        Callback, Unknown
+    }
+}
+
+closed_enum! {
+    /// Earliest incomplete follow-up after the durable account operation succeeded.
+    DegradationKind { BrowserOpen, AccountSync, ContentDiscovery, CustodyRotation, SpaceRotation }
+}
+
+closed_enum! {
+    /// HTTP status category retained without a URL or response body.
+    HttpStatusClass { #[serde(rename = "4xx")] ClientError, #[serde(rename = "5xx")] ServerError }
+}
+
+closed_enum! {
+    /// Stable, explicitly reviewed service code. Unknown input is normalized to `Unknown`.
+    ServiceCode {
+        RootRequired, CredentialRevoked, UpstreamTimeout, UpstreamUnavailable,
+        AccountStateUnavailable, Invalid, Unauthorized, Forbidden, UnknownCustomer,
+        UnknownConsumer, CustomerActive, CustomerInactive, CustomerSuspended, AddressTaken,
+        ConsumerProvided, Internal, Unknown
+    }
+}
+
+impl ServiceCode {
+    /// Normalize an already parsed service code into the allowlist.
+    pub fn from_wire(value: &str) -> Self {
+        match value.trim().to_ascii_lowercase().replace('-', "_").as_str() {
+            "root_required" => Self::RootRequired,
+            "credential_revoked" => Self::CredentialRevoked,
+            "upstream_timeout" => Self::UpstreamTimeout,
+            "upstream_unavailable" => Self::UpstreamUnavailable,
+            "account_state_unavailable" => Self::AccountStateUnavailable,
+            "invalid" => Self::Invalid,
+            "unauthorized" => Self::Unauthorized,
+            "forbidden" => Self::Forbidden,
+            "unknown_customer" => Self::UnknownCustomer,
+            "unknown_consumer" => Self::UnknownConsumer,
+            "customer_active" => Self::CustomerActive,
+            "customer_inactive" => Self::CustomerInactive,
+            "customer_suspended" => Self::CustomerSuspended,
+            "address_taken" => Self::AddressTaken,
+            "consumer_provided" => Self::ConsumerProvided,
+            "internal" => Self::Internal,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Phase {
+    Started,
+    Checkpoint,
+    Finished,
+}
+
+impl Serialize for Phase {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(match self {
+            Self::Started => "started",
+            Self::Checkpoint => "checkpoint",
+            Self::Finished => "finished",
+        })
+    }
+}
+
+/// Closed terminal outcome supplied to [`AccountEvent::finished`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AccountOutcome {
+    result: AccountResult,
+    failure_kind: Option<FailureKind>,
+    degradation_kind: Option<DegradationKind>,
+    http_status_class: Option<HttpStatusClass>,
+    service_code: Option<ServiceCode>,
+}
+
+impl AccountOutcome {
+    /// Full success.
+    pub const fn success() -> Self {
+        Self::new(AccountResult::Success, None, None)
+    }
+
+    /// Success with a non-transactional follow-up left incomplete.
+    pub const fn degraded(kind: DegradationKind) -> Self {
+        Self::new(AccountResult::DegradedSuccess, None, Some(kind))
+    }
+
+    /// User cancellation.
+    pub const fn cancelled() -> Self {
+        Self::new(AccountResult::Cancelled, Some(FailureKind::Cancelled), None)
+    }
+
+    /// Expected account or policy gate.
+    pub const fn blocked(kind: FailureKind) -> Self {
+        Self::new(AccountResult::Blocked, Some(kind), None)
+    }
+
+    /// Failure for which retry is known to be safe.
+    pub const fn retryable(kind: FailureKind) -> Self {
+        Self::new(AccountResult::RetryableFailure, Some(kind), None)
+    }
+
+    /// Failure known not to have committed.
+    pub const fn terminal_failure(kind: FailureKind) -> Self {
+        Self::new(AccountResult::TerminalFailure, Some(kind), None)
+    }
+
+    /// Failure after a boundary at which commitment cannot be disproved.
+    pub const fn unknown_commit(kind: FailureKind) -> Self {
+        Self::new(AccountResult::UnknownCommit, Some(kind), None)
+    }
+
+    const fn new(
+        result: AccountResult,
+        failure_kind: Option<FailureKind>,
+        degradation_kind: Option<DegradationKind>,
+    ) -> Self {
+        Self {
+            result,
+            failure_kind,
+            degradation_kind,
+            http_status_class: None,
+            service_code: None,
+        }
+    }
+
+    /// Add an HTTP status category.
+    pub const fn with_http_status_class(mut self, value: HttpStatusClass) -> Self {
+        self.http_status_class = Some(value);
+        self
+    }
+
+    /// Add an allowlisted stable service code.
+    pub const fn with_service_code(mut self, value: ServiceCode) -> Self {
+        self.service_code = Some(value);
+        self
+    }
+
+    /// Terminal result value.
+    pub const fn result(self) -> AccountResult {
+        self.result
+    }
+
+    /// Failure classification, when applicable.
+    pub const fn failure_kind(self) -> Option<FailureKind> {
+        self.failure_kind
+    }
+
+    /// Degradation classification, when applicable.
+    pub const fn degradation_kind(self) -> Option<DegradationKind> {
+        self.degradation_kind
+    }
+}
+
+/// A canonical account event. Its property map is private and validated.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AccountEvent {
+    journey: Journey,
+    action: AccountAction,
+    phase: Phase,
+    stage: Stage,
+    surface: Surface,
+    trigger: Trigger,
+    account_state: AccountState,
+    attempt_id: String,
+    outcome: Option<AccountOutcome>,
+    duration_ms: Option<u64>,
+}
+
+/// Why an account event shape was rejected.
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+pub enum ValidationError {
+    /// Attempt identifier was empty, too long, or non-ASCII.
+    #[error("attempt_id must be 1..=36 ASCII characters")]
+    InvalidAttemptId,
+    /// A non-terminal event carried terminal properties, or vice versa.
+    #[error("phase and terminal properties are inconsistent")]
+    InvalidPhase,
+    /// Result, failure, and degradation fields do not form a valid outcome.
+    #[error("terminal outcome fields are inconsistent")]
+    InvalidOutcome,
+    /// Duration exceeded the ten-minute analytics cap.
+    #[error("duration_ms exceeds 600000")]
+    DurationTooLong,
+}
+
+impl AccountEvent {
+    fn non_terminal(
+        phase: Phase,
+        journey: Journey,
+        action: AccountAction,
+        stage: Stage,
+        surface: Surface,
+        trigger: Trigger,
+        account_state: AccountState,
+        attempt_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            journey,
+            action,
+            phase,
+            stage,
+            surface,
+            trigger,
+            account_state,
+            attempt_id: attempt_id.into(),
+            outcome: None,
+            duration_ms: None,
+        }
+    }
+
+    /// Begin an account attempt.
+    pub fn started(
+        journey: Journey,
+        action: AccountAction,
+        stage: Stage,
+        surface: Surface,
+        trigger: Trigger,
+        account_state: AccountState,
+        attempt_id: impl Into<String>,
+    ) -> Self {
+        Self::non_terminal(
+            phase::started(),
+            journey,
+            action,
+            stage,
+            surface,
+            trigger,
+            account_state,
+            attempt_id,
+        )
+    }
+
+    /// Record progress in an existing attempt.
+    pub fn checkpoint(
+        journey: Journey,
+        action: AccountAction,
+        stage: Stage,
+        surface: Surface,
+        trigger: Trigger,
+        account_state: AccountState,
+        attempt_id: impl Into<String>,
+    ) -> Self {
+        Self::non_terminal(
+            Phase::Checkpoint,
+            journey,
+            action,
+            stage,
+            surface,
+            trigger,
+            account_state,
+            attempt_id,
+        )
+    }
+
+    /// Finish an account attempt.
+    #[allow(clippy::too_many_arguments)]
+    pub fn finished(
+        journey: Journey,
+        action: AccountAction,
+        stage: Stage,
+        surface: Surface,
+        trigger: Trigger,
+        account_state: AccountState,
+        attempt_id: impl Into<String>,
+        duration_ms: u64,
+        outcome: AccountOutcome,
+    ) -> Self {
+        Self {
+            journey,
+            action,
+            phase: Phase::Finished,
+            stage,
+            surface,
+            trigger,
+            account_state,
+            attempt_id: attempt_id.into(),
+            outcome: Some(outcome),
+            duration_ms: Some(duration_ms.min(MAX_DURATION_MS)),
+        }
+    }
+
+    /// Validate and serialize the exact account-owned property allowlist.
+    pub fn validated_properties(&self) -> Result<Map<String, Value>, ValidationError> {
+        self.validate()?;
+        let mut properties = Map::new();
+        insert(&mut properties, "schema_version", SCHEMA_VERSION);
+        insert(&mut properties, "journey", self.journey);
+        insert(&mut properties, "action", self.action);
+        insert(&mut properties, "phase", self.phase);
+        insert(&mut properties, "stage", self.stage);
+        insert(&mut properties, "surface", self.surface);
+        insert(&mut properties, "trigger", self.trigger);
+        insert(&mut properties, "account_state", self.account_state);
+        insert(&mut properties, "attempt_id", &self.attempt_id);
+        if let Some(outcome) = self.outcome {
+            insert(&mut properties, "result", outcome.result);
+            if let Some(value) = outcome.failure_kind {
+                insert(&mut properties, "failure_kind", value);
+            }
+            if let Some(value) = outcome.degradation_kind {
+                insert(&mut properties, "degradation_kind", value);
+            }
+            if let Some(value) = outcome.http_status_class {
+                insert(&mut properties, "http_status_class", value);
+            }
+            if let Some(value) = outcome.service_code {
+                insert(&mut properties, "service_code", value);
+            }
+        }
+        if let Some(value) = self.duration_ms {
+            insert(&mut properties, "duration_ms", value);
+        }
+        Ok(properties)
+    }
+
+    fn validate(&self) -> Result<(), ValidationError> {
+        if self.attempt_id.is_empty() || self.attempt_id.len() > 36 || !self.attempt_id.is_ascii() {
+            return Err(ValidationError::InvalidAttemptId);
+        }
+        match (self.phase, self.outcome, self.duration_ms) {
+            (Phase::Finished, Some(_), Some(duration)) if duration <= MAX_DURATION_MS => {}
+            (Phase::Started | Phase::Checkpoint, None, None) => return Ok(()),
+            (Phase::Finished, Some(_), Some(_)) => return Err(ValidationError::DurationTooLong),
+            _ => return Err(ValidationError::InvalidPhase),
+        }
+        let outcome = self.outcome.expect("validated terminal outcome");
+        let valid = match outcome.result {
+            AccountResult::Success => {
+                outcome.failure_kind.is_none() && outcome.degradation_kind.is_none()
+            }
+            AccountResult::DegradedSuccess => {
+                outcome.failure_kind.is_none() && outcome.degradation_kind.is_some()
+            }
+            AccountResult::Cancelled => {
+                outcome.failure_kind == Some(FailureKind::Cancelled)
+                    && outcome.degradation_kind.is_none()
+            }
+            AccountResult::Blocked
+            | AccountResult::RetryableFailure
+            | AccountResult::TerminalFailure
+            | AccountResult::UnknownCommit => {
+                outcome.failure_kind.is_some() && outcome.degradation_kind.is_none()
+            }
+        };
+        valid.then_some(()).ok_or(ValidationError::InvalidOutcome)
+    }
+}
+
+fn insert<T: Serialize>(properties: &mut Map<String, Value>, key: &str, value: T) {
+    properties.insert(
+        key.to_owned(),
+        serde_json::to_value(value).expect("closed account value serializes"),
+    );
+}
+
+mod phase {
+    use super::Phase;
+    pub(super) const fn started() -> Phase {
+        Phase::Started
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn started() -> AccountEvent {
+        AccountEvent::started(
+            Journey::Login,
+            AccountAction::Login,
+            Stage::Input,
+            Surface::Settings,
+            Trigger::User,
+            AccountState::None,
+            "attempt-1",
+        )
+    }
+
+    #[test]
+    fn it_serializes_only_the_account_event_allowlist() {
+        let start = started().validated_properties().unwrap();
+        assert_eq!(
+            start.keys().cloned().collect::<Vec<_>>(),
+            [
+                "account_state",
+                "action",
+                "attempt_id",
+                "journey",
+                "phase",
+                "schema_version",
+                "stage",
+                "surface",
+                "trigger"
+            ]
+        );
+        assert_eq!(start["action"], "login");
+        assert_eq!(start["phase"], "started");
+        assert!(!start.contains_key("result"));
+        assert!(!start.contains_key("duration_ms"));
+
+        let terminal = AccountEvent::finished(
+            Journey::Activation,
+            AccountAction::ActivateAccount,
+            Stage::AccessService,
+            Surface::ActivationPage,
+            Trigger::Recovery,
+            AccountState::PendingActivation,
+            "attempt-2",
+            42,
+            AccountOutcome::blocked(FailureKind::AwaitingActivation)
+                .with_http_status_class(HttpStatusClass::ClientError)
+                .with_service_code(ServiceCode::Forbidden),
+        )
+        .validated_properties()
+        .unwrap();
+        assert_eq!(terminal["result"], "blocked");
+        assert_eq!(terminal["failure_kind"], "awaiting_activation");
+        assert_eq!(terminal["http_status_class"], "4xx");
+        assert_eq!(terminal["duration_ms"], 42);
+    }
+
+    #[test]
+    fn it_rejects_invalid_account_event_shapes() {
+        let mut event = started();
+        event.duration_ms = Some(1);
+        assert_eq!(event.validate(), Err(ValidationError::InvalidPhase));
+
+        let mut event = AccountEvent::finished(
+            Journey::Login,
+            AccountAction::Login,
+            Stage::Complete,
+            Surface::Settings,
+            Trigger::User,
+            AccountState::Ready,
+            "x",
+            1,
+            AccountOutcome::success(),
+        );
+        event.outcome.as_mut().unwrap().failure_kind = Some(FailureKind::Unknown);
+        assert_eq!(event.validate(), Err(ValidationError::InvalidOutcome));
+
+        event.outcome = Some(AccountOutcome::degraded(DegradationKind::AccountSync));
+        event.outcome.as_mut().unwrap().degradation_kind = None;
+        assert_eq!(event.validate(), Err(ValidationError::InvalidOutcome));
+
+        event.duration_ms = Some(MAX_DURATION_MS + 1);
+        assert_eq!(event.validate(), Err(ValidationError::DurationTooLong));
+    }
+
+    #[test]
+    fn privacy_sentinels_cannot_enter_the_typed_event() {
+        let nearby_inputs = "person@example.com did:key:zSensitive credential-id https://x/activate?ucan=secret http://127.0.0.1/callback body-secret";
+        let json = Value::Object(started().validated_properties().unwrap()).to_string();
+        for sentinel in nearby_inputs.split_whitespace() {
+            assert!(!json.contains(sentinel));
+        }
+    }
+
+    #[test]
+    fn service_codes_are_allowlisted() {
+        assert_eq!(
+            ServiceCode::from_wire("ROOT-REQUIRED"),
+            ServiceCode::RootRequired
+        );
+        assert_eq!(
+            ServiceCode::from_wire("person@example.com"),
+            ServiceCode::Unknown
+        );
+    }
+}

--- a/rust/tonk-analytics/src/account.rs
+++ b/rust/tonk-analytics/src/account.rs
@@ -466,8 +466,10 @@ mod tests {
     #[test]
     fn it_serializes_only_the_account_event_allowlist() {
         let start = started().validated_properties().unwrap();
+        let mut keys = start.keys().cloned().collect::<Vec<_>>();
+        keys.sort_unstable();
         assert_eq!(
-            start.keys().cloned().collect::<Vec<_>>(),
+            keys,
             [
                 "account_state",
                 "action",

--- a/rust/tonk-analytics/src/account.rs
+++ b/rust/tonk-analytics/src/account.rs
@@ -268,6 +268,9 @@ pub enum ValidationError {
 }
 
 impl AccountEvent {
+    // The public constructors expose the seven canonical event dimensions;
+    // this shared helper additionally receives their non-terminal phase.
+    #[allow(clippy::too_many_arguments)]
     fn non_terminal(
         phase: Phase,
         journey: Journey,

--- a/rust/tonk-analytics/src/lib.rs
+++ b/rust/tonk-analytics/src/lib.rs
@@ -13,6 +13,7 @@
 
 use sha2_0_10::{Digest, Sha256};
 
+pub mod account;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod native;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -21,6 +22,8 @@ pub mod web;
 /// Event names shared by every Tonk surface. Keep dashboards coherent:
 /// never capture a string literal, always one of these.
 pub mod event {
+    /// Typed account journey lifecycle shared by web and CLI.
+    pub const ACCOUNT: &str = "account_event";
     /// One CLI invocation: command, subcommand, duration, outcome.
     pub const CLI_COMMAND_RUN: &str = "cli_command_run";
     /// The web shell finished booting (service worker controlling).

--- a/rust/tonk-analytics/src/native.rs
+++ b/rust/tonk-analytics/src/native.rs
@@ -87,6 +87,18 @@ impl Client {
         });
     }
 
+    /// Validate and queue one canonical account event. Transport context is
+    /// added here so account call sites cannot vary its shape.
+    pub fn capture_account(
+        &mut self,
+        event: &crate::account::AccountEvent,
+    ) -> Result<(), crate::account::ValidationError> {
+        let mut properties = event.validated_properties()?;
+        properties.insert("environment".to_owned(), Value::from("cli"));
+        self.capture(crate::event::ACCOUNT, properties);
+        Ok(())
+    }
+
     /// The `/batch` request body, or `None` when disabled or empty.
     /// Public so tests can assert the wire shape without a server.
     pub fn payload(&self) -> Option<Value> {
@@ -148,6 +160,29 @@ mod tests {
         assert_eq!(event["properties"]["command"], "eval");
         assert_eq!(event["properties"]["os"], std::env::consts::OS);
         assert!(event["properties"]["version"].is_string());
+    }
+
+    #[dialog_common::test]
+    fn account_capture_has_the_validated_shape_and_cli_context() {
+        use crate::account::{
+            AccountAction, AccountEvent, AccountState, Journey, Stage, Surface, Trigger,
+        };
+        let mut client = Client::new("http://localhost:1".into(), "key".into(), "tonk:abc".into());
+        let event = AccountEvent::started(
+            Journey::Login,
+            AccountAction::Login,
+            Stage::Input,
+            Surface::NativeCli,
+            Trigger::User,
+            AccountState::None,
+            "opaque-1",
+        );
+        client.capture_account(&event).unwrap();
+        let event = &client.payload().unwrap()["batch"][0];
+        assert_eq!(event["event"], "account_event");
+        assert_eq!(event["properties"]["environment"], "cli");
+        assert_eq!(event["properties"]["action"], "login");
+        assert_eq!(event["properties"]["version"], env!("CARGO_PKG_VERSION"));
     }
 
     /// Minimal one-shot HTTP server: accept one connection, read one

--- a/rust/tonk-analytics/src/web.rs
+++ b/rust/tonk-analytics/src/web.rs
@@ -11,7 +11,7 @@ use wasm_bindgen::prelude::*;
 static ENABLED: AtomicBool = AtomicBool::new(false);
 
 #[wasm_bindgen(inline_js = r#"
-export function ph_init(key, host) {
+export function ph_init(key, host, version) {
     try {
         if (!key || !window.posthog) return false;
         if (localStorage.getItem("tonk:telemetry") === "off") return false;
@@ -23,6 +23,7 @@ export function ph_init(key, host) {
             capture_performance: false,
             capture_dead_clicks: false,
             capture_heatmaps: false,
+            capture_exceptions: false,
             persistence: "memory",
             person_profiles: "identified_only",
             // posthog-js enriches every event (and the $set/$set_once
@@ -71,7 +72,10 @@ export function ph_init(key, host) {
             host === "tonk.network" ? "production"
             : host === "staging.tonk.xyz" ? "staging"
             : "dev";
-        window.posthog.register({ environment: environment });
+        window.posthog.register({
+            environment: environment,
+            version: version
+        });
         return true;
     } catch (e) {
         return false;
@@ -85,7 +89,7 @@ export function ph_identify(id) {
 }
 "#)]
 extern "C" {
-    fn ph_init(key: &str, host: &str) -> bool;
+    fn ph_init(key: &str, host: &str, version: &str) -> bool;
     fn ph_capture(name: &str, props_json: &str);
     fn ph_identify(id: &str);
 }
@@ -97,17 +101,39 @@ pub fn init() -> bool {
         ENABLED.store(false, Ordering::Relaxed);
         return false;
     };
-    let live = ph_init(&key, &crate::host());
+    let live = ph_init(&key, &crate::host(), env!("CARGO_PKG_VERSION"));
     ENABLED.store(live, Ordering::Relaxed);
     live
 }
 
 /// Forward one event with a JSON-object `properties` value.
 pub fn capture(name: &str, properties: &serde_json::Value) {
+    // Account events may only enter through `capture_account`, whose closed
+    // serializer rejects malformed shapes. This also prevents the generic DOM
+    // event bridge from impersonating the account taxonomy.
+    if name == crate::event::ACCOUNT {
+        return;
+    }
+    capture_unchecked(name, properties);
+}
+
+fn capture_unchecked(name: &str, properties: &serde_json::Value) {
     if !ENABLED.load(Ordering::Relaxed) {
         return;
     }
     ph_capture(name, &properties.to_string());
+}
+
+/// Validate and capture one canonical account event.
+pub fn capture_account(
+    event: &crate::account::AccountEvent,
+) -> Result<(), crate::account::ValidationError> {
+    let properties = event.validated_properties()?;
+    capture_unchecked(
+        crate::event::ACCOUNT,
+        &serde_json::Value::Object(properties),
+    );
+    Ok(())
 }
 
 /// Capture a `$pageview` for `path`, normalized so no space/entity

--- a/rust/tonk-cli/src/account.rs
+++ b/rust/tonk-cli/src/account.rs
@@ -9,6 +9,7 @@ use dialog_ucan::UcanDelegation;
 use dialog_ucan_core::DelegationChain;
 use dialog_varsig::Did;
 use tonk_account::{AccountProviderRecord, AccountStateStatus};
+use tonk_analytics::account::{DegradationKind, Stage};
 use url::Url;
 
 /// Production account API used unless explicitly overridden.
@@ -18,6 +19,18 @@ pub const DEFAULT_ACCOUNT_PAGE: &str = "https://tonk.network/settings";
 /// Production link ceremony page: it reads `?audience=` and `?callback=`
 /// and posts the grant back to the waiting CLI.
 pub const DEFAULT_LINK_PAGE: &str = "https://tonk.network/settings/link";
+
+/// The browser explicitly declined the native device handoff.
+#[derive(Debug, thiserror::Error)]
+#[error("authorization was declined in the browser: {detail}")]
+pub struct BrowserAuthorizationDenied {
+    detail: String,
+}
+
+/// The terminal cancelled the native device handoff before an answer.
+#[derive(Debug, thiserror::Error)]
+#[error("account login cancelled")]
+pub struct LinkCancelled;
 
 /// Open the browser's passkey-protected, review-first account deletion flow.
 pub async fn open_deletion(
@@ -297,8 +310,8 @@ pub async fn logout(profile: &Profile) -> Result<()> {
 
 /// Disconnect only the account session owned by `store`.
 pub async fn logout_in(profile: &Profile, store: &crate::space::SpaceStore) -> Result<()> {
-    let operator = crate::account_state::credential_operator_for_store(profile, store).await?;
-    logout_with_operator_in(profile, &operator, store).await
+    let mut observer = crate::account_observability::NoopAccountObserver;
+    logout_in_observed(profile, store, &mut observer).await
 }
 
 async fn logout_with_operator(
@@ -314,13 +327,34 @@ async fn logout_with_operator_in(
     operator: &dialog_operator::Operator<NativeSpace>,
     store: &crate::space::SpaceStore,
 ) -> Result<()> {
+    let mut observer = crate::account_observability::NoopAccountObserver;
+    logout_with_operator_in_observed(profile, operator, store, &mut observer).await
+}
+
+/// Disconnect the provider session and expose the durable local commit seam.
+pub async fn logout_in_observed(
+    profile: &Profile,
+    store: &crate::space::SpaceStore,
+    observer: &mut dyn crate::account_observability::CliAccountObserver,
+) -> Result<()> {
+    let operator = crate::account_state::credential_operator_for_store(profile, store).await?;
+    logout_with_operator_in_observed(profile, &operator, store, observer).await
+}
+
+async fn logout_with_operator_in_observed(
+    profile: &Profile,
+    operator: &dialog_operator::Operator<NativeSpace>,
+    store: &crate::space::SpaceStore,
+    observer: &mut dyn crate::account_observability::CliAccountObserver,
+) -> Result<()> {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
-    for account in
-        crate::account_session::logout_transition_for_store(profile, operator, store).await?
-    {
+    let accounts =
+        crate::account_session::logout_transition_for_store(profile, operator, store).await?;
+    observer.checkpoint(tonk_analytics::account::Stage::LocalCommit);
+    for account in accounts {
         if let Err(error) = crate::account_session::deliver_detach(profile, &account, now).await {
             eprintln!(
                 "warning: logged out locally; the provider was not notified                  and may list this device until it is revoked: {error:#}"
@@ -529,7 +563,9 @@ async fn hydrate_activated_account(
     store: &crate::space::SpaceStore,
     account: &crate::account_session::ActiveAccount,
     url: String,
+    observer: &mut dyn crate::account_observability::CliAccountObserver,
 ) -> Result<LinkOutcome> {
+    observer.checkpoint(Stage::AccountSync);
     let ensured = ensure_after_link(
         profile,
         operator.clone(),
@@ -538,6 +574,9 @@ async fn hydrate_activated_account(
     )
     .await?;
 
+    if ensured.warning.is_some() {
+        observer.degraded(DegradationKind::AccountSync);
+    }
     Ok(LinkOutcome {
         url,
         root_did: account.root_did.clone(),
@@ -561,7 +600,9 @@ async fn link_via_callback(
     store: &crate::space::SpaceStore,
     options: &LinkOptions,
     page: &str,
+    observer: &mut dyn crate::account_observability::CliAccountObserver,
 ) -> Result<LinkOutcome> {
+    observer.checkpoint(Stage::CallbackBind);
     let callback = crate::callback::Callback::bind().await?;
     let url = login_url(
         page,
@@ -571,8 +612,10 @@ async fn link_via_callback(
     );
 
     println!("Open this URL to approve the device:\n{url}");
+    observer.checkpoint(Stage::BrowserOpen);
     if options.open_browser && webbrowser::open(&url).is_err() {
         eprintln!("Could not open a browser; use the URL above.");
+        observer.degraded(DegradationKind::BrowserOpen);
     }
     // A caller that drives the ceremony itself (tests, or an embedder with
     // its own browser control) receives the URL rather than relying on the
@@ -588,24 +631,27 @@ async fn link_via_callback(
         .map(|page| page.origin().ascii_serialization());
     let ctrl_c = tokio::signal::ctrl_c();
     tokio::pin!(ctrl_c);
+    observer.checkpoint(Stage::CallbackWait);
     let received = tokio::select! {
         result = callback.receive(redirect_origin) => result?,
         signal = &mut ctrl_c => {
             signal.context("failed to listen for Ctrl-C")?;
-            bail!("account login cancelled");
+            return Err(LinkCancelled.into());
         }
     };
     let bytes = match received {
         crate::callback::Authorization::Granted(bytes) => bytes,
         crate::callback::Authorization::Denied(reason) => {
-            bail!("authorization was declined in the browser: {reason}");
+            return Err(BrowserAuthorizationDenied { detail: reason }.into());
         }
     };
+    observer.checkpoint(Stage::DelegationValidate);
     let authorization: CallbackAuthorization =
         serde_json::from_slice(&bytes).context("authorization payload is not readable")?;
     let account = account_from_callback(profile, options, authorization).await?;
+    observer.checkpoint(Stage::ActivationStage);
     complete_staged_account(profile, operator, store, &account).await?;
-    hydrate_activated_account(profile, operator, store, &account, url).await
+    hydrate_activated_account(profile, operator, store, &account, url, observer).await
 }
 
 /// What the authorizing page posts back to the waiting CLI.
@@ -650,6 +696,19 @@ pub async fn link_in(
     link_with_operator(profile, &operator, &options).await
 }
 
+/// [`link_in`] with native stage reporting for the account CLI.
+pub async fn link_in_observed(
+    profile: &Profile,
+    store: &crate::space::SpaceStore,
+    options: &LinkOptions,
+    observer: &mut dyn crate::account_observability::CliAccountObserver,
+) -> Result<LinkOutcome> {
+    let operator = crate::account_state::credential_operator_for_store(profile, store).await?;
+    let mut options = options.clone();
+    options.store = Some(store.clone());
+    link_with_operator_observed(profile, &operator, &options, observer).await
+}
+
 /// [`link`] against a caller-supplied operator.
 ///
 /// [`link`] resolves one from the global install, mounting the profile by
@@ -659,6 +718,17 @@ pub async fn link_with_operator(
     profile: &Profile,
     operator: &dialog_operator::Operator<NativeSpace>,
     options: &LinkOptions,
+) -> Result<LinkOutcome> {
+    let mut observer = crate::account_observability::NoopAccountObserver;
+    link_with_operator_observed(profile, operator, options, &mut observer).await
+}
+
+/// Observed form of [`link_with_operator`] used by the CLI command seam.
+pub async fn link_with_operator_observed(
+    profile: &Profile,
+    operator: &dialog_operator::Operator<NativeSpace>,
+    options: &LinkOptions,
+    observer: &mut dyn crate::account_observability::CliAccountObserver,
 ) -> Result<LinkOutcome> {
     let store = match options.store.clone() {
         Some(store) => store,
@@ -674,12 +744,22 @@ pub async fn link_with_operator(
     };
     if let Some(account) = state.active {
         recorded_account_grant(profile, &account).await?;
-        return hydrate_activated_account(profile, operator, &store, &account, String::new()).await;
+        return hydrate_activated_account(
+            profile,
+            operator,
+            &store,
+            &account,
+            String::new(),
+            observer,
+        )
+        .await;
     }
     match state.pending_login {
         Some(crate::account_session::PendingLogin::Activating { account }) => {
+            observer.checkpoint(Stage::ActivationStage);
             complete_staged_account(profile, operator, &store, &account).await?;
-            hydrate_activated_account(profile, operator, &store, &account, String::new()).await
+            hydrate_activated_account(profile, operator, &store, &account, String::new(), observer)
+                .await
         }
         Some(crate::account_session::PendingLogin::Waiting { .. }) => {
             bail!(
@@ -688,7 +768,7 @@ pub async fn link_with_operator(
         }
         None => {
             let page = options.via.as_deref().unwrap_or(DEFAULT_LINK_PAGE);
-            link_via_callback(profile, operator, &store, options, page).await
+            link_via_callback(profile, operator, &store, options, page, observer).await
         }
     }
 }
@@ -1140,6 +1220,18 @@ pub async fn revoke_in(
     options: &RevokeOptions,
     did: &str,
 ) -> Result<RevokeOutcome> {
+    let mut observer = crate::account_observability::NoopAccountObserver;
+    revoke_in_observed(profile, store, options, did, &mut observer).await
+}
+
+/// [`revoke_in`] with the publication boundary exposed to CLI telemetry.
+pub async fn revoke_in_observed(
+    profile: &Profile,
+    store: &crate::space::SpaceStore,
+    options: &RevokeOptions,
+    did: &str,
+    observer: &mut dyn crate::account_observability::CliAccountObserver,
+) -> Result<RevokeOutcome> {
     let connection = optional_connection_in(profile, store)
         .await?
         .context("no active account; run `tonk account login`")?;
@@ -1168,6 +1260,7 @@ pub async fn revoke_in(
             Ok(false) => {}
             Err(error) => eprintln!("warning: this device's rows were not retracted: {error:#}"),
         }
+        observer.checkpoint(Stage::RemoteCommit);
         publish_revocation(profile, &branch, &operator, store, &artifact).await?;
         return Ok(RevokeOutcome::Revoked);
     }
@@ -1218,6 +1311,7 @@ pub async fn revoke_in(
     )
     .await
     .with_context(|| format!("cannot revoke {did}"))?;
+    observer.checkpoint(Stage::RemoteCommit);
     publish_revocation(profile, &branch, &operator, store, &artifact).await?;
     match retract_device_rows(&branch, &operator, did).await {
         Ok(true) => {

--- a/rust/tonk-cli/src/account_observability.rs
+++ b/rust/tonk-cli/src/account_observability.rs
@@ -1,0 +1,271 @@
+//! Native CLI account-attempt lifecycle.
+
+use std::time::Instant;
+
+use tonk_analytics::account::{
+    AccountAction, AccountEvent, AccountOutcome, AccountState, DegradationKind, Journey, Stage,
+    Surface, Trigger,
+};
+
+/// The narrow stage interface used by native account workflows.
+pub trait CliAccountObserver {
+    /// Record a native-owned stage.
+    fn checkpoint(&mut self, stage: Stage);
+    /// Record a non-transactional follow-up that did not complete.
+    fn degraded(&mut self, kind: DegradationKind);
+    /// Finish at a deep seam that has stronger outcome evidence than the
+    /// top-level exit code.
+    fn finish(&mut self, stage: Stage, outcome: AccountOutcome);
+}
+
+/// Observer for library callers that do not own a telemetry attempt.
+#[derive(Default)]
+pub struct NoopAccountObserver;
+
+impl CliAccountObserver for NoopAccountObserver {
+    fn checkpoint(&mut self, _stage: Stage) {}
+    fn degraded(&mut self, _kind: DegradationKind) {}
+    fn finish(&mut self, _stage: Stage, _outcome: AccountOutcome) {}
+}
+
+/// Exhaustive CLI account operation descriptor.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AccountCommandKind {
+    /// Read account state.
+    Status,
+    /// Browser handoff login.
+    Login,
+    /// Sign out locally.
+    Logout,
+    /// Open account deletion review.
+    Delete,
+    /// List account-owned spaces.
+    SpaceList,
+    /// Pull one account space.
+    SpacePull,
+    /// Open one space's deletion review.
+    SpaceDelete,
+    /// Synchronize account state.
+    Sync,
+    /// List devices.
+    Devices,
+    /// Revoke a device.
+    Revoke,
+}
+
+impl AccountCommandKind {
+    fn classification(self) -> (Journey, AccountAction, Stage) {
+        match self {
+            Self::Status => (
+                Journey::AccountManagement,
+                AccountAction::LoadAccount,
+                Stage::AccountLoad,
+            ),
+            Self::Login => (Journey::Login, AccountAction::Login, Stage::LocalPreflight),
+            Self::Logout => (
+                Journey::AccountManagement,
+                AccountAction::SignOut,
+                Stage::LocalPreflight,
+            ),
+            Self::Delete => (
+                Journey::AccountDeletion,
+                AccountAction::OpenAccountDeletion,
+                Stage::BrowserOpen,
+            ),
+            Self::SpaceList => (
+                Journey::AccountManagement,
+                AccountAction::LoadAccountSpaces,
+                Stage::AccountLoad,
+            ),
+            Self::SpacePull => (
+                Journey::AccountManagement,
+                AccountAction::PullAccountSpace,
+                Stage::AccountSync,
+            ),
+            Self::SpaceDelete => (
+                Journey::AccountDeletion,
+                AccountAction::OpenSpaceDeletion,
+                Stage::BrowserOpen,
+            ),
+            Self::Sync => (
+                Journey::AccountManagement,
+                AccountAction::SyncAccount,
+                Stage::AccountSync,
+            ),
+            Self::Devices => (
+                Journey::AccountManagement,
+                AccountAction::LoadDevices,
+                Stage::AccountLoad,
+            ),
+            Self::Revoke => (
+                Journey::AccountManagement,
+                AccountAction::RevokeDevice,
+                Stage::LocalPreflight,
+            ),
+        }
+    }
+}
+
+/// Process-local buffer for one CLI account attempt.
+pub struct CliAccountAttempt {
+    started: Instant,
+    journey: Journey,
+    action: AccountAction,
+    account_state: AccountState,
+    attempt_id: String,
+    events: Vec<AccountEvent>,
+    finished: bool,
+    degradation: Option<DegradationKind>,
+    last_stage: Stage,
+}
+
+impl CliAccountAttempt {
+    /// Start an account command with native surface ownership.
+    pub fn start(command: AccountCommandKind, account_state: AccountState) -> Self {
+        let (journey, action, stage) = command.classification();
+        let attempt_id = hex::encode(rand::random::<[u8; 16]>());
+        Self {
+            started: Instant::now(),
+            journey,
+            action,
+            account_state,
+            events: vec![AccountEvent::started(
+                journey,
+                action,
+                stage,
+                Surface::NativeCli,
+                Trigger::User,
+                account_state,
+                attempt_id.clone(),
+            )],
+            attempt_id,
+            finished: false,
+            degradation: None,
+            last_stage: stage,
+        }
+    }
+
+    /// Record a native-owned stage.
+    pub fn checkpoint(&mut self, stage: Stage) {
+        if self.finished {
+            return;
+        }
+        self.last_stage = stage;
+        self.events.push(AccountEvent::checkpoint(
+            self.journey,
+            self.action,
+            stage,
+            Surface::NativeCli,
+            Trigger::User,
+            self.account_state,
+            self.attempt_id.clone(),
+        ));
+    }
+
+    /// Retain the earliest incomplete follow-up as the terminal degradation.
+    pub fn degraded(&mut self, kind: DegradationKind) {
+        if !self.finished && self.degradation.is_none() {
+            self.degradation = Some(kind);
+        }
+    }
+
+    /// Success outcome, preserving a previously reported degradation.
+    pub fn success_outcome(&self) -> AccountOutcome {
+        self.degradation
+            .map(AccountOutcome::degraded)
+            .unwrap_or_else(AccountOutcome::success)
+    }
+
+    /// Whether a deep seam already supplied the terminal classification.
+    pub fn is_finished(&self) -> bool {
+        self.finished
+    }
+
+    /// Most recent deep stage, for classifying an error before display text.
+    pub fn last_stage(&self) -> Stage {
+        self.last_stage
+    }
+
+    /// Finish once. Later finishes and checkpoints are ignored.
+    pub fn finish(&mut self, stage: Stage, outcome: AccountOutcome) {
+        if self.finished {
+            return;
+        }
+        self.finished = true;
+        self.events.push(AccountEvent::finished(
+            self.journey,
+            self.action,
+            stage,
+            Surface::NativeCli,
+            Trigger::User,
+            self.account_state,
+            self.attempt_id.clone(),
+            self.started.elapsed().as_millis() as u64,
+            outcome,
+        ));
+    }
+
+    /// Consume the buffered shared-schema events.
+    pub fn into_events(self) -> Vec<AccountEvent> {
+        self.events
+    }
+}
+
+impl CliAccountObserver for CliAccountAttempt {
+    fn checkpoint(&mut self, stage: Stage) {
+        Self::checkpoint(self, stage);
+    }
+
+    fn degraded(&mut self, kind: DegradationKind) {
+        Self::degraded(self, kind);
+    }
+
+    fn finish(&mut self, stage: Stage, outcome: AccountOutcome) {
+        Self::finish(self, stage, outcome);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tonk_analytics::account::{AccountResult, DegradationKind};
+
+    #[test]
+    fn it_records_native_account_start_checkpoints_and_one_terminal() {
+        let mut attempt = CliAccountAttempt::start(AccountCommandKind::Login, AccountState::None);
+        attempt.checkpoint(Stage::CallbackBind);
+        attempt.degraded(DegradationKind::AccountSync);
+        attempt.finish(Stage::AccountSync, attempt.success_outcome());
+        attempt.finish(Stage::Complete, AccountOutcome::success());
+        attempt.checkpoint(Stage::Complete);
+        assert_eq!(attempt.last_stage(), Stage::CallbackBind);
+        let events = attempt.into_events();
+        assert_eq!(events.len(), 3);
+        let values = events
+            .iter()
+            .map(|event| serde_json::Value::Object(event.validated_properties().unwrap()))
+            .collect::<Vec<_>>();
+        assert_eq!(values[0]["surface"], "native_cli");
+        assert_eq!(values[2]["result"], "degraded_success");
+        assert_eq!(values[2]["degradation_kind"], "account_sync");
+        let _ = AccountResult::Success;
+    }
+
+    #[test]
+    fn every_account_command_maps_to_the_shared_vocabulary() {
+        for command in [
+            AccountCommandKind::Status,
+            AccountCommandKind::Login,
+            AccountCommandKind::Logout,
+            AccountCommandKind::Delete,
+            AccountCommandKind::SpaceList,
+            AccountCommandKind::SpacePull,
+            AccountCommandKind::SpaceDelete,
+            AccountCommandKind::Sync,
+            AccountCommandKind::Devices,
+            AccountCommandKind::Revoke,
+        ] {
+            let _ = command.classification();
+        }
+    }
+}

--- a/rust/tonk-cli/src/account_observability.rs
+++ b/rust/tonk-cli/src/account_observability.rs
@@ -8,7 +8,7 @@ use tonk_analytics::account::{
 };
 
 /// The narrow stage interface used by native account workflows.
-pub trait CliAccountObserver {
+pub trait CliAccountObserver: Send {
     /// Record a native-owned stage.
     fn checkpoint(&mut self, stage: Stage);
     /// Record a non-transactional follow-up that did not complete.

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -1149,6 +1149,33 @@ fn descriptor(command: &Command) -> (&'static str, Option<&'static str>) {
     }
 }
 
+fn account_command_kind(
+    command: &Command,
+) -> Option<tonk_cli::account_observability::AccountCommandKind> {
+    use tonk_cli::account_observability::AccountCommandKind as Kind;
+    let Command::Account { command, .. } = command else {
+        return None;
+    };
+    Some(match command {
+        None | Some(AccountCommand::Status { .. }) => Kind::Status,
+        Some(AccountCommand::Login { .. }) => Kind::Login,
+        Some(AccountCommand::Logout) => Kind::Logout,
+        Some(AccountCommand::Delete { .. }) => Kind::Delete,
+        Some(AccountCommand::Space { command: None, .. }) => Kind::SpaceList,
+        Some(AccountCommand::Space {
+            command: Some(AccountSpaceCommand::Pull { .. }),
+            ..
+        }) => Kind::SpacePull,
+        Some(AccountCommand::Space {
+            command: Some(AccountSpaceCommand::Delete { .. }),
+            ..
+        }) => Kind::SpaceDelete,
+        Some(AccountCommand::Sync) => Kind::Sync,
+        Some(AccountCommand::Devices { .. }) => Kind::Devices,
+        Some(AccountCommand::Revoke { .. }) => Kind::Revoke,
+    })
+}
+
 /// Whether a command opens the active space and should name it again
 /// if the operation fails.
 fn uses_active_space(command: &Command) -> bool {
@@ -1239,6 +1266,13 @@ async fn main() {
     }
 
     let started = std::time::Instant::now();
+    let account_kind = account_command_kind(&command);
+    let mut account_attempt = account_kind.map(|kind| {
+        tonk_cli::account_observability::CliAccountAttempt::start(
+            kind,
+            tonk_analytics::account::AccountState::Unknown,
+        )
+    });
     // `command` is moved by the dispatch below, so ask now.
     let is_update = matches!(&command, Command::Update { .. });
     let report_active_space = uses_active_space(&command);
@@ -1247,7 +1281,9 @@ async fn main() {
         Command::Help { all, guides, name } => print_help(all, guides, name.as_deref()),
         Command::Space { command, json } => space_op(command, json, space.as_deref()).await,
         Command::Identity { reset } => identity(reset).await,
-        Command::Account { command, json } => account_op(command, json).await,
+        Command::Account { command, json } => {
+            account_op(command, json, account_attempt.as_mut()).await
+        }
         Command::Eval(args) => eval(args, space.as_deref()).await,
         Command::Show {
             name,
@@ -1312,6 +1348,18 @@ async fn main() {
 
     let duration = started.elapsed();
 
+    if let Some(attempt) = account_attempt.as_mut()
+        && !attempt.is_finished()
+    {
+        use tonk_analytics::account::{AccountOutcome, FailureKind, Stage};
+        let outcome = if exit == ExitCode::Success {
+            attempt.success_outcome()
+        } else {
+            AccountOutcome::terminal_failure(FailureKind::Unknown)
+        };
+        attempt.finish(Stage::Complete, outcome);
+    }
+
     // `tonk update` speaks for itself: a nag mid-update contradicts
     // the command that just ran, and the toggle must stay silent.
     // Run the check alongside the telemetry flush rather than in
@@ -1323,7 +1371,10 @@ async fn main() {
         }
     };
     match recorder {
-        Some(recorder) => {
+        Some(mut recorder) => {
+            if let Some(attempt) = account_attempt {
+                recorder.account_events(attempt.into_events());
+            }
             tokio::join!(recorder.finish(exit, duration), check);
         }
         None => check.await,
@@ -1651,6 +1702,7 @@ async fn link_account(
     service_url: String,
     no_open: bool,
     via: Option<String>,
+    mut observer: Option<&mut tonk_cli::account_observability::CliAccountAttempt>,
 ) -> ExitCode {
     let signed_in = match store.account() {
         Ok(account) => account,
@@ -1662,6 +1714,14 @@ async fn link_account(
             Ok(tonk_cli::account::SignInPhase::Active)
         )
     {
+        if let Some(observer) = observer.as_deref_mut() {
+            observer.finish(
+                tonk_analytics::account::Stage::LocalPreflight,
+                tonk_analytics::account::AccountOutcome::blocked(
+                    tonk_analytics::account::FailureKind::Conflict,
+                ),
+            );
+        }
         return print_error(format!(
             "already signed in as {}\nrun `tonk account logout` first to sign in as another account",
             account.root
@@ -1674,23 +1734,25 @@ async fn link_account(
     let ceremony_page = via
         .clone()
         .unwrap_or_else(|| account::DEFAULT_LINK_PAGE.to_owned());
-    match account::link_in(
-        &profile,
-        store,
-        &account::LinkOptions {
-            service_url: service_url.clone(),
-            device_name: name.unwrap_or_else(account::default_device_name),
-            open_browser: !no_open,
-            via,
-            announce: None,
-            store: Some(store.clone()),
-        },
-    )
-    .await
-    {
+    let options = account::LinkOptions {
+        service_url: service_url.clone(),
+        device_name: name.unwrap_or_else(account::default_device_name),
+        open_browser: !no_open,
+        via,
+        announce: None,
+        store: Some(store.clone()),
+    };
+    let linked = match observer.as_deref_mut() {
+        Some(observer) => account::link_in_observed(&profile, store, &options, observer).await,
+        None => account::link_in(&profile, store, &options).await,
+    };
+    match linked {
         Ok(outcome) => {
             // The deployment that served the ceremony page is the one
             // whose endpoints this account uses.
+            if let Some(observer) = observer.as_deref_mut() {
+                observer.checkpoint(tonk_analytics::account::Stage::ContentDiscovery);
+            }
             let discovery = tonk_cli::deployment::discover(&ceremony_page).await;
             let record = tonk_cli::deployment::account_record(
                 &outcome.root_did,
@@ -1698,6 +1760,14 @@ async fn link_account(
                 discovery.as_ref().ok(),
             );
             if let Err(error) = store.set_account(Some(record)) {
+                if let Some(observer) = observer.as_deref_mut() {
+                    observer.finish(
+                        tonk_analytics::account::Stage::ActivationStage,
+                        tonk_analytics::account::AccountOutcome::unknown_commit(
+                            tonk_analytics::account::FailureKind::LocalState,
+                        ),
+                    );
+                }
                 return print_failure(error);
             }
             println!(
@@ -1713,6 +1783,9 @@ async fn link_account(
             // what restores it, rather than reporting a failure for a link
             // the account service has already granted.
             if let Err(error) = discovery {
+                if let Some(observer) = observer.as_deref_mut() {
+                    observer.degraded(tonk_analytics::account::DegradationKind::ContentDiscovery);
+                }
                 eprintln!(
                     "warning: {ceremony_page} did not answer with its content endpoints: {error:#}"
                 );
@@ -1725,18 +1798,43 @@ async fn link_account(
             // authority and sealed seed onto the account. Hosting does not
             // move — `tonk space link` remains the boundary that provisions
             // and attaches a remote.
+            if let Some(observer) = observer.as_deref_mut() {
+                observer.checkpoint(tonk_analytics::account::Stage::CustodyRotation);
+            }
             match site::default_config() {
                 Ok(config) => {
                     match tonk_cli::custody::rotate_from_onboarding(store, &config).await {
                         Ok(failures) => {
+                            if !failures.is_empty()
+                                && let Some(observer) = observer.as_deref_mut()
+                            {
+                                observer.degraded(
+                                    tonk_analytics::account::DegradationKind::CustodyRotation,
+                                );
+                            }
                             for (subject, reason) in failures {
                                 eprintln!("rotation: {subject} not rotated: {reason}");
                             }
                         }
-                        Err(error) => eprintln!("warning: account rotation did not run: {error:#}"),
+                        Err(error) => {
+                            if let Some(observer) = observer.as_deref_mut() {
+                                observer.degraded(
+                                    tonk_analytics::account::DegradationKind::CustodyRotation,
+                                );
+                            }
+                            eprintln!("warning: account rotation did not run: {error:#}")
+                        }
                     }
                     match tonk_cli::custody::rotate_local_spaces(store, &config).await {
                         Ok(outcomes) => {
+                            if outcomes.iter().any(|(_, outcome)| {
+                                matches!(outcome, tonk_cli::custody::SpaceRotation::Skipped(_))
+                            }) && let Some(observer) = observer.as_deref_mut()
+                            {
+                                observer.degraded(
+                                    tonk_analytics::account::DegradationKind::SpaceRotation,
+                                );
+                            }
                             for (name, outcome) in outcomes {
                                 match outcome {
                                     tonk_cli::custody::SpaceRotation::Moved => {
@@ -1749,19 +1847,107 @@ async fn link_account(
                                 }
                             }
                         }
-                        Err(error) => eprintln!("warning: space custody did not move: {error:#}"),
+                        Err(error) => {
+                            if let Some(observer) = observer.as_deref_mut() {
+                                observer.degraded(
+                                    tonk_analytics::account::DegradationKind::SpaceRotation,
+                                );
+                            }
+                            eprintln!("warning: space custody did not move: {error:#}")
+                        }
                     }
                 }
-                Err(error) => eprintln!("warning: space custody did not move: {error:#}"),
+                Err(error) => {
+                    if let Some(observer) = observer.as_deref_mut() {
+                        observer.degraded(tonk_analytics::account::DegradationKind::SpaceRotation);
+                    }
+                    eprintln!("warning: space custody did not move: {error:#}")
+                }
             }
             print_customer_line(&profile, store).await;
             ExitCode::Success
         }
-        Err(error) => print_failure(error),
+        Err(error) => {
+            if let Some(observer) = observer.as_deref_mut() {
+                let classified = error
+                    .downcast_ref::<tonk_cli::callback::CallbackFailure>()
+                    .map(|callback| {
+                        use tonk_cli::callback::CallbackFailureKind;
+                        match callback.kind() {
+                            CallbackFailureKind::Bind => (
+                                tonk_analytics::account::Stage::CallbackBind,
+                                tonk_analytics::account::AccountOutcome::retryable(
+                                    tonk_analytics::account::FailureKind::Callback,
+                                ),
+                            ),
+                            CallbackFailureKind::Timeout => (
+                                tonk_analytics::account::Stage::CallbackWait,
+                                tonk_analytics::account::AccountOutcome::retryable(
+                                    tonk_analytics::account::FailureKind::Timeout,
+                                ),
+                            ),
+                            CallbackFailureKind::Closed | CallbackFailureKind::Server => (
+                                tonk_analytics::account::Stage::CallbackWait,
+                                tonk_analytics::account::AccountOutcome::retryable(
+                                    tonk_analytics::account::FailureKind::Callback,
+                                ),
+                            ),
+                        }
+                    })
+                    .or_else(|| {
+                        error
+                            .downcast_ref::<tonk_cli::account::BrowserAuthorizationDenied>()
+                            .map(|_| {
+                                (
+                                    tonk_analytics::account::Stage::CallbackWait,
+                                    tonk_analytics::account::AccountOutcome::blocked(
+                                        tonk_analytics::account::FailureKind::AccessDenied,
+                                    ),
+                                )
+                            })
+                    })
+                    .or_else(|| {
+                        error
+                            .downcast_ref::<tonk_cli::account::LinkCancelled>()
+                            .map(|_| {
+                                (
+                                    tonk_analytics::account::Stage::CallbackWait,
+                                    tonk_analytics::account::AccountOutcome::cancelled(),
+                                )
+                            })
+                    });
+                let (stage, outcome) = classified.unwrap_or_else(|| {
+                    let stage = observer.last_stage();
+                    let outcome = match stage {
+                        tonk_analytics::account::Stage::DelegationValidate => {
+                            tonk_analytics::account::AccountOutcome::terminal_failure(
+                                tonk_analytics::account::FailureKind::InvalidResponse,
+                            )
+                        }
+                        tonk_analytics::account::Stage::ActivationStage
+                        | tonk_analytics::account::Stage::AccountSync => {
+                            tonk_analytics::account::AccountOutcome::unknown_commit(
+                                tonk_analytics::account::FailureKind::LocalState,
+                            )
+                        }
+                        _ => tonk_analytics::account::AccountOutcome::terminal_failure(
+                            tonk_analytics::account::FailureKind::LocalState,
+                        ),
+                    };
+                    (stage, outcome)
+                });
+                observer.finish(stage, outcome);
+            }
+            print_failure(error)
+        }
     }
 }
 
-async fn account_op(command: Option<AccountCommand>, json: bool) -> ExitCode {
+async fn account_op(
+    command: Option<AccountCommand>,
+    json: bool,
+    mut observer: Option<&mut tonk_cli::account_observability::CliAccountAttempt>,
+) -> ExitCode {
     let command = command.unwrap_or(AccountCommand::Status { json });
     let store = match tonk_cli::space::SpaceStore::open() {
         Ok(store) => store,
@@ -1774,7 +1960,15 @@ async fn account_op(command: Option<AccountCommand>, json: bool) -> ExitCode {
         via,
     } = command
     {
-        return link_account(&store, name, service_url, no_open, via).await;
+        return link_account(
+            &store,
+            name,
+            service_url,
+            no_open,
+            via,
+            observer.as_deref_mut(),
+        )
+        .await;
     }
     if matches!(command, AccountCommand::Space { .. }) && matches!(store.account(), Ok(None)) {
         return print_error("no account is signed in; run `tonk account login`".to_owned());
@@ -1813,14 +2007,33 @@ async fn account_op(command: Option<AccountCommand>, json: bool) -> ExitCode {
                     {
                         Ok(Ok(outcome)) => {
                             if let Some(warning) = outcome.warning {
+                                if let Some(observer) = observer.as_deref_mut() {
+                                    observer.degraded(
+                                        tonk_analytics::account::DegradationKind::AccountSync,
+                                    );
+                                }
                                 eprintln!("warning: account sync attempt: {warning}");
                             }
                             if let Ok(fresh) = account::status_in(&profile, &store).await {
                                 status = fresh;
                             }
                         }
-                        Ok(Err(error)) => eprintln!("warning: account sync attempt: {error:#}"),
-                        Err(_) => eprintln!("warning: account sync attempt timed out"),
+                        Ok(Err(error)) => {
+                            if let Some(observer) = observer.as_deref_mut() {
+                                observer.degraded(
+                                    tonk_analytics::account::DegradationKind::AccountSync,
+                                );
+                            }
+                            eprintln!("warning: account sync attempt: {error:#}")
+                        }
+                        Err(_) => {
+                            if let Some(observer) = observer.as_deref_mut() {
+                                observer.degraded(
+                                    tonk_analytics::account::DegradationKind::AccountSync,
+                                );
+                            }
+                            eprintln!("warning: account sync attempt timed out")
+                        }
                     }
                 }
                 if json {
@@ -1835,19 +2048,35 @@ async fn account_op(command: Option<AccountCommand>, json: bool) -> ExitCode {
             }
             Err(error) => print_failure(error),
         },
-        AccountCommand::Logout => match account::logout_in(&profile, &store).await {
-            Ok(()) => {
-                // The spaces themselves keep their account tag: logging out
-                // is not disowning them, and this device stays able to work
-                // on every replica it already holds.
-                if let Err(error) = store.set_account(None) {
-                    return print_failure(error);
+        AccountCommand::Logout => {
+            let mut noop = tonk_cli::account_observability::NoopAccountObserver;
+            let observed: &mut dyn tonk_cli::account_observability::CliAccountObserver =
+                match observer.as_deref_mut() {
+                    Some(observer) => observer,
+                    None => &mut noop,
+                };
+            match account::logout_in_observed(&profile, &store, observed).await {
+                Ok(()) => {
+                    // The spaces themselves keep their account tag: logging out
+                    // is not disowning them, and this device stays able to work
+                    // on every replica it already holds.
+                    if let Err(error) = store.set_account(None) {
+                        if let Some(observer) = observer.as_deref_mut() {
+                            observer.finish(
+                                tonk_analytics::account::Stage::LocalCommit,
+                                tonk_analytics::account::AccountOutcome::unknown_commit(
+                                    tonk_analytics::account::FailureKind::LocalState,
+                                ),
+                            );
+                        }
+                        return print_failure(error);
+                    }
+                    println!("signed out\ndevice: {}", profile.did());
+                    ExitCode::Success
                 }
-                println!("signed out\ndevice: {}", profile.did());
-                ExitCode::Success
+                Err(error) => print_failure(error),
             }
-            Err(error) => print_failure(error),
-        },
+        }
         AccountCommand::Delete {
             account_url,
             no_open,
@@ -1903,6 +2132,11 @@ async fn account_op(command: Option<AccountCommand>, json: bool) -> ExitCode {
                             println!("site: {}", outcome.site.display());
                         }
                         if let Some(warning) = outcome.warning {
+                            if let Some(observer) = observer.as_deref_mut() {
+                                observer.degraded(
+                                    tonk_analytics::account::DegradationKind::AccountSync,
+                                );
+                            }
                             eprintln!("warning: {warning}");
                         }
                         ExitCode::Success
@@ -1964,6 +2198,9 @@ async fn account_op(command: Option<AccountCommand>, json: bool) -> ExitCode {
         AccountCommand::Sync => match account::sync(&profile).await {
             Ok(outcome) => {
                 if let Some(warning) = outcome.warning {
+                    if let Some(observer) = observer.as_deref_mut() {
+                        observer.degraded(tonk_analytics::account::DegradationKind::AccountSync);
+                    }
                     eprintln!("warning: {warning}");
                 }
                 println!("account: {:?}", outcome.status);
@@ -1973,16 +2210,49 @@ async fn account_op(command: Option<AccountCommand>, json: bool) -> ExitCode {
         },
         AccountCommand::Revoke { did, service_url } => {
             let options = account::RevokeOptions { service_url };
-            match account::revoke_in(&profile, &store, &options, &did).await {
+            let mut noop = tonk_cli::account_observability::NoopAccountObserver;
+            let observed: &mut dyn tonk_cli::account_observability::CliAccountObserver =
+                match observer.as_deref_mut() {
+                    Some(observer) => observer,
+                    None => &mut noop,
+                };
+            match account::revoke_in_observed(&profile, &store, &options, &did, observed).await {
                 Ok(account::RevokeOutcome::Revoked) => {
+                    if let Some(observer) = observer.as_deref_mut() {
+                        observer.finish(
+                            tonk_analytics::account::Stage::RemoteCommit,
+                            tonk_analytics::account::AccountOutcome::success(),
+                        );
+                    }
                     println!("revoked\ndevice: {did}");
                     ExitCode::Success
                 }
                 Ok(account::RevokeOutcome::AlreadyRevoked) => {
+                    if let Some(observer) = observer.as_deref_mut() {
+                        observer.finish(
+                            tonk_analytics::account::Stage::LocalPreflight,
+                            tonk_analytics::account::AccountOutcome::success(),
+                        );
+                    }
                     println!("already revoked\ndevice: {did}");
                     ExitCode::Success
                 }
-                Err(error) => print_failure(error),
+                Err(error) => {
+                    if let Some(observer) = observer.as_deref_mut() {
+                        let stage = observer.last_stage();
+                        let outcome = if stage == tonk_analytics::account::Stage::RemoteCommit {
+                            tonk_analytics::account::AccountOutcome::unknown_commit(
+                                tonk_analytics::account::FailureKind::Unknown,
+                            )
+                        } else {
+                            tonk_analytics::account::AccountOutcome::terminal_failure(
+                                tonk_analytics::account::FailureKind::Unknown,
+                            )
+                        };
+                        observer.finish(stage, outcome);
+                    }
+                    print_failure(error)
+                }
             }
         }
     }

--- a/rust/tonk-cli/src/bin/tonk.rs
+++ b/rust/tonk-cli/src/bin/tonk.rs
@@ -1868,7 +1868,7 @@ async fn link_account(
             ExitCode::Success
         }
         Err(error) => {
-            if let Some(observer) = observer.as_deref_mut() {
+            if let Some(observer) = observer {
                 let classified = error
                     .downcast_ref::<tonk_cli::callback::CallbackFailure>()
                     .map(|callback| {
@@ -2238,7 +2238,7 @@ async fn account_op(
                     ExitCode::Success
                 }
                 Err(error) => {
-                    if let Some(observer) = observer.as_deref_mut() {
+                    if let Some(observer) = observer {
                         let stage = observer.last_stage();
                         let outcome = if stage == tonk_analytics::account::Stage::RemoteCommit {
                             tonk_analytics::account::AccountOutcome::unknown_commit(

--- a/rust/tonk-cli/src/callback.rs
+++ b/rust/tonk-cli/src/callback.rs
@@ -20,7 +20,6 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{Context, Result, bail};
 use axum::Router;
 use axum::extract::{Form, State};
 use axum::response::Html;
@@ -31,6 +30,60 @@ use tokio::sync::{Notify, oneshot};
 
 /// How long to wait for the browser before giving up.
 const DEADLINE: Duration = Duration::from_secs(300);
+
+/// Stable callback failure classification retained beside the local detail.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallbackFailureKind {
+    /// The loopback listener could not bind or expose its address.
+    Bind,
+    /// The browser connection closed without an answer.
+    Closed,
+    /// The callback HTTP server failed.
+    Server,
+    /// No answer arrived before the deadline.
+    Timeout,
+}
+
+/// A callback failure with closed telemetry evidence and local-only detail.
+#[derive(Debug, thiserror::Error)]
+#[error("{detail}")]
+pub struct CallbackFailure {
+    kind: CallbackFailureKind,
+    detail: String,
+}
+
+impl CallbackFailure {
+    fn new(kind: CallbackFailureKind, detail: impl Into<String>) -> Self {
+        Self {
+            kind,
+            detail: detail.into(),
+        }
+    }
+
+    /// Stable callback failure kind.
+    pub fn kind(&self) -> CallbackFailureKind {
+        self.kind
+    }
+}
+
+#[cfg(test)]
+mod failure_tests {
+    use super::*;
+
+    #[test]
+    fn callback_failure_keeps_kind_beside_local_detail() {
+        for kind in [
+            CallbackFailureKind::Bind,
+            CallbackFailureKind::Closed,
+            CallbackFailureKind::Server,
+            CallbackFailureKind::Timeout,
+        ] {
+            let failure = CallbackFailure::new(kind, "local diagnostic with secret");
+            assert_eq!(failure.kind(), kind);
+            assert!(failure.to_string().contains("local diagnostic"));
+        }
+    }
+}
 
 /// What the authorizing page sent back.
 pub enum Authorization {
@@ -72,13 +125,23 @@ impl Callback {
     ///
     /// Port 0 lets the OS choose, so two `tonk` processes authorizing at once
     /// cannot collide and no scan is needed to find a free port.
-    pub async fn bind() -> Result<Self> {
+    pub async fn bind() -> Result<Self, CallbackFailure> {
         let listener = tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
             .await
-            .context("failed to bind the authorization callback listener")?;
+            .map_err(|error| {
+                CallbackFailure::new(
+                    CallbackFailureKind::Bind,
+                    format!("failed to bind the authorization callback listener: {error}"),
+                )
+            })?;
         let port = listener
             .local_addr()
-            .context("failed to read the callback listener address")?
+            .map_err(|error| {
+                CallbackFailure::new(
+                    CallbackFailureKind::Bind,
+                    format!("failed to read the callback listener address: {error}"),
+                )
+            })?
             .port();
         Ok(Self {
             url: format!("http://127.0.0.1:{port}"),
@@ -97,7 +160,10 @@ impl Callback {
     /// not leave a listener bound for the life of the shell.
     /// `redirect_origin` is the origin of the page this process opened, the
     /// only place a delivered `redirect` may point back to.
-    pub async fn receive(self, redirect_origin: Option<String>) -> Result<Authorization> {
+    pub async fn receive(
+        self,
+        redirect_origin: Option<String>,
+    ) -> Result<Authorization, CallbackFailure> {
         let (sender, receiver) = oneshot::channel();
         let shutdown = Arc::new(Notify::new());
         let state = Waiting {
@@ -119,9 +185,18 @@ impl Callback {
         .await
         {
             Ok((Ok(()), Ok(authorization))) => Ok(authorization),
-            Ok((Ok(()), Err(_))) => bail!("the authorization page closed without answering"),
-            Ok((Err(error), _)) => Err(error).context("the authorization callback server failed"),
-            Err(_) => bail!("timed out waiting for authorization in the browser"),
+            Ok((Ok(()), Err(_))) => Err(CallbackFailure::new(
+                CallbackFailureKind::Closed,
+                "the authorization page closed without answering",
+            )),
+            Ok((Err(error), _)) => Err(CallbackFailure::new(
+                CallbackFailureKind::Server,
+                format!("the authorization callback server failed: {error}"),
+            )),
+            Err(_) => Err(CallbackFailure::new(
+                CallbackFailureKind::Timeout,
+                "timed out waiting for authorization in the browser",
+            )),
         }
     }
 }

--- a/rust/tonk-cli/src/lib.rs
+++ b/rust/tonk-cli/src/lib.rs
@@ -34,6 +34,7 @@
 
 pub mod account;
 mod account_authority;
+pub mod account_observability;
 mod account_session;
 pub mod account_spaces;
 pub mod account_state;

--- a/rust/tonk-cli/src/telemetry.rs
+++ b/rust/tonk-cli/src/telemetry.rs
@@ -131,6 +131,16 @@ pub async fn begin(command: &'static str, subcommand: Option<&'static str>) -> O
 }
 
 impl Recorder {
+    /// Queue canonical account events into this invocation's existing batch.
+    pub fn account_events(
+        &mut self,
+        events: impl IntoIterator<Item = tonk_analytics::account::AccountEvent>,
+    ) {
+        for event in events {
+            let _ = self.client.capture_account(&event);
+        }
+    }
+
     /// Attach one extra content-free property (flags, buckets, counts).
     pub fn property(&mut self, key: &str, value: impl Into<Value>) {
         self.properties.insert(key.to_owned(), value.into());
@@ -199,5 +209,67 @@ mod tests {
         let path = dir.path().join("telemetry.json");
         std::fs::write(&path, "{ not json").expect("write");
         assert!(load_from(&path).enabled);
+    }
+
+    #[dialog_common::test]
+    fn account_and_generic_events_share_one_batch_without_mixing_schemas() {
+        use tonk_analytics::account::{
+            AccountAction, AccountEvent, AccountOutcome, AccountState, Journey, Stage, Surface,
+            Trigger,
+        };
+        let mut recorder = Recorder {
+            client: tonk_analytics::native::Client::new(
+                "http://localhost:1".to_owned(),
+                "key".to_owned(),
+                "tonk:anonymous".to_owned(),
+            ),
+            properties: Map::from_iter([
+                ("command".to_owned(), Value::from("account")),
+                ("subcommand".to_owned(), Value::from("login")),
+                ("environment".to_owned(), Value::from("cli")),
+            ]),
+        };
+        let start = AccountEvent::started(
+            Journey::Login,
+            AccountAction::Login,
+            Stage::CallbackBind,
+            Surface::NativeCli,
+            Trigger::User,
+            AccountState::None,
+            "opaque-attempt",
+        );
+        let finish = AccountEvent::finished(
+            Journey::Login,
+            AccountAction::Login,
+            Stage::Complete,
+            Surface::NativeCli,
+            Trigger::User,
+            AccountState::Ready,
+            "opaque-attempt",
+            10,
+            AccountOutcome::success(),
+        );
+        recorder.account_events([start, finish]);
+        recorder.client.capture(
+            tonk_analytics::event::CLI_COMMAND_RUN,
+            recorder.properties.clone(),
+        );
+        let payload = recorder.client.payload().unwrap();
+        let batch = payload["batch"].as_array().unwrap();
+        assert_eq!(batch.len(), 3);
+        assert_eq!(batch[0]["event"], "account_event");
+        assert_eq!(batch[2]["event"], "cli_command_run");
+        assert!(batch[2]["properties"].get("stage").is_none());
+        assert!(batch[2]["properties"].get("failure_kind").is_none());
+        let wire = payload.to_string();
+        for sentinel in [
+            "person@example.com",
+            "did:key:zSensitive",
+            "http://127.0.0.1/callback",
+            "delegation-secret",
+            "/Users/person/private",
+        ] {
+            assert!(!wire.contains(sentinel));
+        }
     }
 }

--- a/rust/tonk-cli/tests/telemetry.rs
+++ b/rust/tonk-cli/tests/telemetry.rs
@@ -83,6 +83,36 @@ fn run_tonk_help(
     cmd.output().expect("tonk binary runs")
 }
 
+fn run_tonk_account_status(
+    home: &std::path::Path,
+    endpoint: &str,
+    extra_env: &[(&str, &str)],
+) -> Output {
+    let mut cmd = Command::new(tonk_bin());
+    cmd.args(["account", "status", "--json"])
+        .current_dir(home)
+        .env("HOME", home)
+        .env("XDG_DATA_HOME", home.join("data"))
+        .env("TONK_SPACES_STATE", home.join("spaces"))
+        .env("TONK_TELEMETRY_STATE", home.join("telemetry"))
+        .env("TONK_POSTHOG_KEY", "test-key")
+        .env("TONK_POSTHOG_ENDPOINT", endpoint)
+        .env("TONK_NO_UPDATE_CHECK", "1")
+        .env("TONK_UPDATE_STATE", home.join("update"))
+        .env_remove("DO_NOT_TRACK")
+        .env_remove("TONK_TELEMETRY")
+        .env_remove("TONK_SPACE");
+    for (key, value) in extra_env {
+        cmd.env(key, value);
+    }
+    cmd.output().expect("tonk account status runs")
+}
+
+fn request_body(request: &str) -> serde_json::Value {
+    let (_, body) = request.split_once("\r\n\r\n").expect("HTTP body");
+    serde_json::from_str(body).expect("JSON batch")
+}
+
 #[dialog_common::test]
 fn help_posts_one_command_run_event() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
@@ -149,4 +179,67 @@ fn notice_prints_only_once() {
     let second = run_tonk_help(state.path(), &endpoint, &[]);
     assert!(second.status.success());
     assert!(!String::from_utf8_lossy(&second.stderr).contains("tonk telemetry off"));
+}
+
+#[dialog_common::test]
+fn account_command_batches_shared_events_and_generic_summary() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let endpoint = format!("http://{}", listener.local_addr().expect("addr"));
+    let (tx, rx) = mpsc::channel();
+    serve_once(listener, tx);
+
+    let home = tempfile::tempdir().expect("tempdir");
+    let output = run_tonk_account_status(home.path(), &endpoint, &[]);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let request = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("request arrives");
+    let payload = request_body(&request);
+    let batch = payload["batch"].as_array().expect("batch array");
+    let account = batch
+        .iter()
+        .filter(|event| event["event"] == "account_event")
+        .collect::<Vec<_>>();
+    let generic = batch
+        .iter()
+        .filter(|event| event["event"] == "cli_command_run")
+        .collect::<Vec<_>>();
+    assert_eq!(generic.len(), 1);
+    assert_eq!(account.len(), 2);
+    assert_eq!(account[0]["properties"]["action"], "load_account");
+    assert_eq!(account[0]["properties"]["phase"], "started");
+    assert_eq!(account[1]["properties"]["phase"], "finished");
+    assert!(generic[0]["properties"].get("stage").is_none());
+    assert!(generic[0]["properties"].get("failure_kind").is_none());
+
+    let wire = serde_json::to_string(&payload).unwrap();
+    let home_text = home.path().to_string_lossy();
+    for sentinel in [
+        "person@example.com",
+        "did:key:",
+        "callback=http",
+        "delegation",
+        home_text.as_ref(),
+    ] {
+        assert!(
+            !wire.contains(sentinel),
+            "batch exposed {sentinel:?}: {wire}"
+        );
+    }
+}
+
+#[dialog_common::test]
+fn opted_out_account_command_sends_no_batch() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let endpoint = format!("http://{}", listener.local_addr().expect("addr"));
+    let (tx, rx) = mpsc::channel();
+    serve_once(listener, tx);
+    let home = tempfile::tempdir().expect("tempdir");
+    let output = run_tonk_account_status(home.path(), &endpoint, &[("DO_NOT_TRACK", "1")]);
+    assert!(output.status.success());
+    assert!(rx.recv_timeout(Duration::from_secs(1)).is_err());
 }

--- a/rust/tonk-identity/src/passkey.rs
+++ b/rust/tonk-identity/src/passkey.rs
@@ -84,6 +84,19 @@ pub enum CeremonyRefusal {
 }
 
 impl CeremonyRefusal {
+    /// Classify a DOM exception name without depending on its human-readable
+    /// message. Unknown names deliberately collapse to [`Self::Other`].
+    pub fn from_name(name: &str) -> Self {
+        match name {
+            "NotAllowedError" => Self::NotAllowed,
+            "InvalidStateError" => Self::InvalidState,
+            "NotSupportedError" => Self::NotSupported,
+            "SecurityError" => Self::Security,
+            "NoPrfError" => Self::NoPrf,
+            _ => Self::Other,
+        }
+    }
+
     /// The `DOMException` name this refusal came back as, for handing
     /// across the JS boundary.
     pub fn as_str(self) -> &'static str {
@@ -116,13 +129,10 @@ fn ceremony_error(context: &str, value: JsValue) -> anyhow::Error {
         }
     };
     let detail: String = detail.chars().take(512).collect();
-    let reason = match property("name").as_deref() {
-        Some("NotAllowedError") => CeremonyRefusal::NotAllowed,
-        Some("InvalidStateError") => CeremonyRefusal::InvalidState,
-        Some("NotSupportedError") => CeremonyRefusal::NotSupported,
-        Some("SecurityError") => CeremonyRefusal::Security,
-        _ => CeremonyRefusal::Other,
-    };
+    let reason = property("name")
+        .as_deref()
+        .map(CeremonyRefusal::from_name)
+        .unwrap_or(CeremonyRefusal::Other);
     CeremonyError {
         context: context.to_string(),
         reason,
@@ -391,6 +401,16 @@ mod tests {
     /// dismissed prompt from a real failure without reading prose.
     #[dialog_common::test]
     fn it_names_the_reason_a_ceremony_was_refused() {
+        for (name, expected) in [
+            ("NotAllowedError", CeremonyRefusal::NotAllowed),
+            ("InvalidStateError", CeremonyRefusal::InvalidState),
+            ("NotSupportedError", CeremonyRefusal::NotSupported),
+            ("SecurityError", CeremonyRefusal::Security),
+            ("NoPrfError", CeremonyRefusal::NoPrf),
+            ("FutureError", CeremonyRefusal::Other),
+        ] {
+            assert_eq!(CeremonyRefusal::from_name(name), expected);
+        }
         let refusal = |name: &str| {
             let error = js_sys::Error::new("the operation was refused");
             error.set_name(name);

--- a/rust/tonk-ui/Cargo.toml
+++ b/rust/tonk-ui/Cargo.toml
@@ -102,6 +102,7 @@ features = [
     "MessageEvent",
     "Navigator",
     "Node",
+    "Performance",
     "ServiceWorkerContainer",
     "Storage",
     "VisibilityState",

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -35,6 +35,12 @@ enum Confirmation {
     },
 }
 
+enum DeleteFailure {
+    PreflightApi(crate::error::TonkUiError),
+    MutationApi(crate::error::TonkUiError),
+    Diagnostic(String),
+}
+
 /// The top-document account element. WebAuthn must not run in sealed guests.
 #[derive(Default)]
 struct TonkAccount;
@@ -357,7 +363,8 @@ fn log_action_error(action: AccountAction, detail: &str) {
 
 fn show_action_error(host: &HtmlElement, action: AccountAction, detail: &str) {
     log_action_error(action, detail);
-    show_error(host, user_error::diagnostic(action, detail));
+    let problem = user_error::problem_from_diagnostic(action, detail);
+    show_error(host, problem.message);
 }
 
 /// [`show_action_error`] for a failed passkey ceremony, which may carry
@@ -369,17 +376,24 @@ fn show_ceremony_error(
     error: &crate::custody_relay::CeremonyError,
 ) {
     log_action_error(action, &error.message);
-    show_error(host, user_error::ceremony(action, error));
+    let problem = user_error::ceremony_problem(action, error);
+    show_error(host, problem.message);
 }
 
 fn show_api_error(host: &HtmlElement, action: AccountAction, error: &crate::error::TonkUiError) {
     log_action_error(action, &error.to_string());
-    show_error(host, user_error::api(action, error));
+    let problem = user_error::api_problem(action, error);
+    show_error(host, problem.message);
 }
 
-fn show_confirmation_action_error(host: &HtmlElement, action: AccountAction, detail: &str) {
-    log_action_error(action, detail);
-    show_confirmation_error(host, user_error::diagnostic(action, detail));
+fn show_automatic_api_error(
+    host: &HtmlElement,
+    action: AccountAction,
+    error: &crate::error::TonkUiError,
+) {
+    log_action_error(action, &error.to_string());
+    let problem = user_error::api_problem(action, error);
+    show_error(host, problem.message);
 }
 
 fn show_confirmation_api_error(
@@ -388,7 +402,8 @@ fn show_confirmation_api_error(
     error: &crate::error::TonkUiError,
 ) {
     log_action_error(action, &error.to_string());
-    show_confirmation_error(host, user_error::api(action, error));
+    let problem = user_error::api_problem(action, error);
+    show_confirmation_error(host, problem.message);
 }
 
 fn show_display_name_api_error(
@@ -397,7 +412,8 @@ fn show_display_name_api_error(
     error: &crate::error::TonkUiError,
 ) {
     log_action_error(action, &error.to_string());
-    show_display_name_error(host, &user_error::api(action, error));
+    let problem = user_error::api_problem(action, error);
+    show_display_name_error(host, &problem.message);
 }
 
 fn show_account_guidance(host: &HtmlElement, message: &str) {
@@ -531,16 +547,32 @@ fn load_activation_notice(host: HtmlElement) {
             let _ = host.set_attribute("data-backup", "done");
             return;
         }
-        let mut state = match crate::api::customer_state().await {
-            Ok(state) => state,
+        let (mut attempt, result) = crate::account_observability::observe(
+            AccountAction::LoadRegistration,
+            tonk_analytics::account::Surface::Settings,
+            tonk_analytics::account::Trigger::Automatic,
+            tonk_analytics::account::AccountState::Unknown,
+            crate::api::customer_state(),
+        )
+        .await;
+        let mut state = match result {
+            Ok(state) => {
+                attempt.finish(
+                    tonk_analytics::account::Stage::AccountLoad,
+                    tonk_analytics::account::AccountOutcome::success(),
+                );
+                state
+            }
             Err(error) => {
+                let problem = user_error::api_problem(AccountAction::LoadRegistration, &error);
+                attempt.finish(tonk_analytics::account::Stage::AccountLoad, problem.outcome);
                 set_text(
                     &host,
                     "#account-registration-value",
                     "Unavailable — reload to retry",
                 );
                 if host.has_attribute(ACCOUNT_NOT_READY) {
-                    show_api_error(&host, AccountAction::LoadAccount, &error);
+                    show_automatic_api_error(&host, AccountAction::LoadRegistration, &error);
                 } else {
                     log_action_error(AccountAction::LoadAccount, &error.to_string());
                 }
@@ -558,14 +590,30 @@ fn load_activation_notice(host: HtmlElement) {
                 .await
                 .is_ok_and(|config| config.service_did.is_some())
         {
-            match crate::api::enroll_customer(None).await {
+            let (mut enroll_attempt, result) = crate::account_observability::observe(
+                AccountAction::LoadAccount,
+                tonk_analytics::account::Surface::Settings,
+                tonk_analytics::account::Trigger::Recovery,
+                tonk_analytics::account::AccountState::RegisteredUnready,
+                crate::api::enroll_customer(None),
+            )
+            .await;
+            match result {
                 // Enrollment is a command, so this returns once the
                 // transient is committed, not once the service answers.
                 // Re-reading here would race the handler and paint a
                 // state already superseded; the row's subscription is
                 // what shows the outcome, whenever it lands.
-                Ok(()) => {}
+                Ok(()) => enroll_attempt.finish(
+                    tonk_analytics::account::Stage::RemoteCommit,
+                    tonk_analytics::account::AccountOutcome::success(),
+                ),
                 Err(error) => {
+                    let problem = user_error::api_problem(AccountAction::LoadAccount, &error);
+                    enroll_attempt.finish(
+                        tonk_analytics::account::Stage::RemoteCommit,
+                        problem.outcome,
+                    );
                     set_text(
                         &host,
                         "#account-registration-value",
@@ -817,6 +865,34 @@ fn close_confirmation(host: &HtmlElement) {
     let _ = Reflect::delete_property(host.as_ref(), &CONFIRMATION_RETURN_FOCUS.into());
 }
 
+fn cancel_confirmation(host: &HtmlElement) {
+    let action = match confirmation(host) {
+        Some(Confirmation::SignOut) => Some(AccountAction::SignOut),
+        Some(Confirmation::Revoke { .. }) => Some(AccountAction::RevokeDevice),
+        Some(Confirmation::Delete {
+            requested_space, ..
+        }) => Some(if requested_space.is_some() {
+            AccountAction::DeleteSpace
+        } else {
+            AccountAction::DeleteAccount
+        }),
+        None => None,
+    };
+    if let Some(action) = action {
+        let mut attempt = crate::account_observability::WebAccountAttempt::start(
+            action,
+            tonk_analytics::account::Surface::Settings,
+            tonk_analytics::account::Trigger::User,
+            tonk_analytics::account::AccountState::Ready,
+        );
+        attempt.finish(
+            tonk_analytics::account::Stage::Input,
+            tonk_analytics::account::AccountOutcome::cancelled(),
+        );
+    }
+    close_confirmation(host);
+}
+
 fn open_confirmation(host: &HtmlElement, pending: Confirmation) -> Result<(), String> {
     if confirmation(host).is_none()
         && let Some(active) = window()
@@ -917,6 +993,26 @@ fn show_confirmation_error(host: &HtmlElement, message: impl AsRef<str>) {
             let _ = error.focus();
         }
     }
+}
+
+fn show_confirmation_validation_error(
+    host: &HtmlElement,
+    action: AccountAction,
+    message: impl AsRef<str>,
+) {
+    let mut attempt = crate::account_observability::WebAccountAttempt::start(
+        action,
+        tonk_analytics::account::Surface::Settings,
+        tonk_analytics::account::Trigger::User,
+        tonk_analytics::account::AccountState::Ready,
+    );
+    attempt.finish(
+        tonk_analytics::account::Stage::Input,
+        tonk_analytics::account::AccountOutcome::terminal_failure(
+            tonk_analytics::account::FailureKind::InvalidInput,
+        ),
+    );
+    show_confirmation_error(host, message);
 }
 
 fn render_confirmation_result(host: &HtmlElement, message: &str) {
@@ -1112,9 +1208,21 @@ fn render_summary(host: &HtmlElement, summary: &tonk_worker_api::AccountSummary)
 }
 
 fn load_summary(host: HtmlElement) {
+    let mut attempt = crate::account_observability::WebAccountAttempt::start(
+        AccountAction::LoadAccount,
+        tonk_analytics::account::Surface::Settings,
+        tonk_analytics::account::Trigger::Automatic,
+        tonk_analytics::account::AccountState::Unknown,
+    );
     spawn_local(async move {
         match crate::api::account_summary().await {
-            Ok(summary) => render_summary(&host, &summary),
+            Ok(summary) => {
+                attempt.finish(
+                    tonk_analytics::account::Stage::AccountLoad,
+                    tonk_analytics::account::AccountOutcome::success(),
+                );
+                render_summary(&host, &summary)
+            }
             Err(error) => {
                 for selector in [
                     "#account-email-value",
@@ -1129,6 +1237,8 @@ fn load_summary(host: HtmlElement) {
                     "We couldn't load these account details. Check your connection and reload settings.",
                 );
                 log_action_error(AccountAction::LoadAccount, &error.to_string());
+                let problem = user_error::api_problem(AccountAction::LoadAccount, &error);
+                attempt.finish(tonk_analytics::account::Stage::AccountLoad, problem.outcome);
             }
         }
     });
@@ -1390,8 +1500,20 @@ fn commit_display_name(host: HtmlElement) {
         let _ = error.set_attribute("hidden", "");
     }
     spawn_local(async move {
-        match crate::api::set_account_display_name(&name).await {
+        let (mut attempt, result) = crate::account_observability::observe(
+            AccountAction::ChangeDisplayName,
+            tonk_analytics::account::Surface::Settings,
+            tonk_analytics::account::Trigger::User,
+            tonk_analytics::account::AccountState::Ready,
+            crate::api::set_account_display_name(&name),
+        )
+        .await;
+        match result {
             Ok(authoritative) => {
+                attempt.finish(
+                    tonk_analytics::account::Stage::RemoteCommit,
+                    tonk_analytics::account::AccountOutcome::success(),
+                );
                 input.set_value(&authoritative);
                 let _ = input.set_attribute("data-confirmed-name", &authoritative);
                 set_text(
@@ -1401,6 +1523,11 @@ fn commit_display_name(host: HtmlElement) {
                 );
             }
             Err(error) => {
+                let problem = user_error::api_problem(AccountAction::ChangeDisplayName, &error);
+                attempt.finish(
+                    tonk_analytics::account::Stage::RemoteCommit,
+                    problem.outcome,
+                );
                 input.set_value(&confirmed);
                 show_display_name_api_error(&host, AccountAction::ChangeDisplayName, &error);
             }
@@ -1439,10 +1566,26 @@ fn render_choice_profiles(
 
 fn load_profiles(host: HtmlElement) {
     spawn_local(async move {
-        match crate::api::list_profiles().await {
-            Ok(profiles) => render_profiles(&host, &profiles),
+        let (mut attempt, result) = crate::account_observability::observe(
+            AccountAction::LoadProfiles,
+            tonk_analytics::account::Surface::Settings,
+            tonk_analytics::account::Trigger::Automatic,
+            tonk_analytics::account::AccountState::Unknown,
+            crate::api::list_profiles(),
+        )
+        .await;
+        match result {
+            Ok(profiles) => {
+                attempt.finish(
+                    tonk_analytics::account::Stage::AccountLoad,
+                    tonk_analytics::account::AccountOutcome::success(),
+                );
+                render_profiles(&host, &profiles)
+            }
             Err(error) => {
-                show_display_name_api_error(&host, AccountAction::LoadProfiles, &error);
+                let problem = user_error::api_problem(AccountAction::LoadProfiles, &error);
+                attempt.finish(tonk_analytics::account::Stage::AccountLoad, problem.outcome);
+                show_automatic_api_error(&host, AccountAction::LoadProfiles, &error);
             }
         }
     });
@@ -1450,10 +1593,26 @@ fn load_profiles(host: HtmlElement) {
 
 fn load_choice_profiles(host: HtmlElement, root_persisted: bool) {
     spawn_local(async move {
-        match crate::api::list_profiles().await {
-            Ok(profiles) => render_choice_profiles(&host, &profiles, root_persisted),
+        let (mut attempt, result) = crate::account_observability::observe(
+            AccountAction::LoadProfiles,
+            tonk_analytics::account::Surface::Settings,
+            tonk_analytics::account::Trigger::Automatic,
+            tonk_analytics::account::AccountState::Unknown,
+            crate::api::list_profiles(),
+        )
+        .await;
+        match result {
+            Ok(profiles) => {
+                attempt.finish(
+                    tonk_analytics::account::Stage::AccountLoad,
+                    tonk_analytics::account::AccountOutcome::success(),
+                );
+                render_choice_profiles(&host, &profiles, root_persisted)
+            }
             Err(error) => {
-                show_api_error(&host, AccountAction::LoadProfiles, &error);
+                let problem = user_error::api_problem(AccountAction::LoadProfiles, &error);
+                attempt.finish(tonk_analytics::account::Stage::AccountLoad, problem.outcome);
+                show_automatic_api_error(&host, AccountAction::LoadProfiles, &error);
             }
         }
     });
@@ -1577,19 +1736,35 @@ fn consume_revoke_target() {
 fn load_devices(host: HtmlElement) {
     set_busy(&host, true, "Loading devices…");
     spawn_local(async move {
+        let mut attempt = crate::account_observability::WebAccountAttempt::start(
+            AccountAction::LoadDevices,
+            tonk_analytics::account::Surface::Settings,
+            tonk_analytics::account::Trigger::Automatic,
+            tonk_analytics::account::AccountState::Ready,
+        );
         // Which row is this device is answered separately from the list:
         // the rows are shared facts, identical everywhere, and identity
         // is the one thing only this device can answer for itself.
         let own = match crate::api::identify().await {
             Ok(identity) => identity.did,
             Err(error) => {
+                let problem = user_error::api_problem(AccountAction::LoadDevices, &error);
+                attempt.finish(
+                    tonk_analytics::account::Stage::LocalPreflight,
+                    problem.outcome,
+                );
                 set_busy(&host, false, "");
-                show_api_error(&host, AccountAction::LoadDevices, &error);
+                show_automatic_api_error(&host, AccountAction::LoadDevices, &error);
                 return;
             }
         };
+        attempt.checkpoint(tonk_analytics::account::Stage::LocalPreflight);
         match crate::api::account_devices().await {
             Ok(devices) => {
+                attempt.finish(
+                    tonk_analytics::account::Stage::AccountLoad,
+                    tonk_analytics::account::AccountOutcome::success(),
+                );
                 set_busy(&host, false, "");
                 render_devices(&host, &devices, &own);
                 if let Some(did) = revoke_target_from_url() {
@@ -1606,8 +1781,10 @@ fn load_devices(host: HtmlElement) {
                 }
             }
             Err(error) => {
+                let problem = user_error::api_problem(AccountAction::LoadDevices, &error);
+                attempt.finish(tonk_analytics::account::Stage::AccountLoad, problem.outcome);
                 set_busy(&host, false, "");
-                show_api_error(&host, AccountAction::LoadDevices, &error);
+                show_automatic_api_error(&host, AccountAction::LoadDevices, &error);
             }
         }
     });
@@ -1676,11 +1853,27 @@ fn load_status(host: HtmlElement) {
                 // panel.
                 set_busy(&host, true, "Checking this browser…");
                 spawn_local(async move {
-                    match crate::api::account_status().await {
+                    let (mut attempt, result) = crate::account_observability::observe(
+                        AccountAction::LoadAccount,
+                        tonk_analytics::account::Surface::Settings,
+                        tonk_analytics::account::Trigger::Automatic,
+                        tonk_analytics::account::AccountState::Unknown,
+                        crate::api::account_status(),
+                    )
+                    .await;
+                    match result {
                         Ok(AccountStatus::Registered { .. }) => {
+                            attempt.finish(
+                                tonk_analytics::account::Stage::AccountLoad,
+                                tonk_analytics::account::AccountOutcome::success(),
+                            );
                             load_callback_request(host, audience, callback, name);
                         }
                         Ok(status) => {
+                            attempt.finish(
+                                tonk_analytics::account::Stage::AccountLoad,
+                                tonk_analytics::account::AccountOutcome::success(),
+                            );
                             let root_persisted =
                                 matches!(status, AccountStatus::Unregistered { .. });
                             set_busy(&host, false, "");
@@ -1693,9 +1886,15 @@ fn load_status(host: HtmlElement) {
                             load_choice_profiles(host.clone(), root_persisted);
                         }
                         Err(error) => {
+                            let problem =
+                                user_error::api_problem(AccountAction::LoadAccount, &error);
+                            attempt.finish(
+                                tonk_analytics::account::Stage::AccountLoad,
+                                problem.outcome,
+                            );
                             set_busy(&host, false, "");
                             set_mode(&host, "choice");
-                            show_api_error(&host, AccountAction::LinkCli, &error);
+                            show_automatic_api_error(&host, AccountAction::LoadAccount, &error);
                         }
                     }
                 });
@@ -1717,8 +1916,35 @@ fn load_status(host: HtmlElement) {
     // authorization outcome, reported here in the page's own styling.
     let link_outcome = query_value("link").map(|status| (status, query_value("message")));
     set_busy(&host, true, "Checking this browser…");
+    let mut settle_attempt = crate::account_observability::take_settle_pending().then(|| {
+        crate::account_observability::WebAccountAttempt::start(
+            AccountAction::SettleAccount,
+            tonk_analytics::account::Surface::Settings,
+            tonk_analytics::account::Trigger::Recovery,
+            tonk_analytics::account::AccountState::PendingActivation,
+        )
+    });
+    let mut load_attempt = crate::account_observability::WebAccountAttempt::start(
+        AccountAction::LoadAccount,
+        tonk_analytics::account::Surface::Settings,
+        tonk_analytics::account::Trigger::Automatic,
+        tonk_analytics::account::AccountState::Unknown,
+    );
     spawn_local(async move {
         if let Err(error) = service(&host).await {
+            let problem = user_error::problem_from_diagnostic(AccountAction::LoadAccount, &error);
+            load_attempt.finish(
+                tonk_analytics::account::Stage::AccessService,
+                problem.outcome,
+            );
+            if let Some(attempt) = settle_attempt.as_mut() {
+                let problem =
+                    user_error::problem_from_diagnostic(AccountAction::SettleAccount, &error);
+                attempt.finish(
+                    tonk_analytics::account::Stage::AccessService,
+                    problem.outcome,
+                );
+            }
             set_busy(&host, false, "");
             set_mode(&host, NO_PANEL_MODE);
             show_action_error(&host, AccountAction::LoadAccount, &error);
@@ -1726,6 +1952,10 @@ fn load_status(host: HtmlElement) {
         }
         match crate::api::account_status().await {
             Ok(status) => {
+                load_attempt.finish(
+                    tonk_analytics::account::Stage::AccountLoad,
+                    tonk_analytics::account::AccountOutcome::success(),
+                );
                 // A persisted root with no provider is a signed-out
                 // profile: logging in here with a DIFFERENT passkey is
                 // refused, so the Choice panel offers a fresh profile.
@@ -1739,11 +1969,22 @@ fn load_status(host: HtmlElement) {
                 } else {
                     let _ = host.remove_attribute(ACCOUNT_NOT_READY);
                 }
-                match landing(
+                let landing = landing(
                     account_state,
                     revoke_target_from_url().is_some(),
                     adding_account(),
-                ) {
+                );
+                if let Some(attempt) = settle_attempt.as_mut() {
+                    let outcome = if matches!(landing, Landing::Success | Landing::Devices) {
+                        tonk_analytics::account::AccountOutcome::success()
+                    } else {
+                        tonk_analytics::account::AccountOutcome::terminal_failure(
+                            tonk_analytics::account::FailureKind::LocalState,
+                        )
+                    };
+                    attempt.finish(tonk_analytics::account::Stage::Complete, outcome);
+                }
+                match landing {
                     Landing::Devices => show_success(&host),
                     Landing::Success => {
                         // Marked BEFORE settling, because settling starts
@@ -1773,9 +2014,18 @@ fn load_status(host: HtmlElement) {
                 }
             }
             Err(error) => {
+                let load_problem = user_error::api_problem(AccountAction::LoadAccount, &error);
+                load_attempt.finish(
+                    tonk_analytics::account::Stage::AccountLoad,
+                    load_problem.outcome,
+                );
+                if let Some(attempt) = settle_attempt.as_mut() {
+                    let problem = user_error::api_problem(AccountAction::SettleAccount, &error);
+                    attempt.finish(tonk_analytics::account::Stage::AccountSync, problem.outcome);
+                }
                 set_busy(&host, false, "");
                 set_mode(&host, "choice");
-                show_api_error(&host, AccountAction::LoadAccount, &error);
+                show_automatic_api_error(&host, AccountAction::LoadAccount, &error);
             }
         }
     });
@@ -2206,7 +2456,7 @@ fn bind(host: &HtmlElement) {
         "#account-confirm-cancel",
         "[data-confirmation-scrim]",
     ] {
-        on_click(host, selector, |host| close_confirmation(&host));
+        on_click(host, selector, |host| cancel_confirmation(&host));
     }
 
     for event_name in ["input", "change"] {
@@ -2249,6 +2499,12 @@ fn bind(host: &HtmlElement) {
         let device_name = crate::device_name::current();
         set_busy(&host, true, "Waiting for your passkey…");
         spawn_local(async move {
+            let mut attempt = crate::account_observability::WebAccountAttempt::start(
+                AccountAction::CreateAccount,
+                tonk_analytics::account::Surface::Settings,
+                tonk_analytics::account::Trigger::User,
+                tonk_analytics::account::AccountState::None,
+            );
             let result = async {
                 prepare_added_profile().await?;
                 // The page's whole part: one passkey ceremony. The
@@ -2274,9 +2530,23 @@ fn bind(host: &HtmlElement) {
                 Ok::<(), crate::custody_relay::CeremonyError>(())
             }
             .await;
-            if let Err(error) = result {
-                set_busy(&host, false, "");
-                show_ceremony_error(&host, AccountAction::CreateAccount, &error);
+            match result {
+                Ok(()) => attempt.finish(
+                    tonk_analytics::account::Stage::ActivationWait,
+                    tonk_analytics::account::AccountOutcome::blocked(
+                        tonk_analytics::account::FailureKind::AwaitingActivation,
+                    ),
+                ),
+                Err(error) => {
+                    let problem =
+                        user_error::ceremony_problem(AccountAction::CreateAccount, &error);
+                    attempt.finish(
+                        tonk_analytics::account::Stage::WorkerHandoff,
+                        problem.outcome,
+                    );
+                    set_busy(&host, false, "");
+                    show_ceremony_error(&host, AccountAction::CreateAccount, &error);
+                }
             }
         });
     });
@@ -2288,10 +2558,21 @@ fn bind(host: &HtmlElement) {
             // A resend, not a re-enrollment: the rows stand at the
             // service, so the worker only signs the resend invocation —
             // no passkey prompt for someone who is waiting on an inbox.
-            let result = crate::api::resend_activation().await;
+            let (mut attempt, result) = crate::account_observability::observe(
+                AccountAction::ResendActivation,
+                tonk_analytics::account::Surface::Settings,
+                tonk_analytics::account::Trigger::User,
+                tonk_analytics::account::AccountState::PendingActivation,
+                crate::api::resend_activation(),
+            )
+            .await;
             set_busy(&host, false, "");
             match result {
                 Ok(_) => {
+                    attempt.finish(
+                        tonk_analytics::account::Stage::RemoteCommit,
+                        tonk_analytics::account::AccountOutcome::success(),
+                    );
                     set_text(
                         &host,
                         "#account-activation-notice",
@@ -2305,7 +2586,14 @@ fn bind(host: &HtmlElement) {
                     // pressed the button, which is enough to say so.
                     count_down_resend(host.clone());
                 }
-                Err(error) => show_api_error(&host, AccountAction::ResendActivation, &error),
+                Err(error) => {
+                    let problem = user_error::api_problem(AccountAction::ResendActivation, &error);
+                    attempt.finish(
+                        tonk_analytics::account::Stage::RemoteCommit,
+                        problem.outcome,
+                    );
+                    show_api_error(&host, AccountAction::ResendActivation, &error);
+                }
             }
         });
     });
@@ -2314,6 +2602,12 @@ fn bind(host: &HtmlElement) {
         clear_error(&host);
         set_busy(&host, true, "Waiting for your passkey…");
         spawn_local(async move {
+            let mut attempt = crate::account_observability::WebAccountAttempt::start(
+                AccountAction::AddPasskey,
+                tonk_analytics::account::Surface::Settings,
+                tonk_analytics::account::Trigger::User,
+                tonk_analytics::account::AccountState::Ready,
+            );
             let result = async {
                 let (root_did, _delegation_hex) = match crate::api::root_status()
                     .await
@@ -2351,12 +2645,23 @@ fn bind(host: &HtmlElement) {
             set_busy(&host, false, "");
             match result {
                 Ok(()) => {
+                    attempt.finish(
+                        tonk_analytics::account::Stage::RemoteCommit,
+                        tonk_analytics::account::AccountOutcome::success(),
+                    );
                     if let Ok(Some(button)) = host.query_selector("#account-add-passkey") {
                         let _ = button.set_attribute("hidden", "");
                     }
                     load_summary(host.clone());
                 }
-                Err(error) => show_ceremony_error(&host, AccountAction::AddPasskey, &error),
+                Err(error) => {
+                    let problem = user_error::ceremony_problem(AccountAction::AddPasskey, &error);
+                    attempt.finish(
+                        tonk_analytics::account::Stage::WorkerHandoff,
+                        problem.outcome,
+                    );
+                    show_ceremony_error(&host, AccountAction::AddPasskey, &error);
+                }
             }
         });
     });
@@ -2366,6 +2671,12 @@ fn bind(host: &HtmlElement) {
         let device_name = crate::device_name::current();
         set_busy(&host, true, "Waiting for your passkey…");
         spawn_local(async move {
+            let mut attempt = crate::account_observability::WebAccountAttempt::start(
+                AccountAction::LogIn,
+                tonk_analytics::account::Surface::Settings,
+                tonk_analytics::account::Trigger::User,
+                tonk_analytics::account::AccountState::None,
+            );
             let result = async {
                 prepare_added_profile().await?;
                 // One assertion, and the worker does the rest: it
@@ -2385,9 +2696,20 @@ fn bind(host: &HtmlElement) {
                 .await
             }
             .await;
-            if let Err(error) = result {
-                set_busy(&host, false, "");
-                show_ceremony_error(&host, AccountAction::LogIn, &error);
+            match result {
+                Ok(_) => attempt.finish(
+                    tonk_analytics::account::Stage::RemoteCommit,
+                    tonk_analytics::account::AccountOutcome::success(),
+                ),
+                Err(error) => {
+                    let problem = user_error::ceremony_problem(AccountAction::LogIn, &error);
+                    attempt.finish(
+                        tonk_analytics::account::Stage::WorkerHandoff,
+                        problem.outcome,
+                    );
+                    set_busy(&host, false, "");
+                    show_ceremony_error(&host, AccountAction::LogIn, &error);
+                }
             }
         });
     });
@@ -2405,6 +2727,12 @@ fn bind(host: &HtmlElement) {
         {
             set_busy(&host, true, "Waiting for your passkey…");
             spawn_local(async move {
+                let mut attempt = crate::account_observability::WebAccountAttempt::start(
+                    AccountAction::LinkCli,
+                    tonk_analytics::account::Surface::Settings,
+                    tonk_analytics::account::Trigger::User,
+                    tonk_analytics::account::AccountState::Ready,
+                );
                 let result = async {
                     // Registration precedes linking: a device linked to an
                     // unregistered account inherits a dead sync path, so a
@@ -2472,12 +2800,26 @@ fn bind(host: &HtmlElement) {
                     deliver_to_callback(
                         &callback,
                         &[("authorize", &encoded), ("redirect", &redirect)],
-                    )
+                    )?;
+                    Ok::<(), String>(())
                 }
                 .await;
-                if let Err(error) = result {
-                    set_busy(&host, false, "");
-                    show_action_error(&host, AccountAction::LinkCli, &error);
+                match result {
+                    Ok(()) => attempt.finish(
+                        tonk_analytics::account::Stage::CallbackDelivery,
+                        tonk_analytics::account::AccountOutcome::success(),
+                    ),
+                    Err(error) => {
+                        let problem =
+                            user_error::problem_from_diagnostic(AccountAction::LinkCli, &error);
+                        attempt.finish(
+                            tonk_analytics::account::Stage::CallbackDelivery,
+                            problem.outcome,
+                        );
+                        set_busy(&host, false, "");
+                        log_action_error(AccountAction::LinkCli, &error);
+                        show_error(&host, problem.message);
+                    }
                 }
             });
             return;
@@ -2513,6 +2855,17 @@ fn bind(host: &HtmlElement) {
             &[("deny", "declined in the browser"), ("redirect", &redirect)],
         ) {
             show_action_error(&host, AccountAction::LinkCli, &error);
+        } else {
+            let mut attempt = crate::account_observability::WebAccountAttempt::start(
+                AccountAction::LinkCli,
+                tonk_analytics::account::Surface::Settings,
+                tonk_analytics::account::Trigger::User,
+                tonk_analytics::account::AccountState::Ready,
+            );
+            attempt.finish(
+                tonk_analytics::account::Stage::CallbackDelivery,
+                tonk_analytics::account::AccountOutcome::cancelled(),
+            );
         }
     });
 
@@ -2527,8 +2880,20 @@ fn bind(host: &HtmlElement) {
         clear_error(&host);
         set_busy(&host, true, "Loading the permanent deletion scope…");
         spawn_local(async move {
-            match crate::api::account_deletion_plan().await {
+            let (mut attempt, result) = crate::account_observability::observe(
+                AccountAction::LoadDeletionPlan,
+                tonk_analytics::account::Surface::Settings,
+                tonk_analytics::account::Trigger::User,
+                tonk_analytics::account::AccountState::Ready,
+                crate::api::account_deletion_plan(),
+            )
+            .await;
+            match result {
                 Ok(plan) => {
+                    attempt.finish(
+                        tonk_analytics::account::Stage::AccountLoad,
+                        tonk_analytics::account::AccountOutcome::success(),
+                    );
                     set_busy(&host, false, "");
                     let pending = Confirmation::Delete {
                         plan,
@@ -2539,6 +2904,8 @@ fn bind(host: &HtmlElement) {
                     }
                 }
                 Err(error) => {
+                    let problem = user_error::api_problem(AccountAction::LoadDeletionPlan, &error);
+                    attempt.finish(tonk_analytics::account::Stage::AccountLoad, problem.outcome);
                     set_busy(&host, false, "");
                     show_api_error(&host, AccountAction::LoadDeletionPlan, &error);
                 }
@@ -2555,16 +2922,35 @@ fn bind(host: &HtmlElement) {
             Confirmation::SignOut => {
                 set_busy(&host, true, "Signing out…");
                 spawn_local(async move {
-                    match crate::api::unlink_account().await {
-                        Ok(_) => match window().map(|window| window.location().reload()) {
-                            Some(Ok(())) => {}
-                            _ => {
-                                set_busy(&host, false, "");
-                                close_confirmation(&host);
-                                set_mode(&host, "choice");
+                    let (mut attempt, result) = crate::account_observability::observe(
+                        AccountAction::SignOut,
+                        tonk_analytics::account::Surface::Settings,
+                        tonk_analytics::account::Trigger::User,
+                        tonk_analytics::account::AccountState::Ready,
+                        crate::api::unlink_account(),
+                    )
+                    .await;
+                    match result {
+                        Ok(_) => {
+                            attempt.finish(
+                                tonk_analytics::account::Stage::LocalCommit,
+                                tonk_analytics::account::AccountOutcome::success(),
+                            );
+                            match window().map(|window| window.location().reload()) {
+                                Some(Ok(())) => {}
+                                _ => {
+                                    set_busy(&host, false, "");
+                                    close_confirmation(&host);
+                                    set_mode(&host, "choice");
+                                }
                             }
-                        },
+                        }
                         Err(error) => {
+                            let problem = user_error::api_problem(AccountAction::SignOut, &error);
+                            attempt.finish(
+                                tonk_analytics::account::Stage::LocalCommit,
+                                problem.outcome,
+                            );
                             set_busy(&host, false, "");
                             show_confirmation_api_error(&host, AccountAction::SignOut, &error);
                         }
@@ -2615,9 +3001,26 @@ fn bind(host: &HtmlElement) {
             clear_error(&host);
             set_busy(&host, true, "Switching account…");
             spawn_local(async move {
-                match crate::api::activate_profile(profile).await {
-                    Ok(_) => reload_into_switched_profile(&host),
+                let (mut attempt, result) = crate::account_observability::observe(
+                    AccountAction::SwitchProfile,
+                    tonk_analytics::account::Surface::Settings,
+                    tonk_analytics::account::Trigger::User,
+                    tonk_analytics::account::AccountState::Ready,
+                    crate::api::activate_profile(profile),
+                )
+                .await;
+                match result {
+                    Ok(_) => {
+                        attempt.finish(
+                            tonk_analytics::account::Stage::LocalCommit,
+                            tonk_analytics::account::AccountOutcome::success(),
+                        );
+                        reload_into_switched_profile(&host)
+                    }
                     Err(error) => {
+                        let problem = user_error::api_problem(AccountAction::SwitchProfile, &error);
+                        attempt
+                            .finish(tonk_analytics::account::Stage::LocalCommit, problem.outcome);
                         set_busy(&host, false, "");
                         show_api_error(&host, AccountAction::SwitchProfile, &error);
                     }
@@ -2657,12 +3060,13 @@ fn begin_delete(host: HtmlElement, plan: AccountDeletionPlan, requested: Option<
     let confirmed_email = match input(&host, "#account-delete-email") {
         Ok(email) if email == plan.email => email,
         Ok(_) => {
-            return show_confirmation_error(
+            return show_confirmation_validation_error(
                 &host,
+                action,
                 "The confirmation email does not match this account.",
             );
         }
-        Err(error) => return show_confirmation_error(&host, error),
+        Err(error) => return show_confirmation_validation_error(&host, action, error),
     };
     let understood = host
         .query_selector("#account-delete-understood")
@@ -2671,8 +3075,9 @@ fn begin_delete(host: HtmlElement, plan: AccountDeletionPlan, requested: Option<
         .and_then(|element| element.dyn_into::<HtmlInputElement>().ok())
         .is_some_and(|input| input.checked());
     if !understood {
-        return show_confirmation_error(
+        return show_confirmation_validation_error(
             &host,
+            action,
             "Confirm that you understand the permanent consequences.",
         );
     }
@@ -2689,7 +3094,11 @@ fn begin_delete(host: HtmlElement, plan: AccountDeletionPlan, requested: Option<
         .cloned()
         .collect();
     if requested.is_some() && destructive.len() != 1 {
-        return show_confirmation_error(&host, "The selected owned space is already deleted.");
+        return show_confirmation_validation_error(
+            &host,
+            action,
+            "The selected owned space is already deleted.",
+        );
     }
     set_busy(
         &host,
@@ -2699,6 +3108,12 @@ fn begin_delete(host: HtmlElement, plan: AccountDeletionPlan, requested: Option<
         } else {
             "Waiting for your passkey…"
         },
+    );
+    let mut attempt = crate::account_observability::WebAccountAttempt::start(
+        action,
+        tonk_analytics::account::Surface::Settings,
+        tonk_analytics::account::Trigger::User,
+        tonk_analytics::account::AccountState::Ready,
     );
     spawn_local(async move {
         let result = async {
@@ -2711,8 +3126,8 @@ fn begin_delete(host: HtmlElement, plan: AccountDeletionPlan, requested: Option<
                     subject: space.subject.clone(),
                 })
                 .await
-                .map_err(|error| error.to_string())?;
-                return Ok::<_, String>((Some(deleted.subject), None));
+                .map_err(DeleteFailure::MutationApi)?;
+                return Ok::<_, DeleteFailure>((Some(deleted.subject), None));
             }
             // Account deletion asks the human to verify with the
             // account's passkey, then the worker signs every
@@ -2720,7 +3135,7 @@ fn begin_delete(host: HtmlElement, plan: AccountDeletionPlan, requested: Option<
             // authority.
             let credential_id = match crate::api::root_status()
                 .await
-                .map_err(|error| error.to_string())?
+                .map_err(DeleteFailure::PreflightApi)?
             {
                 tonk_worker_api::RootStatus::Ready {
                     root_did,
@@ -2728,19 +3143,21 @@ fn begin_delete(host: HtmlElement, plan: AccountDeletionPlan, requested: Option<
                     ..
                 } => {
                     if root_did != plan.root_did {
-                        return Err("this device's passkey belongs to a different account".into());
+                        return Err(DeleteFailure::Diagnostic(
+                            "this device's passkey belongs to a different account".into(),
+                        ));
                     }
                     credential_id
                 }
                 tonk_worker_api::RootStatus::Missing { .. } => {
-                    return Err(
+                    return Err(DeleteFailure::Diagnostic(
                         "no account passkey is registered on this device to verify with".into(),
-                    );
+                    ));
                 }
             };
             verify_passkey(VerifyPasskeyInput { credential_id })
                 .await
-                .map_err(|error| error.to_string())?;
+                .map_err(|error| DeleteFailure::Diagnostic(error.to_string()))?;
             let spaces = destructive
                 .iter()
                 .map(|space| AccountSpaceDeletionRequest {
@@ -2752,12 +3169,16 @@ fn begin_delete(host: HtmlElement, plan: AccountDeletionPlan, requested: Option<
                 confirmed_email,
             })
             .await
-            .map_err(|error| error.to_string())?;
+            .map_err(DeleteFailure::MutationApi)?;
             Ok((None, Some(deleted)))
         }
         .await;
         match result {
             Ok((Some(subject), None)) => {
+                attempt.finish(
+                    tonk_analytics::account::Stage::Complete,
+                    tonk_analytics::account::AccountOutcome::success(),
+                );
                 render_confirmation_result(
                     &host,
                     &format!(
@@ -2766,6 +3187,10 @@ fn begin_delete(host: HtmlElement, plan: AccountDeletionPlan, requested: Option<
                 );
             }
             Ok((None, Some(result))) => {
+                attempt.finish(
+                    tonk_analytics::account::Stage::Complete,
+                    tonk_analytics::account::AccountOutcome::success(),
+                );
                 render_confirmation_result(
                     &host,
                     &format!(
@@ -2783,11 +3208,43 @@ fn begin_delete(host: HtmlElement, plan: AccountDeletionPlan, requested: Option<
             }
             Ok(_) => {
                 set_busy(&host, false, "");
-                show_confirmation_action_error(&host, action, "the deletion result was incomplete");
+                let problem = user_error::problem_from_diagnostic(
+                    action,
+                    "the deletion result was incomplete",
+                );
+                attempt.finish(tonk_analytics::account::Stage::Complete, problem.outcome);
+                log_action_error(action, "the deletion result was incomplete");
+                show_confirmation_error(&host, problem.message);
             }
-            Err(error) => {
+            Err(DeleteFailure::PreflightApi(error)) => {
                 set_busy(&host, false, "");
-                show_confirmation_action_error(&host, action, &error);
+                let problem = user_error::api_problem(action, &error);
+                attempt.finish(
+                    tonk_analytics::account::Stage::LocalPreflight,
+                    problem.outcome,
+                );
+                log_action_error(action, &error.to_string());
+                show_confirmation_error(&host, problem.message);
+            }
+            Err(DeleteFailure::MutationApi(error)) => {
+                set_busy(&host, false, "");
+                log_action_error(action, &error.to_string());
+                let problem = user_error::mutation_api_problem(action, &error);
+                attempt.finish(
+                    tonk_analytics::account::Stage::RemoteCommit,
+                    problem.outcome,
+                );
+                show_confirmation_error(&host, problem.message);
+            }
+            Err(DeleteFailure::Diagnostic(error)) => {
+                set_busy(&host, false, "");
+                let problem = user_error::problem_from_diagnostic(action, &error);
+                attempt.finish(
+                    tonk_analytics::account::Stage::LocalPreflight,
+                    problem.outcome,
+                );
+                log_action_error(action, &error);
+                show_confirmation_error(&host, problem.message);
             }
         }
     });
@@ -2817,9 +3274,19 @@ fn execute_revoke(host: HtmlElement, did: String, self_revoke: bool) {
             "Revoking device…"
         },
     );
+    let mut attempt = crate::account_observability::WebAccountAttempt::start(
+        AccountAction::RevokeDevice,
+        tonk_analytics::account::Surface::Settings,
+        tonk_analytics::account::Trigger::User,
+        tonk_analytics::account::AccountState::Ready,
+    );
     spawn_local(async move {
         match crate::api::revoke_account_device(did).await {
             Ok(acknowledgement) => {
+                attempt.finish(
+                    tonk_analytics::account::Stage::RemoteCommit,
+                    tonk_analytics::account::AccountOutcome::success(),
+                );
                 clear_error(&host);
                 set_busy(
                     &host,
@@ -2853,7 +3320,13 @@ fn execute_revoke(host: HtmlElement, did: String, self_revoke: bool) {
             }
             Err(error) => {
                 set_busy(&host, false, "");
-                show_confirmation_api_error(&host, AccountAction::RevokeDevice, &error);
+                log_action_error(AccountAction::RevokeDevice, &error.to_string());
+                let problem = user_error::mutation_api_problem(AccountAction::RevokeDevice, &error);
+                attempt.finish(
+                    tonk_analytics::account::Stage::RemoteCommit,
+                    problem.outcome,
+                );
+                show_confirmation_error(&host, problem.message);
             }
         }
     });

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -20,6 +20,65 @@ mod tests {
 
     const EMAIL: &str = "person@example.com";
 
+    async fn install_account_capture_fixture(driver: &WebDriver) -> Result<()> {
+        ChromeDevTools::new(driver.handle.clone())
+            .execute_cdp_with_params(
+                "Page.addScriptToEvaluateOnNewDocument",
+                serde_json::json!({
+                    "source": r#"
+                        (() => {
+                            const read = () => {
+                                try { return JSON.parse(sessionStorage.getItem("tonk:test:account-events") || "[]"); }
+                                catch { return []; }
+                            };
+                            let config = null;
+                            let superProperties = {};
+                            const fixture = {
+                                init(_key, next) { config = next; },
+                                register(next) { superProperties = { ...superProperties, ...next }; },
+                                identify() {},
+                                capture(event, properties = {}) {
+                                    let payload = {
+                                        event,
+                                        properties: {
+                                            ...superProperties,
+                                            ...properties,
+                                            $current_url: location.href,
+                                            $pathname: location.pathname,
+                                            $referrer: document.referrer
+                                        }
+                                    };
+                                    if (config && config.before_send) payload = config.before_send(payload);
+                                    if (!payload) return;
+                                    const events = read();
+                                    events.push({ ...payload, captured_at: Date.now() });
+                                    sessionStorage.setItem("tonk:test:account-events", JSON.stringify(events));
+                                }
+                            };
+                            Object.defineProperty(window, "posthog", {
+                                configurable: false,
+                                get: () => fixture,
+                                set: () => {}
+                            });
+                        })();
+                    "#
+                }),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn captured_account_events(driver: &WebDriver) -> Result<Vec<serde_json::Value>> {
+        let value = driver
+            .execute(
+                r#"return JSON.parse(sessionStorage.getItem("tonk:test:account-events") || "[]")
+                    .filter(event => event.event === "account_event");"#,
+                Vec::new(),
+            )
+            .await?;
+        Ok(serde_json::from_value(value.json().clone())?)
+    }
+
     async fn element(driver: &WebDriver, selector: &str) -> Result<WebElement> {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
         loop {
@@ -743,8 +802,100 @@ mod tests {
     }
 
     #[dialog_common::test]
+    async fn it_captures_the_ordered_signup_account_journey(env: TestEnvironment) -> Result<()> {
+        let driver = driver_with_prf(&env).await?;
+        install_account_capture_fixture(&driver).await?;
+        sign_up(&driver, &env, "observability-signup@example.com").await?;
+
+        let events = captured_account_events(&driver).await?;
+        let wire = serde_json::to_string(&events)?;
+        for sentinel in [
+            "observability-signup@example.com",
+            "did:key:",
+            "credentialId",
+            "activation?ucan=",
+            "/api/account",
+            "127.0.0.1",
+        ] {
+            anyhow::ensure!(
+                !wire.contains(sentinel),
+                "captured account payload exposed privacy sentinel {sentinel:?}: {wire}"
+            );
+        }
+
+        let expected = [
+            (
+                "open_registration",
+                "finished",
+                "input",
+                Some("success"),
+                None,
+            ),
+            ("create_account", "started", "input", None, None),
+            ("create_account", "checkpoint", "email_lookup", None, None),
+            ("create_account", "checkpoint", "passkey_create", None, None),
+            (
+                "create_account",
+                "finished",
+                "activation_wait",
+                Some("blocked"),
+                Some("awaiting_activation"),
+            ),
+            ("activate_account", "started", "input", None, None),
+            (
+                "activate_account",
+                "finished",
+                "complete",
+                Some("success"),
+                None,
+            ),
+            ("settle_account", "started", "account_sync", None, None),
+            (
+                "settle_account",
+                "finished",
+                "complete",
+                Some("success"),
+                None,
+            ),
+        ];
+        let mut cursor = 0;
+        for (action, phase, stage, result, failure) in expected {
+            let Some(offset) = events[cursor..].iter().position(|event| {
+                let properties = &event["properties"];
+                properties["action"] == action
+                    && properties["phase"] == phase
+                    && properties["stage"] == stage
+                    && result.is_none_or(|value| properties["result"] == value)
+                    && failure.is_none_or(|value| properties["failure_kind"] == value)
+            }) else {
+                anyhow::bail!(
+                    "signup account_event sequence missed {action}/{phase}/{stage}: {events:?}"
+                );
+            };
+            cursor += offset + 1;
+        }
+
+        let mut terminals = std::collections::HashMap::<String, usize>::new();
+        for event in &events {
+            if event["properties"]["phase"] == "finished"
+                && let Some(attempt_id) = event["properties"]["attempt_id"].as_str()
+            {
+                *terminals.entry(attempt_id.to_owned()).or_default() += 1;
+            }
+        }
+        anyhow::ensure!(
+            terminals.values().all(|count| *count == 1),
+            "an account attempt emitted more than one terminal event: {events:?}"
+        );
+
+        driver.quit().await?;
+        Ok(())
+    }
+
+    #[dialog_common::test]
     async fn it_signs_up_through_the_account_panels(env: TestEnvironment) -> Result<()> {
         let driver = driver_with_prf(&env).await?;
+        install_account_capture_fixture(&driver).await?;
         sign_up(&driver, &env, EMAIL).await?;
 
         wait_for_text_containing(&driver, "#account-email-value", EMAIL).await?;
@@ -837,6 +988,126 @@ mod tests {
         let settings = driver.current_url().await?;
         goto(&driver, settings.as_str()).await?;
         wait_for_value(&driver, "#account-display-name", "Settings Name").await?;
+
+        let events = captured_account_events(&driver).await?;
+        anyhow::ensure!(
+            !events.is_empty(),
+            "signup emitted no account_event payloads"
+        );
+        let wire = serde_json::to_string(&events)?;
+        for sentinel in [
+            EMAIL,
+            "did:key:",
+            "credentialId",
+            "activation?ucan=",
+            "/api/account",
+            "127.0.0.1",
+        ] {
+            anyhow::ensure!(
+                !wire.contains(sentinel),
+                "captured account payload exposed privacy sentinel {sentinel:?}: {wire}"
+            );
+        }
+        let mut terminals = std::collections::HashMap::<String, usize>::new();
+        for event in &events {
+            let properties = &event["properties"];
+            if properties["phase"] == "finished"
+                && let Some(attempt_id) = properties["attempt_id"].as_str()
+            {
+                *terminals.entry(attempt_id.to_owned()).or_default() += 1;
+            }
+        }
+        anyhow::ensure!(
+            terminals.values().all(|count| *count == 1),
+            "an account attempt emitted more than one terminal event: {events:?}"
+        );
+
+        let event_position = |action: &str,
+                              phase: &str,
+                              stage: Option<&str>,
+                              result: Option<&str>,
+                              failure: Option<&str>| {
+            events.iter().position(|event| {
+                let properties = &event["properties"];
+                properties["action"] == action
+                    && properties["phase"] == phase
+                    && stage.is_none_or(|value| properties["stage"] == value)
+                    && result.is_none_or(|value| properties["result"] == value)
+                    && failure.is_none_or(|value| properties["failure_kind"] == value)
+            })
+        };
+        let registration = event_position(
+            "open_registration",
+            "finished",
+            Some("input"),
+            Some("success"),
+            None,
+        );
+        let create_start = event_position("create_account", "started", None, None, None);
+        let email_lookup = event_position(
+            "create_account",
+            "checkpoint",
+            Some("email_lookup"),
+            None,
+            None,
+        );
+        let passkey_create = event_position(
+            "create_account",
+            "checkpoint",
+            Some("passkey_create"),
+            None,
+            None,
+        );
+        let create_wait = event_position(
+            "create_account",
+            "finished",
+            Some("activation_wait"),
+            Some("blocked"),
+            Some("awaiting_activation"),
+        );
+        let activation_start = event_position("activate_account", "started", None, None, None);
+        let activation_success = event_position(
+            "activate_account",
+            "finished",
+            Some("complete"),
+            Some("success"),
+            None,
+        );
+        let settle_start = event_position("settle_account", "started", None, None, None);
+        let settle_success = event_position(
+            "settle_account",
+            "finished",
+            Some("complete"),
+            Some("success"),
+            None,
+        );
+        let sequence = [
+            registration,
+            create_start,
+            email_lookup,
+            passkey_create,
+            create_wait,
+            activation_start,
+            activation_success,
+            settle_start,
+            settle_success,
+        ];
+        anyhow::ensure!(
+            sequence.iter().all(Option::is_some),
+            "signup account_event sequence was incomplete: {events:?}"
+        );
+        let positions = sequence.into_iter().flatten().collect::<Vec<_>>();
+        anyhow::ensure!(
+            positions.windows(2).all(|pair| pair[0] < pair[1]),
+            "signup account_event sequence was out of order: {events:?}"
+        );
+        anyhow::ensure!(
+            events.windows(2).all(|pair| {
+                pair[0]["captured_at"].as_u64().unwrap_or_default()
+                    <= pair[1]["captured_at"].as_u64().unwrap_or_default()
+            }),
+            "signup account_event timestamps were out of order: {events:?}"
+        );
 
         driver.quit().await?;
         Ok(())

--- a/rust/tonk-ui/src/account_observability.rs
+++ b/rust/tonk-ui/src/account_observability.rs
@@ -1,0 +1,552 @@
+//! Web-local account attempt lifecycle and PostHog adapter.
+
+#![cfg_attr(
+    not(all(target_arch = "wasm32", target_os = "unknown")),
+    allow(dead_code)
+)]
+
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::rc::Rc;
+
+use tonk_analytics::account::{
+    AccountAction as AnalyticsAction, AccountEvent, AccountOutcome, AccountState, FailureKind,
+    Journey, Stage, Surface, Trigger,
+};
+
+/// Start an attempt before an asynchronous operation and return the still-open
+/// recorder beside its result. Callers retain the typed error evidence needed
+/// to choose the terminal outcome at the presentation seam.
+pub(crate) async fn observe<F, T, E>(
+    action: AccountAction,
+    surface: Surface,
+    trigger: Trigger,
+    account_state: AccountState,
+    future: F,
+) -> (WebAccountAttempt, Result<T, E>)
+where
+    F: std::future::Future<Output = Result<T, E>>,
+{
+    let attempt = WebAccountAttempt::start(action, surface, trigger, account_state);
+    let result = future.await;
+    (attempt, result)
+}
+
+use crate::user_error::AccountAction;
+
+thread_local! {
+    static AUTOMATIC_FAILURES: RefCell<HashSet<(AnalyticsAction, FailureKind)>> = RefCell::new(HashSet::new());
+    static FALLBACK_ID: RefCell<u64> = const { RefCell::new(0) };
+}
+
+const PENDING_SETTLE: &str = "tonk:account-observability:pending-settle";
+
+/// Remember that a completed activation still needs to converge into the
+/// account dashboard. Session storage survives the activation-page detour but
+/// does not create a stable cross-session identifier.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) fn mark_settle_pending() {
+    let _ = web_sys::window()
+        .and_then(|window| window.session_storage().ok().flatten())
+        .and_then(|storage| storage.set_item(PENDING_SETTLE, "1").ok());
+}
+
+/// Consume the page-local activation convergence marker exactly once.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) fn take_settle_pending() -> bool {
+    web_sys::window()
+        .and_then(|window| window.session_storage().ok().flatten())
+        .is_some_and(|storage| {
+            let pending = storage.get_item(PENDING_SETTLE).ok().flatten().is_some();
+            if pending {
+                let _ = storage.remove_item(PENDING_SETTLE);
+            }
+            pending
+        })
+}
+
+trait Recorder {
+    fn capture(&self, event: AccountEvent);
+}
+
+#[derive(Clone, Copy)]
+struct PostHogRecorder;
+
+impl Recorder for PostHogRecorder {
+    fn capture(&self, event: AccountEvent) {
+        #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+        let _ = tonk_analytics::web::capture_account(&event);
+        #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+        let _ = event;
+    }
+}
+
+#[cfg(test)]
+#[derive(Clone, Default)]
+struct MemoryRecorder(Rc<RefCell<Vec<AccountEvent>>>);
+
+#[cfg(test)]
+impl Recorder for MemoryRecorder {
+    fn capture(&self, event: AccountEvent) {
+        self.0.borrow_mut().push(event);
+    }
+}
+
+/// One page-local account attempt. Capture is best-effort and terminal calls
+/// are idempotent.
+pub(crate) struct WebAccountAttempt {
+    recorder: Rc<dyn Recorder>,
+    now: Rc<dyn Fn() -> u64>,
+    started_ms: u64,
+    journey: Journey,
+    action: AnalyticsAction,
+    surface: Surface,
+    trigger: Trigger,
+    account_state: AccountState,
+    attempt_id: String,
+    deferred_events: Vec<AccountEvent>,
+    finished: bool,
+}
+
+impl WebAccountAttempt {
+    /// Start and immediately record an attempt.
+    pub(crate) fn start(
+        action: AccountAction,
+        surface: Surface,
+        trigger: Trigger,
+        account_state: AccountState,
+    ) -> Self {
+        Self::start_with(
+            action,
+            surface,
+            trigger,
+            account_state,
+            Rc::new(PostHogRecorder),
+            Rc::new(now_ms),
+        )
+    }
+
+    fn start_with(
+        action: AccountAction,
+        surface: Surface,
+        trigger: Trigger,
+        account_state: AccountState,
+        recorder: Rc<dyn Recorder>,
+        now: Rc<dyn Fn() -> u64>,
+    ) -> Self {
+        let (journey, action, stage) = classification(action);
+        let attempt_id = attempt_id();
+        let started_ms = now();
+        let start = AccountEvent::started(
+            journey,
+            action,
+            stage,
+            surface,
+            trigger,
+            account_state,
+            attempt_id.clone(),
+        );
+        let deferred_events = if trigger == Trigger::Automatic {
+            vec![start]
+        } else {
+            recorder.capture(start);
+            Vec::new()
+        };
+        Self {
+            recorder,
+            now,
+            started_ms,
+            journey,
+            action,
+            surface,
+            trigger,
+            account_state,
+            attempt_id,
+            deferred_events,
+            finished: false,
+        }
+    }
+
+    /// Record a stage reached before the terminal outcome.
+    pub(crate) fn checkpoint(&mut self, stage: Stage) {
+        if self.finished {
+            return;
+        }
+        let event = AccountEvent::checkpoint(
+            self.journey,
+            self.action,
+            stage,
+            self.surface,
+            self.trigger,
+            self.account_state,
+            self.attempt_id.clone(),
+        );
+        if self.trigger == Trigger::Automatic {
+            self.deferred_events.push(event);
+        } else {
+            self.recorder.capture(event);
+        }
+    }
+
+    /// Record exactly one terminal outcome.
+    pub(crate) fn finish(&mut self, stage: Stage, outcome: AccountOutcome) {
+        if self.finished {
+            return;
+        }
+        self.finished = true;
+
+        if self.trigger == Trigger::Automatic {
+            let suppress = AUTOMATIC_FAILURES.with(|streaks| {
+                let mut streaks = streaks.borrow_mut();
+                if let Some(kind) = outcome.failure_kind() {
+                    !streaks.insert((self.action, kind))
+                } else {
+                    streaks.retain(|(action, _)| *action != self.action);
+                    false
+                }
+            });
+            if suppress {
+                return;
+            }
+        }
+
+        let duration = (self.now)().saturating_sub(self.started_ms);
+        for event in self.deferred_events.drain(..) {
+            self.recorder.capture(event);
+        }
+        self.recorder.capture(AccountEvent::finished(
+            self.journey,
+            self.action,
+            stage,
+            self.surface,
+            self.trigger,
+            self.account_state,
+            self.attempt_id.clone(),
+            duration,
+            outcome,
+        ));
+    }
+}
+
+/// Record a synchronous operation whose complete lifetime is this call.
+pub(crate) fn record_instant_success(
+    action: AccountAction,
+    surface: Surface,
+    trigger: Trigger,
+    account_state: AccountState,
+    stage: Stage,
+) {
+    let mut attempt = WebAccountAttempt::start(action, surface, trigger, account_state);
+    attempt.finish(stage, AccountOutcome::success());
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+fn now_ms() -> u64 {
+    web_sys::window()
+        .and_then(|window| window.performance())
+        .map(|performance| performance.now().max(0.0) as u64)
+        .unwrap_or_default()
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+fn now_ms() -> u64 {
+    use std::sync::OnceLock;
+    use std::time::Instant;
+    static START: OnceLock<Instant> = OnceLock::new();
+    START.get_or_init(Instant::now).elapsed().as_millis() as u64
+}
+
+fn attempt_id() -> String {
+    let random = rand::random::<[u8; 16]>();
+    if random.iter().any(|byte| *byte != 0) {
+        return hex::encode(random);
+    }
+    FALLBACK_ID.with(|next| {
+        let mut next = next.borrow_mut();
+        *next = next.saturating_add(1);
+        format!("page-{next}")
+    })
+}
+
+fn classification(action: AccountAction) -> (Journey, AnalyticsAction, Stage) {
+    use AccountAction as Ui;
+    use AnalyticsAction as Event;
+    match action {
+        Ui::OpenRegistration => (Journey::Onboarding, Event::OpenRegistration, Stage::Input),
+        Ui::LoadAccount => (
+            Journey::AccountManagement,
+            Event::LoadAccount,
+            Stage::AccountLoad,
+        ),
+        Ui::LoadRegistration => (
+            Journey::Onboarding,
+            Event::LoadRegistration,
+            Stage::AccountLoad,
+        ),
+        Ui::CheckEmail => (Journey::Onboarding, Event::CheckEmail, Stage::Input),
+        Ui::CreateAccount => (Journey::Onboarding, Event::CreateAccount, Stage::Input),
+        Ui::LogIn => (Journey::Login, Event::Login, Stage::Input),
+        Ui::AddPasskey => (Journey::Passkey, Event::AddPasskey, Stage::Input),
+        Ui::ChangeDisplayName => (
+            Journey::AccountManagement,
+            Event::ChangeDisplayName,
+            Stage::Input,
+        ),
+        Ui::ResendActivation => (Journey::Activation, Event::ResendActivation, Stage::Input),
+        Ui::LoadDevices => (
+            Journey::AccountManagement,
+            Event::LoadDevices,
+            Stage::AccountLoad,
+        ),
+        Ui::LoadProfiles => (
+            Journey::AccountManagement,
+            Event::LoadProfiles,
+            Stage::AccountLoad,
+        ),
+        Ui::LinkCli => (Journey::CliHandoff, Event::LinkCli, Stage::WorkerHandoff),
+        Ui::SwitchProfile => (
+            Journey::AccountManagement,
+            Event::SwitchProfile,
+            Stage::LocalPreflight,
+        ),
+        Ui::SignOut => (
+            Journey::AccountManagement,
+            Event::SignOut,
+            Stage::LocalPreflight,
+        ),
+        Ui::LoadDeletionPlan => (
+            Journey::AccountDeletion,
+            Event::LoadDeletionPlan,
+            Stage::AccountLoad,
+        ),
+        Ui::DeleteAccount => (Journey::AccountDeletion, Event::DeleteAccount, Stage::Input),
+        Ui::DeleteSpace => (Journey::AccountDeletion, Event::DeleteSpace, Stage::Input),
+        Ui::RevokeDevice => (
+            Journey::AccountManagement,
+            Event::RevokeDevice,
+            Stage::Input,
+        ),
+        Ui::FinishAccountBackup => (
+            Journey::AccountManagement,
+            Event::FinishAccountBackup,
+            Stage::PasskeyAssert,
+        ),
+        Ui::ActivateAccount => (Journey::Activation, Event::ActivateAccount, Stage::Input),
+        Ui::WatchActivation => (
+            Journey::Activation,
+            Event::WatchActivation,
+            Stage::ActivationWait,
+        ),
+        Ui::SaveInitialDisplayName => (
+            Journey::Onboarding,
+            Event::SaveInitialDisplayName,
+            Stage::Input,
+        ),
+        Ui::CopyInvite => (
+            Journey::AccountManagement,
+            Event::CopyInvite,
+            Stage::CallbackDelivery,
+        ),
+        Ui::FinishPreviousAction => (
+            Journey::AccountManagement,
+            Event::FinishPreviousAction,
+            Stage::LocalCommit,
+        ),
+        Ui::SettleAccount => (
+            Journey::Activation,
+            Event::SettleAccount,
+            Stage::AccountSync,
+        ),
+        Ui::LoadAccountSpaces => (
+            Journey::AccountManagement,
+            Event::LoadAccountSpaces,
+            Stage::AccountLoad,
+        ),
+        Ui::PullAccountSpace => (
+            Journey::AccountManagement,
+            Event::PullAccountSpace,
+            Stage::AccountSync,
+        ),
+        Ui::OpenAccountDeletion => (
+            Journey::AccountDeletion,
+            Event::OpenAccountDeletion,
+            Stage::Input,
+        ),
+        Ui::OpenSpaceDeletion => (
+            Journey::AccountDeletion,
+            Event::OpenSpaceDeletion,
+            Stage::Input,
+        ),
+        Ui::SyncAccount => (
+            Journey::AccountManagement,
+            Event::SyncAccount,
+            Stage::AccountSync,
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    fn event_json(recorder: &MemoryRecorder) -> Vec<serde_json::Value> {
+        recorder
+            .0
+            .borrow()
+            .iter()
+            .map(|event| serde_json::Value::Object(event.validated_properties().unwrap()))
+            .collect()
+    }
+
+    #[test]
+    fn it_records_one_start_and_one_terminal_outcome() {
+        let recorder = MemoryRecorder::default();
+        let time = Rc::new(Cell::new(0_u64));
+        let clock: Rc<dyn Fn() -> u64> = {
+            let time = time.clone();
+            Rc::new(move || time.get())
+        };
+        let mut attempt = WebAccountAttempt::start_with(
+            AccountAction::LogIn,
+            Surface::Settings,
+            Trigger::User,
+            AccountState::None,
+            Rc::new(recorder.clone()),
+            clock,
+        );
+        attempt.checkpoint(Stage::PasskeyAssert);
+        time.set(700_000);
+        attempt.finish(Stage::Complete, AccountOutcome::success());
+        attempt.finish(Stage::Complete, AccountOutcome::success());
+        attempt.checkpoint(Stage::AccountLoad);
+        let events = event_json(&recorder);
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0]["phase"], "started");
+        assert_eq!(events[2]["duration_ms"], 600_000);
+    }
+
+    #[test]
+    fn it_gives_each_attempt_an_opaque_non_content_id() {
+        let recorder = MemoryRecorder::default();
+        let clock: Rc<dyn Fn() -> u64> = Rc::new(|| 0);
+        let _first = WebAccountAttempt::start_with(
+            AccountAction::LogIn,
+            Surface::Settings,
+            Trigger::User,
+            AccountState::None,
+            Rc::new(recorder.clone()),
+            clock.clone(),
+        );
+        let _second = WebAccountAttempt::start_with(
+            AccountAction::LogIn,
+            Surface::Settings,
+            Trigger::User,
+            AccountState::None,
+            Rc::new(recorder.clone()),
+            clock,
+        );
+        let events = event_json(&recorder);
+        let first = events[0]["attempt_id"].as_str().unwrap();
+        let second = events[1]["attempt_id"].as_str().unwrap();
+        assert_ne!(first, second);
+        assert!(first.len() <= 36 && first.is_ascii());
+        assert!(!first.contains("login"));
+    }
+
+    #[test]
+    fn it_reports_one_automatic_failure_per_streak() {
+        AUTOMATIC_FAILURES.with(|value| value.borrow_mut().clear());
+        let recorder = MemoryRecorder::default();
+        let clock: Rc<dyn Fn() -> u64> = Rc::new(|| 0);
+        for outcome in [
+            AccountOutcome::retryable(FailureKind::Network),
+            AccountOutcome::retryable(FailureKind::Network),
+            AccountOutcome::success(),
+            AccountOutcome::retryable(FailureKind::Network),
+        ] {
+            let mut attempt = WebAccountAttempt::start_with(
+                AccountAction::LoadAccount,
+                Surface::Settings,
+                Trigger::Automatic,
+                AccountState::Ready,
+                Rc::new(recorder.clone()),
+                clock.clone(),
+            );
+            attempt.finish(Stage::AccountLoad, outcome);
+        }
+        let terminals = event_json(&recorder)
+            .into_iter()
+            .filter(|event| event["phase"] == "finished")
+            .collect::<Vec<_>>();
+        assert_eq!(terminals.len(), 3);
+        assert_eq!(terminals[1]["result"], "success");
+        assert_eq!(event_json(&recorder).len(), 6);
+    }
+
+    #[test]
+    fn automatic_attempts_flush_ordered_checkpoints_or_suppress_the_whole_attempt() {
+        AUTOMATIC_FAILURES.with(|value| value.borrow_mut().clear());
+        let recorder = MemoryRecorder::default();
+        let clock: Rc<dyn Fn() -> u64> = Rc::new(|| 0);
+        for _ in 0..2 {
+            let mut attempt = WebAccountAttempt::start_with(
+                AccountAction::LoadAccount,
+                Surface::Settings,
+                Trigger::Automatic,
+                AccountState::Ready,
+                Rc::new(recorder.clone()),
+                clock.clone(),
+            );
+            attempt.checkpoint(Stage::AccountLoad);
+            attempt.finish(
+                Stage::AccountLoad,
+                AccountOutcome::retryable(FailureKind::Network),
+            );
+        }
+        let events = event_json(&recorder);
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0]["phase"], "started");
+        assert_eq!(events[1]["phase"], "checkpoint");
+        assert_eq!(events[2]["phase"], "finished");
+    }
+
+    #[test]
+    fn every_ui_action_has_a_stable_classification() {
+        let actions = [
+            AccountAction::OpenRegistration,
+            AccountAction::LoadAccount,
+            AccountAction::LoadRegistration,
+            AccountAction::CheckEmail,
+            AccountAction::CreateAccount,
+            AccountAction::LogIn,
+            AccountAction::AddPasskey,
+            AccountAction::ChangeDisplayName,
+            AccountAction::ResendActivation,
+            AccountAction::LoadDevices,
+            AccountAction::LoadProfiles,
+            AccountAction::LinkCli,
+            AccountAction::SwitchProfile,
+            AccountAction::SignOut,
+            AccountAction::LoadDeletionPlan,
+            AccountAction::DeleteAccount,
+            AccountAction::DeleteSpace,
+            AccountAction::RevokeDevice,
+            AccountAction::FinishAccountBackup,
+            AccountAction::ActivateAccount,
+            AccountAction::WatchActivation,
+            AccountAction::SaveInitialDisplayName,
+            AccountAction::CopyInvite,
+            AccountAction::FinishPreviousAction,
+            AccountAction::SettleAccount,
+            AccountAction::LoadAccountSpaces,
+            AccountAction::PullAccountSpace,
+            AccountAction::OpenAccountDeletion,
+            AccountAction::OpenSpaceDeletion,
+            AccountAction::SyncAccount,
+        ];
+        for action in actions {
+            let _ = classification(action);
+        }
+    }
+}

--- a/rust/tonk-ui/src/activate.rs
+++ b/rust/tonk-ui/src/activate.rs
@@ -175,16 +175,29 @@ fn bind(host: &HtmlElement, pending: Rc<Cell<bool>>, terminal: Rc<Cell<bool>>) {
         let terminal = action_terminal.clone();
         clear_error(&host);
         set_busy(&host, true, false);
+        let mut attempt = crate::account_observability::WebAccountAttempt::start(
+            AccountAction::ActivateAccount,
+            tonk_analytics::account::Surface::ActivationPage,
+            tonk_analytics::account::Trigger::User,
+            tonk_analytics::account::AccountState::PendingActivation,
+        );
         spawn_local(async move {
             let invocation = match link_invocation() {
                 Ok(bytes) => bytes,
                 Err(error) => {
+                    attempt.finish(
+                        tonk_analytics::account::Stage::Input,
+                        tonk_analytics::account::AccountOutcome::terminal_failure(
+                            tonk_analytics::account::FailureKind::InvalidInput,
+                        ),
+                    );
                     pending.set(false);
                     set_busy(&host, false, false);
                     return show_error(&host, &error);
                 }
             };
             set_status(&host, "Activating…");
+            attempt.checkpoint(tonk_analytics::account::Stage::AccessService);
             let response = reqwest::Client::new()
                 .post(format!("{}/ucan/", crate::api::origin()))
                 .header("content-type", "application/cbor")
@@ -194,6 +207,12 @@ fn bind(host: &HtmlElement, pending: Rc<Cell<bool>>, terminal: Rc<Cell<bool>>) {
             let response = match response {
                 Ok(response) => response,
                 Err(error) => {
+                    attempt.finish(
+                        tonk_analytics::account::Stage::AccessService,
+                        tonk_analytics::account::AccountOutcome::retryable(
+                            tonk_analytics::account::FailureKind::Network,
+                        ),
+                    );
                     web_sys::console::error_1(
                         &format!("account activation request failed: {error}").into(),
                     );
@@ -208,6 +227,10 @@ fn bind(host: &HtmlElement, pending: Rc<Cell<bool>>, terminal: Rc<Cell<bool>>) {
                 return;
             }
             if status.is_success() {
+                attempt.finish(
+                    tonk_analytics::account::Stage::Complete,
+                    tonk_analytics::account::AccountOutcome::success(),
+                );
                 // The service has consumed the one-use link. Claim the
                 // terminal outcome before recording the receipt can yield,
                 // so no later completion can replace success with an error.
@@ -226,6 +249,14 @@ fn bind(host: &HtmlElement, pending: Rc<Cell<bool>>, terminal: Rc<Cell<bool>>) {
                 set_status(&host, "");
                 show_panel(&host, "#activate-done");
             } else if body["error"]["code"].as_str() == Some("Unauthorized") {
+                attempt.finish(
+                    tonk_analytics::account::Stage::AccessService,
+                    tonk_analytics::account::AccountOutcome::terminal_failure(
+                        tonk_analytics::account::FailureKind::AccessDenied,
+                    )
+                    .with_http_status_class(tonk_analytics::account::HttpStatusClass::ClientError)
+                    .with_service_code(tonk_analytics::account::ServiceCode::Unauthorized),
+                );
                 terminal.set(true);
                 pending.set(false);
                 set_busy(&host, false, true);
@@ -234,6 +265,18 @@ fn bind(host: &HtmlElement, pending: Rc<Cell<bool>>, terminal: Rc<Cell<bool>>) {
                     "This activation link has expired. Sign in on your device to get a fresh one.",
                 );
             } else {
+                let outcome = if status.is_server_error() {
+                    tonk_analytics::account::AccountOutcome::retryable(
+                        tonk_analytics::account::FailureKind::ServiceUnavailable,
+                    )
+                    .with_http_status_class(tonk_analytics::account::HttpStatusClass::ServerError)
+                } else {
+                    tonk_analytics::account::AccountOutcome::terminal_failure(
+                        tonk_analytics::account::FailureKind::AccessDenied,
+                    )
+                    .with_http_status_class(tonk_analytics::account::HttpStatusClass::ClientError)
+                };
+                attempt.finish(tonk_analytics::account::Stage::AccessService, outcome);
                 pending.set(false);
                 set_busy(&host, false, false);
                 let message = body["error"]["message"]

--- a/rust/tonk-ui/src/analytics.rs
+++ b/rust/tonk-ui/src/analytics.rs
@@ -44,20 +44,31 @@ pub fn install() {
     spawn_local(identify());
 }
 
-/// Console panic reporting (always) plus a content-free `panic` event
-/// (first line of the panic message only) when capture is live.
+/// Console panic reporting (always) plus a content-free `panic` event. The
+/// local console retains the diagnostic; analytics gets only a static type and
+/// repository-relative source location.
 fn install_panic_hook() {
     std::panic::set_hook(Box::new(|info| {
         console_error_panic_hook::hook(info);
-        let message = info
-            .to_string()
-            .lines()
-            .next()
-            .unwrap_or("panic")
-            .to_owned();
+        let location = info
+            .location()
+            .map(|location| {
+                let file = location.file();
+                let file = file
+                    .find("rust/")
+                    .map(|index| &file[index..])
+                    .unwrap_or("unknown");
+                format!("{file}:{}", location.line())
+            })
+            .unwrap_or_else(|| "unknown".to_owned());
+        let fingerprint = format!("wasm_panic:{location}");
         tonk_analytics::web::capture(
             tonk_analytics::event::PANIC,
-            &serde_json::json!({ "message": message }),
+            &serde_json::json!({
+                "type": "wasm_panic",
+                "location": location,
+                "fingerprint": fingerprint,
+            }),
         );
     }));
 }

--- a/rust/tonk-ui/src/api.rs
+++ b/rust/tonk-ui/src/api.rs
@@ -8,6 +8,7 @@ use tonk_worker_api::{
     SaveRootRequest, SyncResponse, SyncStatusResponse,
 };
 
+use crate::error::AccountTransportKind;
 use crate::error::TonkUiError;
 
 /// Mirrors the worker's error envelope so we can decode
@@ -33,6 +34,110 @@ where
     T: std::fmt::Display,
 {
     TonkUiError::ApiError(format!("{error}"))
+}
+
+fn account_boundary_error(
+    transport_kind: AccountTransportKind,
+    status: Option<u16>,
+    service_code: Option<String>,
+    diagnostic: impl Into<String>,
+) -> TonkUiError {
+    TonkUiError::AccountApi {
+        transport_kind,
+        status,
+        service_code,
+        diagnostic: diagnostic.into(),
+    }
+}
+
+async fn send_account(
+    request: reqwest::RequestBuilder,
+    method: &'static str,
+    path: &'static str,
+) -> Result<reqwest::Response, TonkUiError> {
+    request.send().await.map_err(|error| {
+        account_boundary_error(
+            AccountTransportKind::Network,
+            None,
+            None,
+            format!("{method} {path} did not receive a response: {error}"),
+        )
+    })
+}
+
+async fn decode_account<T: serde::de::DeserializeOwned>(
+    response: reqwest::Response,
+    method: &'static str,
+    path: &'static str,
+) -> Result<T, TonkUiError> {
+    let status = response.status();
+    let text = response.text().await.map_err(|error| {
+        account_boundary_error(
+            AccountTransportKind::Decode,
+            Some(status.as_u16()),
+            None,
+            format!("{method} {path} response body was unreadable: {error}"),
+        )
+    })?;
+    if status.is_success() {
+        return serde_json::from_str(&text).map_err(|error| {
+            account_boundary_error(
+                AccountTransportKind::Decode,
+                Some(status.as_u16()),
+                None,
+                format!("{method} {path} response did not decode: {error}"),
+            )
+        });
+    }
+    let service_code = serde_json::from_str::<ErrorBody>(&text)
+        .ok()
+        .and_then(|body| body.error.code.or(Some(body.error.kind)))
+        .map(|code| {
+            serde_json::to_value(tonk_analytics::account::ServiceCode::from_wire(&code))
+                .ok()
+                .and_then(|value| value.as_str().map(str::to_owned))
+                .unwrap_or_else(|| "unknown".to_owned())
+        });
+    Err(account_boundary_error(
+        AccountTransportKind::Http,
+        Some(status.as_u16()),
+        service_code,
+        format!("{method} {path} returned {status}: {text}"),
+    ))
+}
+
+async fn finish_account(
+    response: reqwest::Response,
+    method: &'static str,
+    path: &'static str,
+) -> Result<(), TonkUiError> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(());
+    }
+    let text = response.text().await.map_err(|error| {
+        account_boundary_error(
+            AccountTransportKind::Decode,
+            Some(status.as_u16()),
+            None,
+            format!("{method} {path} response body was unreadable: {error}"),
+        )
+    })?;
+    let service_code = serde_json::from_str::<ErrorBody>(&text)
+        .ok()
+        .and_then(|body| body.error.code.or(Some(body.error.kind)))
+        .map(|code| {
+            serde_json::to_value(tonk_analytics::account::ServiceCode::from_wire(&code))
+                .ok()
+                .and_then(|value| value.as_str().map(str::to_owned))
+                .unwrap_or_else(|| "unknown".to_owned())
+        });
+    Err(account_boundary_error(
+        AccountTransportKind::Http,
+        Some(status.as_u16()),
+        service_code,
+        format!("{method} {path} returned {status}: {text}"),
+    ))
 }
 
 /// Returns the page origin (`http://host:port`). Used by API
@@ -655,23 +760,25 @@ pub async fn kick_sync() -> Result<(), TonkUiError> {
 /// answer joined with the locally recorded enrollment.
 pub async fn customer_state() -> Result<serde_json::Value, TonkUiError> {
     tonk_host::ready::wait().await;
-    let response = reqwest::Client::new()
-        .get(format!("{}/api/customer", origin()))
-        .send()
-        .await
-        .map_err(into_api_error)?;
-    response.json().await.map_err(into_api_error)
+    let response = reqwest::Client::new().get(format!("{}/api/customer", origin()));
+    decode_account(
+        send_account(response, "GET", "/api/customer").await?,
+        "GET",
+        "/api/customer",
+    )
+    .await
 }
 
 /// Return the current profile's persisted account-link state.
 pub async fn account_status() -> Result<AccountStatus, TonkUiError> {
     tonk_host::ready::wait().await;
-    let response = reqwest::Client::new()
-        .get(format!("{}/api/account", origin()))
-        .send()
-        .await
-        .map_err(into_api_error)?;
-    response.json().await.map_err(into_api_error)
+    let request = reqwest::Client::new().get(format!("{}/api/account", origin()));
+    decode_account(
+        send_account(request, "GET", "/api/account").await?,
+        "GET",
+        "/api/account",
+    )
+    .await
 }
 
 /// Persist a verified account-root delegation in the local profile.
@@ -693,57 +800,37 @@ pub async fn save_account_link(
             delegation_hex,
             remote,
             initialize_name,
-        })
-        .send()
-        .await
-        .map_err(into_api_error)?;
-    if response.status().is_success() {
-        response.json().await.map_err(into_api_error)
-    } else {
-        let status = response.status();
-        let text = response.text().await.unwrap_or_default();
-        Err(TonkUiError::ApiError(format!(
-            "POST /api/account/attach returned {status}: {text}"
-        )))
-    }
+        });
+    decode_account(
+        send_account(response, "POST", "/api/account/attach").await?,
+        "POST",
+        "/api/account/attach",
+    )
+    .await
 }
 
 /// List the devices registered under the linked account.
 pub async fn account_devices() -> Result<Vec<AccountDevice>, TonkUiError> {
     tonk_host::ready::wait().await;
-    let response = reqwest::Client::new()
-        .get(format!("{}/api/account/devices", origin()))
-        .send()
-        .await
-        .map_err(into_api_error)?;
-    if response.status().is_success() {
-        response.json().await.map_err(into_api_error)
-    } else {
-        let status = response.status();
-        let text = response.text().await.unwrap_or_default();
-        Err(TonkUiError::ApiError(format!(
-            "GET /api/account/devices returned {status}: {text}"
-        )))
-    }
+    let response = reqwest::Client::new().get(format!("{}/api/account/devices", origin()));
+    decode_account(
+        send_account(response, "GET", "/api/account/devices").await?,
+        "GET",
+        "/api/account/devices",
+    )
+    .await
 }
 
 /// Load verified account and passkey facts for the linked account.
 pub async fn account_summary() -> Result<AccountSummary, TonkUiError> {
     tonk_host::ready::wait().await;
-    let response = reqwest::Client::new()
-        .get(format!("{}/api/account/summary", origin()))
-        .send()
-        .await
-        .map_err(into_api_error)?;
-    if response.status().is_success() {
-        response.json().await.map_err(into_api_error)
-    } else {
-        let status = response.status();
-        let text = response.text().await.unwrap_or_default();
-        Err(TonkUiError::ApiError(format!(
-            "GET /api/account/summary returned {status}: {text}"
-        )))
-    }
+    let response = reqwest::Client::new().get(format!("{}/api/account/summary", origin()));
+    decode_account(
+        send_account(response, "GET", "/api/account/summary").await?,
+        "GET",
+        "/api/account/summary",
+    )
+    .await
 }
 
 /// Commit the authoritative display name for the active account/profile.
@@ -753,33 +840,15 @@ pub async fn set_account_display_name(name: &str) -> Result<String, TonkUiError>
         .post(format!("{}/api/account/display-name", origin()))
         .json(&tonk_worker_api::AccountDisplayNameRequest {
             name: name.to_owned(),
-        })
-        .send()
-        .await
-        .map_err(into_api_error)?;
-    if response.status().is_success() {
-        response
-            .json::<tonk_worker_api::AccountDisplayNameResponse>()
-            .await
-            .map(|response| response.name)
-            .map_err(into_api_error)
-    } else {
-        let status = response.status();
-        let text = response.text().await.unwrap_or_default();
-        Err(display_name_error(status, &text))
-    }
-}
-
-fn display_name_error(status: reqwest::StatusCode, text: &str) -> TonkUiError {
-    match serde_json::from_str::<ErrorBody>(text) {
-        Ok(body) if body.error.kind == "account_state_unavailable" => TonkUiError::Account(
-            "Please verify your email using the verification link we sent before changing your display name."
-                .to_owned(),
-        ),
-        _ => TonkUiError::ApiError(format!(
-            "POST /api/account/display-name returned {status}: {text}"
-        )),
-    }
+        });
+    let response = send_account(response, "POST", "/api/account/display-name").await?;
+    decode_account::<tonk_worker_api::AccountDisplayNameResponse>(
+        response,
+        "POST",
+        "/api/account/display-name",
+    )
+    .await
+    .map(|response| response.name)
 }
 
 /// Register a freshly authorized device in the account service's
@@ -795,39 +864,26 @@ pub async fn provision_custody(custody: &str, consent_hex: &str) -> Result<(), T
         .json(&serde_json::json!({
             "custody": custody,
             "consentHex": consent_hex,
-        }))
-        .send()
-        .await
-        .map_err(into_api_error)?;
-    if response.status().is_success() {
-        Ok(())
-    } else {
-        let status = response.status();
-        let text = response.text().await.unwrap_or_default();
-        Err(TonkUiError::ApiError(format!(
-            "POST /api/custody/provision returned {status}: {text}"
-        )))
-    }
+        }));
+    finish_account(
+        send_account(response, "POST", "/api/custody/provision").await?,
+        "POST",
+        "/api/custody/provision",
+    )
+    .await
 }
 
 /// The work queued until the account confirms its email, so the page
 /// can run the parts only it can sign.
 pub async fn pending_work() -> Result<tonk_account::pending::PendingQueue, TonkUiError> {
     tonk_host::ready::wait().await;
-    let response = reqwest::Client::new()
-        .get(format!("{}/api/customer/pending", origin()))
-        .send()
-        .await
-        .map_err(into_api_error)?;
-    if response.status().is_success() {
-        response.json().await.map_err(into_api_error)
-    } else {
-        let status = response.status();
-        let text = response.text().await.unwrap_or_default();
-        Err(TonkUiError::ApiError(format!(
-            "GET /api/customer/pending returned {status}: {text}"
-        )))
-    }
+    let response = reqwest::Client::new().get(format!("{}/api/customer/pending", origin()));
+    decode_account(
+        send_account(response, "GET", "/api/customer/pending").await?,
+        "GET",
+        "/api/customer/pending",
+    )
+    .await
 }
 
 /// Record the complete custody handoff. The worker queues provisioning before
@@ -846,19 +902,13 @@ pub async fn queue_custody_publish(
             "consentHex": consent_hex,
             "sealedHex": sealed_hex,
             "invocationHex": invocation_hex,
-        }))
-        .send()
-        .await
-        .map_err(into_api_error)?;
-    if response.status().is_success() {
-        Ok(())
-    } else {
-        let status = response.status();
-        let text = response.text().await.unwrap_or_default();
-        Err(TonkUiError::ApiError(format!(
-            "POST /api/custody/queue returned {status}: {text}"
-        )))
-    }
+        }));
+    finish_account(
+        send_account(response, "POST", "/api/custody/queue").await?,
+        "POST",
+        "/api/custody/queue",
+    )
+    .await
 }
 
 /// Register a device with the account service through the worker, so a
@@ -875,19 +925,13 @@ pub async fn register_account_device(
             "did": did,
             "name": name,
             "delegationHex": delegation_hex,
-        }))
-        .send()
-        .await
-        .map_err(into_api_error)?;
-    if response.status().is_success() {
-        response.json().await.map_err(into_api_error)
-    } else {
-        let status = response.status();
-        let text = response.text().await.unwrap_or_default();
-        Err(TonkUiError::ApiError(format!(
-            "POST /api/account/devices/register returned {status}: {text}"
-        )))
-    }
+        }));
+    decode_account(
+        send_account(response, "POST", "/api/account/devices/register").await?,
+        "POST",
+        "/api/account/devices/register",
+    )
+    .await
 }
 
 /// Revoke one of the account's devices and return the canonical publication
@@ -899,38 +943,25 @@ pub async fn revoke_account_device(
     tonk_host::ready::wait().await;
     let response = reqwest::Client::new()
         .post(format!("{}/api/account/devices/revoke", origin()))
-        .json(&RevokeDeviceRequest { did })
-        .send()
-        .await
-        .map_err(into_api_error)?;
-    if response.status().is_success() {
-        response.json().await.map_err(into_api_error)
-    } else {
-        let status = response.status();
-        let text = response.text().await.unwrap_or_default();
-        Err(TonkUiError::ApiError(format!(
-            "POST /api/account/devices/revoke returned {status}: {text}"
-        )))
-    }
+        .json(&RevokeDeviceRequest { did });
+    decode_account(
+        send_account(response, "POST", "/api/account/devices/revoke").await?,
+        "POST",
+        "/api/account/devices/revoke",
+    )
+    .await
 }
 
 /// List every profile signed in (or local) on this browser.
 pub async fn list_profiles() -> Result<ProfilesResponse, TonkUiError> {
     tonk_host::ready::wait().await;
-    let response = reqwest::Client::new()
-        .get(format!("{}/api/profiles", origin()))
-        .send()
-        .await
-        .map_err(into_api_error)?;
-    if response.status().is_success() {
-        response.json().await.map_err(into_api_error)
-    } else {
-        let status = response.status();
-        let text = response.text().await.unwrap_or_default();
-        Err(TonkUiError::ApiError(format!(
-            "GET /api/profiles returned {status}: {text}"
-        )))
-    }
+    let response = reqwest::Client::new().get(format!("{}/api/profiles", origin()));
+    decode_account(
+        send_account(response, "GET", "/api/profiles").await?,
+        "GET",
+        "/api/profiles",
+    )
+    .await
 }
 
 /// Swap the worker onto another roster profile. The caller reloads the
@@ -939,19 +970,13 @@ pub async fn activate_profile(profile: String) -> Result<ProfilesResponse, TonkU
     tonk_host::ready::wait().await;
     let response = reqwest::Client::new()
         .post(format!("{}/api/profiles/activate", origin()))
-        .json(&ActivateProfileRequest { profile })
-        .send()
-        .await
-        .map_err(into_api_error)?;
-    if response.status().is_success() {
-        response.json().await.map_err(into_api_error)
-    } else {
-        let status = response.status();
-        let text = response.text().await.unwrap_or_default();
-        Err(TonkUiError::ApiError(format!(
-            "POST /api/profiles/activate returned {status}: {text}"
-        )))
-    }
+        .json(&ActivateProfileRequest { profile });
+    decode_account(
+        send_account(response, "POST", "/api/profiles/activate").await?,
+        "POST",
+        "/api/profiles/activate",
+    )
+    .await
 }
 
 /// Rotate onto a fresh profile — the landing pad the account ceremony then
@@ -959,58 +984,37 @@ pub async fn activate_profile(profile: String) -> Result<ProfilesResponse, TonkU
 /// opening the account choice must remain reversible navigation.
 pub async fn add_account_profile() -> Result<ProfilesResponse, TonkUiError> {
     tonk_host::ready::wait().await;
-    let response = reqwest::Client::new()
-        .post(format!("{}/api/profiles/add", origin()))
-        .send()
-        .await
-        .map_err(into_api_error)?;
-    if response.status().is_success() {
-        response.json().await.map_err(into_api_error)
-    } else {
-        let status = response.status();
-        let text = response.text().await.unwrap_or_default();
-        Err(TonkUiError::ApiError(format!(
-            "POST /api/profiles/add returned {status}: {text}"
-        )))
-    }
+    let response = reqwest::Client::new().post(format!("{}/api/profiles/add", origin()));
+    decode_account(
+        send_account(response, "POST", "/api/profiles/add").await?,
+        "POST",
+        "/api/profiles/add",
+    )
+    .await
 }
 
 /// Sign out on this device while preserving its local profile and spaces.
 pub async fn unlink_account() -> Result<AccountStatus, TonkUiError> {
     tonk_host::ready::wait().await;
-    let response = reqwest::Client::new()
-        .delete(format!("{}/api/account", origin()))
-        .send()
-        .await
-        .map_err(into_api_error)?;
-    if response.status().is_success() {
-        response.json().await.map_err(into_api_error)
-    } else {
-        let status = response.status();
-        let text = response.text().await.unwrap_or_default();
-        Err(TonkUiError::ApiError(format!(
-            "DELETE /api/account returned {status}: {text}"
-        )))
-    }
+    let response = reqwest::Client::new().delete(format!("{}/api/account", origin()));
+    decode_account(
+        send_account(response, "DELETE", "/api/account").await?,
+        "DELETE",
+        "/api/account",
+    )
+    .await
 }
 
 /// Load the exact, service-authoritative destructive scope for review.
 pub async fn account_deletion_plan() -> Result<AccountDeletionPlan, TonkUiError> {
     tonk_host::ready::wait().await;
-    let response = reqwest::Client::new()
-        .get(format!("{}/api/account/deletion/plan", origin()))
-        .send()
-        .await
-        .map_err(into_api_error)?;
-    if response.status().is_success() {
-        response.json().await.map_err(into_api_error)
-    } else {
-        let status = response.status();
-        let text = response.text().await.unwrap_or_default();
-        Err(TonkUiError::ApiError(format!(
-            "GET /api/account/deletion/plan returned {status}: {text}"
-        )))
-    }
+    let response = reqwest::Client::new().get(format!("{}/api/account/deletion/plan", origin()));
+    decode_account(
+        send_account(response, "GET", "/api/account/deletion/plan").await?,
+        "GET",
+        "/api/account/deletion/plan",
+    )
+    .await
 }
 
 /// Execute the root-signed destructive plan in service-safe order.
@@ -1020,19 +1024,13 @@ pub async fn delete_account(
     tonk_host::ready::wait().await;
     let response = reqwest::Client::new()
         .post(format!("{}/api/account/delete", origin()))
-        .json(request)
-        .send()
-        .await
-        .map_err(into_api_error)?;
-    if response.status().is_success() {
-        response.json().await.map_err(into_api_error)
-    } else {
-        let status = response.status();
-        let text = response.text().await.unwrap_or_default();
-        Err(TonkUiError::ApiError(format!(
-            "POST /api/account/delete returned {status}: {text}"
-        )))
-    }
+        .json(request);
+    decode_account(
+        send_account(response, "POST", "/api/account/delete").await?,
+        "POST",
+        "/api/account/delete",
+    )
+    .await
 }
 
 /// Permanently delete one owned hosted space without deleting the account.
@@ -1042,38 +1040,13 @@ pub async fn delete_owned_space(
     tonk_host::ready::wait().await;
     let response = reqwest::Client::new()
         .post(format!("{}/api/account/spaces/delete", origin()))
-        .json(request)
-        .send()
-        .await
-        .map_err(into_api_error)?;
-    if response.status().is_success() {
-        response.json().await.map_err(into_api_error)
-    } else {
-        let status = response.status();
-        let text = response.text().await.unwrap_or_default();
-        Err(TonkUiError::ApiError(format!(
-            "POST /api/account/spaces/delete returned {status}: {text}"
-        )))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_explains_email_verification_for_an_unavailable_account_name() {
-        let error = display_name_error(
-            reqwest::StatusCode::SERVICE_UNAVAILABLE,
-            r#"{"error":{"kind":"account_state_unavailable","message":"Finish or retry account setup at /account before changing the linked account name"}}"#,
-        );
-        let message = error.to_string();
-
-        assert!(message.contains("verification link"));
-        assert!(message.contains("verify your email"));
-        assert!(!message.contains("503 Service Unavailable"));
-        assert!(!message.contains("account_state_unavailable"));
-    }
+        .json(request);
+    decode_account(
+        send_account(response, "POST", "/api/account/spaces/delete").await?,
+        "POST",
+        "/api/account/spaces/delete",
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/rust/tonk-ui/src/custody_relay.rs
+++ b/rust/tonk-ui/src/custody_relay.rs
@@ -153,22 +153,58 @@ fn show_consent() {
     host.set_inner_html(CARD_HTML);
     let _ = body.append_child(&host);
 
-    on_click(&host, "#tonk-custody-dismiss", remove_card);
+    on_click(&host, "#tonk-custody-dismiss", || {
+        let mut attempt = crate::account_observability::WebAccountAttempt::start(
+            AccountAction::FinishAccountBackup,
+            tonk_analytics::account::Surface::CustodyConsent,
+            tonk_analytics::account::Trigger::User,
+            tonk_analytics::account::AccountState::Ready,
+        );
+        attempt.finish(
+            tonk_analytics::account::Stage::PasskeyAssert,
+            tonk_analytics::account::AccountOutcome::cancelled(),
+        );
+        remove_card();
+    });
     on_click(&host, "#tonk-custody-continue", move || {
         set_card_text("Waiting for your passkey…");
+        let mut attempt = crate::account_observability::WebAccountAttempt::start(
+            AccountAction::FinishAccountBackup,
+            tonk_analytics::account::Surface::CustodyConsent,
+            tonk_analytics::account::Trigger::User,
+            tonk_analytics::account::AccountState::Ready,
+        );
         wasm_bindgen_futures::spawn_local(async move {
             match publish_encryption_key().await {
                 Ok(true) => {
+                    attempt.finish(
+                        tonk_analytics::account::Stage::Complete,
+                        tonk_analytics::account::AccountOutcome::success(),
+                    );
                     tonk_common::log!("custody: encryption key published for the worker");
                     set_card_text("Account key saved on this device.");
                 }
-                Ok(false) => set_card_text("Nothing was needed after all."),
+                Ok(false) => {
+                    attempt.finish(
+                        tonk_analytics::account::Stage::Complete,
+                        tonk_analytics::account::AccountOutcome::success(),
+                    );
+                    set_card_text("Nothing was needed after all.")
+                }
                 Err(error) => {
                     tonk_common::log!("custody: encryption key not published: {error}");
                     set_card_text(&user_error::diagnostic(
                         AccountAction::FinishAccountBackup,
                         &error,
                     ));
+                    let problem = user_error::problem_from_diagnostic(
+                        AccountAction::FinishAccountBackup,
+                        &error,
+                    );
+                    attempt.finish(
+                        tonk_analytics::account::Stage::PasskeyAssert,
+                        problem.outcome,
+                    );
                 }
             }
             remove_card_after(4000);
@@ -287,6 +323,8 @@ pub(crate) struct CeremonyError {
     pub message: String,
     /// Why the access service refused, when it is what refused.
     pub denial: Option<tonk_identity::custody::CustodyDenial>,
+    /// Browser refusal, independently of a service denial.
+    pub refusal: Option<tonk_identity::passkey::CeremonyRefusal>,
 }
 
 impl std::fmt::Display for CeremonyError {
@@ -376,6 +414,7 @@ impl CeremonyError {
         Self {
             message: message.into(),
             denial: None,
+            refusal: None,
         }
     }
 
@@ -395,9 +434,14 @@ impl CeremonyError {
                     .unwrap_or_default();
                 tonk_identity::custody::CustodyDenial::from_code(&code, &message)
             });
+        let refusal = js_sys::Reflect::get(error, &"name".into())
+            .ok()
+            .and_then(|name| name.as_string())
+            .map(|name| tonk_identity::passkey::CeremonyRefusal::from_name(&name));
         Self {
             message: describe(error),
             denial,
+            refusal,
         }
     }
 }

--- a/rust/tonk-ui/src/error.rs
+++ b/rust/tonk-ui/src/error.rs
@@ -1,5 +1,18 @@
 use thiserror::Error;
 
+/// Closed transport boundary for account API failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccountTransportKind {
+    /// Request did not receive an HTTP response.
+    Network,
+    /// HTTP response reported a failure.
+    Http,
+    /// Response body did not match the expected wire shape.
+    Decode,
+    /// Browser-local state could not satisfy the operation.
+    Local,
+}
+
 /// Errors that can occur in the Tonk UI application.
 #[derive(Error, Debug, Clone)]
 pub enum TonkUiError {
@@ -12,6 +25,19 @@ pub enum TonkUiError {
     /// someone needs to read beneath transport details.
     #[error("{0}")]
     Account(String),
+
+    /// Structured account boundary evidence plus a local-only diagnostic.
+    #[error("{diagnostic}")]
+    AccountApi {
+        /// Which boundary failed.
+        transport_kind: AccountTransportKind,
+        /// Numeric HTTP status, when a response was received.
+        status: Option<u16>,
+        /// Stable service code. It is normalized again by analytics before use.
+        service_code: Option<String>,
+        /// Exact local diagnostic; never included in account analytics.
+        diagnostic: String,
+    },
 
     /// Structured synchronization failure returned by the worker.
     #[error("{message}")]

--- a/rust/tonk-ui/src/helpers.rs
+++ b/rust/tonk-ui/src/helpers.rs
@@ -271,7 +271,12 @@ mod native {
                 .parent()
                 .and_then(std::path::Path::parent)
                 .ok_or_else(|| anyhow!("tonk-ui manifest has no workspace root"))?;
-            let test_server = format!("path:{}#tonk-ui-test-server", workspace.display());
+            // Use the Git worktree view so ignored build products (`target`,
+            // linked worktrees, benchmark runs) are not copied into the Nix
+            // store every time an integration test starts its web server.
+            // Newly added test source must be staged, just as it must be for
+            // the committed CI revision that ultimately runs this harness.
+            let test_server = format!("git+file:{}#tonk-ui-test-server", workspace.display());
             let service_worker_root = caddy_data.join("service-worker");
             std::fs::create_dir_all(&service_worker_root)?;
             let service_worker_script = service_worker_root.join("service_worker.js");

--- a/rust/tonk-ui/src/lib.rs
+++ b/rust/tonk-ui/src/lib.rs
@@ -9,6 +9,8 @@ pub mod account;
 /// Customer activation page reached from the activation email.
 pub mod activate;
 
+mod account_observability;
+
 /// The account panel's registration row, kept live by a subscription to
 /// the fact rather than a fetch, so an activation performed elsewhere
 /// reaches this tab.

--- a/rust/tonk-ui/src/register_dialog.rs
+++ b/rust/tonk-ui/src/register_dialog.rs
@@ -66,6 +66,13 @@ thread_local! {
     /// typed, when it was an answer about nothing on screen.
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     static ANSWER: RefCell<Option<Answer>> = const { RefCell::new(None) };
+    /// Long-lived automatic probes hold their attempt across subscription
+    /// setup and the first meaningful frame instead of fabricating duration at
+    /// the completion callback.
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    static REGISTRATION_WATCH: RefCell<Option<crate::account_observability::WebAccountAttempt>> = const { RefCell::new(None) };
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    static ACTIVATION_WATCH: RefCell<Option<crate::account_observability::WebAccountAttempt>> = const { RefCell::new(None) };
 }
 
 enum ReturnFocus {
@@ -131,6 +138,14 @@ const DIALOG_HTML: &str = r##"
 
 /// Raise the dialog. A no-op while one is already up.
 pub fn open() {
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    crate::account_observability::record_instant_success(
+        AccountAction::OpenRegistration,
+        tonk_analytics::account::Surface::RegistrationDialog,
+        tonk_analytics::account::Trigger::User,
+        tonk_analytics::account::AccountState::Unknown,
+        tonk_analytics::account::Stage::Input,
+    );
     open_with_return(None);
 }
 
@@ -419,6 +434,16 @@ pub fn close() {
             }
         });
         DELEGATES.with(|held| held.borrow_mut().clear());
+        for attempt in [&REGISTRATION_WATCH, &ACTIVATION_WATCH] {
+            attempt.with(|held| {
+                if let Some(mut attempt) = held.borrow_mut().take() {
+                    attempt.finish(
+                        tonk_analytics::account::Stage::Complete,
+                        tonk_analytics::account::AccountOutcome::cancelled(),
+                    );
+                }
+            });
+        }
         // The answer belongs to the dialog that asked, so the next one
         // starts from nothing rather than from what this one was told.
         ANSWER.with(|held| *held.borrow_mut() = None);
@@ -622,13 +647,29 @@ fn check_now() {
     // dialog renders. Painting it here too would be a second source of
     // truth that disagrees with the row while the lookup runs.
     wasm_bindgen_futures::spawn_local(async move {
-        if let Err(error) = crate::api::transact_profile(check_email_claim(&email)).await {
-            tonk_common::log!("register: could not ask about the address: {error}");
-            clear_state();
-            set_status(&user_error::diagnostic(
-                AccountAction::CheckEmail,
-                &error.to_string(),
-            ));
+        let (mut attempt, result) = crate::account_observability::observe(
+            AccountAction::CheckEmail,
+            tonk_analytics::account::Surface::RegistrationDialog,
+            tonk_analytics::account::Trigger::User,
+            tonk_analytics::account::AccountState::None,
+            crate::api::transact_profile(check_email_claim(&email)),
+        )
+        .await;
+        match result {
+            Ok(()) => attempt.finish(
+                tonk_analytics::account::Stage::EmailLookup,
+                tonk_analytics::account::AccountOutcome::success(),
+            ),
+            Err(error) => {
+                tonk_common::log!("register: could not ask about the address: {error}");
+                clear_state();
+                let problem = user_error::problem_from_diagnostic(
+                    AccountAction::CheckEmail,
+                    &error.to_string(),
+                );
+                attempt.finish(tonk_analytics::account::Stage::EmailLookup, problem.outcome);
+                set_status(&problem.message);
+            }
         }
     });
 }
@@ -679,6 +720,14 @@ async fn account_is_activated() -> bool {
 /// crosses.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 fn await_activation(host: &Element) {
+    ACTIVATION_WATCH.with(|held| {
+        *held.borrow_mut() = Some(crate::account_observability::WebAccountAttempt::start(
+            AccountAction::WatchActivation,
+            tonk_analytics::account::Surface::RegistrationDialog,
+            tonk_analytics::account::Trigger::Automatic,
+            tonk_analytics::account::AccountState::PendingActivation,
+        ));
+    });
     let mut delegates = Vec::new();
     for method in ["reset", "update"] {
         let is_delta = method == "update";
@@ -716,6 +765,15 @@ fn activation_watch_failed(detail: &str) {
         detail,
     ));
     set_action(RETURN_TO_SPACE, true);
+    let problem = user_error::problem_from_diagnostic(AccountAction::WatchActivation, detail);
+    ACTIVATION_WATCH.with(|held| {
+        if let Some(mut attempt) = held.borrow_mut().take() {
+            attempt.finish(
+                tonk_analytics::account::Stage::ActivationWait,
+                problem.outcome,
+            );
+        }
+    });
 }
 
 /// Whether a failed ceremony is the ordinary wait for an emailed link.
@@ -842,6 +900,14 @@ pub(crate) fn answer_query_body() -> String {
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 fn watch_answers(host: &Element) {
     let _ = host.set_attribute("with", "main@profile:tonk");
+    REGISTRATION_WATCH.with(|held| {
+        *held.borrow_mut() = Some(crate::account_observability::WebAccountAttempt::start(
+            AccountAction::LoadRegistration,
+            tonk_analytics::account::Surface::RegistrationDialog,
+            tonk_analytics::account::Trigger::Automatic,
+            tonk_analytics::account::AccountState::Unknown,
+        ));
+    });
 
     let mut delegates = Vec::new();
     for method in ["reset", "update"] {
@@ -851,6 +917,14 @@ fn watch_answers(host: &Element) {
             Closure::<dyn FnMut(JsValue, JsValue)>::new(move |payload: JsValue, _opts: JsValue| {
                 let _ = &target;
                 if let Some(answer) = read_answer(&payload, is_delta) {
+                    REGISTRATION_WATCH.with(|held| {
+                        if let Some(mut attempt) = held.borrow_mut().take() {
+                            attempt.finish(
+                                tonk_analytics::account::Stage::AccountLoad,
+                                tonk_analytics::account::AccountOutcome::success(),
+                            );
+                        }
+                    });
                     ANSWER.with(|held| *held.borrow_mut() = Some(answer.clone()));
                     show_answer(&answer);
                 }
@@ -898,6 +972,12 @@ fn registration_watch_failed(detail: &str) {
         AccountAction::LoadRegistration,
         detail,
     ));
+    let problem = user_error::problem_from_diagnostic(AccountAction::LoadRegistration, detail);
+    REGISTRATION_WATCH.with(|held| {
+        if let Some(mut attempt) = held.borrow_mut().take() {
+            attempt.finish(tonk_analytics::account::Stage::AccountLoad, problem.outcome);
+        }
+    });
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -1145,11 +1225,20 @@ fn copy_the_share_link() {
     };
     set_action("copying link…", false);
     wasm_bindgen_futures::spawn_local(async move {
+        let mut attempt = crate::account_observability::WebAccountAttempt::start(
+            AccountAction::CopyInvite,
+            tonk_analytics::account::Surface::RegistrationDialog,
+            tonk_analytics::account::Trigger::User,
+            tonk_analytics::account::AccountState::Ready,
+        );
         let claim = enable_sync_claim(&space, js_sys::Date::now());
         if let Err(error) = crate::api::transact_profile(claim).await {
             tonk_common::log!("register: could not finish the share: {error}");
             set_status("Could not create the link. Share the space again.");
             set_action(COPY_LINK, true);
+            let problem =
+                user_error::problem_from_diagnostic(AccountAction::CopyInvite, &error.to_string());
+            attempt.finish(tonk_analytics::account::Stage::LocalCommit, problem.outcome);
             return;
         }
         // The link arrives as a fact on the space's own branch, so this
@@ -1157,6 +1246,10 @@ fn copy_the_share_link() {
         match await_invite_link(&space).await {
             Some(link) => match write_to_clipboard(&link).await {
                 Ok(()) => {
+                    attempt.finish(
+                        tonk_analytics::account::Stage::CallbackDelivery,
+                        tonk_analytics::account::AccountOutcome::success(),
+                    );
                     set_status("You can use the copied link to invite someone into a space.");
                     set_action(RETURN_TO_SPACE, true);
                     focus_action();
@@ -1164,10 +1257,22 @@ fn copy_the_share_link() {
                 Err(error) => {
                     tonk_common::log!("register: could not copy the invite link: {error}");
                     set_status(&user_error::diagnostic(AccountAction::CopyInvite, &error));
+                    let problem =
+                        user_error::problem_from_diagnostic(AccountAction::CopyInvite, &error);
+                    attempt.finish(
+                        tonk_analytics::account::Stage::CallbackDelivery,
+                        problem.outcome,
+                    );
                     set_action(COPY_LINK, true);
                 }
             },
             None => {
+                attempt.finish(
+                    tonk_analytics::account::Stage::CallbackDelivery,
+                    tonk_analytics::account::AccountOutcome::retryable(
+                        tonk_analytics::account::FailureKind::Timeout,
+                    ),
+                );
                 set_status("The link is taking longer than expected. Share the space again.");
                 set_action(COPY_LINK, true);
             }
@@ -1298,6 +1403,27 @@ pub(crate) fn run_signup_ceremony() {
     // attention is earned by blinking, never by hue.
     set_action("waiting for your device", false);
 
+    let account_action = if existing {
+        AccountAction::LogIn
+    } else {
+        AccountAction::CreateAccount
+    };
+    let mut account_attempt = crate::account_observability::WebAccountAttempt::start(
+        account_action,
+        tonk_analytics::account::Surface::RegistrationDialog,
+        tonk_analytics::account::Trigger::User,
+        if existing {
+            tonk_analytics::account::AccountState::Unknown
+        } else {
+            tonk_analytics::account::AccountState::None
+        },
+    );
+    account_attempt.checkpoint(tonk_analytics::account::Stage::EmailLookup);
+    account_attempt.checkpoint(if existing {
+        tonk_analytics::account::Stage::PasskeyAssert
+    } else {
+        tonk_analytics::account::Stage::PasskeyCreate
+    });
     wasm_bindgen_futures::spawn_local(async move {
         let outcome = if existing {
             crate::account::run_login_ceremony(set_status).await
@@ -1318,6 +1444,12 @@ pub(crate) fn run_signup_ceremony() {
             // one click away, with no way to tell from the screen that
             // waiting was all it needed.
             Err(error) if awaits_confirmation(error.denial.as_ref()) => {
+                let problem = user_error::ceremony_problem(account_action, &error);
+                account_attempt.finish(
+                    tonk_analytics::account::Stage::ActivationWait,
+                    problem.outcome,
+                );
+                crate::account_observability::mark_settle_pending();
                 tonk_common::log!("register: the account awaits its email confirmation");
                 hide_action();
                 add_row(
@@ -1339,14 +1471,12 @@ pub(crate) fn run_signup_ceremony() {
             }
             Err(error) => {
                 tonk_common::log!("register: the ceremony did not complete: {error}");
-                set_status(&user_error::ceremony(
-                    if existing {
-                        AccountAction::LogIn
-                    } else {
-                        AccountAction::CreateAccount
-                    },
-                    &error,
-                ));
+                let problem = user_error::ceremony_problem(account_action, &error);
+                account_attempt.finish(
+                    tonk_analytics::account::Stage::PasskeyAssert,
+                    problem.outcome,
+                );
+                set_status(&problem.message);
                 // Back to something clickable: a control left mid-flight
                 // refuses every later attempt.
                 set_action(
@@ -1391,8 +1521,19 @@ pub(crate) fn run_signup_ceremony() {
                 // device, since what it waits on is a fact that syncs.
                 if existing && account_is_activated().await {
                     // Already activated: nothing to wait for.
+                    account_attempt.finish(
+                        tonk_analytics::account::Stage::Complete,
+                        tonk_analytics::account::AccountOutcome::success(),
+                    );
                     finish_ceremony();
                 } else {
+                    account_attempt.finish(
+                        tonk_analytics::account::Stage::ActivationWait,
+                        tonk_analytics::account::AccountOutcome::blocked(
+                            tonk_analytics::account::FailureKind::AwaitingActivation,
+                        ),
+                    );
+                    crate::account_observability::mark_settle_pending();
                     // What happens next arrives as facts: the emailed
                     // link lands `AccountCustomer`, and the subscription
                     // renders it. Nothing here polls for it.
@@ -1686,11 +1827,22 @@ pub(crate) fn finish_ceremony() {
     if host.query_selector(NAME_ROW).ok().flatten().is_some() {
         return;
     }
+    let activation_was_pending = host.query_selector(CONFIRM_ROW).ok().flatten().is_some();
     // The row that was awaiting the link is the one that resolves; the
     // address row above it keeps saying which address. Where no
     // confirmation row stands — signing in with an existing passkey
     // never raises one — there is nothing to settle.
     settle_named_row(CONFIRM_ROW, "email", "verified");
+    if activation_was_pending {
+        ACTIVATION_WATCH.with(|held| {
+            if let Some(mut attempt) = held.borrow_mut().take() {
+                attempt.finish(
+                    tonk_analytics::account::Stage::Complete,
+                    tonk_analytics::account::AccountOutcome::success(),
+                );
+            }
+        });
+    }
 
     // Only REGISTRATION asks. A login reaches an account that already
     // belongs to someone: it may be named already, or its naming may
@@ -1821,14 +1973,30 @@ fn offer_the_link(name: &str) {
     wasm_bindgen_futures::spawn_local({
         let name = name.to_owned();
         async move {
-            let status = match crate::api::transact_profile(profile_rename_claim(&name)).await {
-                Ok(()) => "Your account is ready.".to_owned(),
+            let (mut attempt, result) = crate::account_observability::observe(
+                AccountAction::SaveInitialDisplayName,
+                tonk_analytics::account::Surface::RegistrationDialog,
+                tonk_analytics::account::Trigger::User,
+                tonk_analytics::account::AccountState::Ready,
+                crate::api::transact_profile(profile_rename_claim(&name)),
+            )
+            .await;
+            let status = match result {
+                Ok(()) => {
+                    attempt.finish(
+                        tonk_analytics::account::Stage::LocalCommit,
+                        tonk_analytics::account::AccountOutcome::success(),
+                    );
+                    "Your account is ready.".to_owned()
+                }
                 Err(error) => {
                     tonk_common::log!("register: could not record the display name: {error}");
-                    user_error::diagnostic(
+                    let problem = user_error::problem_from_diagnostic(
                         AccountAction::SaveInitialDisplayName,
                         &error.to_string(),
-                    )
+                    );
+                    attempt.finish(tonk_analytics::account::Stage::LocalCommit, problem.outcome);
+                    problem.message
                 }
             };
             conclude(&status);

--- a/rust/tonk-ui/src/user_error.rs
+++ b/rust/tonk-ui/src/user_error.rs
@@ -289,6 +289,7 @@ pub(crate) fn api_problem(action: AccountAction, error: &TonkUiError) -> Account
 
 /// Classify a dispatched destructive mutation. A missing or malformed reply
 /// cannot prove that the service did not commit the mutation.
+#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
 pub(crate) fn mutation_api_problem(action: AccountAction, error: &TonkUiError) -> AccountProblem {
     let problem = api_problem(action, error);
     if matches!(

--- a/rust/tonk-ui/src/user_error.rs
+++ b/rust/tonk-ui/src/user_error.rs
@@ -1,14 +1,28 @@
 //! User-facing recovery messages for account actions.
 
 use crate::error::TonkUiError;
+use tonk_analytics::account::{AccountOutcome, FailureKind, HttpStatusClass, ServiceCode};
+
+/// One account failure projected into safe presentation and analytics fields.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct AccountProblem {
+    /// Caller-facing recovery copy.
+    pub message: String,
+    /// Closed terminal outcome.
+    pub outcome: AccountOutcome,
+}
+
+impl AccountProblem {
+    fn new(message: String, outcome: AccountOutcome) -> Self {
+        Self { message, outcome }
+    }
+}
 
 /// The account action whose failure needs to be explained.
-#[cfg_attr(
-    not(all(target_arch = "wasm32", target_os = "unknown")),
-    allow(dead_code)
-)]
+#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum AccountAction {
+    OpenRegistration,
     LoadAccount,
     LoadRegistration,
     CheckEmail,
@@ -32,10 +46,29 @@ pub(crate) enum AccountAction {
     SaveInitialDisplayName,
     CopyInvite,
     FinishPreviousAction,
+    SettleAccount,
+    LoadAccountSpaces,
+    PullAccountSpace,
+    OpenAccountDeletion,
+    OpenSpaceDeletion,
+    SyncAccount,
 }
 
 /// Present an internal/browser diagnostic at an account action boundary.
 pub(crate) fn diagnostic(action: AccountAction, detail: &str) -> String {
+    problem_from_diagnostic(action, detail).message
+}
+
+/// Compatibility diagnostics have no typed evidence. Their prose may improve
+/// recovery copy, but analytics always sees `unknown`.
+pub(crate) fn problem_from_diagnostic(action: AccountAction, detail: &str) -> AccountProblem {
+    AccountProblem::new(
+        diagnostic_message(action, detail),
+        AccountOutcome::retryable(FailureKind::Unknown),
+    )
+}
+
+fn diagnostic_message(action: AccountAction, detail: &str) -> String {
     let original = detail.trim();
     if original
         == "Your account is ready, but this browser couldn't finish signing in. Log in to continue."
@@ -122,47 +155,174 @@ pub(crate) fn diagnostic(action: AccountAction, detail: &str) -> String {
 /// a dismissed prompt, an unsupported authenticator -- falls through to
 /// the ordinary diagnostic.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+#[allow(dead_code)]
 pub(crate) fn ceremony(
     action: AccountAction,
     error: &crate::custody_relay::CeremonyError,
 ) -> String {
+    ceremony_problem(action, error).message
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) fn ceremony_problem(
+    action: AccountAction,
+    error: &crate::custody_relay::CeremonyError,
+) -> AccountProblem {
     use tonk_identity::custody::CustodyDenial;
+    use tonk_identity::passkey::CeremonyRefusal;
 
     match &error.denial {
-        Some(CustodyDenial::AwaitingActivation) => {
-            "Open the confirmation link in your email to finish signing in. You can leave this page open."
-                .to_owned()
+        Some(CustodyDenial::AwaitingActivation) => AccountProblem::new(
+            "Open the confirmation link in your email to finish signing in. You can leave this page open.".to_owned(),
+            AccountOutcome::blocked(FailureKind::AwaitingActivation),
+        ),
+        Some(CustodyDenial::Suspended(_)) => AccountProblem::new(
+            "This account is suspended, so it cannot be used on this device. Contact support to restore it.".to_owned(),
+            AccountOutcome::blocked(FailureKind::Suspended),
+        ),
+        Some(CustodyDenial::NotProvisioned(_)) => AccountProblem::new(
+            "This account is not set up for syncing yet. Finish creating it on the browser that holds its passkey, then try again.".to_owned(),
+            AccountOutcome::blocked(FailureKind::NotProvisioned),
+        ),
+        Some(CustodyDenial::Other(_)) => AccountProblem::new(
+            diagnostic_message(action, &error.message),
+            AccountOutcome::terminal_failure(FailureKind::AccessDenied),
+        ),
+        None => {
+            let outcome = match error.refusal.unwrap_or(CeremonyRefusal::Other) {
+                CeremonyRefusal::NotAllowed => AccountOutcome::cancelled(),
+                CeremonyRefusal::InvalidState => AccountOutcome::terminal_failure(FailureKind::CredentialExists),
+                CeremonyRefusal::NotSupported => AccountOutcome::terminal_failure(FailureKind::PasskeyUnsupported),
+                CeremonyRefusal::Security => AccountOutcome::terminal_failure(FailureKind::SecurityContext),
+                CeremonyRefusal::NoPrf => AccountOutcome::terminal_failure(FailureKind::PrfUnsupported),
+                CeremonyRefusal::Other => AccountOutcome::retryable(FailureKind::Unknown),
+            };
+            AccountProblem::new(diagnostic_message(action, &error.message), outcome)
         }
-        Some(CustodyDenial::Suspended(_)) => {
-            "This account is suspended, so it cannot be used on this device. Contact support to restore it."
-                .to_owned()
-        }
-        Some(CustodyDenial::NotProvisioned(_)) => {
-            "This account is not set up for syncing yet. Finish creating it on the browser that holds its passkey, then try again."
-                .to_owned()
-        }
-        Some(CustodyDenial::Other(reason)) => diagnostic(action, reason.as_str()),
-        None => diagnostic(action, &error.message),
     }
 }
 
 /// Present a typed local API error at an account action boundary.
-#[cfg_attr(
-    not(all(target_arch = "wasm32", target_os = "unknown")),
-    allow(dead_code)
-)]
+#[allow(dead_code)]
 pub(crate) fn api(action: AccountAction, error: &TonkUiError) -> String {
-    match error {
-        TonkUiError::Account(message) => diagnostic(action, message),
-        TonkUiError::Sync { message, .. } => message.clone(),
-        TonkUiError::ApiError(_) | TonkUiError::Analyze { .. } => {
-            diagnostic(action, &error.to_string())
+    api_problem(action, error).message
+}
+
+pub(crate) fn api_problem(action: AccountAction, error: &TonkUiError) -> AccountProblem {
+    use crate::error::AccountTransportKind;
+    let message = match error {
+        TonkUiError::AccountApi {
+            service_code: Some(code),
+            ..
+        } if action == AccountAction::ChangeDisplayName
+            && ServiceCode::from_wire(code) == ServiceCode::AccountStateUnavailable =>
+        {
+            "Please verify your email using the verification link we sent before changing your display name."
+                .to_owned()
         }
+        TonkUiError::Account(message) => diagnostic_message(action, message),
+        TonkUiError::Sync { message, .. } => message.clone(),
+        TonkUiError::AccountApi { diagnostic, .. } => diagnostic_message(action, diagnostic),
+        TonkUiError::ApiError(_) | TonkUiError::Analyze { .. } => {
+            diagnostic_message(action, &error.to_string())
+        }
+    };
+    match error {
+        TonkUiError::AccountApi {
+            transport_kind,
+            status,
+            service_code,
+            ..
+        } => {
+            let kind = match (transport_kind, status) {
+                (AccountTransportKind::Network, _) => FailureKind::Network,
+                (AccountTransportKind::Decode, None | Some(200..=299)) => {
+                    FailureKind::InvalidResponse
+                }
+                (AccountTransportKind::Local, _) => FailureKind::LocalState,
+                (AccountTransportKind::Http | AccountTransportKind::Decode, Some(404)) => {
+                    FailureKind::NotFound
+                }
+                (AccountTransportKind::Http | AccountTransportKind::Decode, Some(409)) => {
+                    FailureKind::Conflict
+                }
+                (AccountTransportKind::Http | AccountTransportKind::Decode, Some(429)) => {
+                    FailureKind::RateLimited
+                }
+                (AccountTransportKind::Http | AccountTransportKind::Decode, Some(401 | 403)) => {
+                    FailureKind::AccessDenied
+                }
+                (AccountTransportKind::Http | AccountTransportKind::Decode, Some(500..=599)) => {
+                    FailureKind::ServiceUnavailable
+                }
+                _ => FailureKind::Unknown,
+            };
+            let mut outcome = if matches!(
+                kind,
+                FailureKind::Network | FailureKind::RateLimited | FailureKind::ServiceUnavailable
+            ) {
+                AccountOutcome::retryable(kind)
+            } else {
+                AccountOutcome::terminal_failure(kind)
+            };
+            if let Some(status) = status {
+                if (400..500).contains(status) {
+                    outcome = outcome.with_http_status_class(HttpStatusClass::ClientError);
+                }
+                if (500..600).contains(status) {
+                    outcome = outcome.with_http_status_class(HttpStatusClass::ServerError);
+                }
+            }
+            if let Some(code) = service_code {
+                outcome = outcome.with_service_code(ServiceCode::from_wire(code));
+            }
+            AccountProblem::new(message, outcome)
+        }
+        TonkUiError::Sync { code, .. } => AccountProblem::new(
+            message,
+            AccountOutcome::terminal_failure(FailureKind::AccessDenied)
+                .with_service_code(ServiceCode::from_wire(code)),
+        ),
+        _ => AccountProblem::new(message, AccountOutcome::retryable(FailureKind::Unknown)),
     }
+}
+
+/// Classify a dispatched destructive mutation. A missing or malformed reply
+/// cannot prove that the service did not commit the mutation.
+pub(crate) fn mutation_api_problem(action: AccountAction, error: &TonkUiError) -> AccountProblem {
+    let problem = api_problem(action, error);
+    if matches!(
+        action,
+        AccountAction::DeleteAccount | AccountAction::DeleteSpace | AccountAction::RevokeDevice
+    ) && matches!(
+        error,
+        TonkUiError::AccountApi {
+            transport_kind: crate::error::AccountTransportKind::Network,
+            ..
+        } | TonkUiError::AccountApi {
+            transport_kind: crate::error::AccountTransportKind::Decode,
+            status: None | Some(200..=299) | Some(500..=599),
+            ..
+        } | TonkUiError::AccountApi {
+            transport_kind: crate::error::AccountTransportKind::Http,
+            status: None | Some(500..=599),
+            ..
+        }
+    ) {
+        let kind = problem
+            .outcome
+            .failure_kind()
+            .unwrap_or(FailureKind::Unknown);
+        return AccountProblem::new(problem.message, AccountOutcome::unknown_commit(kind));
+    }
+    problem
 }
 
 fn fallback(action: AccountAction) -> &'static str {
     match action {
+        AccountAction::OpenRegistration => {
+            "We couldn't open account options. Close settings and try again."
+        }
         AccountAction::LoadAccount => {
             "We couldn't load your account settings. Check your connection and reload the page."
         }
@@ -232,12 +392,28 @@ fn fallback(action: AccountAction) -> &'static str {
         AccountAction::FinishPreviousAction => {
             "You're signed in, but we couldn't finish what you started. Return to the previous page and try again."
         }
+        AccountAction::SettleAccount | AccountAction::SyncAccount => {
+            "We couldn't finish syncing your account. Check your connection and try again."
+        }
+        AccountAction::LoadAccountSpaces => {
+            "We couldn't load your account spaces. Check your connection and try again."
+        }
+        AccountAction::PullAccountSpace => {
+            "We couldn't pull this account space. Check your connection and try again."
+        }
+        AccountAction::OpenAccountDeletion => {
+            "We couldn't open account deletion. Reload settings and try again."
+        }
+        AccountAction::OpenSpaceDeletion => {
+            "We couldn't open space deletion. Reload settings and try again."
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::AccountTransportKind;
 
     #[test]
     fn it_turns_passkey_diagnostics_into_specific_recovery_steps() {
@@ -336,6 +512,117 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn it_classifies_typed_account_boundaries_without_leaking_diagnostics() {
+        let cases = [
+            (AccountTransportKind::Network, None, FailureKind::Network),
+            (
+                AccountTransportKind::Decode,
+                Some(200),
+                FailureKind::InvalidResponse,
+            ),
+            (AccountTransportKind::Local, None, FailureKind::LocalState),
+            (AccountTransportKind::Http, Some(404), FailureKind::NotFound),
+            (AccountTransportKind::Http, Some(409), FailureKind::Conflict),
+            (
+                AccountTransportKind::Http,
+                Some(429),
+                FailureKind::RateLimited,
+            ),
+            (
+                AccountTransportKind::Http,
+                Some(503),
+                FailureKind::ServiceUnavailable,
+            ),
+        ];
+        for (transport_kind, status, expected) in cases {
+            let error = TonkUiError::AccountApi {
+                transport_kind,
+                status,
+                service_code: Some("upstream_timeout".to_owned()),
+                diagnostic: "person@example.com did:key:zSensitive response body secret".to_owned(),
+            };
+            let problem = api_problem(AccountAction::LoadAccount, &error);
+            assert_eq!(problem.outcome.failure_kind(), Some(expected));
+            assert!(!problem.message.contains("person@example.com"));
+            assert!(!problem.message.contains("did:key"));
+            assert!(!problem.message.contains("response body"));
+        }
+    }
+
+    #[test]
+    fn destructive_mutations_distinguish_unknown_commit_from_proved_rejection() {
+        for transport_kind in [AccountTransportKind::Network, AccountTransportKind::Decode] {
+            let error = TonkUiError::AccountApi {
+                transport_kind,
+                status: (transport_kind == AccountTransportKind::Decode).then_some(200),
+                service_code: None,
+                diagnostic: "person@example.com response was lost after dispatch".to_owned(),
+            };
+            let problem = mutation_api_problem(AccountAction::DeleteAccount, &error);
+            assert_eq!(
+                problem.outcome.result(),
+                tonk_analytics::account::AccountResult::UnknownCommit
+            );
+            assert!(!problem.message.contains("person@example.com"));
+        }
+
+        let rejected = TonkUiError::AccountApi {
+            transport_kind: AccountTransportKind::Http,
+            status: Some(409),
+            service_code: Some("customer_active".to_owned()),
+            diagnostic: "server proved the deletion did not commit".to_owned(),
+        };
+        let problem = mutation_api_problem(AccountAction::DeleteAccount, &rejected);
+        assert_eq!(
+            problem.outcome.result(),
+            tonk_analytics::account::AccountResult::TerminalFailure
+        );
+        assert_eq!(problem.outcome.failure_kind(), Some(FailureKind::Conflict));
+
+        let unreadable_server_response = TonkUiError::AccountApi {
+            transport_kind: AccountTransportKind::Decode,
+            status: Some(503),
+            service_code: None,
+            diagnostic: "server rejected the mutation with an unreadable body".to_owned(),
+        };
+        let problem =
+            mutation_api_problem(AccountAction::DeleteAccount, &unreadable_server_response);
+        assert_eq!(
+            problem.outcome.result(),
+            tonk_analytics::account::AccountResult::UnknownCommit
+        );
+
+        let server_failure = TonkUiError::AccountApi {
+            transport_kind: AccountTransportKind::Http,
+            status: Some(503),
+            service_code: Some("upstream_unavailable".to_owned()),
+            diagnostic: "service failed after accepting the mutation".to_owned(),
+        };
+        let problem = mutation_api_problem(AccountAction::RevokeDevice, &server_failure);
+        assert_eq!(
+            problem.outcome.result(),
+            tonk_analytics::account::AccountResult::UnknownCommit
+        );
+    }
+
+    #[test]
+    fn unavailable_display_name_keeps_the_activation_recovery_copy() {
+        let error = TonkUiError::AccountApi {
+            transport_kind: AccountTransportKind::Http,
+            status: Some(503),
+            service_code: Some("account_state_unavailable".to_owned()),
+            diagnostic: "raw upstream response".to_owned(),
+        };
+        let problem = api_problem(AccountAction::ChangeDisplayName, &error);
+        assert!(problem.message.contains("verify your email"));
+        assert!(!problem.message.contains("upstream"));
+        assert_eq!(
+            problem.outcome.failure_kind(),
+            Some(FailureKind::ServiceUnavailable)
+        );
     }
 
     #[test]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,8 +2,17 @@ name = "tonk-access-service"
 main = "./result/tonk-access-service/worker/shim.mjs"
 compatibility_date = "2026-01-01"
 compatibility_flags = ["nodejs_compat"]
-
 routes = [{ pattern = "tonk.network", custom_domain = true }]
+
+[observability]
+enabled = true
+head_sampling_rate = 1
+redact_query_string = true
+
+[observability.logs]
+enabled = true
+head_sampling_rate = 1
+invocation_logs = false
 
 [build]
 command = "nix build .#tonk-cloudflare-artifacts"
@@ -98,6 +107,16 @@ EMAIL_FROM = "tonk <accounts@tonk.xyz>"
 [env.staging]
 routes = [{ pattern = "staging.tonk.xyz", custom_domain = true }]
 
+[env.staging.observability]
+enabled = true
+head_sampling_rate = 1
+redact_query_string = true
+
+[env.staging.observability.logs]
+enabled = true
+head_sampling_rate = 1
+invocation_logs = false
+
 [[env.staging.r2_buckets]]
 binding = "BUCKET"
 bucket_name = "tonk-spaces-staging"
@@ -152,6 +171,16 @@ EMAIL_FROM = "tonk <accounts@tonk.xyz>"
 [env.preview]
 workers_dev = true
 routes = []
+
+[env.preview.observability]
+enabled = true
+head_sampling_rate = 1
+redact_query_string = true
+
+[env.preview.observability.logs]
+enabled = true
+head_sampling_rate = 1
+invocation_logs = false
 
 [[env.preview.r2_buckets]]
 binding = "BUCKET"


### PR DESCRIPTION
## Summary

- add one privacy-validated account event schema shared by web and CLI attempt recorders
- instrument account, passkey, activation, destructive-action, callback, and degraded/unknown-commit boundaries
- add content-free access Worker failure logs with query-string redaction and explicit environment configuration
- document the telemetry inventory and runbook; add the live Account health dashboard with nine validated aggregate insights and two disabled rollout alerts

## Verification

- cargo test -p tonk-analytics (14 passed)
- cargo test -p tonk-ui --lib (28 passed)
- cargo check -p tonk-ui --target wasm32-unknown-unknown
- cargo test -p tonk-access-service --features helpers --lib (79 passed)
- cargo check -p tonk-access-service --target wasm32-unknown-unknown
- cargo test -p tonk-cli --lib (189 passed)
- cargo test -p tonk-cli --test telemetry (5 passed)
- focused real-Chrome ordered signup telemetry journey (1 passed)
- Storybook build check (26 screens, 78 journeys, 115 verification items)
- Storybook links (168 valid)
- Wrangler 4.128 accepts staging observability/query-redaction configuration
- PostHog dashboard queries executed successfully against the empty pre-deploy stream

## Known rollout gates

- no deployment is part of this PR
- the full Wrangler custom-build dry run remains incomplete because the local disk had about 6 GB free
- the older full signup browser journey still times out on its pre-existing post-activation passkey-device label assertion; the focused telemetry journey passes
- generic exception capture remains disabled pending source-map and outbound-redaction proof
- PostHog alerts remain disabled until staging evidence is reviewed

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements related to account observability, telemetry, and error handling in the Tonk application, including new modules, structured logging, and refined event tracking for account-related actions.

### Detailed summary
- Added `thiserror` dependency for better error handling.
- Introduced `observability` module for structured logging.
- Enhanced account event tracking with `account_event` schema.
- Updated `Cargo.toml` and `Cargo.lock` to include new dependencies.
- Improved error handling in various request handlers.
- Added tests for account event capturing and CLI commands.
- Documented observability practices in `docs/account-observability.md`.

> The following files were skipped due to too many changes: `rust/tonk-ui/src/account_flow.rs`, `rust/tonk-access-service/src/handlers/ucan.rs`, `rust/tonk-cli/src/account.rs`, `rust/tonk-ui/src/register_dialog.rs`, `rust/tonk-ui/src/user_error.rs`, `rust/tonk-ui/src/account_observability.rs`, `rust/tonk-cli/src/bin/tonk.rs`, `rust/tonk-analytics/src/account.rs`, `rust/tonk-ui/src/api.rs`, `rust/tonk-ui/src/account.rs`, `plan/account-observability.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->