### PR TITLE
perf(ui): defer service worker offline cache fill

### DIFF
--- a/rust/tonk-ui/assets/service_worker.js
+++ b/rust/tonk-ui/assets/service_worker.js
@@ -13,14 +13,16 @@ import init, { activate } from "./worker.js";
 //
 // `WORKER_WASM_HASH` is the sha256 prefix of `worker_bg.wasm` as built
 // ALONGSIDE this exact glue. `ASSET_MANIFEST_HASH` is the full sha256 of the
-// publisher-generated UI/guest resource graph. `oninstall` verifies both and
-// every listed asset before making the incoming generation installable.
+// publisher-generated UI/guest resource graph. A first install verifies only
+// its matching worker Wasm before activation; it verifies and publishes the
+// complete offline graph atomically after taking control. Successor workers
+// still complete that graph behind the incumbent before replacing it.
 const BUILD_ID = "dev";
 const WORKER_WASM_HASH = "dev";
 const ASSET_MANIFEST_HASH = "dev";
 // Replaced with the exact publisher-produced resource graph. The dev sentinel
 // preserves Trunk's live-file behavior; a stamped worker serves only members
-// it proved complete during install.
+// it proved complete before publishing an offline generation.
 const ASSET_PATHS = ["dev"];
 const ASSET_PATH_SET = new Set(ASSET_PATHS);
 
@@ -124,6 +126,10 @@ const SHELL_CACHE = `TONK_SHELL_${BUILD_ID}`;
 // Where this worker's own wasm lives. Separate from the shell graph because it
 // is instantiated as bytes rather than returned as an ordinary response.
 const WORKER_CACHE = `TONK_WORKER_${BUILD_ID}`;
