### PR TITLE
test(e2e): wait for the activation done panel to show, not just exist

### DIFF
--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -744,7 +744,12 @@ mod tests {
         driver.switch_to_window(confirm).await?;
         goto(driver, &link).await?;
         element(driver, "#activate-accept").await?.click().await?;
-        element(driver, "#activate-done").await?;
+        // Displayed, not merely present: the done panel is in the DOM
+        // from page load, only hidden, so a presence wait returns while
+        // the activation POST is still in flight — and closing the tab
+        // then abandons the request and drops the flow's terminal
+        // telemetry event. Visible means the response landed.
+        wait_for_displayed(driver, "#activate-done").await?;
         driver.close_window().await?;
         driver.switch_to_window(ceremony).await?;
         Ok(())
@@ -895,7 +900,12 @@ mod tests {
         let account = driver.current_url().await?;
         goto(driver, &link).await?;
         element(driver, "#activate-accept").await?.click().await?;
-        element(driver, "#activate-done").await?;
+        // Displayed, not merely present: the done panel is in the DOM
+        // from page load, only hidden, so a presence wait returns while
+        // the activation POST is still in flight — and navigating away
+        // then abandons the request and drops the flow's terminal
+        // telemetry event. Visible means the response landed.
+        wait_for_displayed(driver, "#activate-done").await?;
         // Activation is what unblocks the deferred account work, and the
         // custody-cell publish in that queue is what every later ceremony
         // (unlock, CLI approval, legacy link) resolves. The dashboard


### PR DESCRIPTION
## What changed

Follow-up to #858: the staging push run [2319](https://github.com/tonk-labs/tonk/actions/runs/33589384885) failed 1 of 78 — `it_captures_the_ordered_signup_account_journey`, with the captured stream showing `activate_account` started and checkpointed at `access_service` but never finished.

Root cause is in the harness's activation helpers, not the product: the activation page keeps `#activate-done` in the DOM from load, only `hidden`, and the harness's `element()` matches on presence. Both helpers could therefore sail past the accept click while the activation POST was still in flight and navigate away (or close the tab), abandoning the request. The activation itself usually survived — the service had already consumed the invocation — which is why every other test passed; only the page's terminal telemetry event died with the document, and the journey test is the one place that asserts on it. The same race could in principle abandon the activation entirely on a slow service, so the tightened wait also hardens every flow that goes through these helpers.

The fix: wait for `#activate-done` to be **displayed**, which means the response landed and the attempt finished before the flow moves on.

## Verification

In the local harness (`cargo nextest run -p tonk-ui --features integration-tests --profile e2e -E '…'`): `it_captures_the_ordered_signup_account_journey`, `it_finishes_both_waiting_devices_when_a_third_confirms` (multi-tab helper), and `it_signs_up_through_the_account_panels` (same-tab helper) all pass three consecutive rounds (9/9).

## Storybook impact

- [ ] This fixes a user-visible bug. The regression test and Storybook now share this ID: 
- [x] No user-visible contract changed because: this is a test-harness-only change; no product code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuH1TzUwQiar2362kTvMoq

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuH1TzUwQiar2362kTvMoq)_

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the visibility handling of the `#activate-done` element in the account flow, ensuring it waits for the element to be displayed rather than just present in the DOM, preventing issues with abandoned requests.

### Detailed summary
- Removed direct wait for the presence of `#activate-done`.
- Added comments explaining the importance of waiting for the element to be displayed.
- Introduced `wait_for_displayed(driver, "#activate-done").await?` to ensure the element is visible before proceeding.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->