### PR TITLE
fix(ci): get staging's Test workflow green again

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -16,6 +16,15 @@ test-threads = 1
 # Report every failure: a fail-fast pass over an hour-long suite hides
 # everything after the first broken test.
 fail-fast = false
+# Each test drives a real Caddy + Chrome + wasm stack, and a shared CI
+# runner is 2-3x slower than the hand-rolled deadlines in these tests
+# assume: the same commit has passed every shard in one run and failed
+# three in another, tripping a different deadline each time. Retry the
+# flakes rather than widen forty scattered budgets by guesswork. This
+# disables nothing — a test that fails all three attempts still fails
+# the run — and the durable fix is to make the ceremonies faster or to
+# give the deadlines one scalable knob.
+retries = 2
 # The #852 quarantine is drained: every account flow it named is
 # repaired and back in the suite. To quarantine a newly broken test,
 # add a `default-filter` here excluding it, with a linked issue.

--- a/rust/tonk-ui/tests/service-worker.test.mjs
+++ b/rust/tonk-ui/tests/service-worker.test.mjs
@@ -20,6 +20,10 @@ import { dirname, join } from "node:path";
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SW_PATH = join(HERE, "..", "assets", "service_worker.js");
 const CACHE_RS_PATH = join(HERE, "..", "..", "tonk-worker", "src", "cache.rs");
+// Ceiling for "the background fill got as far as requesting the shell". Only a
+// fill that never starts should reach it, so it is generous enough that a
+// contended runner cannot trip it on timing alone.
+const FILL_START_TIMEOUT_MS = 30_000;
 const source = readFileSync(SW_PATH, "utf8");
 
 /** A minimal Cache/CacheStorage good enough for the decisions here. */
@@ -774,8 +778,15 @@ describe("immutable generation install", () => {
     });
     const manifestHash = await sha256Hex(utf8(manifestText));
     let releaseShell;
-    let shellRequested = false;
+    let announceShellRequest;
     const shellReady = new Promise((resolve) => { releaseShell = resolve; });
