### PR TITLE
test: stabilize and shard browser e2e

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,11 +39,11 @@ jobs:
 
   e2e-build:
     name: 'Build end-to-end test archive'
-    needs: ['lints']
     runs-on: 'ubuntu-latest'
     # Build the source-dependent archive once. The shards below realize these
     # exact store paths from Cachix instead of racing three identical cold
-    # builds on separate runners.
+    # builds on separate runners. This is independent of lint, so overlap the
+    # two expensive prerequisites; shards still require both to succeed.
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -67,7 +67,7 @@ jobs:
 
   e2e-shard:
     name: 'End-to-end shard ${{ matrix.shard }}/3'
-    needs: ['e2e-build']
+    needs: ['lints', 'e2e-build']
     runs-on: 'ubuntu-latest'
     timeout-minutes: 45
     strategy:
@@ -76,10 +76,6 @@ jobs:
         shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@v4
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
       - uses: wimpysworld/nothing-but-nix@main
         with:
           root-safe-haven: 40960

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,15 +37,43 @@ jobs:
         run: |
           nix --accept-flake-config develop .#ci -c lint
 
-  e2e:
-    name: 'End-to-end account tests'
+  e2e-build:
+    name: 'Build end-to-end test archive'
     needs: ['lints']
     runs-on: 'ubuntu-latest'
-    # A cold build of the tests-e2e archive can take ~20 minutes before the
-    # suite starts; a warm cachix hit cuts that to a download. Keep a bound
-    # for wedged WebDriver or network calls while leaving headroom for
-    # runner variance.
-    timeout-minutes: 60
+    # Build the source-dependent archive once. The shards below realize these
+    # exact store paths from Cachix instead of racing three identical cold
+    # builds on separate runners.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+      - uses: wimpysworld/nothing-but-nix@main
+        with:
+          root-safe-haven: 40960
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v16
+        with:
+          name: tonk-test-cache
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - name: 'Build end-to-end test inputs'
+        shell: bash
+        run: nix build --accept-flake-config .#tonk-cli .#tests-e2e
+
+  e2e-shard:
+    name: 'End-to-end shard ${{ matrix.shard }}/3'
+    needs: ['e2e-build']
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@v4
       - name: Free disk space
@@ -72,8 +100,32 @@ jobs:
         run: echo '127.0.0.1 tonk.network' | sudo tee -a /etc/hosts
       - name: 'Run end-to-end tests'
         shell: bash
+        env:
+          TONK_E2E_DIAGNOSTICS_DIR: '${{ runner.temp }}/tonk-e2e-diagnostics'
         run: |
-          nix develop --accept-flake-config .#ci --command test:e2e
+          nix develop --accept-flake-config .#ci --command test:e2e \
+            --partition 'count:${{ matrix.shard }}/3'
+      - name: 'Upload end-to-end timing diagnostics'
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'e2e-diagnostics-${{ matrix.shard }}'
+          path: '${{ runner.temp }}/tonk-e2e-diagnostics'
+          if-no-files-found: ignore
+          retention-days: 14
+
+  e2e:
+    # Preserve the required-check context while the implementation is sharded.
+    name: 'End-to-end account tests'
+    needs: ['e2e-shard']
+    if: always()
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 5
+    steps:
+      - name: 'Require every end-to-end shard'
+        env:
+          SHARD_RESULT: '${{ needs.e2e-shard.result }}'
+        run: test "$SHARD_RESULT" = success
 
   service-worker:
     name: 'Service-worker lifecycle tests'

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -79,18 +79,94 @@ mod tests {
         Ok(serde_json::from_value(value.json().clone())?)
     }
 
