### PR TITLE
chore: release 0.6.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "dialog-reactor"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4630,7 +4630,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-access-service"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4685,7 +4685,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-account"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "blake3",
@@ -4713,7 +4713,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-analytics"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "dialog-common",
  "hex",
@@ -4730,7 +4730,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-analyzer"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4755,7 +4755,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-board"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "custom-elements",
  "js-sys",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-cli"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4836,7 +4836,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-code"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4845,7 +4845,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-common"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "dialog-common",
  "futures-util",
@@ -4858,7 +4858,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-core"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "base58",
  "dialog-artifacts",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-display"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4902,7 +4902,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-email"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "serde",
  "serde_json",
@@ -4911,7 +4911,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-evaluator"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "dialog-artifacts",
@@ -4934,7 +4934,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-fab"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4955,7 +4955,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-guest"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "console_error_panic_hook",
  "custom-elements",
@@ -4978,7 +4978,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-host"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "bytes",
  "custom-elements",
@@ -5001,7 +5001,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-identity"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-inspector"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "bs58",
  "custom-elements",
@@ -5059,7 +5059,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-invite"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "bs58",
@@ -5076,7 +5076,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-language-server"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-macros"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-notation"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "dialog-common",
  "lsp-types",
@@ -5124,7 +5124,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-portal"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "bs58",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-prose"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5161,7 +5161,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-render"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "async-trait",
  "dialog-common",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-router"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "dialog-common",
  "tokio",
@@ -5187,7 +5187,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-schema"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5224,7 +5224,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-sigil"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "blake3",
  "bs58",
@@ -5236,7 +5236,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-table"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-template"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "dialog-common",
  "indexmap",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-tree"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "custom-elements",
  "js-sys",
@@ -5273,7 +5273,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-ui"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5321,7 +5321,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-worker"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5394,7 +5394,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-worker-api"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "dialog-artifacts",
  "dialog-capability",
@@ -5412,7 +5412,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-workspace"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "custom-elements",
  "dialog-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.10"
+version = "0.6.11"
 authors = ["Tonk Labs"]
 edition = "2024"
 license = "MIT"


### PR DESCRIPTION
## What changed

- Bump the workspace release from `0.6.10` to `0.6.11`.
- Regenerate the inherited workspace-package versions in `Cargo.lock`.
- Give the staging release workflow a new final version so it can create immutable tag `v0.6.11` and publish the matching CLI package.

This release commit unblocks the exact-SHA promotion tracked by #865. After this PR merges, `v0.6.11^{}` must equal the resulting `staging` head before `stable` is fast-forwarded to it.

## Verification

- Confirmed there was no existing `release/0.6.11` branch or PR.
- Confirmed `v0.6.11` does not exist remotely.
- Confirmed npm has no published `@tonk/cli@0.6.11` version.
- `cargo check -p tonk-cli`
- `cargo pkgid -p tonk-cli` reports `tonk-cli#0.6.11`.
- `cargo fmt --all -- --check`
- `cargo test -p tonk-cli` — passed: 190 library tests, 32 binary tests, and all executed integration and doc tests; one pre-existing schema-render test remains ignored.
- `git diff --check`

## Storybook impact

- [ ] User-visible browser or CLI behavior changed. I updated these screen, journey, verification, or triage IDs:
- [ ] This fixes a user-visible bug. The regression test and Storybook now share this ID:
- [x] No user-visible contract changed because: this PR changes release metadata only; the product changes and their Storybook coverage are already on `staging`.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version number for multiple packages in the `Cargo.toml` and `Cargo.lock` files from `0.6.10` to `0.6.11`, indicating a new release for these packages.

### Detailed summary
- Updated `version` for the following packages from `0.6.10` to `0.6.11`:
  - `dialog-reactor`
  - `tonk-access-service`
  - `tonk-account`
  - `tonk-analytics`
  - `tonk-analyzer`
  - `tonk-board`
  - `tonk-cli`
  - `tonk-code`
  - `tonk-common`
  - `tonk-core`
  - `tonk-display`
  - `tonk-email`
  - `tonk-evaluator`
  - `tonk-fab`
  - `tonk-guest`
  - `tonk-host`
  - `tonk-identity`
  - `tonk-inspector`
  - `tonk-invite`
  - `tonk-language-server`
  - `tonk-macros`
  - `tonk-notation`
  - `tonk-portal`
  - `tonk-prose`
  - `tonk-render`
  - `tonk-router`
  - `tonk-schema`
  - `tonk-sigil`
  - `tonk-table`
  - `tonk-template`
  - `tonk-tree`
  - `tonk-ui`
  - `tonk-worker`
  - `tonk-worker-api`
  - `tonk-workspace`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->