### PR TITLE
fix(ui): simplify expired share link recovery

### DIFF
--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -427,16 +427,11 @@ view!:
       <!-- Revoked and deleted intentionally share this one screen. The
            diagnostic reason remains in the console/worker status; rendering it
            here would reveal whether the space still exists. -->
-      <section class="edge-wall edge-wall--closed" aria-labelledby="edge-closed-title">
-        <div class="edge-statement" id="edge-closed-title">this share link is closed</div>
-        <div class="edge-field edge-field--settled">
-          <span class="edge-noun">share link</span>
-          <span class="edge-value">closed</span>
-        </div>
-        <div class="edge-narrator">this link no longer opens a space; ask its sender for a current share link</div>
+      <section class="edge-wall edge-wall--closed" role="status" aria-labelledby="edge-closed-title" aria-describedby="edge-closed-guidance">
+        <h1 class="edge-statement" id="edge-closed-title">this share link expired</h1>
+        <div class="edge-narrator" id="edge-closed-guidance">ask the person who shared this space to send you a new link</div>
         <div class="edge-run">
-          <a class="ebtn quiet" href="/">start a new space</a>
-          <tonk-join-retry class="ebtn solid" kind={kind}>join this space</tonk-join-retry>
+          <a class="ebtn solid" href="/">go to home</a>
         </div>
       </section>
 
@@ -633,7 +628,7 @@ view!:
               margin-top:43px; display:flex; flex-direction:column; gap:7px; }
             .edge-statement, .edge-field, .edge-narrator { min-height:36px;
               background:var(--edge-card); box-shadow:0 0 0 1px var(--edge-ring); }
-            .edge-statement { padding:10px 14px; display:flex; align-items:flex-end;
+            .edge-statement { margin:0; padding:10px 14px; display:flex; align-items:flex-end;
               font-family:'IBM Plex Sans',system-ui,sans-serif; font-size:13.5px;
               line-height:1.55; text-wrap:balance; }
             .edge-field { height:36px; min-width:0; padding:0 10px 8px 12px;

--- a/rust/tonk-worker/tests/standard_library.rs
+++ b/rust/tonk-worker/tests/standard_library.rs
@@ -430,8 +430,17 @@ fn it_renders_join_refusals_as_neutral_edge_walls() {
             "the closed-invitation wall must not expose `{rejected}`",
         );
     }
-    assert!(failure.contains("this share link is closed"));
+    assert!(failure.contains("this share link expired"));
+    assert!(failure.contains("ask the person who shared this space to send you a new link"));
+    assert!(failure.contains("go to home"));
+    assert!(!failure.contains("edge-field edge-field--settled"));
+    assert!(!failure.contains("paste a new link"));
+    assert!(!failure.contains("tonk-join-retry"));
+    assert!(!failure.contains("join this space"));
+    assert!(!failure.contains("start a new space"));
     assert!(route.contains("you do not have access to this space"));
+    assert!(route.contains("start a new space"));
+    assert!(route.contains("join this space"));
     for wall in [("closed", failure), ("no-access", route)] {
         assert_eq!(
             wall.1.matches("class=\"ebtn solid\"").count(),
@@ -439,8 +448,6 @@ fn it_renders_join_refusals_as_neutral_edge_walls() {
             "the {} wall must carry exactly one solid ink door",
             wall.0,
         );
-        assert!(wall.1.contains("start a new space"));
-        assert!(wall.1.contains("join this space"));
     }
 }
 


### PR DESCRIPTION
## Summary

- explain that the share link expired without exposing revoked/deleted diagnostics
- remove the redundant status row and retry action
- leave one full-width Home recovery action with accessible status semantics

## Testing

- cargo test -p tonk-worker --test standard_library
- cargo fmt --all -- --check
- git diff --check

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the error messages and UI elements related to share link statuses in the `tonk-worker` and `tonk-core` components. It improves user feedback when a share link is expired or inaccessible.

### Detailed summary
- Updated assertion messages in `rust/tonk-worker/tests/standard_library.rs` for link expiration.
- Added assertions for new messages about requesting a new link and guidance to go home.
- Modified HTML structure in `rust/tonk-core/assets/library/profile.yaml`:
  - Changed the statement from "this share link is closed" to "this share link expired."
  - Updated the narrator text for clarity on requesting a new link.
  - Changed button text from "start a new space" to "go to home."

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->