+// A first install verifies and pins only the worker's own executable runtime
+// before activation. The complete offline generation is assembled after the
+// page is controlled, then this bootstrap copy is superseded by WORKER_CACHE.
+const RUNTIME_CACHE = `TONK_RUNTIME_${BUILD_ID}`;
 const GENERATION_CACHE = `TONK_GENERATION_${BUILD_ID}`;
 const GENERATION_MARKER_URL = new URL(
     `./.tonk-generation-${BUILD_ID}`,
@@ -136,6 +142,7 @@ const ASSET_MANIFEST_URL = new URL("./asset-manifest.json", self.location.href).
 
 const FINAL_SHELL_CACHE_RE = /^TONK_SHELL_([0-9a-f]{16})$/;
 const FINAL_WORKER_CACHE_RE = /^TONK_WORKER_([0-9a-f]{16})$/;
+const RUNTIME_CACHE_RE = /^TONK_RUNTIME_([0-9a-f]{16})$/;
 const GENERATION_CACHE_RE = /^TONK_GENERATION_([0-9a-f]{16})$/;
 const SHELL_STAGE_CACHE_RE = /^TONK_SHELL_STAGE_([0-9a-f]{16})_([0-9a-f]{32})$/;
 const WORKER_STAGE_CACHE_RE = /^TONK_WORKER_STAGE_([0-9a-f]{16})_([0-9a-f]{32})$/;
@@ -150,6 +157,10 @@ function parseFinalShellGeneration(name) {
 
 function parseFinalWorkerGeneration(name) {
     return parsedBuild(name, FINAL_WORKER_CACHE_RE);
+}
+
+function parseRuntimeGeneration(name) {
+    return parsedBuild(name, RUNTIME_CACHE_RE);
 }
 
 function parseGenerationMarkerCache(name) {
@@ -421,6 +432,7 @@ async function verifiedGenerationResponse(cacheNames, key, expectedHash) {
         try {
             const response = await caches.match(key, { cacheName });
             if (!response) continue;
+            if (expectedHash === "dev") return response;
             const actual = await digestOf(await response.clone().arrayBuffer());
             if (actual.slice(0, expectedHash.length) === expectedHash) {
                 return response;
@@ -430,6 +442,34 @@ async function verifiedGenerationResponse(cacheNames, key, expectedHash) {
         }
     }
     return null;
+}
+
+/// Pin the one generated artifact that must match this service-worker glue
+/// before the worker can safely control a page. Fetch and verify before opening
+/// the cache so a bad deployment cannot leave a new partial runtime behind.
+async function installWorkerRuntime() {
+    if (await verifiedGenerationResponse(
+        [RUNTIME_CACHE],
+        WORKER_WASM_URL,
+        WORKER_WASM_HASH,
+    )) return;
+
+    const names = await caches.keys();
+    const reusable = names.filter(name => {
+        const build = parseFinalWorkerGeneration(name);
+        return build != null && build !== BUILD_ID;
+    });
+    const bytes = await fetchVerifiedWorkerWasm(reusable);
+    const runtimeExisted = names.includes(RUNTIME_CACHE);
+    try {
+        const runtime = await caches.open(RUNTIME_CACHE);
+        await runtime.put(WORKER_WASM_URL, new Response(bytes, {
+            headers: { "content-type": "application/wasm" },
+        }));
+    } catch (error) {
+        if (!runtimeExisted) await caches.delete(RUNTIME_CACHE);
+        throw error;
+    }
 }
 
 async function fetchVerifiedAssets(entries, cacheNames = []) {
@@ -635,7 +675,7 @@ async function installGeneration() {
     });
     const [assets, wasmBytes] = await Promise.all([
         fetchVerifiedAssets(entries, reusableShellCaches),
-        fetchVerifiedWorkerWasm(reusableWorkerCaches),
+        fetchVerifiedWorkerWasm([RUNTIME_CACHE, ...reusableWorkerCaches]),
     ]);
 
     const nonce = freshStageNonce();
@@ -695,6 +735,7 @@ async function installGeneration() {
         await Promise.allSettled([
             caches.delete(marker.shellStage),
             caches.delete(marker.workerStage),
+            caches.delete(RUNTIME_CACHE),
         ]);
         await reportInstallProgress("adopted", assets.length, assets.length, true);
     } catch (error) {
@@ -709,6 +750,7 @@ async function installGeneration() {
 function lifecycleCacheBuild(name) {
     return parseFinalShellGeneration(name) ??
         parseFinalWorkerGeneration(name) ??
+        parseRuntimeGeneration(name) ??
         parseGenerationMarkerCache(name) ??
         parseShellStageGeneration(name) ??
         parseWorkerStageGeneration(name);
@@ -738,12 +780,38 @@ async function pruneObsoleteGenerationCaches() {
     });
 }
 
-/// The wasm bytes this worker boots from: the copy precached at
-/// install. If storage pressure evicts that entry, recover only by fetching
-/// with `no-store` and re-verifying against this glue's stamp. The verified
-/// bytes may boot this instance but must not backfill the retained cache.
+let offlineGenerationResolves;
+
+/// Complete offline availability after control without making it a readiness
+/// prerequisite. The shared promise prevents duplicate fills within one worker
+/// lifetime; the durable marker makes later worker instances return cheaply.
+function ensureOfflineGeneration() {
+    if (offlineGenerationResolves == null) {
+        offlineGenerationResolves = (async () => {
+            const marker = await readGenerationMarker();
+            if (marker?.state !== "adopted") await installGeneration();
+            await pruneObsoleteGenerationCaches();
+        })().catch(error => {
+            offlineGenerationResolves = null;
+            log("Offline generation fill failed; it will retry later:", error);
+        });
+    }
+    return offlineGenerationResolves;
+}
+
+function extendOfflineGeneration(event) {
+    if (typeof event.waitUntil !== "function") return;
+    event.waitUntil(ensureOfflineGeneration());
+}
+
+/// The wasm bytes this worker boots from: prefer the complete offline
+/// generation, then the first-install runtime pin. If storage pressure evicts
+/// both entries, recover only by fetching with `no-store` and re-verifying
+/// against this glue's stamp. The verified bytes may boot this instance but
+/// must not backfill the retained cache.
 async function workerWasmModule() {
-    const cached = await caches.match(WORKER_WASM_URL, { cacheName: WORKER_CACHE });
+    const cached = await caches.match(WORKER_WASM_URL, { cacheName: WORKER_CACHE }) ??
+        await caches.match(WORKER_WASM_URL, { cacheName: RUNTIME_CACHE });
     if (cached) return cached.arrayBuffer();
     log("Worker wasm missing from cache — refetching");
     return fetchVerifiedWorkerWasm();
@@ -800,10 +868,15 @@ async function activateWorker() {
 
 self.oninstall = event => {
     event.waitUntil((async () => {
-        // Uncaught by design: a worker becomes installable only after its
-        // provenance-bound UI, lazy, guest, and worker-Wasm graph is complete.
-        // A failed incoming build leaves every retained generation untouched.
-        await installGeneration();
+        // A first page must not wait for the whole offline graph. Pin only the
+        // worker's glue-bound Wasm, then assemble the graph under later
+        // fetch/message lifetimes. An update still fills behind its live
+        // incumbent before takeover, preserving offline-safe replacement.
+        if (self.registration.active == null) {
+            await installWorkerRuntime();
+        } else {
+            await installGeneration();
+        }
         // One-release rollout bridge: pages deployed before this lifecycle
         // protocol never send an `activate` message. A verified successor must
         // therefore activate automatically even when an incumbent exists.
@@ -1307,6 +1380,7 @@ function retireIfSuperseded(event) {
 
 self.onfetch = event => {
     const path = new URL(event.request.url).pathname;
+    if (event.request.mode === "navigate") extendOfflineGeneration(event);
     // A waiting successor means this worker is retiring. Checked on the
     // fetch path because a worker pinned by its own open streams never
     // restarts to run the startup check.
@@ -1409,12 +1483,14 @@ self.onfetch = event => {
 self.onmessage = event => {
     if (event.data && event.data.type === "claim") {
         event.waitUntil?.(self.clients.claim());
+        extendOfflineGeneration(event);
         return;
     }
     // Connectivity nudge from the active page on an `online`/`offline`
     // transition. The worker re-reads `navigator.onLine` itself and reconciles;
     // this just wakes it so the overlay updates without waiting for a fetch.
     if (event.data && event.data.type === "connectivity") {
+        extendOfflineGeneration(event);
         event.waitUntil?.(
             (async () => {
                 try {

--- a/rust/tonk-ui/index.html
+++ b/rust/tonk-ui/index.html
@@ -340,8 +340,15 @@
             }
 
             // Begin registration and update detection eagerly, while the UI
-            // Wasm downloads. Every caller receives this exact promise, so the
-            // pre-mount gate and later host IO cannot start duplicate updates.
+            // Wasm downloads. Page readiness resolves once the current
+            // generation controls the document; successor observation may
+            // continue behind it without blocking the pre-mount gate.
+            let markServiceWorkerReady;
+            let failServiceWorkerReady;
+            const serviceWorkerReadiness = new Promise((resolve, reject) => {
+                markServiceWorkerReady = resolve;
+                failServiceWorkerReady = reject;
+            });
             const serviceWorkerActivation = (async () => {
                 if (!serviceWorkersSupported) {
                     throw new Error(
@@ -431,6 +438,7 @@
                     } catch {}
                     observingInstallLifecycle = false;
                     await sendConnectivity();
+                    markServiceWorkerReady();
                     return;
                 }
                 navigator.serviceWorker.removeEventListener(
@@ -451,8 +459,12 @@
                         sessionStorage.removeItem(UPGRADE_RELOAD);
                     } catch {}
                     await sendConnectivity();
+                    markServiceWorkerReady();
                     return;
                 }
+
+                await sendConnectivity();
+                markServiceWorkerReady();
 
                 let incoming = null;
                 let settled = false;
@@ -543,7 +555,6 @@
                             try {
                                 sessionStorage.removeItem(UPGRADE_RELOAD);
                             } catch {}
-                            await sendConnectivity();
                             return;
                         }
                         throw error;
@@ -575,13 +586,13 @@
                         `service-worker update failed in state ${incoming?.state ?? "unknown"}; keeping the active worker`,
                     );
                 }
-                await sendConnectivity();
             })();
 
-            // Observe rejection immediately so the eager promise cannot create
-            // a transient `unhandledrejection` before Rust reaches its strict
-            // await. The original promise remains rejected for that await.
+            // Observe rejection immediately so the eager background task
+            // cannot create a transient `unhandledrejection`. Fail readiness
+            // too when registration/control fails before it has resolved.
             serviceWorkerActivation.catch((error) => {
+                failServiceWorkerReady(error);
                 console.error("service-worker activation failed", error);
                 presentBootFailure(
                     !serviceWorkersSupported
@@ -589,7 +600,7 @@
                         : GENERIC_BOOT_FAILURE,
                 );
             });
-            self.serviceWorkerActivates = () => serviceWorkerActivation;
+            self.serviceWorkerActivates = () => serviceWorkerReadiness;
 
             // Register a one-shot background sync under `tag` so a
             // local commit reaches its upstream even if the tab goes

--- a/rust/tonk-ui/tests/service-worker-claim.test.mjs
+++ b/rust/tonk-ui/tests/service-worker-claim.test.mjs
@@ -244,12 +244,18 @@ class FakeBroadcastChannel {
   close() {}
 }
 
-function pageHarness({ mode, alignmentReload = false, updateFails = false } = {}) {
+function pageHarness({
+  mode,
+  alignmentReload = false,
+  updateFails = false,
+  updatePending = false,
+} = {}) {
   const messages = [];
   const storage = new Map();
   if (alignmentReload) storage.set("tonk:sw-upgrade-reload", "1");
   let reloads = 0;
   let updates = 0;
+  let resolveUpdate;
   let resolveReady;
   const incumbent = mode === "cold" ? null : eventTarget({
     state: "activated",
@@ -273,6 +279,9 @@ function pageHarness({ mode, alignmentReload = false, updateFails = false } = {}
     async update() {
       updates += 1;
       if (updateFails) throw new TypeError("offline");
+      if (updatePending) {
+        await new Promise((resolve) => { resolveUpdate = resolve; });
+      }
     },
   });
   const ready = mode === "cold"
@@ -319,6 +328,7 @@ function pageHarness({ mode, alignmentReload = false, updateFails = false } = {}
     messages,
     reloads: () => reloads,
     updates: () => updates,
+    releaseUpdate: () => resolveUpdate?.(),
     activateColdWorker() {
       registration.installing = null;
       registration.active = incoming;
@@ -338,7 +348,7 @@ function pageHarness({ mode, alignmentReload = false, updateFails = false } = {}
 }
 
 function multiPageReplacementHarness() {
-  const incumbent = eventTarget({ state: "activated" });
+  const incumbent = eventTarget({ state: "activated", postMessage() {} });
   const incoming = eventTarget({ state: "installing", postMessage() {} });
   const registration = eventTarget({
     active: incumbent,
@@ -486,11 +496,32 @@ test("a cold first install waits for activation, then claims", async () => {
   assert.deepEqual(result.messages.map((message) => message.type), ["claim", "connectivity"]);
 });
 
+test("a controlled page becomes ready while its update continues in the background", async () => {
+  const result = pageHarness({ mode: "warm", updatePending: true });
+  let ready = false;
+  const readiness = result.ready().then(() => { ready = true; });
+  while (result.updates() === 0) await new Promise(setImmediate);
+  await new Promise(setImmediate);
+
+  assert.equal(
+    ready,
+    true,
+    "the current coherent page must not wait for update caching",
+  );
+
+  result.releaseUpdate();
+  await readiness;
+});
+
 test("successor activation replaces the controller and causes one guarded reload", async () => {
   const result = pageHarness({ mode: "warm-update" });
   await new Promise(setImmediate);
   await result.activateWarmWorker();
-  assert.deepEqual(result.messages, []);
+  assert.deepEqual(
+    result.messages.map((message) => message.type),
+    ["connectivity"],
+    "the incumbent page becomes live before its successor finishes",
+  );
   assert.equal(result.storage.get("tonk:sw-upgrade-reload"), "1");
   assert.equal(result.reloads(), 1);
 });

--- a/rust/tonk-ui/tests/service-worker.test.mjs
+++ b/rust/tonk-ui/tests/service-worker.test.mjs
@@ -75,7 +75,7 @@ async function loadServiceWorker({ fetchImpl, registration } = {}) {
   const listeners = new Map();
   const scope = {
     location: { href: "https://tonk.test/service_worker.js", origin: "https://tonk.test" },
-    registration: registration ?? { waiting: null, installing: null, addEventListener() {} },
+    registration: registration ?? { active: {}, waiting: null, installing: null, addEventListener() {} },
     serviceWorker: {},
     skipWaiting: async () => {},
     clients: { claim: async () => {}, matchAll: async () => [] },
@@ -93,7 +93,7 @@ async function loadServiceWorker({ fetchImpl, registration } = {}) {
   // Expose the internals under test without altering the shipped file.
   const instrumented =
     body +
-    "\nexport { isShellCacheable, SHELL_CACHE, WORKER_CACHE, BUILD_ID, fetchVerifiedWorkerWasm, digestOf };\n";
+    "\nexport { isShellCacheable, SHELL_CACHE, WORKER_CACHE, RUNTIME_CACHE, BUILD_ID, fetchVerifiedWorkerWasm, digestOf };\n";
 
   const module = await import(
     "data:text/javascript;base64," + Buffer.from(instrumented).toString("base64")
@@ -107,7 +107,7 @@ function withGlobals({ fetchImpl, registration, BroadcastChannelImpl } = {}) {
   const listeners = new Map();
   const self = {
     location: { href: "https://tonk.test/service_worker.js", origin: "https://tonk.test" },
-    registration: registration ?? { waiting: null, installing: null, addEventListener() {} },
+    registration: registration ?? { active: {}, waiting: null, installing: null, addEventListener() {} },
     serviceWorker: {},
     skipWaiting: async () => {},
     clients: { claim: async () => {}, matchAll: async () => [] },
@@ -551,7 +551,7 @@ describe("exact fetch routing", () => {
 });
 
 describe("cache naming", () => {
-  test("scopes both caches to the build", async () => {
+  test("scopes runtime and generation caches to the build", async () => {
     // Per-build names are what make an install atomic: the incoming
     // worker populates its OWN caches, so the still-serving old worker
     // never observes a half-written one.
@@ -559,7 +559,9 @@ describe("cache naming", () => {
     const { module } = await loadServiceWorker();
     assert.ok(module.SHELL_CACHE.endsWith(module.BUILD_ID));
     assert.ok(module.WORKER_CACHE.endsWith(module.BUILD_ID));
+    assert.ok(module.RUNTIME_CACHE.endsWith(module.BUILD_ID));
     assert.notEqual(module.SHELL_CACHE, module.WORKER_CACHE);
+    assert.notEqual(module.RUNTIME_CACHE, module.WORKER_CACHE);
   });
 
   test("accepts only exact lifecycle-owned cache names", async () => {
@@ -568,6 +570,7 @@ describe("cache naming", () => {
       exports: [
         "parseFinalShellGeneration",
         "parseFinalWorkerGeneration",
+        "parseRuntimeGeneration",
         "parseGenerationMarkerCache",
         "parseShellStageGeneration",
         "parseWorkerStageGeneration",
@@ -577,6 +580,7 @@ describe("cache naming", () => {
     const nonce = "a".repeat(32);
     assert.equal(mod.parseFinalShellGeneration(`TONK_SHELL_${build}`), build);
     assert.equal(mod.parseFinalWorkerGeneration(`TONK_WORKER_${build}`), build);
+    assert.equal(mod.parseRuntimeGeneration(`TONK_RUNTIME_${build}`), build);
     assert.equal(mod.parseGenerationMarkerCache(`TONK_GENERATION_${build}`), build);
     assert.equal(mod.parseShellStageGeneration(`TONK_SHELL_STAGE_${build}_${nonce}`), build);
     assert.equal(mod.parseWorkerStageGeneration(`TONK_WORKER_STAGE_${build}_${nonce}`), build);
@@ -587,11 +591,13 @@ describe("cache naming", () => {
       `TONK_SHELL_${build}_extra`,
       `TONK_SHELL_STAGE_${build}_${nonce}_extra`,
       `TONK_WORKER_STAGE_${build}_short`,
+      `TONK_RUNTIMES_${build}`,
       `TONK_GENERATIONS_${build}`,
       "tonk-sw-upgrade-sentinel",
     ]) {
       assert.equal(mod.parseFinalShellGeneration(name), null, name);
       assert.equal(mod.parseFinalWorkerGeneration(name), null, name);
+      assert.equal(mod.parseRuntimeGeneration(name), null, name);
       assert.equal(mod.parseGenerationMarkerCache(name), null, name);
       assert.equal(mod.parseShellStageGeneration(name), null, name);
       assert.equal(mod.parseWorkerStageGeneration(name), null, name);
@@ -618,11 +624,13 @@ describe("cache naming", () => {
     const obsolete = [
       `TONK_SHELL_${old}`,
       `TONK_WORKER_${old}`,
+      `TONK_RUNTIME_${old}`,
       `TONK_GENERATION_${old}`,
       `TONK_SHELL_STAGE_${old}_${"c".repeat(32)}`,
       `TONK_WORKER_STAGE_${old}_${"c".repeat(32)}`,
       `TONK_SHELL_${oldest}`,
       `TONK_WORKER_${oldest}`,
+      `TONK_RUNTIME_${oldest}`,
       `TONK_GENERATION_${oldest}`,
       `TONK_SHELL_STAGE_${oldest}_${"d".repeat(32)}`,
       `TONK_WORKER_STAGE_${oldest}_${"d".repeat(32)}`,
@@ -689,6 +697,139 @@ describe("cache naming", () => {
 });
 
 describe("immutable generation install", () => {
+  test("a first install activates after verifying only its worker runtime", async () => {
+    const buildId = "first-install-build";
+    const wasm = new Uint8Array([9, 8, 7, 6]);
+    const wasmHash = (await sha256Hex(wasm)).slice(0, 16);
+    const fetches = [];
+    const { self, caches } = withGlobals({
+      registration: { active: null, waiting: null, installing: {}, addEventListener() {} },
+      fetchImpl: async (input, init) => {
+        const path = new URL(typeof input === "string" ? input : input.url).pathname;
+        fetches.push({ path, cache: init?.cache });
+        if (path === "/worker_bg.wasm") {
+          return new Response(wasm, {
+            status: 200,
+            headers: { "content-type": "application/wasm" },
+          });
+        }
+        throw new Error(`the offline asset graph blocked first activation: ${path}`);
+      },
+    });
+    let activationRequests = 0;
+    self.skipWaiting = async () => {
+      activationRequests += 1;
+    };
+    const mod = await loadWith({
+      buildId,
+      wasmHash,
+      exports: ["RUNTIME_CACHE", "WORKER_WASM_URL"],
+    });
+
+    let install;
+    self.oninstall({ waitUntil: (promise) => { install = promise; } });
+    await install;
+
+    assert.equal(activationRequests, 1);
+    assert.deepEqual(fetches, [{ path: "/worker_bg.wasm", cache: "no-store" }]);
+    const runtime = await caches.open(mod.RUNTIME_CACHE);
+    assert.deepEqual(
+      new Uint8Array(await (await runtime.match(mod.WORKER_WASM_URL)).arrayBuffer()),
+      wasm,
+    );
+  });
+
+  test("a first install refuses an incompatible worker runtime", async () => {
+    const { self, caches } = withGlobals({
+      registration: { active: null, waiting: null, installing: {}, addEventListener() {} },
+      fetchImpl: async () => new Response(new Uint8Array([1, 2, 3]), { status: 200 }),
+    });
+    let activationRequests = 0;
+    self.skipWaiting = async () => {
+      activationRequests += 1;
+    };
+    const mod = await loadWith({
+      buildId: "incompatible-runtime",
+      wasmHash: "0000000000000000",
+      exports: ["RUNTIME_CACHE"],
+    });
+
+    let install;
+    self.oninstall({ waitUntil: (promise) => { install = promise; } });
+
+    await assert.rejects(install, /worker wasm hash mismatch/);
+    assert.equal(activationRequests, 0);
+    assert.equal((await caches.keys()).includes(mod.RUNTIME_CACHE), false);
+  });
+
+  test("a claimed first page stays ready while its offline generation fills", async () => {
+    const buildId = "background-fill-build";
+    const wasm = new Uint8Array([4, 3, 2, 1]);
+    const wasmHash = (await sha256Hex(wasm)).slice(0, 16);
+    const shellBody = "background shell";
+    const manifestText = JSON.stringify({
+      version: 1,
+      build: buildId,
+      assets: { "/": await sha256Hex(utf8(shellBody)) },
+    });
+    const manifestHash = await sha256Hex(utf8(manifestText));
+    let releaseShell;
+    let shellRequested = false;
+    const shellReady = new Promise((resolve) => { releaseShell = resolve; });
+    const { self, caches } = withGlobals({
+      registration: { active: null, waiting: null, installing: {}, addEventListener() {} },
+      fetchImpl: async (input) => {
+        const path = new URL(typeof input === "string" ? input : input.url).pathname;
+        if (path === "/worker_bg.wasm") return new Response(wasm, { status: 200 });
+        if (path === "/asset-manifest.json") return new Response(manifestText, { status: 200 });
+        if (path === "/") {
+          shellRequested = true;
+          await shellReady;
+          return new Response(shellBody, { status: 200 });
+        }
+        return new Response("missing", { status: 404 });
+      },
+    });
+    let claimed = false;
+    self.clients.claim = async () => { claimed = true; };
+    const mod = await loadWith({
+      buildId,
+      wasmHash,
+      assetManifestHash: manifestHash,
+      assetPaths: ["/"],
+      exports: ["SHELL_CACHE", "GENERATION_CACHE"],
+    });
+
+    let install;
+    self.oninstall({ waitUntil: (promise) => { install = promise; } });
+    await install;
+
+    const pending = [];
+    self.onmessage({
+      data: { type: "claim" },
+      waitUntil: (promise) => pending.push(promise),
+    });
+    for (let turns = 0; !shellRequested && turns < 20; turns += 1) {
+      await new Promise(setImmediate);
+    }
+
+    assert.equal(claimed, true, "control must not wait for the offline shell");
+    assert.equal(shellRequested, true, "claim starts the background fill");
+    assert.equal(
+      await caches.match("/", { cacheName: mod.SHELL_CACHE }),
+      undefined,
+      "a partial background fill must remain unpublished",
+    );
+
+    releaseShell();
+    await Promise.all(pending);
+    assert.equal(
+      await (await caches.match("/", { cacheName: mod.SHELL_CACHE })).text(),
+      shellBody,
+    );
+    assert.ok((await caches.keys()).includes(mod.GENERATION_CACHE));
+  });
+
   test("client discovery cannot stall verified install progress", async () => {
     const { self } = withGlobals();
     self.clients.matchAll = () => new Promise(() => {});
@@ -1567,6 +1708,27 @@ describe("worker wasm verification", () => {
 });
 
 describe("booting from the precached wasm", () => {
+  test("boots from the verified first-install runtime without another fetch", async () => {
+    const bytes = new Uint8Array([6, 5, 4]);
+    let fetches = 0;
+    const { caches } = withGlobals({
+      fetchImpl: async () => {
+        fetches += 1;
+        return new Response("unexpected", { status: 500 });
+      },
+    });
+    const mod = await loadWith({
+      exports: ["workerWasmModule", "RUNTIME_CACHE", "WORKER_WASM_URL"],
+    });
+    await (await caches.open(mod.RUNTIME_CACHE)).put(
+      mod.WORKER_WASM_URL,
+      new Response(bytes),
+    );
+
+    assert.deepEqual(new Uint8Array(await mod.workerWasmModule()), bytes);
+    assert.equal(fetches, 0);
+  });
+
   test("verifies an eviction recovery fetch without backfilling the retained cache", async () => {
     // Storage pressure can evict the entry. The old worker may use live bytes
     // only after proving they still match its stamped glue; it must not mutate


### PR DESCRIPTION
## Summary

- gate a first service-worker activation only on its digest-verified worker Wasm runtime
- fill and atomically publish the complete offline asset generation after the page is controlled
- let an already-controlled page become ready while successor update observation continues in the background
- retain full manifest and per-asset digest verification, immutable generation publication, and offline-safe successor takeover
- cover cold activation, incompatible runtime rejection, lazy fill, cache lifecycle, and warm-page readiness

## Performance

The existing staging build mounted cold pages in 15.47-21.11s because installation fetched and verified all 847 offline assets before activation.

Against the stamped production artifact from this branch, three brand-new isolated headless Chrome profiles on localhost were controlled and mounted by:

- 1.09s
- 1.12s
- 1.16s

Median observed upper bound: 1.12s. These are unthrottled localhost results, not staging-network measurements; the foreground integrity gate still downloads the 19 MB worker Wasm. The 847-asset offline fill is no longer on the page-readiness path.

## Validation

- `node --test --test-reporter=dot 'rust/tonk-ui/tests/*.test.mjs'` (115 passed)
- `nix build .#tonk-ui --no-link --print-out-paths`
- three fresh isolated Chrome cold profiles against the stamped Nix artifact
- `git diff --check`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the service worker lifecycle management and update handling in the `rust/tonk-ui` application. It introduces new mechanisms for ensuring readiness and managing updates more efficiently, including handling background updates and runtime verification.

### Detailed summary
- Introduced `serviceWorkerReadiness` and `markServiceWorkerReady` for better service worker readiness management.
- Updated `serviceWorkerActivation` to handle connectivity and readiness more effectively.
- Added `updatePending` to `pageHarness` for simulating update scenarios.
- Enhanced test cases for controlled pages and first install scenarios.
- Implemented runtime cache verification and management in `service_worker.js`.
- Improved error handling and logging for service worker activation failures.
- Added support for background update filling without blocking the main thread.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->