### PR TITLE
fix(account): leave the deletion result on a fresh settings page

### DIFF
--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -3047,8 +3047,16 @@ fn bind(host: &HtmlElement) {
         }
     });
 
+    // The result stands on a page that no longer describes the profile
+    // under it: permanent deletion rotated the browser onto a fresh
+    // profile, and a space deletion removed a listed space. A client-side
+    // route to the same path is a no-op, so load the settings document
+    // afresh, dropping any `?delete-space` entry that would re-open the
+    // flow for a space that is now gone.
     on_click(host, "#account-confirm-result-back", |_| {
-        tonk_host::navigate_to("/settings");
+        if let Some(window) = window() {
+            let _ = window.location().assign("/settings");
+        }
     });
 
     // Opening Add account is reversible navigation. The final Create or Log

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -5249,18 +5249,27 @@ mod tests {
             "wrong confirmation email must refuse: {refused}"
         );
 
-        let deleted = post_json(
+        // The real thing: the reviewed dialog, the typed address, the
+        // acknowledgement, and the passkey gesture the virtual
+        // authenticator answers — the path a person takes.
+        click(&driver, "#account-delete-review").await?;
+        wait_for_displayed(&driver, "#account-delete-arming").await?;
+        element(&driver, "#account-delete-email")
+            .await?
+            .send_keys(email)
+            .await?;
+        element(&driver, "#account-delete-understood")
+            .await?
+            .click()
+            .await?;
+        click(&driver, "#account-delete-submit").await?;
+        wait_for_text(&driver, "#account-confirm-title", "complete").await?;
+        wait_for_text_containing(
             &driver,
-            "/api/account/delete",
-            serde_json::json!({
-                "spaces": [{ "subject": subject }],
-                "confirmedEmail": email,
-            }),
+            "#account-confirm-body",
+            "1 owned space removed from Tonk services; 0 joined spaces left intact",
         )
         .await?;
-        let receipt = successful_body("delete the account", &deleted);
-        assert_eq!(receipt["deletedSpaces"], 1, "one hosted space purged");
-        assert_eq!(receipt["retainedJoinedSpaces"], 0);
 
         // The profile is unlinked: the deletion plan is no longer
         // reviewable because there is no account to review.
@@ -5268,6 +5277,19 @@ mod tests {
         assert_eq!(
             after["status"], 404,
             "a deleted account leaves nothing to plan against: {after}"
+        );
+
+        // Leaving the result must land on the fresh profile's page, not
+        // the deleted account's panel still standing under the dialog.
+        click(&driver, "#account-confirm-result-back").await?;
+        element(&driver, "tonk-account[data-mode=\"choice\"]").await?;
+        assert!(
+            element(&driver, "#account-confirmation")
+                .await?
+                .attr("hidden")
+                .await?
+                .is_some(),
+            "the result dialog must not survive leaving it"
         );
 
         // Permanent deletion retires this account's local profile rather


### PR DESCRIPTION
Account deletion looked broken from the settings page. The purge, unlink, and profile rotation all completed, but the "back to settings" action on the result was a client-side route to `/settings`, which `navigate_to` treats as a no-op from `/settings`. The "complete" dialog stayed open over the deleted account's panel, still showing its email, passkey, and sign-out controls.

The result action now loads the settings document afresh, the way sign-out reloads, so the page rebuilds on the rotated profile. That also drops any `?delete-space` entry a CLI-opened space deletion carried, which would otherwise re-open the flow for a space that is gone.

The e2e test posted to the delete API directly and never saw the dialog. It now drives the real review, typed address, acknowledgement, passkey gesture, and the result action, and asserts the page lands in the fresh profile's mode before re-signing up on the released email.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the user experience during account deletion by ensuring proper navigation and updating the UI to reflect the changes after a profile is deleted.

### Detailed summary
- Added comments explaining the behavior after permanent deletion.
- Changed navigation method to ensure the settings document is loaded afresh.
- Updated the account deletion flow with additional UI interactions and checks.
- Ensured that the result dialog does not persist after leaving the deletion confirmation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->