### PR TITLE
Update view docs for the show dictionary

### DIFF
--- a/plan/view-anchor-render-parity.md
+++ b/plan/view-anchor-render-parity.md
@@ -1,5 +1,15 @@
 # View anchors and render parity
 
+Status: **superseded, not shipped.** Do not follow this plan.
+
+It assumes a view is its own entity with a `model` back pointer, and proposes
+pinning that entity through `--anchor`. The dictionary redesign (#808) removed
+the view entity instead: a view's `this` IS the model, and its templates are
+`show` entries keyed by facet, cardinality one per (model, facet). So there is
+nothing left to anchor, `--anchor` and `--name` are both rejected at parse
+time, and the duplicate-view ordering problem the render-parity half solves
+cannot arise. See `rust/tonk-core/docs/templates.md` and `tonk help views`.
+
 **Goal:** Make view identity explicit at authoring time and make `tonk render`
 show every view entry that the browser would mount, so an accidental duplicate
 is visible from the CLI instead of being hidden by first-row selection.

--- a/rust/tonk-cli/src/guide-element-tonk-display.md
+++ b/rust/tonk-cli/src/guide-element-tonk-display.md
@@ -12,7 +12,7 @@ you render ultimately hangs off a `<tonk-display>`.
 <!-- every instance, the directory view -->
 <tonk-display model="task"></tonk-display>
 
-<!-- one entity through the built-in label-view concept -->
+<!-- one entity through the built-in label facet -->
 <tonk-display model="person" entity="did:key:z6Mk…" view="label"></tonk-display>
 ```
 
@@ -22,7 +22,7 @@ you render ultimately hangs off a `<tonk-display>`.
 |------|---------|
 | `model` | The concept to render — bookmark name (`person`) or entity URI. **Required.** |
 | `entity` | The single entity to render. Absent → **directory mode** (every instance). |
-| `view` | The *view concept* to resolve the template through (named or URI). Omitted uses the model's built-in detail view (`entity` present) or directory view (absent). |
+| `view` | The *show facet* to render (`label`, `title`, or any key the model's `show` dictionary carries) — a plain key, never a concept URI. Omitted uses the mode default: `ui` (`entity` present) or `directory` (absent). |
 
 All three are live subscriptions: seed a concept, edit a template, or add
 an instance after mount and the display updates without a reload. A
@@ -32,7 +32,7 @@ context attributes thread into the mounted view in place.
 ## Nesting (following references)
 
 To render a reference field, nest a display over it — `entity` is the
-reference, `model` the referenced concept, `view` the view you want:
+reference, `model` the referenced concept, `view` the facet you want:
 
 ```html
 <strong>
@@ -40,7 +40,7 @@ reference, `model` the referenced concept, `view` the view you want:
 </strong>
 ```
 
-`tonk:view/label` renders just a name; `tonk:view` the full detail card.
+The `label` facet renders just a name; omitting `view` renders the `ui` facet, the full detail card.
 
 ## Directory data-rows
 

--- a/rust/tonk-cli/tests/render.rs
+++ b/rust/tonk-cli/tests/render.rs
@@ -11,9 +11,9 @@ use tonk_cli::render::{self, RenderRoute};
 
 use crate::common::TestSite;
 
-// Site init seeds the standard library (`tonk:view`,
-// `tonk:view/directory`, etc.), so these tests rely on the built-in
-// view concepts being present rather than seeding them by hand.
+// Site init seeds the standard library (the `tonk:view` concept and
+// the `tonk:_` default dictionary), so these tests rely on the
+// built-in view concept being present rather than seeding it by hand.
 
 const PERSON_CONCEPT: &str = r#"attribute!: &person-name
   description: "person name"

--- a/rust/tonk-display/README.md
+++ b/rust/tonk-display/README.md
@@ -11,7 +11,7 @@ The element is a `cdylib` WASM custom element. You place it in the page, point i
 <!-- every instance of the model, default directory view -->
 <tonk-display model="task"></tonk-display>
 
-<!-- a named or URI view concept -->
+<!-- an explicit show facet -->
 <tonk-display model="task" view="board"></tonk-display>
 ```
 
@@ -19,7 +19,7 @@ The element is a `cdylib` WASM custom element. You place it in the page, point i
 
 - `model`: names the subject's model concept, by bookmark name (`person`) or entity URI (anything containing `:`). Required.
 - `entity`: the URI of the single entity to render. Absent selects directory mode (every instance of the model).
-- `view`: names the *view concept* to resolve the template through (named or URI). Omitting it uses the built-in `view` concept in detail mode or the built-in `view/directory` concept in directory mode. `view="about:blank"` is reserved for a future carousel mode and currently errors.
+- `view`: names the *show facet* to render (`label`, `title`, or any key the model's `show` dictionary carries). Omitting it uses the mode default: `ui` in detail mode, `directory` in directory mode. A facet containing `:` is rejected as a descriptor error, since a facet is a plain key and not a concept URI. `view="about:blank"` is checked before that guard and stays reserved for a future carousel mode, which currently errors.
 
 A change to `model`, `entity`, or `view` restarts the resolve/subscribe flow. `data-active` (and other `dom.host/*` context attributes a parent view threads in) is propagated into the already-mounted view in place without restarting.
 
@@ -29,7 +29,7 @@ Resolving one display walks model -> view -> entities -> bind:
 
 1. **Model.** The `model` attribute is resolved to a concept descriptor. A bookmark name is first turned into its referent URI through the Name concept (`name_query`), then `phase1_query` reads the concept-of-concept row and pulls the descriptor JSON out of its `source` field. This is a *live* subscription: a concept seeded after the element mounts pushes a frame and the display recovers without a reload.
 
-2. **View.** With the model entity and a view-concept descriptor in hand, `view_by_model_query` finds the instance of that view concept whose `model` field equals the model entity and projects its `display` field, the template HTML. This too is a live subscription, so editing the template on the branch swaps the rendered DOM. The view concept is the query predicate and `model` is the constraint, so the `view` attribute names a *concept*, not one fixed entity. Detail mode reads `display` from `xyz.tonk.view/display`; directory mode reads it from `xyz.tonk.view/directory`, letting a model declare a detail view and a directory view independently.
+2. **View.** With the model entity in hand, `view_query` pins `this` to it and projects its whole `show` dictionary, one flat row per facet. This too is a live subscription, so editing a template on the branch swaps the rendered DOM. A view instance's `this` IS the model, so there is no `model` field to constrain and no separate view entity to find. `select_rows` folds the rows into one conclusion and `show_template` picks the facet: the `view` attribute names a *facet* (`label`, `title`, ...), not a concept. Detail mode defaults to the `ui` facet, directory mode to `directory`, letting a model declare both independently in the same dictionary.
 
 3. **Entities.** A third live subscription projects every field in the model descriptor's `with:` map. `entity_query` pins `this` to the `entity` URI (detail); `instances_query` leaves `this` unbound (directory), matching every instance. `?key=value` filters on the `model` attribute are applied as constants on those terms.
 
@@ -64,15 +64,15 @@ A nested `<tonk-display>` inside a template mounts exactly once: rows build deta
 
 The presence of the `entity` attribute selects the mode:
 
-- **Detail** (`entity` set): pins `this` to that URI, resolves the model's detail view (`xyz.tonk.view/display`), and renders a single entity. The entity subscription frame is size 0 (entity absent or removed) or 1.
-- **Directory** (`entity` absent): leaves `this` unbound, resolves the model's directory view (`xyz.tonk.view/directory`), and renders every instance. A directory view declared with `model: _:_` matches any model.
+- **Detail** (`entity` set): pins `this` to that URI, resolves the model's `ui` facet, and renders a single entity. The entity subscription frame is size 0 (entity absent or removed) or 1.
+- **Directory** (`entity` absent): leaves `this` unbound, resolves the model's `directory` facet, and renders every instance. A view declared with `this: tonk:_` supplies the facet for any model that lacks its own.
 
 In both modes the query engine emits one flat row per tuple, so cardinality-many fields and multiple subjects arrive as separate rows. [`select_rows`] (in `fold`) groups rows by `this` and folds each group into one conclusion per subject, collapsing multi-valued fields to a list in first-seen order (identical values stay a scalar). Detail mode is then just a one-conclusion frame and directory mode a many-conclusion frame, rendered by the same repeat machinery.
 
 ## Modules
 
 - [`element`](src/element.rs): the `<tonk-display>` orchestrator: lifecycle, the three subscriptions, mode selection, slide mounting (wasm only).
-- [`resolve`](src/resolve.rs): wire-query construction (`name_query`, `phase1_query`, `view_by_model_query`, `entity_query`, `instances_query`) and `source` parsing. Query builders are target-independent.
+- [`resolve`](src/resolve.rs): wire-query construction (`name_query`, `phase1_query`, `view_query`, `entity_query`, `instances_query`) and `source` parsing. Query builders are target-independent.
 - [`view`](src/view.rs): the `<tonk-view>` dumb renderer (wasm only).
 - [`template`](src/template.rs): segment parsing, the chrome/repeat binding plan, and DOM walking (planning is target-independent; DOM walking is wasm only).
 - [`render`](src/render.rs): the mounted-state DOM renderer for a `<tonk-view>` frame (wasm only).

--- a/rust/tonk-template/README.md
+++ b/rust/tonk-template/README.md
@@ -19,12 +19,13 @@ construction.
   fields lowered to `PlanNode::Iteration`. This half is std-only and
   target-agnostic.
 - **[`resolve`]** — the wire-query builders (`phase1_query`, `name_query`,
-  `view_by_model_query`, `entity_query`, `instances_query`, `view_predicate`,
-  `directory_view_predicate`, `parse_source`) that drive the model → view →
-  entity resolution. They produce `tonk_schema::query::Query`.
+  `view_query`, `entity_query`, `instances_query`, `view_predicate`,
+  `parse_source`) that drive the model → view → entity resolution. They
+  produce `tonk_schema::query::Query`.
 - **[`fold`]** — `select_rows`, which groups flat query rows by `this` into one
   folded `Conclusion` per subject, collapsing cardinality-many fields to
-  `Ipld::List`.
+  `Ipld::List`, and `show_template`, which picks one facet's template out of a
+  folded `show` dictionary.
 
 ## Dependencies
 


### PR DESCRIPTION
#808 made a view its model's `show` dictionary, but several docs still describe the shape it replaced: a view as its own entity carrying a `model` back-pointer to the concept it renders. Anyone reading them to author a view gets a design that no longer exists, and the two READMEs name functions (`view_by_model_query`, `directory_view_predicate`) that were deleted in that PR.

The `<tonk-display>` guide is the sharpest case. Its attribute table still calls `view` a *view concept, named or URI*, when a `:` in that attribute is now rejected outright with "`view` names a show facet (e.g. `label`), not a concept URI". The table tells you to write the one thing that errors.

Corrected to the shipped shape throughout: `this` is the model, `show` holds templates keyed by facet, and `view=` names a facet.

`plan/view-anchor-render-parity.md` needed different handling. It argues for keeping per-view entities and pinning them with `--anchor`, which is the opposite of what shipped, and `--anchor` is now rejected at parse time by a test in `bin/tonk.rs`. It reads as current planned work rather than history, so it gets a `Status: superseded, not shipped` header explaining why, following the convention other plans in that directory already use. Kept rather than deleted since it records a decision.

Verified with `cargo check` on the affected crates (the CLI guide is `include_str!`d into the binary) and `cargo clippy --all --all-targets --all-features -- -D warnings`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating terminology and clarifying concepts related to views and facets in the `tonk` framework, enhancing documentation and comments for better understanding.

### Detailed summary
- Updated comments in `rust/tonk-cli/tests/render.rs` to clarify the standard library concepts.
- Changed references from "view concept" to "show facet" in multiple documentation files.
- Adjusted descriptions of the `view` attribute in `rust/tonk-cli/src/guide-element-tonk-display.md`.
- Modified explanations of rendering modes (detail and directory) to reflect updated terminology.
- Revised the description of query construction in `rust/tonk-display/README.md` to specify the use of facets instead of concepts.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->