### PR TITLE
Retry the settings customer probe instead of freezing

### DIFF
--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -566,17 +566,22 @@ fn load_activation_notice(host: HtmlElement) {
             Err(error) => {
                 let problem = user_error::api_problem(AccountAction::LoadRegistration, &error);
                 attempt.finish(tonk_analytics::account::Stage::AccountLoad, problem.outcome);
-                set_text(
-                    &host,
-                    "#account-registration-value",
-                    "Unavailable — reload to retry",
-                );
                 if host.has_attribute(ACCOUNT_NOT_READY) {
                     show_automatic_api_error(&host, AccountAction::LoadRegistration, &error);
                 } else {
                     log_action_error(AccountAction::LoadAccount, &error.to_string());
                 }
-                return;
+                // One failed probe is not an answer. The dashboard often
+                // loads while the worker is still hydrating the account
+                // it navigated in from — activation hands the tab
+                // straight here — and returning froze the panel on
+                // "reload to retry" with `data-backup` never settled,
+                // so nothing downstream (the pending-backup drain, the
+                // e2e waiter) ever ran. Fall into the retry loop below
+                // instead; `Value::Null` marks the probe as unanswered,
+                // which also keeps the enrollment fallthrough from
+                // treating a failure as an authoritative absence.
+                serde_json::Value::Null
             }
         };
         // A linked account the access service does not know is one that
@@ -585,7 +590,8 @@ fn load_activation_notice(host: HtmlElement) {
         // that — registration is web-only — so enroll right here, with
         // the device-chained deposit since no ceremony is at hand, and
         // fall through to the ordinary pending notice.
-        if state["status"].is_null()
+        if !state.is_null()
+            && state["status"].is_null()
             && crate::deployment::get()
                 .await
                 .is_ok_and(|config| config.service_did.is_some())
@@ -620,6 +626,9 @@ fn load_activation_notice(host: HtmlElement) {
                         "Not registered — reload to retry",
                     );
                     show_api_error(&host, AccountAction::LoadAccount, &error);
+                    // Settled the same way the exhausted probe is:
+                    // a reload retries, so say so.
+                    let _ = host.set_attribute("data-backup", "stuck");
                     return;
                 }
             }
@@ -650,6 +659,12 @@ fn load_activation_notice(host: HtmlElement) {
                 if let Some(error) = last_probe_error {
                     log_action_error(AccountAction::LoadAccount, &error);
                 }
+                // The settled answer for a probe that never came:
+                // "stuck" is the state a reload retries, which is what
+                // the message asks for and what the e2e waiter does —
+                // leaving the attribute unset left both waiting on
+                // nothing.
+                let _ = host.set_attribute("data-backup", "stuck");
                 return;
             }
             wait_for(500).await;


### PR DESCRIPTION
Staging's e2e job keeps failing intermittently on "the dashboard never reported the account backup done (last state: None)" — `it_authorizes_a_waiting_cli_from_the_browser` on the last two staging runs, `it_cuts_off_storage_access_when_an_invite_is_revoked` on the latest. The service log for the failing window shows the account activating and syncing fine, then total silence: no custody provisioning, no publish, no `data-backup` — the dashboard never acted on the Active answer at all.

That silence is the signature of `load_activation_notice`'s early returns. A single failed `/api/customer` read at dashboard load — likely exactly when the tab arrives from the activation page while the worker is still hydrating — returned with "Unavailable — reload to retry" and stopped: no retry, no pending-backup drain, and `data-backup` never set, so `wait_for_backup_done` (whose only recovery, a reload, triggers on `stuck`) stared at an absent attribute for its whole 90 seconds.

Three repairs, all inside the one function: a failed initial probe now falls into the retry loop that already existed for the transiently-absent-status case, instead of returning; the enrollment fallthrough fires only on an *answered* null status, so a probe failure can never be mistaken for an authoritative "this customer does not exist" and trigger a spurious re-enrollment; and every give-up path settles `data-backup` as `stuck`, which is the state whose remedy — a reload — is both what the message asks the person for and what the e2e waiter does automatically.

These two tests are the un-quarantined stragglers of #852's cluster; the deterministic ones stay quarantined and tracked there.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of account loading errors and the retry mechanism in the `load_activation_notice` function, ensuring a smoother user experience when the account is not ready.

### Detailed summary
- Removed the old error handling that set a text message for unavailable registration.
- Added comments explaining the rationale for handling unanswered probes.
- Changed the condition to check if `state` is not null before checking `status`.
- Updated the logic to set the `data-backup` attribute to "stuck" when a reload is needed.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->