### PR TITLE
fix(sw): compose account setup with upgrades

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -650,7 +650,7 @@
 
           # This package is used by integration tests to run a web server
           # over a local deployment of tonk-ui with Caddy as reverse proxy
-          # to route /ucan/* to the access service
+          # to route the access-service surface behind the page origin
           tonk-ui-test-server =
             with pkgs;
             writeScriptBin "tonk-ui-test-server" ''
@@ -688,6 +688,9 @@
               https://tonk.network:$PORT, https://localhost:$PORT {
                   tls internal
                   handle /.well-known/tonk {
+                      reverse_proxy localhost:$ACCESS_SERVICE_PORT
+                  }
+                  handle /capabilities {
                       reverse_proxy localhost:$ACCESS_SERVICE_PORT
                   }
                   handle /ucan/* {

--- a/rust/tonk-access-service/src/handlers.rs
+++ b/rust/tonk-access-service/src/handlers.rs
@@ -1,5 +1,6 @@
 //! HTTP request handlers.
 
+pub mod capabilities;
 pub mod config;
 pub mod deletion;
 pub mod health;

--- a/rust/tonk-access-service/src/handlers/capabilities.rs
+++ b/rust/tonk-access-service/src/handlers/capabilities.rs
@@ -1,0 +1,62 @@
+//! Privacy-neutral setup protocol discovery.
+
+use serde::Serialize;
+use worker::*;
+
+/// Version required by the account producer before it can create a passkey.
+pub(crate) const ACCOUNT_SETUP_LIFECYCLE_VERSION: u8 = 1;
+
+#[derive(Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Capabilities {
+    account_setup_lifecycle: u8,
+}
+
+/// Exact additive response shared by the Worker and native test server.
+#[derive(Debug, PartialEq, Eq, Serialize)]
+pub(crate) struct CapabilitiesResponse {
+    service: &'static str,
+    capabilities: Capabilities,
+}
+
+/// Build the stable marker without consulting account or customer state.
+pub(crate) const fn response_body() -> CapabilitiesResponse {
+    CapabilitiesResponse {
+        service: "tonk-access-service",
+        capabilities: Capabilities {
+            account_setup_lifecycle: ACCOUNT_SETUP_LIFECYCLE_VERSION,
+        },
+    }
+}
+
+fn with_cors(response: Response) -> Response {
+    let headers = response.headers().clone();
+    let _ = headers.set("Access-Control-Allow-Origin", "*");
+    let _ = headers.set("Access-Control-Allow-Methods", "GET, OPTIONS");
+    let _ = headers.set("Access-Control-Allow-Headers", "Content-Type");
+    let _ = headers.set("Access-Control-Expose-Headers", "Content-Type");
+    response.with_headers(headers)
+}
+
+/// Advertise the setup protocol the deployed access service implements.
+pub async fn handle(_req: Request, _ctx: RouteContext<()>) -> Result<Response> {
+    Response::from_json(&response_body()).map(with_cors)
+}
+
+/// Answer capability discovery preflight without reading account state.
+pub async fn handle_options(_req: Request, _ctx: RouteContext<()>) -> Result<Response> {
+    Ok(with_cors(Response::empty()?.with_status(204)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::response_body;
+
+    #[test]
+    fn it_pins_the_account_setup_lifecycle_marker() {
+        assert_eq!(
+            serde_json::to_string(&response_body()).unwrap(),
+            r#"{"service":"tonk-access-service","capabilities":{"accountSetupLifecycle":1}}"#
+        );
+    }
+}

--- a/rust/tonk-access-service/src/helpers/server.rs
+++ b/rust/tonk-access-service/src/helpers/server.rs
@@ -354,6 +354,18 @@ async fn handle_request(
         };
         return Ok(cors_response(response));
     }
+    if req.method() == Method::GET && req.uri().path() == "/capabilities" {
+        return Ok(cors_response(
+            Response::builder()
+                .status(StatusCode::OK)
+                .header(CONTENT_TYPE, "application/json")
+                .body(Full::new(Bytes::from(
+                    serde_json::to_vec(&crate::handlers::capabilities::response_body())
+                        .expect("capability marker serializes"),
+                )))
+                .unwrap(),
+        ));
+    }
     if req.method() == Method::GET && req.uri().path() == "/.well-known/did.json" {
         // The configured origin's host, for the same reason the customer
         // documents use it: a proxy's `Host` header is not the name the

--- a/rust/tonk-access-service/src/lib.rs
+++ b/rust/tonk-access-service/src/lib.rs
@@ -95,6 +95,9 @@ async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
         .get_async("/", handlers::info::handle)
         // Health check
         .get_async("/health", handlers::health::handle)
+        // Privacy-neutral protocol marker checked before account WebAuthn.
+        .get_async("/capabilities", handlers::capabilities::handle)
+        .options_async("/capabilities", handlers::capabilities::handle_options)
         // UCAN authorization CORS preflight; POST is served above.
         .options_async("/ucan/", handlers::ucan::handle_options)
         // Shortcut service: permissionless same-origin link shortening

--- a/rust/tonk-access-service/tests/deployment_config.rs
+++ b/rust/tonk-access-service/tests/deployment_config.rs
@@ -47,3 +47,25 @@ async fn it_returns_not_found_without_deployment_config() -> anyhow::Result<()> 
     service.stop().await?;
     Ok(())
 }
+
+#[dialog_common::test]
+async fn it_advertises_account_setup_lifecycle_without_account_state() -> anyhow::Result<()> {
+    let service = access_service(AccessServiceSettings::default()).await?;
+    let response = reqwest::get(format!(
+        "{}/capabilities",
+        service.address.access_service_url
+    ))
+    .await?;
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    assert_eq!(response.headers()["access-control-allow-origin"], "*");
+    assert_eq!(
+        response.json::<serde_json::Value>().await?,
+        serde_json::json!({
+            "service": "tonk-access-service",
+            "capabilities": { "accountSetupLifecycle": 1 },
+        })
+    );
+
+    service.stop().await?;
+    Ok(())
+}

--- a/rust/tonk-identity/src/ceremony.rs
+++ b/rust/tonk-identity/src/ceremony.rs
@@ -336,6 +336,23 @@ pub async fn unlock_root(endpoint: &str) -> Result<Ed25519Signer> {
     secret.signer().await
 }
 
+/// Unlock an account and mint the local root record for this browser.
+///
+/// Current sign-in is worker-mediated. This compatibility producer remains
+/// necessary for a page from before encryption-key persistence: it deliberately
+/// hands the caller the key so the test can omit it from the local root record
+/// and exercise the worker's assertion recovery path.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub async fn unlock_account(
+    device_did: dialog_varsig::Did,
+    endpoint: &str,
+) -> Result<RootCeremony> {
+    let (secret, credential_id) = assert_unlock(endpoint, None).await?;
+    let root = secret.signer().await?;
+    let encryption_key = secret.secret().did().to_string();
+    root_ceremony(root, credential_id, device_did, None, Some(encryption_key)).await
+}
+
 /// Derive the account's X25519 recipient through a custody assertion,
 /// for a device whose root record predates the key: the worker asks the
 /// page for this when it needs custody set up and nothing recorded it.

--- a/rust/tonk-identity/src/install.rs
+++ b/rust/tonk-identity/src/install.rs
@@ -32,6 +32,12 @@ fn js_error(error: anyhow::Error) -> JsValue {
     if let Some(name) = name {
         value.set_name(name);
     }
+    if error
+        .downcast_ref::<crate::passkey::CredentialCreatedError>()
+        .is_some()
+    {
+        let _ = Reflect::set(&value, &"tonkPasskeyCreated".into(), &JsValue::TRUE);
+    }
     value.into()
 }
 
@@ -65,7 +71,13 @@ async fn create_passkey(input: JsValue) -> Result<JsValue, JsValue> {
         .await
         .map_err(js_error)?;
     let request = Reflect::get(&input, &"request".into()).unwrap_or(JsValue::UNDEFINED);
-    mediate(custodian, request).await
+    mediate(custodian, request).await.map_err(|error| {
+        // `credentials.create()` has already returned a credential. Preserve
+        // that boundary across the JS/Rust relay so account setup never treats
+        // a later worker failure like a safe pre-creation retry.
+        let _ = Reflect::set(&error, &"tonkPasskeyCreated".into(), &JsValue::TRUE);
+        error
+    })
 }
 
 /// `addPasskey({ name?, displayName?, request })` → `{ credentialId }`.
@@ -332,6 +344,33 @@ async fn authorize_device(input: JsValue) -> Result<JsValue, JsValue> {
     Ok(output.into())
 }
 
+/// `unlockWithPasskey({ deviceDid, endpoint })` → the asserted local root.
+///
+/// This compatibility surface lets a legacy recovery test persist the exact
+/// pre-encryption-key record while keeping the derived recipient available to
+/// prove that the later page assertion restores it.
+async fn unlock_with_passkey(input: JsValue) -> Result<JsValue, JsValue> {
+    let device_did = string_property(&input, "deviceDid")?
+        .parse()
+        .map_err(|error| JsValue::from_str(&format!("invalid deviceDid: {error}")))?;
+    let endpoint = string_property(&input, "endpoint")?;
+    let unlock = crate::ceremony::unlock_account(device_did, &endpoint)
+        .await
+        .map_err(js_error)?;
+    let result = Object::new();
+    for (name, value) in [
+        ("rootDid", unlock.root_did),
+        ("credentialId", unlock.credential_id),
+        ("delegationHex", unlock.delegation_hex),
+    ] {
+        Reflect::set(&result, &name.into(), &value.into())?;
+    }
+    if let Some(encryption_key) = unlock.encryption_key {
+        Reflect::set(&result, &"encryptionKey".into(), &encryption_key.into())?;
+    }
+    Ok(result.into())
+}
+
 /// Install `window.tonkIdentity` on the page. Idempotent; a no-op
 /// outside a window context.
 pub fn install() {
@@ -359,6 +398,16 @@ pub fn install() {
         authorize_device.as_ref().unchecked_ref(),
     );
     authorize_device.forget();
+
+    let unlock_with_passkey = Closure::<dyn FnMut(JsValue) -> Promise>::new(|input: JsValue| {
+        future_to_promise(unlock_with_passkey(input))
+    });
+    let _ = Reflect::set(
+        &identity,
+        &"unlockWithPasskey".into(),
+        unlock_with_passkey.as_ref().unchecked_ref(),
+    );
+    unlock_with_passkey.forget();
 
     let sign_revocation = Closure::<dyn FnMut(JsValue) -> Promise>::new(|input: JsValue| {
         future_to_promise(sign_revocation(input))
@@ -429,6 +478,7 @@ mod tests {
             "createPasskey",
             "usePasskey",
             "addPasskey",
+            "unlockWithPasskey",
             "authorizeDevice",
             "signRevocation",
             "verifyPasskey",
@@ -436,5 +486,19 @@ mod tests {
             let function = Reflect::get(&identity, &name.into()).unwrap();
             assert!(function.is_function(), "{name} must be a function");
         }
+    }
+
+    #[dialog_common::test]
+    fn it_marks_failures_after_credentials_create_returns() {
+        let error = crate::passkey::after_credential_created(anyhow::anyhow!(
+            "the follow-up PRF assertion failed"
+        ));
+        let value = js_error(error);
+        assert_eq!(
+            Reflect::get(&value, &"tonkPasskeyCreated".into())
+                .unwrap()
+                .as_bool(),
+            Some(true)
+        );
     }
 }

--- a/rust/tonk-identity/src/passkey.rs
+++ b/rust/tonk-identity/src/passkey.rs
@@ -42,6 +42,29 @@ pub struct CustodyCredential {
     pub evaluation: Option<CustodyEvaluation>,
 }
 
+/// A later ceremony step failed after `credentials.create()` returned.
+///
+/// Callers use this phase marker to distinguish an ordinary pre-creation
+/// refusal from an outcome where retrying could mint a second credential.
+#[derive(Debug)]
+pub struct CredentialCreatedError(anyhow::Error);
+
+impl std::fmt::Display for CredentialCreatedError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, formatter)
+    }
+}
+
+impl std::error::Error for CredentialCreatedError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.0.as_ref())
+    }
+}
+
+pub(crate) fn after_credential_created(error: anyhow::Error) -> anyhow::Error {
+    anyhow::Error::new(CredentialCreatedError(error))
+}
+
 /// Why a passkey ceremony did not produce a credential.
 ///
 /// The browser answers with a `DOMException` whose `name` is the whole
@@ -295,7 +318,11 @@ pub async fn create_custody_passkey(
         .await
         .map_err(|e| ceremony_error("custody passkey creation failed", e))?
         .dyn_into()
-        .map_err(|_| anyhow!("credentials.create returned a non-public-key credential"))?;
+        .map_err(|_| {
+            after_credential_created(anyhow!(
+                "credentials.create returned a non-public-key credential"
+            ))
+        })?;
     let id = Uint8Array::new(&credential.raw_id()).to_vec();
     let evaluation = extract_custody(&credential);
     Ok(CustodyCredential { id, evaluation })

--- a/rust/tonk-identity/src/webcrypto_kek.rs
+++ b/rust/tonk-identity/src/webcrypto_kek.rs
@@ -597,7 +597,9 @@ impl dialog_capability::Provider<CreateCustodian> for Page {
             input.display_name.as_deref(),
         )
         .await?;
-        Custodian::from_credential(created).await
+        Custodian::from_credential(created)
+            .await
+            .map_err(crate::passkey::after_credential_created)
     }
 }
 

--- a/rust/tonk-ui/src/account.rs
+++ b/rust/tonk-ui/src/account.rs
@@ -2242,7 +2242,7 @@ pub(crate) async fn run_login_ceremony(
         }),
     )
     .await?;
-    Ok(())
+    await_registered_account().await
 }
 
 /// Run the account-creation ceremony, with no panel to report into.
@@ -2261,7 +2261,11 @@ pub(crate) async fn run_account_ceremony(
     email: &str,
     narrate: impl Fn(&str),
 ) -> Result<(), crate::custody_relay::CeremonyError> {
-    prepare_added_profile().await?;
+    let lease = crate::account_setup::begin().await?;
+    if let Err(error) = prepare_added_profile().await {
+        crate::account_setup::abandon_before_credential(&lease).await?;
+        return Err(crate::custody_relay::CeremonyError::said(error));
+    }
     narrate("Waiting for your passkey…");
 
     // The page's whole part: one passkey ceremony. The worker
@@ -2270,7 +2274,7 @@ pub(crate) async fn run_account_ceremony(
     // no key material exists in this document at any point.
     let provider = proposed_remote()?;
     narrate("Creating your account…");
-    crate::custody_relay::mediate_now(
+    let outcome = crate::custody_relay::mediate_now(
         "createPasskey",
         tonk_worker_api::CustodyIntent::CreateAccount(tonk_worker_api::AccountCreation {
             email: email.to_owned(),
@@ -2280,9 +2284,56 @@ pub(crate) async fn run_account_ceremony(
             created_on: Some(crate::device_name::current()),
         }),
     )
-    .await
-    .map_err(|error| error.message)?;
-    Ok(())
+    .await;
+    match outcome {
+        Ok(()) => settle_created_account(&lease).await,
+        Err(error) if !error.passkey_created => {
+            crate::account_setup::abandon_before_credential(&lease).await?;
+            Err(error)
+        }
+        Err(_) => Err(crate::account_setup::retained()),
+    }
+}
+
+/// Release update safety only after the worker can read back the account link
+/// its custody command persisted.
+///
+/// The custody reply follows the operator write, but the worker reactor can
+/// briefly keep serving the profile snapshot from before that write. Clearing
+/// the hold in that window lets a navigation or replacement worker render the
+/// browser as signed out even though a new passkey already exists. A bounded
+/// read-back closes that gap; failure retains the hold and therefore remains an
+/// unsafe-to-retry post-WebAuthn outcome.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn settle_created_account(
+    lease: &crate::account_setup::Lease,
+) -> Result<(), crate::custody_relay::CeremonyError> {
+    await_registered_account()
+        .await
+        .map_err(|_| crate::account_setup::retained())?;
+    crate::account_setup::settle(lease).await
+}
+
+/// Wait until the account reactor observes a worker-persisted attachment.
+///
+/// Custody replies after the operator write, but an immediate account read can
+/// still come from the reactor snapshot that preceded it. Both creation and
+/// login must cross this read-back boundary before their UI announces success;
+/// otherwise dismissing the ceremony can render the profile as signed out.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+async fn await_registered_account() -> Result<(), crate::custody_relay::CeremonyError> {
+    for _ in 0..60 {
+        if matches!(
+            crate::api::account_status().await,
+            Ok(AccountStatus::Registered { .. })
+        ) {
+            return Ok(());
+        }
+        wait_for(250).await;
+    }
+    Err(crate::custody_relay::CeremonyError::said(
+        "the linked account did not become readable",
+    ))
 }
 
 /// Whether this deployment registers accounts with an access service at
@@ -2569,7 +2620,6 @@ fn bind(host: &HtmlElement) {
             Ok(value) => value,
             Err(error) => return show_error(&host, error),
         };
-        let device_name = crate::device_name::current();
         set_busy(&host, true, "Waiting for your passkey…");
         spawn_local(async move {
             let mut attempt = crate::account_observability::WebAccountAttempt::start(
@@ -2578,30 +2628,10 @@ fn bind(host: &HtmlElement) {
                 tonk_analytics::account::Trigger::User,
                 tonk_analytics::account::AccountState::None,
             );
-            let result = async {
-                prepare_added_profile().await?;
-                // The page's whole part: one passkey ceremony. The
-                // worker generates the account secret, seals it under
-                // the new passkey's KEK, records the root, signs the
-                // creation request and enrolls — so no key material
-                // exists in this document at any point.
-                let provider = service(&host).await?;
-                crate::custody_relay::mediate_now(
-                    "createPasskey",
-                    tonk_worker_api::CustodyIntent::CreateAccount(
-                        tonk_worker_api::AccountCreation {
-                            email: email.clone(),
-                            device_name,
-                            remote: proposed_remote()?,
-                            provider,
-                            created_on: Some(crate::device_name::current()),
-                        },
-                    ),
-                )
-                .await?;
-                set_busy(&host, true, "Creating your account…");
-                Ok::<(), crate::custody_relay::CeremonyError>(())
-            }
+            let narration_host = host.clone();
+            let result = run_account_ceremony(&email, move |status| {
+                set_busy(&narration_host, true, status);
+            })
             .await;
             match result {
                 Ok(()) => attempt.finish(
@@ -2617,7 +2647,14 @@ fn bind(host: &HtmlElement) {
                         tonk_analytics::account::Stage::WorkerHandoff,
                         problem.outcome,
                     );
-                    set_busy(&host, false, "");
+                    set_busy(
+                        &host,
+                        error.retry_unsafe,
+                        error
+                            .retry_unsafe
+                            .then_some("Account recovery needs attention")
+                            .unwrap_or(""),
+                    );
                     show_ceremony_error(&host, AccountAction::CreateAccount, &error);
                 }
             }
@@ -2871,6 +2908,7 @@ fn bind(host: &HtmlElement) {
                         "remote": proposed_remote()?,
                         "descriptorHex": authorized.descriptor_hex,
                         "credentialId": authorized.root_did,
+                        "remote": proposed_remote()?,
                         "attachmentId": attachment_id,
                         "serviceUrl": service(&host).await.unwrap_or_default(),
                     })

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -220,7 +220,33 @@ mod tests {
     /// touches the bar or a space page goes through here.
     async fn enter_guest(driver: &WebDriver) -> Result<()> {
         driver.enter_default_frame().await?;
-        let frame = element(driver, "tonk-site > iframe").await?;
+        let frame = match element(driver, "tonk-site > iframe").await {
+            Ok(frame) => frame,
+            Err(error) => {
+                let state = driver
+                    .execute(
+                        r##"const site = document.querySelector("tonk-site");
+                           return {
+                             url: String(location.href),
+                             ready: document.readyState,
+                             controlled: !!navigator.serviceWorker?.controller,
+                             bodyChildren: [...document.body.children].map(node => node.localName),
+                             root: document.querySelector("#tonk-root")?.outerHTML || null,
+                             site: site ? {
+                               attributes: Object.fromEntries([...site.attributes].map(attr => [attr.name, attr.value])),
+                               children: [...site.children].map(node => node.localName),
+                             } : null,
+                             errors: globalThis.__tonkTestErrors || [],
+                             installProgress: globalThis.__tonkTestInstallProgress || [],
+                           };"##,
+                        Vec::new(),
+                    )
+                    .await
+                    .map(|result| result.json().clone())
+                    .unwrap_or(serde_json::Value::Null);
+                return Err(error).context(format!("top-document guest state: {state}"));
+            }
+        };
         frame.enter_frame().await?;
         Ok(())
     }
@@ -346,10 +372,30 @@ mod tests {
             if controlled == Some(true) {
                 return Ok(());
             }
-            anyhow::ensure!(
-                tokio::time::Instant::now() < deadline,
-                "the service worker never took control of the page"
-            );
+            if tokio::time::Instant::now() >= deadline {
+                let state = driver
+                    .execute_async(
+                        r#"const done = arguments[arguments.length - 1];
+                           navigator.serviceWorker.getRegistration().then(registration => done({
+                             url: String(location.href),
+                             ready: document.readyState,
+                             build: document.querySelector('meta[name="tonk-worker-build"]')?.content || null,
+                             controller: navigator.serviceWorker.controller?.scriptURL || null,
+                             active: registration?.active?.state || null,
+                             waiting: registration?.waiting?.state || null,
+                             installing: registration?.installing?.state || null,
+                             errors: globalThis.__tonkTestErrors || [],
+                             progress: globalThis.__tonkTestInstallProgress || [],
+                           })).catch(error => done({ error: String(error) }));"#,
+                        vec![],
+                    )
+                    .await
+                    .map(|ret| ret.json().clone())
+                    .unwrap_or(serde_json::Value::Null);
+                return Err(anyhow!(
+                    "the service worker never took control of the page: {state}"
+                ));
+            }
             tokio::time::sleep(Duration::from_millis(250)).await;
         }
     }
@@ -402,38 +448,10 @@ mod tests {
         first: &WebDriver,
         first_authenticator: &str,
     ) -> Result<(WebDriver, String)> {
-        let source = ChromeDevTools::new(first.handle.clone());
-        let credentials = source
-            .execute_cdp_with_params(
-                "WebAuthn.getCredentials",
-                serde_json::json!({ "authenticatorId": first_authenticator }),
-            )
-            .await?;
-        let credentials = credentials["credentials"]
-            .as_array()
-            .cloned()
-            .ok_or_else(|| anyhow!("Chrome omitted the virtual authenticator credentials"))?;
-        if credentials.is_empty() {
-            return Err(anyhow!(
-                "the first device registered no passkey, so there is none to carry over"
-            ));
-        }
-
         let (second, authenticator) = driver_with_prf_authenticator(env).await?;
-        let devtools = ChromeDevTools::new(second.handle.clone());
-        for credential in credentials {
-            devtools
-                .execute_cdp_with_params(
-                    "WebAuthn.addCredential",
-                    serde_json::json!({
-                        "authenticatorId": authenticator,
-                        "credential": credential,
-                    }),
-                )
-                .await?;
-        }
+        copy_credentials(first, first_authenticator, &second, &authenticator).await?;
 
-        // What the copy above loses: the credential's PRF secret.
+        // What the credential copy loses: the credential's PRF secret.
         // `WebAuthn.getCredentials` exports the signing key but not the
         // hmac-secret, so the copied passkey signs fine and yields no
         // PRF outputs — and custody derives its keys from those, so a
@@ -1520,12 +1538,27 @@ mod tests {
         let row = match element(&second, "#tonk-register-confirm-row").await {
             Ok(row) => row,
             Err(error) => {
-                if let Ok(status) = second.find(By::Css("#tonk-register-status")).await {
-                    let text = status.text().await.unwrap_or_default();
-                    eprintln!("PROBE register status: {text:?}");
-                }
+                let state = second
+                    .execute_async(
+                        r##"const done = arguments[arguments.length - 1];
+                           const action = document.querySelector('#tonk-register-action');
+                           fetch('/api/account').then(async response => done({
+                             status: document.querySelector('#tonk-register-status')?.textContent?.trim() || null,
+                             action: action?.textContent?.trim() || null,
+                             actionHidden: action?.hasAttribute('hidden') ?? null,
+                             rows: [...document.querySelectorAll('#tonk-register .orow')].map(row => row.textContent.trim()),
+                             accountStatus: response.status,
+                             account: await response.text(),
+                           })).catch(error => done({ diagnosticError: String(error) }));"##,
+                        Vec::new(),
+                    )
+                    .await
+                    .map(|result| result.json().clone())
+                    .unwrap_or(serde_json::Value::Null);
                 dump_browser_log(&second, &env).await;
-                return Err(error);
+                return Err(error).context(format!(
+                    "second-device confirmation row did not appear: {state}"
+                ));
             }
         };
         let text = row.text().await?;
@@ -2284,6 +2317,225 @@ mod tests {
         Ok(())
     }
 
+    /// The producer compares the immutable page and controlling-worker builds
+    /// under the shared lock before WebAuthn. A stale answer must leave both
+    /// the authenticator and durable hold untouched.
+    #[dialog_common::test]
+    async fn it_refuses_a_stale_worker_before_creating_a_passkey(
+        env: TestEnvironment,
+    ) -> Result<()> {
+        let driver = driver_with_prf(&env).await?;
+        wait_for_service_worker(&driver).await?;
+        goto(&driver, env.tonk_web.join("settings")?.as_str()).await?;
+        element(&driver, "tonk-account[data-mode=\"choice\"]").await?;
+        click(&driver, "#account-choose-link").await?;
+        await_register_dialog(&driver).await?;
+        type_into_register_dialog(&driver, "stale-before-passkey@example.com").await?;
+        await_register_action(&driver, "create a passkey").await?;
+
+        driver
+            .execute(
+                r#"window.__tonkOriginalFetch = window.fetch;
+                   window.__stalePasskeyCalls = 0;
+                   window.fetch = (input, init) => {
+                     const url = new URL(
+                       typeof input === 'string' ? input : input.url,
+                       window.location.href,
+                     );
+                     if (url.pathname === '/api/health') {
+                       return Promise.resolve(new Response(JSON.stringify({
+                         build: 'ffffffffffffffff', worker: 'ok'
+                       }), { status: 200, headers: { 'content-type': 'application/json' } }));
+                     }
+                     return window.__tonkOriginalFetch(input, init);
+                   };
+                   Object.defineProperty(navigator.credentials, 'create', {
+                     configurable: true,
+                     value: () => {
+                       window.__stalePasskeyCalls += 1;
+                       return Promise.reject(new Error('WebAuthn must not run'));
+                     }
+                   });"#,
+                Vec::new(),
+            )
+            .await?;
+        click(&driver, "#tonk-register-action").await?;
+        await_narrator_containing(&driver, "Reload Tonk").await?;
+
+        let state = driver
+            .execute_async(
+                r#"const done = arguments[arguments.length - 1];
+                   (async () => {
+                     const database = await new Promise((resolve, reject) => {
+                       const request = indexedDB.open('tonk-update-safety-v1', 1);
+                       request.onsuccess = () => resolve(request.result);
+                       request.onerror = () => reject(request.error);
+                     });
+                     const hold = await new Promise((resolve, reject) => {
+                       const transaction = database.transaction('holds', 'readonly');
+                       const request = transaction.objectStore('holds').get('account-setup');
+                       let value;
+                       request.onsuccess = () => { value = request.result; };
+                       request.onerror = () => reject(request.error);
+                       transaction.oncomplete = () => resolve(value);
+                     });
+                     database.close();
+                     done({
+                       calls: window.__stalePasskeyCalls,
+                       holdAbsent: hold === undefined,
+                       critical: document.documentElement.hasAttribute(
+                         'data-tonk-account-setup-critical'
+                       ),
+                     });
+                   })().catch(error => done({ error: String(error) }));"#,
+                Vec::new(),
+            )
+            .await?;
+        assert_eq!(
+            state.json(),
+            &serde_json::json!({ "calls": 0, "holdAbsent": true, "critical": false }),
+            "a stale worker reached WebAuthn or left update safety armed"
+        );
+
+        driver.quit().await?;
+        Ok(())
+    }
+
+    /// The access service deploys independently of the immutable page and
+    /// worker. Every missing, unavailable, malformed, or drifted capability
+    /// answer must stop while the ceremony is still safe to repeat.
+    #[dialog_common::test]
+    async fn it_refuses_an_incompatible_account_provider_before_creating_a_passkey(
+        env: TestEnvironment,
+    ) -> Result<()> {
+        let driver = driver_with_prf(&env).await?;
+        wait_for_service_worker(&driver).await?;
+        goto(&driver, env.tonk_web.join("settings")?.as_str()).await?;
+        element(&driver, "tonk-account[data-mode=\"choice\"]").await?;
+        click(&driver, "#account-choose-link").await?;
+        await_register_dialog(&driver).await?;
+        type_into_register_dialog(&driver, "provider-before-passkey@example.com").await?;
+        await_register_action(&driver, "create a passkey").await?;
+
+        driver
+            .execute(
+                r#"window.__tonkOriginalFetch = window.fetch;
+                   window.__capabilityMode = "missing";
+                   window.__capabilityFetches = 0;
+                   window.__providerPasskeyCalls = 0;
+                   window.fetch = (input, init) => {
+                     const url = new URL(
+                       typeof input === 'string' ? input : input.url,
+                       window.location.href,
+                     );
+                     if (url.pathname !== '/api/account/setup-capabilities') {
+                       return window.__tonkOriginalFetch(input, init);
+                     }
+                     window.__capabilityFetches += 1;
+                     const json = value => Promise.resolve(new Response(JSON.stringify(value), {
+                       status: 200,
+                       headers: { 'content-type': 'application/json' },
+                     }));
+                     switch (window.__capabilityMode) {
+                       case 'missing':
+                         return Promise.resolve(new Response('', { status: 404 }));
+                       case 'timeout':
+                         return Promise.resolve(new Response('', { status: 504 }));
+                       case 'malformed':
+                         return json({ service: 'tonk-access-service', capabilities: {} });
+                       case 'drifted':
+                         return json({
+                           service: 'tonk-access-service',
+                           capabilities: { accountSetupLifecycle: 2 },
+                         });
+                       default:
+                         return Promise.reject(new Error('unknown capability mode'));
+                     }
+                   };
+                   Object.defineProperty(navigator.credentials, 'create', {
+                     configurable: true,
+                     value: () => {
+                       window.__providerPasskeyCalls += 1;
+                       return Promise.reject(new Error('WebAuthn must not run'));
+                     }
+                   });"#,
+                Vec::new(),
+            )
+            .await?;
+
+        for (attempt, mode) in ["missing", "timeout", "malformed", "drifted"]
+            .into_iter()
+            .enumerate()
+        {
+            driver
+                .execute(
+                    "window.__capabilityMode = arguments[0];",
+                    vec![serde_json::json!(mode)],
+                )
+                .await?;
+            click(&driver, "#tonk-register-action").await?;
+            let observed = driver
+                .execute_async(
+                    r#"const expected = arguments[0];
+                       const done = arguments[arguments.length - 1];
+                       const deadline = Date.now() + 30000;
+                       const poll = () => {
+                         const action = document.querySelector('#tonk-register-action');
+                         if (window.__capabilityFetches >= expected && action && !action.disabled) {
+                           done({
+                             fetches: window.__capabilityFetches,
+                             passkeys: window.__providerPasskeyCalls,
+                             critical: document.documentElement.hasAttribute(
+                               'data-tonk-account-setup-critical'
+                             ),
+                           });
+                         } else if (Date.now() >= deadline) {
+                           done({ timeout: true, fetches: window.__capabilityFetches,
+                             passkeys: window.__providerPasskeyCalls });
+                         } else {
+                           setTimeout(poll, 50);
+                         }
+                       };
+                       poll();"#,
+                    vec![serde_json::json!(attempt + 1)],
+                )
+                .await?;
+            assert_eq!(
+                observed.json()["fetches"],
+                attempt + 1,
+                "{mode}: {observed:?}"
+            );
+            assert_eq!(observed.json()["passkeys"], 0, "{mode}: {observed:?}");
+            assert_eq!(observed.json()["critical"], false, "{mode}: {observed:?}");
+        }
+
+        let hold = driver
+            .execute_async(
+                r#"const done = arguments[arguments.length - 1];
+                   (async () => {
+                     const database = await new Promise((resolve, reject) => {
+                       const request = indexedDB.open('tonk-update-safety-v1', 1);
+                       request.onsuccess = () => resolve(request.result);
+                       request.onerror = () => reject(request.error);
+                     });
+                     const value = await new Promise((resolve, reject) => {
+                       const transaction = database.transaction('holds', 'readonly');
+                       const request = transaction.objectStore('holds').get('account-setup');
+                       request.onsuccess = () => resolve(request.result);
+                       request.onerror = () => reject(request.error);
+                     });
+                     database.close();
+                     done({ absent: value === undefined });
+                   })().catch(error => done({ error: String(error) }));"#,
+                Vec::new(),
+            )
+            .await?;
+        assert_eq!(hold.json(), &serde_json::json!({ "absent": true }));
+
+        driver.quit().await?;
+        Ok(())
+    }
+
     #[dialog_common::test]
     async fn it_submits_activation_once_while_the_request_is_pending(
         env: TestEnvironment,
@@ -2674,7 +2926,6 @@ mod tests {
                 if outcome_line.trim_end() != "signed in" {
                     child.kill().await?;
                     let mut stderr_text = String::new();
-                    use tokio::io::AsyncReadExt as _;
                     let _ = tokio::time::timeout(
                         Duration::from_secs(5),
                         stderr.read_to_string(&mut stderr_text),
@@ -3825,7 +4076,28 @@ mod tests {
                 return Ok(last);
             }
             if tokio::time::Instant::now() >= deadline {
-                return Err(anyhow!("the {noun:?} row never settled"));
+                let state = driver
+                    .execute_async(
+                        r##"const done = arguments[arguments.length - 1];
+                           const host = document.querySelector('tonk-account');
+                           const action = document.querySelector('#tonk-register-action');
+                           fetch('/api/account').then(async response => done({
+                             mode: host?.getAttribute('data-mode') || null,
+                             status: document.querySelector('#tonk-register-status')?.textContent?.trim() || null,
+                             action: action?.textContent?.trim() || null,
+                             actionHidden: action?.hasAttribute('hidden') ?? null,
+                             rows: [...document.querySelectorAll('#tonk-register .orow')].map(row => row.textContent.trim()),
+                             accountStatus: response.status,
+                             account: await response.text(),
+                           })).catch(error => done({ diagnosticError: String(error) }));"##,
+                        Vec::new(),
+                    )
+                    .await
+                    .map(|result| result.json().clone())
+                    .unwrap_or(serde_json::Value::Null);
+                return Err(anyhow!(
+                    "the {noun:?} row never settled; ceremony state: {state}"
+                ));
             }
             tokio::time::sleep(Duration::from_millis(250)).await;
         }
@@ -4487,9 +4759,15 @@ mod tests {
             .execute_async(
                 r#"
                 const done = arguments[arguments.length - 1];
+                const build = document.querySelector(
+                    'meta[name="tonk-worker-build"]'
+                )?.content;
                 fetch(arguments[0], {
                     method: "POST",
-                    headers: { "content-type": "application/json" },
+                    headers: {
+                        "content-type": "application/json",
+                        "x-tonk-build": build,
+                    },
                     body: JSON.stringify(arguments[1]),
                 }).then(async response => {
                     // A body is not always JSON — an empty 200, or an
@@ -4519,9 +4797,15 @@ mod tests {
             .execute_async(
                 r#"
                 const done = arguments[arguments.length - 1];
+                const build = document.querySelector(
+                    'meta[name="tonk-worker-build"]'
+                )?.content;
                 fetch(arguments[0], {
                     method: "POST",
-                    headers: { "content-type": "application/yaml" },
+                    headers: {
+                        "content-type": "application/yaml",
+                        "x-tonk-build": build,
+                    },
                     body: arguments[1],
                 }).then(async response => done({
                     status: response.status,
@@ -4636,11 +4920,18 @@ mod tests {
     }
 
     async fn wait_for_callback_device_rows(
+        driver: &WebDriver,
         profile: &TempDir,
         env: &TestEnvironment,
     ) -> Result<(CliOutput, Vec<CliDeviceRow>)> {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
         loop {
+            // Registration commits the browser and terminal rows locally,
+            // then publishes them through the ordinary account sync drain.
+            // Drive that drain explicitly: a quiet test page has no later
+            // user traffic to schedule one when the registration's initial
+            // best-effort push loses a concurrent pull/push race.
+            let _ = post_json(driver, "/api/sync", serde_json::json!({})).await;
             let output = devices(profile, env).await?;
             if !output.status.success() {
                 return Err(anyhow!("devices failed: {}", output.stderr));
@@ -5026,7 +5317,7 @@ mod tests {
             .to_string();
         creator.quit().await?;
 
-        let claimer = driver_with_prf(&env).await?;
+        let (claimer, claimer_authenticator) = driver_with_prf_authenticator(&env).await?;
         sign_up(&claimer, &env, "claimer@example.com").await?;
         let visited = post_json(
             &claimer,
@@ -5106,18 +5397,15 @@ mod tests {
              directory; last `account space` output was: {last_seen}"
         );
 
-        let devtools = ChromeDevTools::new(claimer.handle.clone());
-        devtools
-            .execute_cdp_with_params(
-                "Storage.clearDataForOrigin",
-                serde_json::json!({
-                    "origin": env.tonk_web.origin().ascii_serialization(),
-                    "storageTypes": "all",
-                }),
-            )
-            .await?;
-        goto(&claimer, env.tonk_web.as_str()).await?;
-        wait_for_service_worker(&claimer).await?;
+        // A second account device is a fresh browser with the synced
+        // passkey, not a live browser whose origin storage is erased from
+        // underneath its page and worker. The latter leaves Chrome in a CDP-
+        // synthetic lifecycle state and also bypasses the actual cross-device
+        // PRF boundary this journey is meant to cover.
+        let (second_device, _) =
+            second_device_with_same_passkey(&env, &claimer, &claimer_authenticator).await?;
+        claimer.quit().await?;
+        let claimer = second_device;
         goto(&claimer, env.tonk_web.join("account")?.as_str()).await?;
         element(&claimer, "tonk-account[data-mode=\"choice\"]").await?;
         run_cluster_login(&claimer, "claimer@example.com").await?;
@@ -5392,7 +5680,7 @@ mod tests {
             .as_array()
             .context("profile roster is not an array")?
             .len();
-        let (first_profile, first_label) = active_profile_and_label(profiles_before_add)?;
+        let first_profile = active_profile_and_label(profiles_before_add)?.0;
 
         // The real Hub frame renders the first account's space.
         goto(&driver, env.tonk_web.as_str()).await?;
@@ -5550,8 +5838,8 @@ mod tests {
             .clone();
         enter_hub(&driver).await?;
         click(&driver, "[data-account-trigger]").await?;
-        wait_for_text_containing(&driver, "[data-account-menu]", &first_label).await?;
         let selector = format!("button[data-profile=\"{first_profile}\"]");
+        wait_for_displayed(&driver, &selector).await?;
         click(&driver, &selector).await?;
         driver.enter_default_frame().await?;
         let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
@@ -5614,7 +5902,8 @@ mod tests {
         // its terminal row can appear before the signing browser's remote
         // row. Each `devices` call pulls again: wait for BOTH sides rather
         // than exiting on that guaranteed local row.
-        let (devices, device_rows) = wait_for_callback_device_rows(&linked.profile, &env).await?;
+        let (devices, device_rows) =
+            wait_for_callback_device_rows(&driver, &linked.profile, &env).await?;
         assert!(
             device_rows
                 .iter()
@@ -6106,7 +6395,8 @@ mod tests {
         // Cache the complete callback view before revocation. The CLI creates
         // its own row locally, so a terminal-only list does not prove it has
         // pulled the browser row that must remain visible in its stale cache.
-        let (_listed, listed_rows) = wait_for_callback_device_rows(&linked.profile, &env).await?;
+        let (_listed, listed_rows) =
+            wait_for_callback_device_rows(&driver, &linked.profile, &env).await?;
         let cli_did = did_for_device(&listed_rows, "e2e terminal")
             .context("CLI device was absent from the account device list")?
             .to_string();
@@ -6293,27 +6583,7 @@ mod tests {
         let created = post_json(
             &creator,
             "/api/profile/branch/main/transact",
-            serde_json::json!({
-                "claims": [{
-                    "op": "assert",
-                    "application": {
-                        "predicate": {
-                            "kind": "transient",
-                            "concept": {
-                                "description": "A request to create a new space from the wizard form.",
-                                "with": {
-                                    "name":     { "the": "dom.event.current-target.elements.name/value", "as": "Text" },
-                                    "remote":   { "the": "dom.event.current-target.elements.remote/value", "as": "Text" }
-                                }
-                            }
-                        },
-                        "parameters": {
-                            "name": "Custodied After Assertion",
-                            "remote": env.tonk_web.join("ucan/")?
-                        }
-                    }
-                }]
-            }),
+            tonk_worker_api::create_space_claim_json("Custodied After Assertion"),
         )
         .await?;
         successful_body("create space command", &created);

--- a/rust/tonk-ui/src/account_setup.rs
+++ b/rust/tonk-ui/src/account_setup.rs
@@ -1,0 +1,427 @@
+//! Account-creation side of the service-worker update-safety contract.
+//!
+//! The boot script and service worker consume one origin-global durable hold.
+//! This module is its sole producer: it compares the page and controlling
+//! worker while holding the shared Web Lock, commits the hold before WebAuthn,
+//! and removes that exact hold only after the worker-mediated ceremony settles
+//! safely. Broadcasts and DOM events are wakeups; IndexedDB under the lock is
+//! the authority.
+
+use wasm_bindgen::JsValue;
+
+use crate::custody_relay::CeremonyError;
+
+const LEASED_REVISION: &str = "0";
+
+/// The exact durable hold this attempt owns.
+#[derive(Debug)]
+pub(crate) struct Lease {
+    operation_id: String,
+}
+
+impl Lease {
+    fn new() -> Self {
+        Self {
+            operation_id: hex::encode(rand::random::<[u8; 32]>()),
+        }
+    }
+}
+
+/// Install the synchronous document contract and reconcile it with IndexedDB.
+///
+/// Installation starts closed: a reload cannot become eligible between Wasm
+/// taking ownership of the producer contract and the authoritative hold read.
+/// The JS adapter removes the root attribute only after it proves hold absence.
+pub fn install_reload_contract() {
+    tonk_install_account_setup_safety();
+}
+
+/// Publish a hold before the account ceremony can create a credential.
+///
+/// The adapter compares `/api/health` with this document's immutable build id
+/// inside the same exclusive lock used by worker claim/reload callbacks. A
+/// successor may win the lock first, but then the comparison refuses this
+/// attempt before WebAuthn.
+pub(crate) async fn begin() -> Result<Lease, CeremonyError> {
+    let lease = Lease::new();
+    tonk_begin_account_setup(&lease.operation_id, LEASED_REVISION)
+        .await
+        .map_err(|error| {
+            let detail = describe(&error);
+            if detail.contains("account setup is already held") {
+                CeremonyError::update_safety(
+                    "Account setup is already in progress in this browser. Finish it in the other tab before trying again.",
+                    false,
+                )
+            } else {
+                CeremonyError::update_safety(
+                    "Tonk could not confirm that this page and its service worker are the same version. Reload Tonk before creating a passkey.",
+                    true,
+                )
+            }
+        })?;
+    Ok(lease)
+}
+
+/// Remove this attempt's exact hold after the worker reports success.
+pub(crate) async fn settle(lease: &Lease) -> Result<(), CeremonyError> {
+    let removed = tonk_clear_account_setup(&lease.operation_id, LEASED_REVISION)
+        .await
+        .map_err(|_| retained())?
+        .as_bool()
+        .ok_or_else(retained)?;
+    if removed { Ok(()) } else { Err(retained()) }
+}
+
+/// Remove the hold after a ceremony error that proves no credential existed.
+pub(crate) async fn abandon_before_credential(lease: &Lease) -> Result<(), CeremonyError> {
+    settle(lease).await
+}
+
+/// An attempt that crossed credential creation remains update-critical until a
+/// later recovery path can prove its durable result. Retrying creation would
+/// risk minting a second passkey, so the UI must not offer that action.
+pub(crate) fn retained() -> CeremonyError {
+    CeremonyError::update_safety(
+        "Your passkey may have been created, but Tonk could not prove that account recovery finished. Keep this tab open and do not create another passkey. Reload only after account settings show this device, or contact Tonk support.",
+        false,
+    )
+}
+
+fn describe(error: &JsValue) -> String {
+    js_sys::Reflect::get(error, &"message".into())
+        .ok()
+        .and_then(|value| value.as_string())
+        .unwrap_or_else(|| format!("{error:?}"))
+}
+
+#[wasm_bindgen::prelude::wasm_bindgen(inline_js = r#"
+const NAME = "tonk-update-safety-v1";
+const STORE = "holds";
+const KEY = "account-setup";
+const ATTRIBUTE = "data-tonk-account-setup-critical";
+const EVENT = "tonk:account-setup-critical-change";
+const MAX_U64 = 18446744073709551615n;
+
+function validate(value) {
+    if (value === undefined) return undefined;
+    if (value === null || typeof value !== "object" || Array.isArray(value)) {
+        throw new Error("malformed account setup hold");
+    }
+    const keys = Reflect.ownKeys(value).sort();
+    const expected = ["kind", "leasedRevision", "operationId", "version"];
+    if (keys.length !== expected.length ||
+        keys.some((key, index) => typeof key !== "string" || key !== expected[index]) ||
+        value.version !== 1 || value.kind !== KEY ||
+        typeof value.operationId !== "string" || !/^[0-9a-f]{64}$/.test(value.operationId) ||
+        typeof value.leasedRevision !== "string" || !/^(0|[1-9][0-9]*)$/.test(value.leasedRevision) ||
+        BigInt(value.leasedRevision) > MAX_U64) {
+        throw new Error("malformed account setup hold");
+    }
+    return value;
+}
+
+function setCritical(critical) {
+    const root = document.documentElement;
+    if (!root) return;
+    const previous = root.hasAttribute(ATTRIBUTE);
+    if (critical) root.setAttribute(ATTRIBUTE, "");
+    else root.removeAttribute(ATTRIBUTE);
+    if (previous === critical) return;
+    window.dispatchEvent(new CustomEvent(EVENT, {
+        detail: { critical, mayReload: !critical },
+    }));
+}
+
+function announce() {
+    const message = { type: "account-setup-hold-changed", version: 1 };
+    try {
+        const channel = new BroadcastChannel(NAME);
+        channel.postMessage(message);
+        channel.close();
+    } catch {}
+    try {
+        // Wake the exact incumbent that served this ceremony. It re-reads the
+        // durable hold before retiring; the broadcast remains the peer-page
+        // wakeup and the worker fetch path remains a missed-message fallback.
+        navigator.serviceWorker?.controller?.postMessage(message);
+    } catch {}
+}
+
+function openDatabase() {
+    return new Promise((resolve, reject) => {
+        let settled = false;
+        const fail = error => {
+            if (settled) return;
+            settled = true;
+            reject(error);
+        };
+        if (!globalThis.indexedDB) return fail(new Error("IndexedDB unavailable"));
+        let request;
+        try {
+            request = indexedDB.open(NAME, 1);
+        } catch (error) {
+            return fail(error);
+        }
+        request.onupgradeneeded = event => {
+            try {
+                if (event.oldVersion !== 0 || request.result.objectStoreNames.contains(STORE)) {
+                    request.transaction?.abort();
+                    return;
+                }
+                request.result.createObjectStore(STORE);
+            } catch {
+                try { request.transaction?.abort(); } catch {}
+            }
+        };
+        request.onerror = () => fail(request.error || new Error("update safety database open failed"));
+        request.onblocked = () => fail(new Error("update safety database open blocked"));
+        request.onsuccess = () => {
+            const database = request.result;
+            if (settled) {
+                database.close();
+                return;
+            }
+            settled = true;
+            database.onversionchange = () => database.close();
+            if (database.version !== 1 || !database.objectStoreNames.contains(STORE)) {
+                database.close();
+                reject(new Error("unsupported update safety database"));
+                return;
+            }
+            resolve(database);
+        };
+    });
+}
+
+function read(database) {
+    return new Promise((resolve, reject) => {
+        let value;
+        try {
+            const transaction = database.transaction(STORE, "readonly");
+            const request = transaction.objectStore(STORE).get(KEY);
+            request.onsuccess = () => { value = request.result; };
+            request.onerror = () => reject(request.error || new Error("account setup hold read failed"));
+            transaction.oncomplete = () => resolve(value);
+            transaction.onerror = () => reject(transaction.error || new Error("account setup hold transaction failed"));
+            transaction.onabort = () => reject(transaction.error || new Error("account setup hold transaction aborted"));
+        } catch (error) {
+            reject(error);
+        }
+    });
+}
+
+async function durableCritical() {
+    const database = await openDatabase();
+    try {
+        return validate(await read(database)) !== undefined;
+    } finally {
+        database.close();
+    }
+}
+
+function putAbsent(database, value) {
+    return new Promise((resolve, reject) => {
+        try {
+            const transaction = database.transaction(STORE, "readwrite");
+            const store = transaction.objectStore(STORE);
+            const request = store.get(KEY);
+            request.onsuccess = () => {
+                try {
+                    if (validate(request.result) !== undefined) {
+                        transaction.abort();
+                        return;
+                    }
+                    const write = store.put(value, KEY);
+                    write.onerror = () => { try { transaction.abort(); } catch {} };
+                } catch {
+                    try { transaction.abort(); } catch {}
+                }
+            };
+            request.onerror = () => reject(request.error || new Error("account setup hold compare failed"));
+            transaction.oncomplete = resolve;
+            transaction.onerror = () => reject(transaction.error || new Error("account setup hold write failed"));
+            transaction.onabort = () => reject(new Error("account setup is already held"));
+        } catch (error) {
+            reject(error);
+        }
+    });
+}
+
+function clearExact(database, expected) {
+    return new Promise((resolve, reject) => {
+        let removed = false;
+        try {
+            const transaction = database.transaction(STORE, "readwrite");
+            const store = transaction.objectStore(STORE);
+            const request = store.get(KEY);
+            request.onsuccess = () => {
+                try {
+                    const current = validate(request.result);
+                    if (current && current.operationId === expected.operationId &&
+                        current.leasedRevision === expected.leasedRevision) {
+                        const deletion = store.delete(KEY);
+                        deletion.onsuccess = () => { removed = true; };
+                        deletion.onerror = () => { try { transaction.abort(); } catch {} };
+                    }
+                } catch {
+                    try { transaction.abort(); } catch {}
+                }
+            };
+            request.onerror = () => reject(request.error || new Error("account setup hold compare failed"));
+            transaction.oncomplete = () => resolve(removed);
+            transaction.onerror = () => reject(transaction.error || new Error("account setup hold clear failed"));
+            transaction.onabort = () => reject(transaction.error || new Error("account setup hold clear aborted"));
+        } catch (error) {
+            reject(error);
+        }
+    });
+}
+
+function withLock(callback) {
+    const locks = navigator.locks;
+    if (!locks || typeof locks.request !== "function") {
+        return Promise.reject(new Error("Web Locks unavailable"));
+    }
+    return locks.request(NAME, { mode: "exclusive" }, callback);
+}
+
+async function assertCompatibleWorker() {
+    const page = document.querySelector('meta[name="tonk-worker-build"]')?.content;
+    if (!page) throw new Error("page build is absent");
+    const healthResponse = await fetch("/api/health", {
+        cache: "no-store",
+        headers: { "x-tonk-build": page },
+    });
+    if (!healthResponse.ok) {
+        throw new Error(`worker health returned ${healthResponse.status}`);
+    }
+    const health = await healthResponse.json();
+    if (!health || health.build !== page) {
+        throw new Error(`stale worker: page ${page}, worker ${health?.build || "unknown"}`);
+    }
+
+    // The account provider deploys independently of the immutable page/worker
+    // generation. Ask this exact worker to negotiate its provider before the
+    // durable hold is published and before credentials.create can run. An old
+    // worker, missing route, timeout, malformed marker, or drifted provider all
+    // fail on the repeatable side of WebAuthn.
+    const capabilityResponse = await fetch("/api/account/setup-capabilities", {
+        cache: "no-store",
+        headers: { "x-tonk-build": page },
+    });
+    if (!capabilityResponse.ok) {
+        throw new Error(`account setup capability returned ${capabilityResponse.status}`);
+    }
+    const marker = await capabilityResponse.json();
+    const markerKeys = marker && typeof marker === "object" && !Array.isArray(marker)
+        ? Reflect.ownKeys(marker).sort()
+        : [];
+    const capabilities = marker?.capabilities;
+    const capabilityKeys = capabilities && typeof capabilities === "object" &&
+        !Array.isArray(capabilities)
+        ? Reflect.ownKeys(capabilities).sort()
+        : [];
+    if (
+        markerKeys.length !== 2 || markerKeys[0] !== "capabilities" ||
+        markerKeys[1] !== "service" || marker.service !== "tonk-access-service" ||
+        capabilityKeys.length !== 1 ||
+        capabilityKeys[0] !== "accountSetupLifecycle" ||
+        capabilities.accountSetupLifecycle !== 1
+    ) {
+        throw new Error("account setup capability is malformed or unsupported");
+    }
+}
+
+export function tonk_install_account_setup_safety() {
+    setCritical(true);
+    if (typeof window.tonkAccountSetupMayReload !== "function") {
+        window.tonkAccountSetupMayReload = () =>
+            !document.documentElement?.hasAttribute(ATTRIBUTE);
+    }
+    const reconcile = () => {
+        // A wakeup is advisory. Close synchronously, then re-read the durable
+        // authority under the shared lock before changing the page predicate.
+        setCritical(true);
+        withLock(async () => {
+            setCritical(await durableCritical());
+        }).catch(error => {
+            console.warn("account setup safety restore failed; deferring update", error);
+        });
+    };
+    if (!window.__tonkAccountSetupSafetyInstalled) {
+        window.__tonkAccountSetupSafetyInstalled = true;
+        window.addEventListener("tonk:account-setup-hold-change", reconcile);
+    }
+    reconcile();
+}
+
+export async function tonk_begin_account_setup(operationId, leasedRevision) {
+    const value = validate({
+        version: 1,
+        kind: KEY,
+        operationId,
+        leasedRevision,
+    });
+    await withLock(async () => {
+        setCritical(true);
+        try {
+            await assertCompatibleWorker();
+            const database = await openDatabase();
+            try {
+                await putAbsent(database, value);
+            } finally {
+                database.close();
+            }
+        } catch (error) {
+            // This attempt may have failed because another tab already owns
+            // the durable hold. Mirror the authority before reopening the
+            // local predicate; if the read itself fails, remain fail-closed.
+            try {
+                setCritical(await durableCritical());
+            } catch {
+                setCritical(true);
+            }
+            throw error;
+        }
+    });
+    announce();
+}
+
+export async function tonk_clear_account_setup(operationId, leasedRevision) {
+    const expected = validate({
+        version: 1,
+        kind: KEY,
+        operationId,
+        leasedRevision,
+    });
+    const removed = await withLock(async () => {
+        const database = await openDatabase();
+        try {
+            return await clearExact(database, expected);
+        } finally {
+            database.close();
+        }
+    });
+    if (removed) {
+        setCritical(false);
+        announce();
+    }
+    return removed;
+}
+"#)]
+extern "C" {
+    fn tonk_install_account_setup_safety();
+
+    #[wasm_bindgen::prelude::wasm_bindgen(catch)]
+    async fn tonk_begin_account_setup(
+        operation_id: &str,
+        leased_revision: &str,
+    ) -> Result<(), JsValue>;
+
+    #[wasm_bindgen::prelude::wasm_bindgen(catch)]
+    async fn tonk_clear_account_setup(
+        operation_id: &str,
+        leased_revision: &str,
+    ) -> Result<JsValue, JsValue>;
+}

--- a/rust/tonk-ui/src/bin/ui.rs
+++ b/rust/tonk-ui/src/bin/ui.rs
@@ -62,6 +62,10 @@ async fn main() {
     // page must never look like one.
     tonk_identity::install();
     tonk_ui::custody_relay::install();
+    // Take ownership of the account side of update safety before any account
+    // UI can run. Installation starts reload-closed until IndexedDB proves no
+    // durable account-setup hold exists.
+    tonk_ui::account_setup::install_reload_contract();
     // A guest asking to register raises the dialog here, in the only
     // document that can run the ceremony.
     tonk_portal::on_register(|reason, return_focus| {

--- a/rust/tonk-ui/src/custody_relay.rs
+++ b/rust/tonk-ui/src/custody_relay.rs
@@ -325,6 +325,13 @@ pub(crate) struct CeremonyError {
     pub denial: Option<tonk_identity::custody::CustodyDenial>,
     /// Browser refusal, independently of a service denial.
     pub refusal: Option<tonk_identity::passkey::CeremonyRefusal>,
+    /// This is update-safety guidance, safe to present without replacing it
+    /// with a generic account-action diagnostic.
+    pub update_safety: bool,
+    /// Repeating account creation could mint a second credential.
+    pub retry_unsafe: bool,
+    /// `credentials.create()` returned before the later failure.
+    pub passkey_created: bool,
 }
 
 impl std::fmt::Display for CeremonyError {
@@ -415,6 +422,21 @@ impl CeremonyError {
             message: message.into(),
             denial: None,
             refusal: None,
+            update_safety: false,
+            retry_unsafe: false,
+            passkey_created: false,
+        }
+    }
+
+    /// A failure at the account/service-worker composition boundary.
+    pub(crate) fn update_safety(message: impl Into<String>, retry_safe: bool) -> Self {
+        Self {
+            message: message.into(),
+            denial: None,
+            refusal: None,
+            update_safety: true,
+            retry_unsafe: !retry_safe,
+            passkey_created: false,
         }
     }
 
@@ -442,6 +464,12 @@ impl CeremonyError {
             message: describe(error),
             denial,
             refusal,
+            update_safety: false,
+            retry_unsafe: false,
+            passkey_created: js_sys::Reflect::get(error, &"tonkPasskeyCreated".into())
+                .ok()
+                .and_then(|value| value.as_bool())
+                == Some(true),
         }
     }
 }

--- a/rust/tonk-ui/src/lib.rs
+++ b/rust/tonk-ui/src/lib.rs
@@ -6,6 +6,9 @@
 /// Top-document account creation and self-link element.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub mod account;
+/// Account-creation producer for the shared service-worker update-safety hold.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub mod account_setup;
 /// Customer activation page reached from the activation email.
 pub mod activate;
 

--- a/rust/tonk-ui/src/register_dialog.rs
+++ b/rust/tonk-ui/src/register_dialog.rs
@@ -1606,16 +1606,23 @@ pub(crate) fn run_signup_ceremony() {
                     problem.outcome,
                 );
                 set_status(&problem.message);
-                // Back to something clickable: a control left mid-flight
-                // refuses every later attempt.
-                set_action(
-                    if existing {
-                        "log in with your passkey"
-                    } else {
-                        "create a passkey"
-                    },
-                    true,
-                );
+                if error.retry_unsafe {
+                    // A durable account-setup hold means credential creation
+                    // may have crossed its irreversible boundary. Offering
+                    // Create again here could mint a second passkey.
+                    hide_action();
+                } else {
+                    // Back to something clickable: a control left mid-flight
+                    // refuses every later attempt.
+                    set_action(
+                        if existing {
+                            "log in with your passkey"
+                        } else {
+                            "create a passkey"
+                        },
+                        true,
+                    );
+                }
             }
             Ok(()) => {
                 // The account exists as of this line — created, or

--- a/rust/tonk-ui/src/service_worker_upgrade.rs
+++ b/rust/tonk-ui/src/service_worker_upgrade.rs
@@ -59,6 +59,10 @@ mod tests {
                             count: Number(sessionStorage.getItem("tonk:test:sw-documents")) || 0,
                             roots: JSON.parse(sessionStorage.getItem("tonk:test:sw-roots") || "{}"),
                             mounted: !!document.querySelector("#tonk-root, tonk-site, tonk-account, tonk-activate"),
+                            accountSetupCritical: document.documentElement.hasAttribute(
+                                "data-tonk-account-setup-critical",
+                            ),
+                            accountSetupMayReload: window.tonkAccountSetupMayReload?.(),
                             guard: sessionStorage.getItem("tonk:sw-upgrade-reload"),
                         };
                         "##,
@@ -601,6 +605,228 @@ mod tests {
         Ok(())
     }
 
+    /// Start account creation through the real UI producer, pausing only the
+    /// browser's credential call so the identity bridge, worker ceremony, and
+    /// durable settlement remain production-real.
+    async fn begin_paused_account_setup(driver: &WebDriver, email: &str) -> Result<Value> {
+        let result = driver
+            .execute_async(
+                r##"
+                const email = arguments[0];
+                const done = arguments[arguments.length - 1];
+                const waitFor = async (read, description) => {
+                    const deadline = Date.now() + 30000;
+                    while (Date.now() < deadline) {
+                        const value = await read();
+                        if (value) return value;
+                        await new Promise(resolve => setTimeout(resolve, 50));
+                    }
+                    throw new Error(`timed out waiting for ${description}`);
+                };
+                const readHold = async () => {
+                    const database = await new Promise((resolve, reject) => {
+                        const request = indexedDB.open("tonk-update-safety-v1", 1);
+                        request.onsuccess = () => resolve(request.result);
+                        request.onerror = () => reject(request.error);
+                        request.onblocked = () => reject(new Error("hold database blocked"));
+                    });
+                    try {
+                        return await new Promise((resolve, reject) => {
+                            const transaction = database.transaction("holds", "readonly");
+                            const request = transaction.objectStore("holds").get("account-setup");
+                            let value;
+                            request.onsuccess = () => { value = request.result; };
+                            request.onerror = () => reject(request.error);
+                            transaction.oncomplete = () => resolve(value);
+                            transaction.onerror = () => reject(transaction.error);
+                            transaction.onabort = () => reject(transaction.error);
+                        });
+                    } finally {
+                        database.close();
+                    }
+                };
+                (async () => {
+                    const choose = await waitFor(
+                        () => document.querySelector("#account-choose-link"),
+                        "the account chooser",
+                    );
+                    choose.click();
+                    const input = await waitFor(
+                        () => document.querySelector("#tonk-register-email"),
+                        "the account email input",
+                    );
+                    input.value = email;
+                    input.dispatchEvent(new Event("input", { bubbles: true }));
+                    input.dispatchEvent(new Event("change", { bubbles: true }));
+                    const action = await waitFor(() => {
+                        const candidate = document.querySelector("#tonk-register-action");
+                        return candidate && !candidate.disabled &&
+                            candidate.textContent.trim() === "create a passkey" && candidate;
+                    }, "the create-passkey action");
+
+                    const createCredential = navigator.credentials.create.bind(
+                        navigator.credentials,
+                    );
+                    navigator.credentials.create = options => new Promise((resolve, reject) => {
+                        globalThis.__tonkSettlePausedAccountSetup = () => {
+                            createCredential(options).then(resolve, reject);
+                            return true;
+                        };
+                    });
+                    action.click();
+                    await waitFor(
+                        () => globalThis.__tonkSettlePausedAccountSetup,
+                        "the paused account ceremony",
+                    );
+                    const hold = await waitFor(async () => await readHold(), "the durable account hold");
+                    done({
+                        hold,
+                        critical: document.documentElement.hasAttribute(
+                            "data-tonk-account-setup-critical",
+                        ),
+                        mayReload: window.tonkAccountSetupMayReload?.(),
+                        documents: Number(sessionStorage.getItem("tonk:test:sw-documents")) || 0,
+                    });
+                })().catch(error => done({ error: String(error) }));
+                "##,
+                vec![email.into()],
+            )
+            .await?;
+        ensure!(
+            result.json()["hold"]["version"] == 1
+                && result.json()["hold"]["kind"] == "account-setup"
+                && result.json()["hold"]["operationId"]
+                    .as_str()
+                    .is_some_and(|value| value.len() == 64)
+                && result.json()["hold"]["leasedRevision"] == "0"
+                && result.json()["critical"] == true
+                && result.json()["mayReload"] == false,
+            "account producer did not publish its full reload-safety contract: {}",
+            result.json()
+        );
+        Ok(result.json().clone())
+    }
+
+    async fn release_paused_account_setup(driver: &WebDriver) -> Result<()> {
+        let result = driver
+            .execute(
+                "return globalThis.__tonkSettlePausedAccountSetup?.() === true;",
+                Vec::new(),
+            )
+            .await?;
+        ensure!(
+            result.json() == true,
+            "the paused account ceremony had no settlement callback"
+        );
+
+        // Keep the producer tab foregrounded until the WebAuthn continuation
+        // has reached its durable safe outcome. Switching to the sibling as
+        // soon as the callback is invoked can suspend the credential ceremony
+        // before the account hold is cleared, which tests tab scheduling
+        // rather than the origin-wide upgrade contract.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        let mut last = Value::Null;
+        loop {
+            if let Ok(state) = driver
+                .execute_async(
+                    r#"
+                    const done = arguments[arguments.length - 1];
+                    (async () => {
+                        const database = await new Promise((resolve, reject) => {
+                            const request = indexedDB.open("tonk-update-safety-v1", 1);
+                            request.onsuccess = () => resolve(request.result);
+                            request.onerror = () => reject(request.error);
+                        });
+                        const hold = await new Promise((resolve, reject) => {
+                            const transaction = database.transaction("holds", "readonly");
+                            const request = transaction.objectStore("holds").get("account-setup");
+                            let value;
+                            request.onsuccess = () => { value = request.result; };
+                            request.onerror = () => reject(request.error);
+                            transaction.oncomplete = () => resolve(value);
+                        });
+                        database.close();
+                        done({
+                            absent: hold === undefined,
+                            critical: document.documentElement.hasAttribute(
+                                "data-tonk-account-setup-critical",
+                            ),
+                            mayReload: window.tonkAccountSetupMayReload?.(),
+                        });
+                    })().catch(error => done({ error: String(error) }));
+                    "#,
+                    Vec::new(),
+                )
+                .await
+            {
+                last = state.json().clone();
+                if last["absent"] == true && last["critical"] == false && last["mayReload"] == true
+                {
+                    return Ok(());
+                }
+            }
+            ensure!(
+                tokio::time::Instant::now() < deadline,
+                "the account producer did not reach its durable safe outcome: {last}"
+            );
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+
+    /// Ask the stale sibling's static update surface to adopt the successor.
+    /// The click must queue while the origin-global account hold is live.
+    async fn queue_waiting_update_reload(driver: &WebDriver) -> Result<Value> {
+        let result = driver
+            .execute_async(
+                r#"
+                const done = arguments[arguments.length - 1];
+                (async () => {
+                    const deadline = Date.now() + 30000;
+                    let registration;
+                    while (Date.now() < deadline) {
+                        registration = await navigator.serviceWorker.getRegistration();
+                        if (registration?.waiting?.state === "installed") break;
+                        await new Promise(resolve => setTimeout(resolve, 50));
+                    }
+                    if (registration?.waiting?.state !== "installed") {
+                        throw new Error("successor did not reach the waiting state");
+                    }
+                    document.dispatchEvent(new Event("visibilitychange"));
+                    let reload;
+                    while (Date.now() < deadline) {
+                        reload = [...document.querySelectorAll("button")].find(
+                            button => button.textContent.trim() === "Reload" &&
+                                button.closest('[role="status"]'),
+                        );
+                        if (reload) break;
+                        await new Promise(resolve => setTimeout(resolve, 50));
+                    }
+                    if (!reload) throw new Error("update-ready Reload action did not appear");
+                    reload.click();
+                    await new Promise(resolve => setTimeout(resolve, 250));
+                    registration = await navigator.serviceWorker.getRegistration();
+                    done({
+                        waiting: registration?.waiting?.state || null,
+                        critical: document.documentElement.hasAttribute(
+                            "data-tonk-account-setup-critical",
+                        ),
+                        documentBuild: document.querySelector(
+                            'meta[name="tonk-worker-build"]',
+                        )?.content || null,
+                    });
+                })().catch(error => done({ error: String(error) }));
+                "#,
+                Vec::new(),
+            )
+            .await?;
+        ensure!(
+            result.json()["waiting"] == "installed" && result.json()["critical"] == true,
+            "the sibling did not queue its update behind account setup: {}",
+            result.json()
+        );
+        Ok(result.json().clone())
+    }
+
     async fn tab_build_state(driver: &WebDriver) -> Result<Value> {
         let result = driver
             .execute_async(
@@ -616,6 +842,7 @@ mod tests {
                     installing: registration?.installing?.state || null,
                     waiting: registration?.waiting?.state || null,
                     mounted: !!document.querySelector("#tonk-root, tonk-site, tonk-account, tonk-activate"),
+                    documents: Number(sessionStorage.getItem("tonk:test:sw-documents")) || 0,
                 })).catch(error => done({ error: String(error) }));
                 "##,
                 vec![],
@@ -644,6 +871,10 @@ mod tests {
                             waiting: registration?.waiting?.state || null,
                             mounted: !!document.querySelector("#tonk-root, tonk-site, tonk-account, tonk-activate"),
                             guard: sessionStorage.getItem("tonk:sw-upgrade-reload"),
+                            accountSetupCritical: document.documentElement.hasAttribute(
+                                "data-tonk-account-setup-critical",
+                            ),
+                            accountSetupMayReload: window.tonkAccountSetupMayReload?.(),
                             testErrors: globalThis.__tonkTestErrors || [],
                             testInstallProgress: (globalThis.__tonkTestInstallProgress || []).slice(-5),
                             documents: Number(sessionStorage.getItem("tonk:test:sw-documents")) || 0,
@@ -939,6 +1170,37 @@ mod tests {
         );
         fetched_asset_digests(&driver, &generation_b.probes).await?;
 
+        let pre_protocol_write = driver
+            .execute_async(
+                r#"
+                const done = arguments[arguments.length - 1];
+                fetch("/api/profile", { method: "POST" })
+                    .then(async response => done({
+                        status: response.status,
+                        kind: response.headers.get("x-tonk-error-kind"),
+                        body: await response.json(),
+                    }))
+                    .catch(error => done({ error: String(error) }));
+                "#,
+                vec![],
+            )
+            .await?;
+        assert_eq!(
+            pre_protocol_write.json()["status"],
+            409,
+            "{pre_protocol_write:?}"
+        );
+        assert_eq!(
+            pre_protocol_write.json()["kind"],
+            "stale-build",
+            "{pre_protocol_write:?}"
+        );
+        assert_eq!(
+            pre_protocol_write.json()["body"]["error"]["page"],
+            "pre-protocol",
+            "{pre_protocol_write:?}"
+        );
+
         let sentinels = state_sentinels(&driver).await?;
         assert_eq!(sentinels["indexedDb"], "preserved", "{sentinels}");
         assert_eq!(sentinels["cache"], "preserved", "{sentinels}");
@@ -1105,26 +1367,34 @@ mod tests {
         env: TestEnvironment,
     ) -> Result<()> {
         let (generation_a, generation_b) = prepare_second_generation(&env)?;
-        let driver = env.driver().await?;
+        let driver = crate::helpers::driver_with_prf(&env).await?;
         let primary = driver.window().await?;
         let build_a = generation_a.build;
         let build_b = generation_b.build;
         let initial = wait_for_mounted_build(&driver, &build_a).await?;
         assert_eq!(initial["health"]["build"], build_a, "{initial}");
         create_state_sentinels(&driver).await?;
-        set_update_hold(&driver, true).await?;
+        driver.goto(env.tonk_web.join("settings")?.as_str()).await?;
+        wait_for_mounted_build(&driver, &build_a).await?;
+        let producer = begin_paused_account_setup(&driver, "upgrade-hold@example.com").await?;
+        let primary_documents = producer["documents"]
+            .as_u64()
+            .context("account producer omitted its document count")?;
 
         let sibling = driver.new_tab().await?;
         driver.switch_to_window(sibling.clone()).await?;
         driver.goto(env.tonk_web.as_str()).await?;
         let sibling_a = wait_for_mounted_build(&driver, &build_a).await?;
         assert_eq!(sibling_a["documentBuild"], build_a, "{sibling_a}");
+        let sibling_documents = sibling_a["documents"]
+            .as_u64()
+            .context("sibling omitted its document count")?;
 
-        driver.switch_to_window(primary.clone()).await?;
         promote_second_generation(&env)?;
         request_registration_update(&driver).await?;
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        queue_waiting_update_reload(&driver).await?;
 
+        driver.switch_to_window(primary.clone()).await?;
         let primary_held = tab_build_state(&driver).await?;
         assert_eq!(primary_held["health"]["build"], build_a, "{primary_held}");
         assert_eq!(primary_held["documentBuild"], build_a, "{primary_held}");
@@ -1134,13 +1404,60 @@ mod tests {
         assert_eq!(sibling_held["documentBuild"], build_a, "{sibling_held}");
 
         driver.switch_to_window(primary.clone()).await?;
-        set_update_hold(&driver, false).await?;
-        driver.refresh().await?;
-        let primary_b = wait_for_mounted_build(&driver, &build_b).await?;
-        assert_eq!(primary_b["health"]["build"], build_b, "{primary_b}");
-        driver.switch_to_window(sibling).await?;
+        release_paused_account_setup(&driver).await?;
+        driver.switch_to_window(sibling.clone()).await?;
         let sibling_b = wait_for_mounted_build(&driver, &build_b).await?;
         assert_eq!(sibling_b["health"]["build"], build_b, "{sibling_b}");
+        assert_eq!(
+            sibling_b["documents"].as_u64(),
+            Some(sibling_documents + 1),
+            "the queued update action must reload its sibling exactly once: {sibling_b}"
+        );
+        driver.switch_to_window(primary.clone()).await?;
+        let primary_b = wait_for_mounted_build(&driver, &build_b).await?;
+        assert_eq!(primary_b["health"]["build"], build_b, "{primary_b}");
+        assert_eq!(
+            primary_b["documents"].as_u64(),
+            Some(primary_documents + 1),
+            "the peer claim must reload the account producer exactly once: {primary_b}"
+        );
+
+        let settled = driver
+            .execute_async(
+                r#"
+                const done = arguments[arguments.length - 1];
+                (async () => {
+                    const database = await new Promise((resolve, reject) => {
+                        const request = indexedDB.open("tonk-update-safety-v1", 1);
+                        request.onsuccess = () => resolve(request.result);
+                        request.onerror = () => reject(request.error);
+                    });
+                    const hold = await new Promise((resolve, reject) => {
+                        const transaction = database.transaction("holds", "readonly");
+                        const request = transaction.objectStore("holds").get("account-setup");
+                        let value;
+                        request.onsuccess = () => { value = request.result; };
+                        request.onerror = () => reject(request.error);
+                        transaction.oncomplete = () => resolve(value);
+                    });
+                    database.close();
+                    done({
+                        absent: hold === undefined,
+                        critical: document.documentElement.hasAttribute(
+                            "data-tonk-account-setup-critical",
+                        ),
+                        mayReload: window.tonkAccountSetupMayReload?.(),
+                    });
+                })().catch(error => done({ error: String(error) }));
+                "#,
+                Vec::new(),
+            )
+            .await?;
+        assert_eq!(
+            settled.json(),
+            &serde_json::json!({ "absent": true, "critical": false, "mayReload": true }),
+            "the producer did not settle its durable and document contracts"
+        );
 
         let sentinels = state_sentinels(&driver).await?;
         assert_eq!(sentinels["indexedDb"], "preserved", "{sentinels}");
@@ -1153,10 +1470,14 @@ mod tests {
     async fn it_withdraws_a_generation_without_deleting_local_state(
         env: TestEnvironment,
     ) -> Result<()> {
+        let (generation_a, generation_b) = prepare_second_generation(&env)?;
         let driver = env.driver().await?;
-        let build = worker_build_id(&env.service_worker_script)?;
+        let build = generation_a.build;
         let initial = wait_for_mounted_build(&driver, &build).await?;
         assert_eq!(initial["health"]["build"], build, "{initial}");
+        let initial_documents = initial["documents"]
+            .as_u64()
+            .context("initial generation omitted its document count")?;
         create_state_sentinels(&driver).await?;
         let caches_before = driver
             .execute_async(
@@ -1194,6 +1515,27 @@ mod tests {
         };
         assert_eq!(withdrawn["body"]["build"], build, "{withdrawn}");
 
+        // The withdrawal can be observed by the health poll after the shell
+        // navigation has already completed. Navigate once more so the failed
+        // worker serves its recovery document and its update action.
+        driver.refresh().await?;
+        driver.find(By::Css("#update")).await?;
+        let failure_documents = driver
+            .execute(
+                r#"return Number(sessionStorage.getItem("tonk:test:sw-documents")) || 0;"#,
+                Vec::new(),
+            )
+            .await?;
+        let failure_documents = failure_documents
+            .json()
+            .as_u64()
+            .context("failure page omitted its document count")?;
+        assert_eq!(
+            failure_documents,
+            initial_documents + 1,
+            "entering the failure page must be one navigation"
+        );
+
         let after = driver
             .execute_async(
                 r#"
@@ -1225,6 +1567,26 @@ mod tests {
             after.json()["refused"]["body"]["error"]["kind"],
             "worker-failed",
             "{after:?}"
+        );
+        let sentinels = state_sentinels(&driver).await?;
+        assert_eq!(sentinels["indexedDb"], "preserved", "{sentinels}");
+        assert_eq!(sentinels["cache"], "preserved", "{sentinels}");
+
+        // The recovery button must not reload back into withdrawn A. Publish
+        // B after the failure page is visible, then require the button to
+        // install, activate, and claim B before its single reload.
+        promote_second_generation(&env)?;
+        driver.find(By::Css("#update")).await?.click().await?;
+        let recovered = wait_for_mounted_build(&driver, &generation_b.build).await?;
+        assert_eq!(
+            recovered["health"]["build"], generation_b.build,
+            "{recovered}"
+        );
+        assert_eq!(recovered["controlled"], true, "{recovered}");
+        assert_eq!(
+            recovered["documents"].as_u64(),
+            Some(failure_documents + 1),
+            "withdrawal recovery must reload exactly once into B: {recovered}"
         );
         let sentinels = state_sentinels(&driver).await?;
         assert_eq!(sentinels["indexedDb"], "preserved", "{sentinels}");

--- a/rust/tonk-ui/src/user_error.rs
+++ b/rust/tonk-ui/src/user_error.rs
@@ -171,6 +171,13 @@ pub(crate) fn ceremony_problem(
     use tonk_identity::custody::CustodyDenial;
     use tonk_identity::passkey::CeremonyRefusal;
 
+    if error.update_safety {
+        return AccountProblem::new(
+            error.message.clone(),
+            update_safety_outcome(error.retry_unsafe),
+        );
+    }
+
     match &error.denial {
         Some(CustodyDenial::AwaitingActivation) => AccountProblem::new(
             "Open the confirmation link in your email to finish signing in. You can leave this page open.".to_owned(),
@@ -199,6 +206,15 @@ pub(crate) fn ceremony_problem(
             };
             AccountProblem::new(diagnostic_message(action, &error.message), outcome)
         }
+    }
+}
+
+#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
+fn update_safety_outcome(retry_unsafe: bool) -> AccountOutcome {
+    if retry_unsafe {
+        AccountOutcome::unknown_commit(FailureKind::LocalState)
+    } else {
+        AccountOutcome::retryable(FailureKind::LocalState)
     }
 }
 
@@ -415,6 +431,22 @@ fn fallback(action: AccountAction) -> &'static str {
 mod tests {
     use super::*;
     use crate::error::AccountTransportKind;
+
+    #[test]
+    fn update_safety_distinguishes_safe_retry_from_an_unknown_commit() {
+        assert_eq!(
+            update_safety_outcome(false).result(),
+            tonk_analytics::account::AccountResult::RetryableFailure
+        );
+        assert_eq!(
+            update_safety_outcome(true).result(),
+            tonk_analytics::account::AccountResult::UnknownCommit
+        );
+        assert_eq!(
+            update_safety_outcome(true).failure_kind(),
+            Some(FailureKind::LocalState)
+        );
+    }
 
     #[test]
     fn it_turns_passkey_diagnostics_into_specific_recovery_steps() {

--- a/rust/tonk-ui/tests/build-artifacts.test.mjs
+++ b/rust/tonk-ui/tests/build-artifacts.test.mjs
@@ -145,6 +145,20 @@ test("the browser harness serves stamped directory aliases from their own index"
   );
 });
 
+test("the browser harness exposes account setup capability discovery", () => {
+  const flake = readFileSync(join(UI, "..", "..", "flake.nix"), "utf8");
+  const packageStart = flake.indexOf("tonk-ui-test-server =");
+  const server = flake.slice(packageStart);
+  const capability = server.indexOf("handle /capabilities {");
+  const fallback = server.indexOf("handle {", capability);
+
+  assert.ok(capability >= 0, "the provider capability route must be proxied");
+  assert.ok(
+    fallback > capability,
+    "capability discovery must reach the access service before the SPA fallback",
+  );
+});
+
 test("tonk-code source identity changes when its TypeScript configuration changes", () => {
   const root = mkdtempSync(join(tmpdir(), "tonk-code-fingerprint-"));
   try {

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -53,6 +53,7 @@ mod claim;
 pub use claim::{AssertPath, AssertResponse, ClaimQuery, ClaimResponse, QueryResponse};
 
 mod account;
+mod account_capabilities;
 mod account_deletion;
 pub(crate) mod customer;
 #[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
@@ -428,6 +429,10 @@ pub fn api_router_from_state(state: AppState) -> (Router, Arc<LspHub>) {
             get(identity::get).post(identity::save),
         )
         .route("/api/account", get(account::get).delete(account::unlink))
+        .route(
+            "/api/account/setup-capabilities",
+            get(account_capabilities::get),
+        )
         .route("/api/account/deletion/plan", get(account_deletion::plan))
         .route("/api/account/delete", post(account_deletion::delete))
         .route(

--- a/rust/tonk-worker/src/router/account_capabilities.rs
+++ b/rust/tonk-worker/src/router/account_capabilities.rs
@@ -1,0 +1,80 @@
+//! Account setup protocol negotiation with the deployed access service.
+
+use axum::Json;
+use axum_wasm_macros::wasm_compat;
+use serde::Deserialize;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use tokio::sync::oneshot;
+
+use crate::TonkWorkerError;
+
+const ACCOUNT_SETUP_LIFECYCLE_VERSION: u8 = 1;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct Capabilities {
+    account_setup_lifecycle: u8,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CapabilityResponse {
+    service: String,
+    capabilities: Capabilities,
+}
+
+fn validates(body: &[u8]) -> bool {
+    serde_json::from_slice::<CapabilityResponse>(body).is_ok_and(|response| {
+        response.service == "tonk-access-service"
+            && response.capabilities.account_setup_lifecycle == ACCOUNT_SETUP_LIFECYCLE_VERSION
+    })
+}
+
+fn unavailable() -> TonkWorkerError {
+    TonkWorkerError::Upstream {
+        status: 503,
+        code: Some("ACCOUNT_SETUP_PROTOCOL_UNAVAILABLE".to_string()),
+        message: "the account service does not support this Tonk setup protocol".to_string(),
+    }
+}
+
+/// Confirm that this worker and its independently deployed account provider
+/// implement the same pre-WebAuthn setup protocol.
+#[wasm_compat]
+pub async fn get() -> Result<Json<serde_json::Value>, TonkWorkerError> {
+    let endpoint = super::customer::service_origin()?
+        .join("capabilities")
+        .map_err(|error| TonkWorkerError::Internal(format!("capability endpoint: {error}")))?;
+    let response = super::http::get(&endpoint).await?;
+    if !validates(&response.body) {
+        return Err(unavailable());
+    }
+    Ok(Json(serde_json::json!({
+        "service": "tonk-access-service",
+        "capabilities": {
+            "accountSetupLifecycle": ACCOUNT_SETUP_LIFECYCLE_VERSION,
+        },
+    })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validates;
+
+    #[test]
+    fn it_accepts_only_the_exact_account_setup_protocol() {
+        assert!(validates(
+            br#"{"service":"tonk-access-service","capabilities":{"accountSetupLifecycle":1}}"#
+        ));
+        for rejected in [
+            &br#"{"service":"tonk-access-service","capabilities":{"accountSetupLifecycle":0}}"#[..],
+            &br#"{"service":"tonk-access-service","capabilities":{"accountSetupLifecycle":2}}"#[..],
+            &br#"{"service":"other","capabilities":{"accountSetupLifecycle":1}}"#[..],
+            &br#"{"service":"tonk-access-service","capabilities":{}}"#[..],
+            &br#"{"service":"tonk-access-service","capabilities":{"accountSetupLifecycle":1},"extra":true}"#[..],
+            &b"not json"[..],
+        ] {
+            assert!(!validates(rejected), "accepted {rejected:?}");
+        }
+    }
+}

--- a/rust/tonk-worker/src/router/account_deletion.rs
+++ b/rust/tonk-worker/src/router/account_deletion.rs
@@ -242,15 +242,10 @@ pub async fn delete(
         Ok(_) => {}
         Err(super::http::HttpError::Upstream(failure)) if failure.status == 404 => {
             // A previous attempt may have completed access-service cleanup
-            // before the account-service call failed. Continue that retry.
+            // before local profile cleanup finished. Continue that retry.
         }
         Err(error) => return Err(error.into()),
     }
-
-    // The access service's customer row is keyed on the account and
-    // its email is unique, so leaving it behind keeps the address taken
-    // after the account that held it is gone.
-    delete_customer(&state).await?;
 
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     for space in &request.spaces {
@@ -274,27 +269,4 @@ pub async fn delete(
         deleted_spaces: request.spaces.len(),
         retained_joined_spaces: current.joined_spaces,
     }))
-}
-
-/// Tell the access service to drop the customer row, releasing the
-/// address it holds.
-async fn delete_customer(state: &AppState) -> Result<(), TonkWorkerError> {
-    let (device, link) = {
-        let tonk = state.read().await;
-        let link = super::account::account_link(&tonk).await.ok_or_else(|| {
-            TonkWorkerError::NotFound("this profile is not linked to an account".to_string())
-        })?;
-        (tonk.profile.signer().signer().clone(), link)
-    };
-    let body = tonk_identity::request::build_device_invocation(
-        device,
-        &link,
-        vec!["customer".to_string(), "delete".to_string()],
-        BTreeMap::new(),
-    )
-    .await
-    .map_err(|error| TonkWorkerError::Internal(format!("build customer deletion: {error}")))?;
-    let endpoint = super::customer::ucan_endpoint(&super::customer::service_origin()?)?;
-    super::http::post_cbor(&endpoint, &body).await?;
-    Ok(())
 }

--- a/rust/tonk-worker/src/router/account_devices.rs
+++ b/rust/tonk-worker/src/router/account_devices.rs
@@ -174,22 +174,20 @@ pub async fn register(
     Ok(Json(serde_json::json!({ "attachmentId": attachment_id })))
 }
 
-/// Prefer the portable account-space fact; fall back to what the provider
-/// recorded at account creation.
+/// Prefer the portable account-space fact; fall back to this device's local
+/// root creation metadata.
 ///
-/// The provider row is not a legacy-only path. Every account still writes it at
-/// creation, and it answers three live cases: an account created before the
-/// space fact existed, a device that never held the passkey and so cannot seed
-/// it, and a fresh account read in the window between account creation and the
-/// first sweep that seeds the space.
+/// The local root answers the fresh-account window before the first account
+/// sweep exposes the portable fact. It is only a fallback: another device's
+/// newer account-space fact must win over this device's creation record.
 fn merge_summary(
     email: Option<String>,
     space: Option<PasskeyMetadata>,
-    provider: Option<PasskeyMetadata>,
+    local: Option<PasskeyMetadata>,
 ) -> AccountSummary {
     AccountSummary {
         email,
-        passkey: space.or(provider),
+        passkey: space.or(local),
         display_name: None,
     }
 }
@@ -211,7 +209,11 @@ pub(crate) async fn account_summary(state: &TonkState) -> Result<AccountSummary,
     // them was asking for a second copy of what this branch holds.
     let email = super::customer::account_registration(state).await.email;
     let passkey = super::account_state::passkey_facts(state).await;
-    let mut summary = merge_summary(email, passkey, None);
+    let local = super::identity::local_root(state)
+        .await
+        .ok()
+        .and_then(|root| root.passkey);
+    let mut summary = merge_summary(email, passkey, local);
     summary.display_name = account_display_name(state).await;
     Ok(summary)
 }
@@ -574,12 +576,12 @@ mod tests {
     }
 
     #[dialog_common::test]
-    fn it_prefers_the_account_space_passkey_fact_over_the_provider_row() {
+    fn it_prefers_the_account_space_passkey_fact_over_the_local_root() {
         let space = PasskeyMetadata {
             created_at: 1_754_380_800,
             created_on: "Chrome on macOS".to_string(),
         };
-        let provider = PasskeyMetadata {
+        let local = PasskeyMetadata {
             created_at: 1_600_000_000,
             created_on: "Safari on iOS".to_string(),
         };
@@ -587,19 +589,19 @@ mod tests {
         let merged = merge_summary(
             Some("person@example.com".to_string()),
             Some(space.clone()),
-            Some(provider.clone()),
+            Some(local.clone()),
         );
         assert_eq!(merged.passkey, Some(space.clone()));
 
         let fallback = merge_summary(
             Some("person@example.com".to_string()),
             None,
-            Some(provider.clone()),
+            Some(local.clone()),
         );
         assert_eq!(
             fallback.passkey,
-            Some(provider),
-            "an account created before the space fact existed still has the provider row"
+            Some(local),
+            "a fresh account renders its creation metadata before the first sweep"
         );
 
         let neither = merge_summary(Some("person@example.com".to_string()), None, None);

--- a/rust/tonk-worker/src/router/route_table.rs
+++ b/rust/tonk-worker/src/router/route_table.rs
@@ -12,7 +12,9 @@
 /// Every route the worker serves, sorted. The data plane (branch query,
 /// transact, evaluate, blob, sync) belongs here; account, membership,
 /// invite, and custody operations are commands or are on their way to
-/// becoming ones.
+/// becoming ones. The account-setup compatibility probe is lifecycle control
+/// plane: a read-only negotiation across independently deployed components,
+/// not a durable domain operation.
 const ROUTES: &[&str] = &[
     "/api",
     "/api/account",
@@ -23,6 +25,7 @@ const ROUTES: &[&str] = &[
     "/api/account/devices/register",
     "/api/account/devices/revoke",
     "/api/account/display-name",
+    "/api/account/setup-capabilities",
     "/api/account/spaces/delete",
     "/api/account/summary",
     "/api/custody/provision",
@@ -151,13 +154,14 @@ const STATE_CHANGING_ROUTES: &[(&str, &str)] = &[
     ("POST", "/api/custody/queue"),
     ("POST", "/api/customer/activated"),
     ("POST", "/api/identity/root"),
-    ("POST", "/api/language-server"),
+    ("POST", "/api/profile/tonk/branch/main/language-server"),
     ("POST", "/api/profile/branch/main/evaluate"),
     ("POST", "/api/profile/branch/main/site"),
     ("POST", "/api/profile/branch/main/transact"),
     ("POST", "/api/profile/join"),
     ("POST", "/api/profiles/activate"),
     ("POST", "/api/profiles/add"),
+    ("POST", "/api/repository/space/branch/main/language-server"),
     ("POST", "/api/repository/space/branch/main/blob"),
     (
         "POST",


### PR DESCRIPTION
## Summary

- hold activation/claim while a non-repeatable account setup ceremony is in its critical window
- persist and reconcile operation-owned update holds across reloads and tabs
- negotiate account setup capabilities before WebAuthn and classify recovery outcomes for the UI
- compose first-install and ordinary upgrade convergence with account creation, deletion, and device flows

## Stack

- base: #868 (`fix/sw-nested-runtime`)
- top of the service-worker lifecycle stack

## Scope

- 25 files, +1,646 / -185 relative to the nested-runtime PR
- account hold producer, identity/account ceremony integration, capability endpoint, UI composition, and focused tests

## Verification

- `cargo fmt --all -- --check`
- account capability worker test: 1 passed
- account/lifecycle Node suite: 47 passed
- `tonk-ui` all-features native test targets compile
- final rebased stack: `nix build .#checks.aarch64-darwin.clippy --no-link --print-build-logs` passed under Rust 1.93.0

## Known unrelated test-harness issue

Running every `tonk-access-service` library test without its helper feature still fails because existing `dialog_common::test` cases expand to `tokio` while that crate is not a test dependency. The changed deployment-config integration target compiles separately; the Nix workspace clippy check passes.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new account setup protocol and enhances the capabilities of the `tonk-access-service` and `tonk-ui` modules, focusing on improving the account creation process, error handling, and overall safety during credential management.

### Detailed summary
- Added `capabilities` module for account setup lifecycle management.
- Introduced `/capabilities` endpoint in `tonk-access-service`.
- Enhanced error handling for credential creation failures.
- Implemented account setup safety checks in `tonk-ui`.
- Updated account creation flow to ensure safe retries and proper state management.
- Added tests for new capabilities and error handling scenarios.

> The following files were skipped due to too many changes: `rust/tonk-ui/src/account_flow.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->