+    fn retryable_find_error(error: &thirtyfour::error::WebDriverErrorInner) -> bool {
+        matches!(
+            error,
+            thirtyfour::error::WebDriverErrorInner::NoSuchElement(_)
+                | thirtyfour::error::WebDriverErrorInner::StaleElementReference(_)
+        )
+    }
+
+    fn retryable_element_read_error(error: &thirtyfour::error::WebDriverErrorInner) -> bool {
+        matches!(
+            error,
+            thirtyfour::error::WebDriverErrorInner::StaleElementReference(_)
+        )
+    }
+
+    #[test]
+    fn it_only_retries_expected_dom_races() {
+        use thirtyfour::error::{WebDriverErrorInfo, WebDriverErrorInner, WebDriverErrorValue};
+
+        let info = |error: &str| WebDriverErrorInfo {
+            status: 400,
+            error: error.to_string(),
+            value: WebDriverErrorValue::new(error.to_string()),
+        };
+
+        assert!(retryable_find_error(&WebDriverErrorInner::NoSuchElement(
+            info("no such element")
+        )));
+        assert!(retryable_find_error(
+            &WebDriverErrorInner::StaleElementReference(info("stale element reference"))
+        ));
+        assert!(!retryable_find_error(
+            &WebDriverErrorInner::InvalidSelector(info("invalid selector"))
+        ));
+        assert!(retryable_element_read_error(
+            &WebDriverErrorInner::StaleElementReference(info("stale element reference"))
+        ));
+        assert!(!retryable_element_read_error(
+            &WebDriverErrorInner::ElementClickIntercepted(info("element click intercepted"))
+        ));
+    }
+
+    async fn page_diagnostic_state(driver: &WebDriver) -> serde_json::Value {
+        driver
+            .execute(
+                r##"
+                const account = document.querySelector("tonk-account");
+                const error = document.querySelector("#account-error");
+                const firstSegment = location.pathname.split("/").filter(Boolean)[0] || "";
+                const path = ["", "account", "activate", "settings"].includes(firstSegment)
+                    ? `/${firstSegment}`
+                    : "/<redacted>";
+                return {
+                    path,
+                    addingAccount: new URLSearchParams(location.search).has("add"),
+                    ready: document.readyState,
+                    controlled: !!(navigator.serviceWorker && navigator.serviceWorker.controller),
+                    accountMode: account?.getAttribute("data-mode") || null,
+                    accountBusy: account?.getAttribute("aria-busy") || null,
+                    accountError: (error?.textContent || "").slice(0, 500) || null,
+                };
+                "##,
+                vec![],
+            )
+            .await
+            .map(|value| value.json().clone())
+            .unwrap_or_else(|_| serde_json::json!({ "webdriverError": "diagnostic query failed" }))
+    }
+
     async fn element(driver: &WebDriver, selector: &str) -> Result<WebElement> {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
         loop {
             match driver.find(By::Css(selector.to_string())).await {
                 Ok(element) => return Ok(element),
-                Err(error) if tokio::time::Instant::now() < deadline => {
-                    let _ = error;
+                Err(error)
+                    if retryable_find_error(error.as_inner())
+                        && tokio::time::Instant::now() < deadline =>
+                {
                     tokio::time::sleep(Duration::from_millis(100)).await;
                 }
                 Err(error) => {
-                    return Err(error)
-                        .with_context(|| format!("timed out waiting for `{selector}`"));
+                    if retryable_find_error(error.as_inner()) {
+                        let state = page_diagnostic_state(driver).await;
+                        return Err(error).with_context(|| {
+                            format!("timed out waiting for `{selector}`; page={state}")
+                        });
+                    }
+                    return Err(error).with_context(|| format!("failed to find `{selector}`"));
                 }
             }
         }
@@ -111,12 +187,19 @@ mod tests {
             let found = element(driver, selector).await?;
             match found.click().await {
                 Ok(()) => return Ok(()),
-                Err(error) if tokio::time::Instant::now() < deadline => {
-                    let _ = error;
+                Err(error)
+                    if retryable_element_read_error(error.as_inner())
+                        && tokio::time::Instant::now() < deadline =>
+                {
                     tokio::time::sleep(Duration::from_millis(100)).await;
                 }
                 Err(error) => {
-                    return Err(error).with_context(|| format!("timed out clicking `{selector}`"));
+                    let action = if retryable_element_read_error(error.as_inner()) {
+                        "timed out clicking"
+                    } else {
+                        "failed to click"
+                    };
+                    return Err(error).with_context(|| format!("{action} `{selector}`"));
                 }
             }
         }
@@ -124,15 +207,26 @@ mod tests {
 
     async fn wait_for_text(driver: &WebDriver, selector: &str, expected: &str) -> Result<()> {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        let mut last: String;
         loop {
-            if let Ok(found) = driver.find(By::Css(selector.to_string())).await
-                && found.text().await.ok().as_deref() == Some(expected)
-            {
-                return Ok(());
+            match driver.find(By::Css(selector.to_string())).await {
+                Ok(found) => match found.text().await {
+                    Ok(text) if text == expected => return Ok(()),
+                    Ok(text) => last = format!("text was {text:?}"),
+                    Err(error) if retryable_element_read_error(error.as_inner()) => {
+                        last = error.to_string();
+                    }
+                    Err(error) => return Err(error).context("failed to read element text"),
+                },
+                Err(error) if retryable_find_error(error.as_inner()) => {
+                    last = error.to_string();
+                }
+                Err(error) => return Err(error).context("failed to find element for text wait"),
             }
             if tokio::time::Instant::now() >= deadline {
+                let state = page_diagnostic_state(driver).await;
                 return Err(anyhow!(
-                    "timed out waiting for `{selector}` to equal {expected:?}"
+                    "timed out waiting for `{selector}` to equal {expected:?}; last={last}; page={state}"
                 ));
             }
             tokio::time::sleep(Duration::from_millis(100)).await;
@@ -141,15 +235,26 @@ mod tests {
 
     async fn wait_for_value(driver: &WebDriver, selector: &str, expected: &str) -> Result<()> {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        let mut last: String;
         loop {
-            if let Ok(found) = driver.find(By::Css(selector.to_string())).await
-                && found.prop("value").await?.as_deref() == Some(expected)
-            {
-                return Ok(());
+            match driver.find(By::Css(selector.to_string())).await {
+                Ok(found) => match found.prop("value").await {
+                    Ok(value) if value.as_deref() == Some(expected) => return Ok(()),
+                    Ok(value) => last = format!("value was {value:?}"),
+                    Err(error) if retryable_element_read_error(error.as_inner()) => {
+                        last = error.to_string();
+                    }
+                    Err(error) => return Err(error).context("failed to read element value"),
+                },
+                Err(error) if retryable_find_error(error.as_inner()) => {
+                    last = error.to_string();
+                }
+                Err(error) => return Err(error).context("failed to find element for value wait"),
             }
             if tokio::time::Instant::now() >= deadline {
+                let state = page_diagnostic_state(driver).await;
                 return Err(anyhow!(
-                    "timed out waiting for `{selector}` value to equal {expected:?}"
+                    "timed out waiting for `{selector}` value to equal {expected:?}; last={last}; page={state}"
                 ));
             }
             tokio::time::sleep(Duration::from_millis(100)).await;
@@ -162,21 +267,31 @@ mod tests {
         expected: &str,
     ) -> Result<()> {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        let mut last: String;
         loop {
             // The text read is fallible for the same reason the find is:
             // a list that re-renders between the two invalidates the
             // handle ("stale element reference"). Treat that as "not yet"
             // and go round again — propagating it aborts the wait on a
             // race the wait exists to absorb.
-            if let Ok(found) = driver.find(By::Css(selector.to_string())).await
-                && let Ok(text) = found.text().await
-                && text.contains(expected)
-            {
-                return Ok(());
+            match driver.find(By::Css(selector.to_string())).await {
+                Ok(found) => match found.text().await {
+                    Ok(text) if text.contains(expected) => return Ok(()),
+                    Ok(text) => last = format!("text was {text:?}"),
+                    Err(error) if retryable_element_read_error(error.as_inner()) => {
+                        last = error.to_string();
+                    }
+                    Err(error) => return Err(error).context("failed to read element text"),
+                },
+                Err(error) if retryable_find_error(error.as_inner()) => {
+                    last = error.to_string();
+                }
+                Err(error) => return Err(error).context("failed to find element for text wait"),
             }
             if tokio::time::Instant::now() >= deadline {
+                let state = page_diagnostic_state(driver).await;
                 return Err(anyhow!(
-                    "timed out waiting for `{selector}` to contain {expected:?}"
+                    "timed out waiting for `{selector}` to contain {expected:?}; last={last}; page={state}"
                 ));
             }
             tokio::time::sleep(Duration::from_millis(100)).await;
@@ -187,16 +302,26 @@ mod tests {
     /// a retraction takes in the DOM.
     async fn wait_for_text_without(driver: &WebDriver, selector: &str, gone: &str) -> Result<()> {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        let mut last: String;
         loop {
-            if let Ok(found) = driver.find(By::Css(selector.to_string())).await
-                && let Ok(text) = found.text().await
-                && !text.contains(gone)
-            {
-                return Ok(());
+            match driver.find(By::Css(selector.to_string())).await {
+                Ok(found) => match found.text().await {
+                    Ok(text) if !text.contains(gone) => return Ok(()),
+                    Ok(text) => last = format!("text was {text:?}"),
+                    Err(error) if retryable_element_read_error(error.as_inner()) => {
+                        last = error.to_string();
+                    }
+                    Err(error) => return Err(error).context("failed to read element text"),
+                },
+                Err(error) if retryable_find_error(error.as_inner()) => {
+                    last = error.to_string();
+                }
+                Err(error) => return Err(error).context("failed to find element for text wait"),
             }
             if tokio::time::Instant::now() >= deadline {
+                let state = page_diagnostic_state(driver).await;
                 return Err(anyhow!(
-                    "timed out waiting for `{selector}` to stop containing {gone:?}"
+                    "timed out waiting for `{selector}` to stop containing {gone:?}; last={last}; page={state}"
                 ));
             }
             tokio::time::sleep(Duration::from_millis(100)).await;
@@ -235,15 +360,28 @@ mod tests {
 
     async fn wait_for_displayed(driver: &WebDriver, selector: &str) -> Result<WebElement> {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        let mut last: String;
         loop {
-            if let Ok(found) = driver.find(By::Css(selector.to_string())).await
-                && found.is_displayed().await.unwrap_or(false)
-            {
-                return Ok(found);
+            match driver.find(By::Css(selector.to_string())).await {
+                Ok(found) => match found.is_displayed().await {
+                    Ok(true) => return Ok(found),
+                    Ok(false) => last = "element was hidden".to_string(),
+                    Err(error) if retryable_element_read_error(error.as_inner()) => {
+                        last = error.to_string();
+                    }
+                    Err(error) => return Err(error).context("failed to read element visibility"),
+                },
+                Err(error) if retryable_find_error(error.as_inner()) => {
+                    last = error.to_string();
+                }
+                Err(error) => {
+                    return Err(error).context("failed to find element for visibility wait");
+                }
             }
             if tokio::time::Instant::now() >= deadline {
+                let state = page_diagnostic_state(driver).await;
                 return Err(anyhow!(
-                    "timed out waiting for `{selector}` to be displayed"
+                    "timed out waiting for `{selector}` to be displayed; last={last}; page={state}"
                 ));
             }
             tokio::time::sleep(Duration::from_millis(100)).await;
@@ -256,15 +394,16 @@ mod tests {
             match driver.find_all(By::Css(selector.to_string())).await {
                 Ok(found) if found.is_empty() => return Ok(()),
                 Ok(_) => {}
-                Err(error) if tokio::time::Instant::now() >= deadline => {
-                    return Err(error).with_context(|| {
-                        format!("timed out waiting for `{selector}` to disappear")
-                    });
+                Err(error) if retryable_find_error(error.as_inner()) => {}
+                Err(error) => {
+                    return Err(error).context("failed to find elements for absence wait");
                 }
-                Err(_) => {}
             }
             if tokio::time::Instant::now() >= deadline {
-                return Err(anyhow!("timed out waiting for `{selector}` to disappear"));
+                let state = page_diagnostic_state(driver).await;
+                return Err(anyhow!(
+                    "timed out waiting for `{selector}` to disappear; page={state}"
+                ));
             }
             tokio::time::sleep(Duration::from_millis(100)).await;
         }

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -1151,14 +1151,6 @@ mod tests {
                 Some("success"),
                 None,
             ),
-            ("settle_account", "started", "account_sync", None, None),
-            (
-                "settle_account",
-                "finished",
-                "complete",
-                Some("success"),
-                None,
-            ),
         ];
         let mut cursor = 0;
         for (action, phase, stage, result, failure) in expected {

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -568,12 +568,8 @@ mod tests {
     /// consent card in the TOP document, and its button runs the
     /// assertion the virtual authenticator answers.
     async fn use_passkey_consent(driver: &WebDriver) -> Result<()> {
-        // The prompt opens on the worker's ask without a further click:
-        // the guest's own click activated the top document too. The
-        // card is a fallback for a prompt the browser refused, so it
-        // is pressed only when it appears.
         driver.enter_default_frame().await?;
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
         while tokio::time::Instant::now() < deadline {
             if let Ok(button) = driver.find(By::Css("#tonk-custody-continue")).await {
                 button.click().await?;
@@ -581,7 +577,7 @@ mod tests {
             }
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
-        Ok(())
+        Err(anyhow!("the worker never raised its passkey consent card"))
     }
 
     /// A second browser holding the same passkey: a different device, the

--- a/rust/tonk-ui/src/custody_relay.rs
+++ b/rust/tonk-ui/src/custody_relay.rs
@@ -113,12 +113,16 @@ fn card() -> Option<Element> {
     web_sys::window()?.document()?.get_element_by_id(CARD_ID)
 }
 
-fn set_card_text(text: &str) {
+fn set_card_message(text: &str) {
     if let Some(card) = card()
         && let Ok(Some(message)) = card.query_selector("#tonk-custody-text")
     {
         message.set_text_content(Some(text));
     }
+}
+
+fn set_card_text(text: &str) {
+    set_card_message(text);
     if let Some(card) = card()
         && let Ok(Some(actions)) = card.query_selector("#tonk-custody-actions")
     {
@@ -147,21 +151,24 @@ fn on_click(card: &Element, selector: &str, callback: impl FnMut() + 'static) {
     closure.forget();
 }
 
+fn mount_card() -> Option<Element> {
+    let document = web_sys::window().and_then(|window| window.document())?;
+    let body = document.body()?;
+    let host = document.create_element("div").ok()?;
+    host.set_id(CARD_ID);
+    host.set_inner_html(CARD_HTML);
+    body.append_child(&host).ok()?;
+    Some(host)
+}
+
 /// Raise the consent card. The continue button runs the assertion inside
 /// the click and reports the outcome on the card; dismissing leaves the
 /// worker's wait to time out, failing the operation that asked.
 fn show_consent() {
-    let Some(document) = web_sys::window().and_then(|window| window.document()) else {
+    let Some(host) = mount_card() else {
         BUSY.with(|busy| busy.set(false));
         return;
     };
-    let (Some(body), Ok(host)) = (document.body(), document.create_element("div")) else {
-        BUSY.with(|busy| busy.set(false));
-        return;
-    };
-    host.set_id(CARD_ID);
-    host.set_inner_html(CARD_HTML);
-    let _ = body.append_child(&host);
 
     on_click(&host, "#tonk-custody-dismiss", || {
         let mut attempt = crate::account_observability::WebAccountAttempt::start(
@@ -222,30 +229,61 @@ fn show_consent() {
     });
 }
 
-/// Run the passkey ceremony a guest-asserted command needs, now.
+fn command_action(intent: &tonk_worker_api::CustodyIntent) -> AccountAction {
+    match intent {
+        tonk_worker_api::CustodyIntent::PurgeAccount(_) => AccountAction::DeleteAccount,
+        tonk_worker_api::CustodyIntent::AuthorizeDevice(_) => AccountAction::LinkCli,
+        tonk_worker_api::CustodyIntent::AddPasskey(_) => AccountAction::AddPasskey,
+        tonk_worker_api::CustodyIntent::Enroll(_)
+        | tonk_worker_api::CustodyIntent::CreateAccount(_)
+        | tonk_worker_api::CustodyIntent::Login(_) => AccountAction::FinishPreviousAction,
+    }
+}
+
+/// Raise the top-document consent a guest-asserted command needs.
 ///
-/// The person just pressed the act's own verb in the settings page,
-/// which told them the passkey would be asked for; a card asking the
-/// same question again would be one dialog too many. Progress and
-/// failure are reported where the ask was made: the worker writes the
-/// ceremony row the settings page watches, and a prompt this document
-/// could not finish is logged here and says so in that row through the
-/// worker's own timeout. Pinned to the account's passkey, so a browser
-/// holding several for this origin cannot answer with another
-/// account's.
+/// The command starts in a sealed guest, crosses an asynchronous worker
+/// transaction, and only then reaches this document. The guest's click
+/// activation is not reliable across that boundary, so the assertion is
+/// invoked synchronously by this card's click. The worker still owns the
+/// operation and reports its status in the settings row. The assertion is
+/// pinned to the account's passkey so a browser holding several for this
+/// origin cannot answer with another account's.
 fn run_command_ceremony(intent: tonk_worker_api::CustodyIntent, credential_id: Option<String>) {
+    if BUSY.with(|busy| busy.replace(true)) {
+        return;
+    }
+    let Some(host) = mount_card() else {
+        BUSY.with(|busy| busy.set(false));
+        return;
+    };
+    set_card_message("Confirm this account action with your passkey.");
+    on_click(&host, "#tonk-custody-dismiss", remove_card);
+
     let method = match &intent {
         tonk_worker_api::CustodyIntent::AddPasskey(_) => "addPasskey",
         _ => "usePasskey",
     };
-    match begin_with(method, intent, credential_id) {
-        Ok(mediation) => wasm_bindgen_futures::spawn_local(async move {
-            if let Err(error) = mediation.finish().await {
+    let action = command_action(&intent);
+    on_click(&host, "#tonk-custody-continue", move || {
+        set_card_text("Waiting for your passkey…");
+        match begin_with(method, intent.clone(), credential_id.clone()) {
+            Ok(mediation) => wasm_bindgen_futures::spawn_local(async move {
+                if let Err(error) = mediation.finish().await {
+                    report(&error.message);
+                    set_card_text(&user_error::ceremony(action, &error));
+                    remove_card_after(4000);
+                } else {
+                    remove_card();
+                }
+            }),
+            Err(error) => {
                 report(&error.message);
+                set_card_text(&user_error::ceremony(action, &error));
+                remove_card_after(4000);
             }
-        }),
-        Err(error) => report(&error.message),
-    }
+        }
+    });
 }
 
 /// Install the service-worker message listener on the top document.
@@ -310,10 +348,9 @@ pub fn install() {
                     // Enrollment arrives mid-ceremony, on a page whose
                     // gesture is still live.
                     intent @ tonk_worker_api::CustodyIntent::Enroll(_) => mediate_custody(intent),
-                    // A command the guest asserted. The click that asked
-                    // activated this document too (activation reaches every
-                    // ancestor), so the prompt runs at once; the card is
-                    // only for a prompt the browser would not open.
+                    // A command the guest asserted. Its async trip through the
+                    // worker cannot carry transient activation, so this page
+                    // asks for one explicit top-document click.
                     intent => run_command_ceremony(intent, message.credential_id),
                 }
             }

--- a/rust/tonk-ui/src/helpers.rs
+++ b/rust/tonk-ui/src/helpers.rs
@@ -33,7 +33,7 @@ mod native {
     use async_trait::async_trait;
     use dialog_common::helpers::{Provider, Service};
     use port_check::free_local_port;
-    use std::io::{BufRead, BufReader};
+    use std::io::{BufRead, BufReader, Write};
     use std::process::{Child, Stdio};
     #[cfg(test)]
     use thirtyfour::extensions::cdp::ChromeDevTools;
@@ -44,6 +44,55 @@ mod native {
     use tonk_access_service::helpers::{AccessServiceAddress, AccessServiceSettings};
     use tonk_worker_api::DeploymentConfig;
     use url::Url;
+
+    fn current_test_name() -> String {
+        std::env::args()
+            .find(|argument| argument.contains("::"))
+            .unwrap_or_else(|| format!("pid-{}", std::process::id()))
+    }
+
+    fn record_diagnostic(event: impl AsRef<str>) {
+        let event = format!("{} {}", current_test_name(), event.as_ref());
+        eprintln!("E2E DIAGNOSTIC: {event}");
+
+        let Ok(directory) = std::env::var("TONK_E2E_DIAGNOSTICS_DIR") else {
+            return;
+        };
+        let directory = std::path::PathBuf::from(directory);
+        if let Err(error) = std::fs::create_dir_all(&directory) {
+            eprintln!(
+                "E2E DIAGNOSTIC: could not create {}: {error}",
+                directory.display()
+            );
+            return;
+        }
+        let path = directory.join(format!("events-{}.log", std::process::id()));
+        match std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+        {
+            Ok(mut file) => {
+                if let Err(error) = writeln!(file, "{event}") {
+                    eprintln!("E2E DIAGNOSTIC: could not write timing event: {error}");
+                }
+            }
+            Err(error) => eprintln!("E2E DIAGNOSTIC: could not open timing log: {error}"),
+        }
+    }
+
+    fn diagnostic_route(url: &str) -> &'static str {
+        let Ok(url) = Url::parse(url) else {
+            return "<invalid-url>";
+        };
+        match url.path_segments().and_then(|mut segments| segments.next()) {
+            Some("") | None => "/",
+            Some("account") => "/account",
+            Some("activate") => "/activate",
+            Some("settings") => "/settings",
+            Some(_) => "/<redacted>",
+        }
+    }
 
     /// Reaps a spawned test dependency on every success and failure path.
     struct ManagedChild(Option<Child>);
@@ -212,6 +261,7 @@ mod native {
 
         /// Creates a new WebDriver instance connected to the test environment.
         pub async fn driver(&self) -> Result<WebDriver> {
+            let started = std::time::Instant::now();
             let safari = std::env::var("TONK_TEST_BROWSER").as_deref() == Ok("safari");
             let driver = if safari {
                 let mut caps = DesiredCapabilities::safari();
@@ -221,6 +271,10 @@ mod native {
                 let caps = self.chrome_capabilities()?;
                 WebDriver::new(&self.chromedriver.to_string(), caps).await?
             };
+            record_diagnostic(format!(
+                "phase=webdriver-connect elapsed_ms={}",
+                started.elapsed().as_millis()
+            ));
             // Bound each navigation well under the suite's patience. The
             // default page-load allowance is five minutes, so one wedged
             // renderer would eat the whole run before `goto` below ever
@@ -270,6 +324,10 @@ mod native {
                     .await?;
             }
             goto(&driver, &self.tonk_web.to_string()).await?;
+            record_diagnostic(format!(
+                "phase=driver-ready elapsed_ms={}",
+                started.elapsed().as_millis()
+            ));
             Ok(driver)
         }
     }
@@ -283,6 +341,18 @@ mod native {
                 info.value.message.contains("net::ERR_SSL_PROTOCOL_ERROR")
             }
             _ => false,
+        }
+    }
+
+    fn retryable_navigation_reason(error: &thirtyfour::error::WebDriverErrorInner) -> &'static str {
+        use thirtyfour::error::WebDriverErrorInner;
+
+        match error {
+            WebDriverErrorInner::WebDriverTimeout(_) | WebDriverErrorInner::Timeout(_) => {
+                "page-load-timeout"
+            }
+            WebDriverErrorInner::UnknownError(_) => "tls-handshake",
+            _ => "unexpected",
         }
     }
 
@@ -300,13 +370,34 @@ mod native {
     /// retry crosses that readiness boundary without hiding other failures.
     pub async fn goto(driver: &WebDriver, url: impl AsRef<str>) -> Result<()> {
         let url = url.as_ref();
+        let path = diagnostic_route(url);
+        let started = std::time::Instant::now();
         match driver.goto(url).await {
             Err(error) if retryable_navigation_error(error.as_inner()) => {
-                eprintln!("navigation to {url} failed transiently ({error}); retrying once");
+                record_diagnostic(format!(
+                    "phase=navigation-retry path={path:?} elapsed_ms={} reason={}",
+                    started.elapsed().as_millis(),
+                    retryable_navigation_reason(error.as_inner())
+                ));
                 tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                Ok(driver.goto(url).await?)
+                driver.goto(url).await?;
+                record_diagnostic(format!(
+                    "phase=navigation-recovered path={path:?} elapsed_ms={}",
+                    started.elapsed().as_millis()
+                ));
+                Ok(())
             }
-            other => Ok(other?),
+            Ok(()) => {
+                let elapsed = started.elapsed();
+                if elapsed >= std::time::Duration::from_secs(5) {
+                    record_diagnostic(format!(
+                        "phase=navigation-slow path={path:?} elapsed_ms={}",
+                        elapsed.as_millis()
+                    ));
+                }
+                Ok(())
+            }
+            Err(error) => Err(error.into()),
         }
     }
 
@@ -414,6 +505,7 @@ mod native {
         /// 2. Start Caddy web server with access service port
         /// 3. Start the selected WebDriver server
         pub async fn start() -> Result<(Self, TestEnvironment)> {
+            let started = std::time::Instant::now();
             let workspace = TestWorkspace::new()?;
             let caddy_data = workspace.directory("caddy-data")?;
             let caddy_config = workspace.directory("caddy-config")?;
@@ -434,6 +526,10 @@ mod native {
             };
             let access_service = tonk_access_service::helpers::access_service(settings).await?;
             let access_service_address = access_service.address.clone();
+            record_diagnostic(format!(
+                "phase=access-service-ready elapsed_ms={}",
+                started.elapsed().as_millis()
+            ));
 
             // Extract port from access service URL (e.g., "http://127.0.0.1:8090" -> "8090")
             let access_service_port = Url::parse(&access_service_address.access_service_url)?
@@ -562,6 +658,10 @@ mod native {
             // process-wide `SSL_CERT_FILE` makes concurrent runs trust
             // the wrong root and fail to connect.
             let ca_certificate = Some(caddy_root);
+            record_diagnostic(format!(
+                "phase=web-server-ready elapsed_ms={}",
+                started.elapsed().as_millis()
+            ));
 
             // Safari has no host-resolver rule equivalent, so its release gate
             // uses the loopback hostname that the same Caddy fixture also
@@ -640,6 +740,10 @@ mod native {
                         Url::parse(&format!("http://127.0.0.1:{chromedriver_port}"))?,
                     )
                 };
+            record_diagnostic(format!(
+                "phase=test-servers-ready elapsed_ms={}",
+                started.elapsed().as_millis()
+            ));
 
             Ok((
                 Self {
@@ -729,7 +833,8 @@ mod native {
     #[cfg(test)]
     mod tests {
         use super::{
-            ChromeCapabilities, TestEnvironment, TestWorkspace, retryable_navigation_error,
+            ChromeCapabilities, TestEnvironment, TestWorkspace, diagnostic_route,
+            retryable_navigation_error,
         };
         use thirtyfour::error::{WebDriverErrorInfo, WebDriverErrorInner, WebDriverErrorValue};
         use url::Url;
@@ -750,6 +855,22 @@ mod native {
             assert!(!retryable_navigation_error(&unknown_navigation_error(
                 "unknown error: net::ERR_CONNECTION_REFUSED"
             )));
+        }
+
+        #[test]
+        fn it_redacts_values_from_navigation_diagnostics() {
+            assert_eq!(
+                diagnostic_route("https://tonk.network:8443/account?add=1"),
+                "/account"
+            );
+            assert_eq!(
+                diagnostic_route("https://tonk.network:8443/activate/secret-token"),
+                "/activate"
+            );
+            assert_eq!(
+                diagnostic_route("https://tonk.network:8443/space/secret-id"),
+                "/<redacted>"
+            );
         }
 
         #[test]

--- a/rust/tonk-ui/src/register_dialog.rs
+++ b/rust/tonk-ui/src/register_dialog.rs
@@ -143,14 +143,6 @@ const DIALOG_HTML: &str = r##"
 
 /// Raise the dialog. A no-op while one is already up.
 pub fn open() {
-    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-    crate::account_observability::record_instant_success(
-        AccountAction::OpenRegistration,
-        tonk_analytics::account::Surface::RegistrationDialog,
-        tonk_analytics::account::Trigger::User,
-        tonk_analytics::account::AccountState::Unknown,
-        tonk_analytics::account::Stage::Input,
-    );
     open_with_return(None);
 }
 
@@ -187,6 +179,15 @@ fn open_with_return(guest_restore: Option<Box<dyn FnOnce()>>) {
     let _ = host.set_attribute("aria-describedby", "tonk-register-status");
     host.set_inner_html(DIALOG_HTML);
     let _ = body.append_child(&host);
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    crate::account_observability::record_instant_success(
+        AccountAction::OpenRegistration,
+        tonk_analytics::account::Surface::RegistrationDialog,
+        tonk_analytics::account::Trigger::User,
+        tonk_analytics::account::AccountState::Unknown,
+        tonk_analytics::account::Stage::Input,
+    );
 
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     on_click(&host, DISMISS, return_to_space);


### PR DESCRIPTION
## Summary

- retry only expected DOM absence and stale-element races, and include redacted page state when bounded waits expire
- persist safe per-phase navigation and harness timings as CI artifacts
- build the exact E2E archive once in parallel with lint, then run three count-balanced serialized shards behind the existing required-check name
- require a fresh top-document click for passkey-gated Hub commands instead of relying on transient activation across an async guest/worker round trip

## Findings

The original investigation confirmed that the old service-worker upgrade test used `startedAt` as worker identity. Chrome can recreate the incumbent worker global while a successor installs, so the timestamp can change without the successor taking control. That test could then spend 60 seconds waiting for the right mounted worker to report the wrong identity.

Staging now contains #860 and #881, which supersede that test with a complete immutable-generation contract keyed by build identity. This branch is rebased onto that implementation and deliberately drops its earlier worker-hash patch rather than weakening or duplicating the lifecycle protocol.

Recent green runs also contained passing tests delayed by almost exactly the 60-second page-load timeout. Passing-test capture discarded the retry evidence. The new timing events retain that signal without storing URLs, query values, browser console contents, or credentials. Account-flow polling now retries only expected missing/stale DOM races, so selector, protocol, and click failures surface immediately instead of being hidden behind a generic 30-second timeout.

The first sharded CI run exposed another teardown race: the authorize/decline handoff tests were the only browser tests in `account_flow.rs` that did not explicitly await `driver.quit()`. Successful tests then raced Chrome profile writes against workspace deletion and failed with `Directory not empty`. The branch originally added those awaited shutdowns and two consecutive post-fix PR runs passed all three E2E shards. Staging #864 now independently contains the same fix with explanatory comments, so the rebase retains staging's version and drops the redundant follow-up commit.

Before #864, the suite had 52 real-browser cases and 86 total tests. A warm staging run spent 461.759 seconds in the serialized suite, while staging SHA `609d42d58` took 14m19s and failed after a 627.547-second serialized suite. On that base, the archive producer completed in 4m37s and the fixed shards completed in 6m32s, 5m51s, and 6m45s. Measured from workflow start through the required E2E check, staging took 16m51s versus 11m55s on the PR: 4m56s, or about 29%, faster. Three isolated runners keep each shard serial, while the producer prevents three identical cold archive builds. The producer overlaps lint and the shards omit redundant disk cleanup.

After rebasing onto #864 and #880, the current suite has 47 real-browser cases and 75 total tests, partitioned exactly 25 + 25 + 25.

The rebase also exposed three deterministic staging-boundary failures:

- the Hub opens registration through `open_with_return_focus`, while telemetry was recorded only by the sibling `open`; recording after the shared host is attached restores the ordered `open_registration` event without recording duplicate opens
- #864 removed the old settle lifecycle but retained two `settle_account` expectations in the signup journey test; the test now asserts the Hub lifecycle that actually exists
- passkey-gated Hub commands crossed an async guest transaction and service-worker message before the top document invoked WebAuthn, making the original transient activation timing-dependent; those commands now use the existing top-document consent card and invoke WebAuthn synchronously from its click

The command fix changes the failed paths from one-minute route waits to successful focused runs: device authorization passed in 5.8 seconds, and account deletion passed twice with 7.5- and 7.8-second browser phases. The corrected signup telemetry journey passed in 5.4 seconds. A cold local Nix web derivation took 283.5 seconds before the first browser phase, reinforcing that build/setup is the dominant fixed cost and should happen once per CI run.

## Verification

- `cargo clippy -p tonk-ui --features integration-tests --tests -- -D warnings`
- focused retry-classification regression: 1 passed
- harness native regressions: 4 passed
- focused real-browser regressions: deletion 2/2, device authorization 1/1, signup telemetry 1/1
- count partition audit: 75 total = 25 + 25 + 25
- exact `tests-e2e` and `tonk-cli` Nix derivations evaluate successfully
- `cargo fmt`, `git diff --check`, and workflow YAML parse pass
- the pre-#864 PR commit was fully green: E2E archive, all three E2E shards and aggregate gate, lint, service-worker, web debug/release, and native debug/release all passed
- final Linux CI on rebased head `1af11bda6` is fully green: all 75 E2E tests, lint, service-worker lifecycle, native debug/release, web debug/release, both CLI builds, and Cloudflare artifacts
- final E2E archive: 14m10s; shards: 7m16s, 6m35s, and 6m15s; aggregate required check: passed

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refining the handling of registration dialogs and enhancing end-to-end testing workflows in the `tonk-ui` project, along with improving error handling and diagnostics for WebDriver interactions.

### Detailed summary
- Removed redundant success recording in `open` function.
- Added success recording in `open_with_return` function.
- Updated GitHub Actions workflow for improved e2e testing.
- Introduced a new `set_card_message` function for clarity.
- Implemented a `command_action` function to handle various custody intents.
- Enhanced error handling for WebDriver interactions with retry logic.
- Added diagnostic logging for various phases of the WebDriver and test execution.
- Improved element waiting functions to provide better context on failures.

> Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->