+    // Settles the moment the fill asks for the shell, so the assertion below
+    // waits on that event instead of a fixed number of event-loop turns. The
+    // fill reaches this request only after reading the generation marker and
+    // digesting the manifest; on a loaded runner a turn budget drains while
+    // that work is still outstanding, which failed the test for timing rather
+    // than for behaviour.
+    const shellRequested = new Promise((resolve) => { announceShellRequest = resolve; });
     const { self, caches } = withGlobals({
       registration: { active: null, waiting: null, installing: {}, addEventListener() {} },
       fetchImpl: async (input) => {
@@ -783,7 +794,7 @@ describe("immutable generation install", () => {
         if (path === "/worker_bg.wasm") return new Response(wasm, { status: 200 });
         if (path === "/asset-manifest.json") return new Response(manifestText, { status: 200 });
         if (path === "/") {
-          shellRequested = true;
+          announceShellRequest();
           await shellReady;
           return new Response(shellBody, { status: 200 });
         }
@@ -809,12 +820,17 @@ describe("immutable generation install", () => {
       data: { type: "claim" },
       waitUntil: (promise) => pending.push(promise),
     });
-    for (let turns = 0; !shellRequested && turns < 20; turns += 1) {
-      await new Promise(setImmediate);
-    }
+    const fillStarted = await Promise.race([
+      shellRequested.then(() => true),
+      new Promise((resolve) => {
+        setTimeout(() => resolve(false), FILL_START_TIMEOUT_MS).unref?.();
+      }),
+    ]);
 
+    // Both hold while the shell response is still withheld: control landed
+    // without waiting for the offline copy, and the fill is already fetching.
     assert.equal(claimed, true, "control must not wait for the offline shell");
-    assert.equal(shellRequested, true, "claim starts the background fill");
+    assert.equal(fillStarted, true, "claim starts the background fill");
     assert.equal(
       await caches.match("/", { cacheName: mod.SHELL_CACHE }),
       undefined,


### PR DESCRIPTION
## What changed

`staging`'s `Test` workflow has been red for days across two unrelated causes. This addresses both.

**1. `Service-worker lifecycle tests` — a real bug in the test.**

The job fails on an assertion, not a timeout:

```
test at rust/tonk-ui/tests/service-worker.test.mjs:765:3
✖ a claimed first page stays ready while its offline generation fills
  AssertionError [ERR_ASSERTION]: claim starts the background fill
  false !== true
```

The test sends `{type:"claim"}`, spins a fixed **20 event-loop turns** waiting for the offline fill to request the shell, then asserts it has. But `claim` only reaches that request after `ensureOfflineGeneration()` awaits `readGenerationMarker()` and digests the manifest. That is real work; `setImmediate` turns are not. Idle, the fill arrives in 2 turns and the budget looks generous; on a contended runner the 20 turns drain while the digest is still outstanding.

Now it waits on the shell request itself, bounded by a generous ceiling so a fill that never starts still fails with the same message. Both assertions keep their meaning — they are still checked while the shell response is withheld. The service worker is unchanged; its behaviour was never wrong.

**2. `End-to-end shard 1..3` — a load-flaky suite.**

The shards fail on a different test each run — account ceremonies and service-worker upgrades alike — always by a deadline expiring, never by a wrong value. The same commit has passed every shard in one run and failed all three in another. `test-threads = 1` already stops the tests fighting each other, so the contention is the runner itself, which is 2–3× slower than the deadlines assume.

Those deadlines are ~40 hand-rolled literals scattered through `account_flow.rs`. Widening them one at a time would be guesswork against a suite that cannot be run outside CI, so the e2e nextest profile retries instead.

Nothing is skipped, disabled or quarantined. Every test still runs, and one that fails all three attempts still fails the run. The shard job allows 45 minutes against ~8 minutes of tests.

This second part is mitigation, not a cure. The durable fix is to make the ceremonies faster, or to give those deadlines one scalable knob so a slow runner is accommodated deliberately rather than by attrition.

## Verification

The service-worker fix is verified directly — the job **passes** on this branch, having failed on `staging`.

Reproducing it locally needed the missing ingredient, load. Saturating the CPU reproduces CI exactly:

```console
$ node --test --test-name-pattern 'a claimed first page stays ready' rust/tonk-ui/tests/service-worker.test.mjs
        claim starts the background fill
# pass 0
# fail 1
```

After the change, idle and under that same load:

```console
$ node --test rust/tonk-ui/tests/service-worker.test.mjs      # idle
# pass 67
# fail 0

$ # under nproc*3 busy loops, three consecutive runs
loaded run 1: # pass 67 # fail 0
loaded run 2: # pass 67 # fail 0
loaded run 3: # pass 67 # fail 0
```

The assertion is not hollow — with `extendOfflineGeneration` removed from the claim path so the fill never starts, it still catches it:

```console
    not ok 3 - a claimed first page stays ready while its offline generation fills
```

`node --check` passes; `.config/nextest.toml` parses.

The retry change can only be judged by CI, which is the point of it — it is aimed at a failure mode that does not exist on an idle machine.

## Storybook impact

Choose one and explain it:

- [x] No user-visible contract changed because: this changes how a test waits and how CI retries a flaky suite. No product code is touched, so no screen, journey, verification or triage ID is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GL7ZLoBMGKy1yJS1A6tQs

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances test reliability by introducing a retry mechanism and improving timeout handling in the `service-worker.test.mjs` file, ensuring that tests are less likely to fail due to timing issues.

### Detailed summary
- Added `retries = 2` in `.config/nextest.toml` for test retries.
- Introduced `FILL_START_TIMEOUT_MS` constant for fill request timeout.
- Changed `let shellRequested` to `let announceShellRequest` and updated its handling.
- Used a promise to manage shell request timing with `fillStarted`.
- Updated assertions to reflect changes in shell request handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->