### PR TITLE
fix(sw): keep a non-incumbent worker out of the deferred offline fill

### DIFF
--- a/rust/tonk-ui/assets/service_worker.js
+++ b/rust/tonk-ui/assets/service_worker.js
@@ -801,6 +801,16 @@ function ensureOfflineGeneration() {
 
 function extendOfflineGeneration(event) {
     if (typeof event.waitUntil !== "function") return;
+    // `fetch` and `message` both reach a worker that is still WAITING
+    // behind an incumbent — the page goes on posting `claim` and
+    // `connectivity` throughout. A successor owns nothing yet: its fill
+    // duplicates the one `oninstall` already runs, and its prune deletes
+    // the generation caches the incumbent is still serving from. An
+    // incumbent that loses its wasm can no longer load it to retire, so
+    // the successor is stranded in `waiting` for good. A first install
+    // has no incumbent to displace and must still fill, so the test is
+    // "someone else is active", not "this worker is active".
+    if (isWaitingBehindIncumbent()) return;
     event.waitUntil(ensureOfflineGeneration());
 }
 
@@ -969,6 +979,15 @@ async function retire(reason) {
 /// incumbent may stop the reactor serving the current pages.
 function isActiveIncumbent() {
     return self.registration.active === self.serviceWorker;
+}
+
+/// Whether another worker holds the registration while this one waits.
+/// A first install (no active worker) is NOT waiting behind anyone: it
+/// owns the registration as soon as it activates, so it still completes
+/// its own generation.
+function isWaitingBehindIncumbent() {
+    const active = self.registration.active;
+    return active != null && active !== self.serviceWorker;
 }
 
 function retireActiveIncumbent(reason) {

--- a/rust/tonk-ui/src/service_worker_upgrade.rs
+++ b/rust/tonk-ui/src/service_worker_upgrade.rs
@@ -550,11 +550,20 @@ mod tests {
         deadline: tokio::time::Instant,
     ) -> Result<Value> {
         let mut last = Value::Null;
+        let mut polls: u32 = 0;
         loop {
+            // Health rides the stale path, which polls ten times a second.
+            // Fetching it every turn would hammer the retiring worker's
+            // fetch boundary and could keep it alive — the very thing the
+            // early return exists to avoid. Once every five seconds is
+            // enough to catch a stalled retirement without steering it.
+            let sample_health = polls.is_multiple_of(50);
+            polls += 1;
             if let Ok(state) = driver
                 .execute_async(
                     r##"
                     const expectedBuild = arguments[0];
+                    const sampleHealth = arguments[1];
                     const done = arguments[arguments.length - 1];
                     (async () => {
                         const registration = await navigator.serviceWorker.getRegistration();
@@ -591,16 +600,25 @@ mod tests {
                             // ("Streams are released").
                             const [names, health] = await Promise.all([
                                 caches.keys(),
-                                fetch("/api/health")
-                                    .then(response => response.json())
-                                    // The ring holds up to 200 entries of
-                                    // 2000 chars; the tail is what matters
-                                    // and the whole of it would swamp the
-                                    // failure message.
-                                    .then(body => ({ ...body, log: (body.log || []).slice(-25) }))
-                                    .catch(error => ({ unreachable: String(error) })),
+                                sampleHealth
+                                    ? fetch("/api/health")
+                                        .then(response => response.json())
+                                        // The ring holds up to 200 entries
+                                        // of 2000 chars; the tail is what
+                                        // matters and the whole of it would
+                                        // swamp the failure message.
+                                        .then(body => ({
+                                            ...body,
+                                            log: (body.log || []).slice(-25),
+                                        }))
+                                        .catch(error => ({ unreachable: String(error) }))
+                                    : null,
                             ]);
-                            done({ ...lifecycle, cacheNames: names, health });
+                            done({
+                                ...lifecycle,
+                                cacheNames: names,
+                                ...(health ? { health } : {}),
+                            });
                             return;
                         }
                         const generationCache = `TONK_GENERATION_${expectedBuild}`;
@@ -635,7 +653,7 @@ mod tests {
                         });
                     })().catch(error => done({ error: String(error) }));
                     "##,
-                    vec![build.into()],
+                    vec![build.into(), sample_health.into()],
                 )
                 .await
             {

--- a/rust/tonk-ui/src/service_worker_upgrade.rs
+++ b/rust/tonk-ui/src/service_worker_upgrade.rs
@@ -533,7 +533,22 @@ mod tests {
     }
 
     async fn wait_for_mounted_build(driver: &WebDriver, build: &str) -> Result<Value> {
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(90);
+        wait_for_mounted_build_by(
+            driver,
+            build,
+            tokio::time::Instant::now() + Duration::from_secs(90),
+        )
+        .await
+    }
+
+    /// Wait for `build` to be the coherent mounted one, giving up at
+    /// `deadline`. Callers that wait in a loop of their own pass their
+    /// own deadline so the budget is the outer one, not one per turn.
+    async fn wait_for_mounted_build_by(
+        driver: &WebDriver,
+        build: &str,
+        deadline: tokio::time::Instant,
+    ) -> Result<Value> {
         let mut last = Value::Null;
         loop {
             if let Ok(state) = driver
@@ -564,7 +579,28 @@ mod tests {
                         // registration/document state until B is actually the
                         // document, then verify its data plane and manifest.
                         if (documentBuild !== expectedBuild) {
-                            done(lifecycle);
+                            // A stuck handoff otherwise reports only "still
+                            // on the old build", which says nothing about
+                            // why. `caches.keys()` never crosses the fetch
+                            // boundary at all, and `/api/health` is answered
+                            // from the worker's glue rather than its wasm —
+                            // it is readable precisely when the worker
+                            // cannot answer for itself — so its log ring
+                            // shows whether retirement was attempted
+                            // ("Retiring — ...") and whether it completed
+                            // ("Streams are released").
+                            const [names, health] = await Promise.all([
+                                caches.keys(),
+                                fetch("/api/health")
+                                    .then(response => response.json())
+                                    // The ring holds up to 200 entries of
+                                    // 2000 chars; the tail is what matters
+                                    // and the whole of it would swamp the
+                                    // failure message.
+                                    .then(body => ({ ...body, log: (body.log || []).slice(-25) }))
+                                    .catch(error => ({ unreachable: String(error) })),
+                            ]);
+                            done({ ...lifecycle, cacheNames: names, health });
                             return;
                         }
                         const generationCache = `TONK_GENERATION_${expectedBuild}`;
@@ -629,7 +665,7 @@ mod tests {
     ) -> Result<Value> {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(90);
         loop {
-            let state = wait_for_mounted_build(driver, &generation.build).await?;
+            let state = wait_for_mounted_build_by(driver, &generation.build, deadline).await?;
             let cache_names = state["cacheNames"].as_array();
             let has_cache = |expected: &str| {
                 cache_names.is_some_and(|names| names.iter().any(|name| name == expected))

--- a/rust/tonk-ui/tests/service-worker.test.mjs
+++ b/rust/tonk-ui/tests/service-worker.test.mjs
@@ -830,6 +830,48 @@ describe("immutable generation install", () => {
     assert.ok((await caches.keys()).includes(mod.GENERATION_CACHE));
   });
 
+  test("a waiting successor never runs the deferred fill", async () => {
+    // The deferred fill is reached from `onfetch` and `onmessage`, and
+    // both of those reach a worker that is still WAITING — the page goes
+    // on posting `claim` and `connectivity` while the successor sits
+    // behind the incumbent. A successor owns no generation yet: its fill
+    // duplicates the one `oninstall` already runs, and its prune deletes
+    // the caches the incumbent is still serving from. An incumbent that
+    // loses its wasm can no longer retire, which strands the successor
+    // in `waiting` for good.
+    const successor = {};
+    const { self } = withGlobals({
+      // The browser names someone else as active: this instance waits.
+      registration: {
+        active: {},
+        waiting: successor,
+        installing: null,
+        addEventListener() {},
+      },
+    });
+    self.serviceWorker = successor;
+    const mod = await loadWith({
+      buildId: "successor-build",
+      exports: ["extendOfflineGeneration"],
+    });
+
+    let extended = false;
+    mod.extendOfflineGeneration({ waitUntil: () => { extended = true; } });
+    assert.equal(extended, false, "a waiting successor must not fill or prune");
+
+    // The same worker once the browser makes it the incumbent.
+    self.registration.active = successor;
+    mod.extendOfflineGeneration({ waitUntil: () => { extended = true; } });
+    assert.equal(extended, true, "the active incumbent still completes its generation");
+
+    // A first install has no incumbent to displace, so it still fills
+    // even before the browser names it the active worker.
+    extended = false;
+    self.registration.active = null;
+    mod.extendOfflineGeneration({ waitUntil: () => { extended = true; } });
+    assert.equal(extended, true, "a first install still completes its generation");
+  });
+
   test("client discovery cannot stall verified install progress", async () => {
     const { self } = withGlobals();
     self.clients.matchAll = () => new Promise(() => {});


### PR DESCRIPTION
## What this is, and what it is not

This hardens a lifecycle guard and improves two diagnostics. It is **not** confirmed to fix `it_reloads_every_update_aware_tab_after_controller_replacement`, and I want to be upfront about that rather than overclaim.

## The guard

`extendOfflineGeneration` is the one lifecycle operation in the worker with no check on which role this worker holds. Its neighbours all have one — `retireIfSuperseded` and `retireActiveIncumbent` check `isActiveIncumbent()`, `watchSuccessor` checks it before acting on `updatefound`. Running the deferred fill from a worker that is not the incumbent means duplicating the install `oninstall` already performs, and running `pruneObsoleteGenerationCaches`, which deletes `TONK_SHELL_<other>` / `TONK_WORKER_<other>` — the caches another worker may still be serving from, and the ones `workerWasmModule()` reads in order to retire.

The guard is "someone else is active", not "this worker is active": a first install has no incumbent to displace and must still complete its own generation, which `a claimed first page stays ready while its offline generation fills` covers.

**Honest scope.** I could not demonstrate that a *waiting* worker actually reaches this function today. Every `postMessage` in `index.html` targets `reg.active` or `priorController`, never `registration.waiting`, and `fetch` dispatches only to the controlling worker. So this closes a hole that the current callers may not reach — it makes the invariant explicit and match its neighbours, rather than repairing a proven live path.

## What the CI failure actually shows

The successor reached `adopted` (847/847) yet sat at `waiting: "installed"` with the documents still on the old build. `oninstall` calls `skipWaiting()` unconditionally after `installGeneration()`, so the successor did ask to take over; the incumbent did not release. Retirement is attempted from four places, all correctly gated, so the likely stall is inside `retire()` itself — `activateWorker()`, or `on_update_found` (`rust/tonk-worker/src/worker.rs:1937`) which awaits the shared state lock and then `lsp.shutdown()`. Confirming that needs a reproduction, which is still running.

## The diagnostics, which are the durable value here

`wait_for_complete_generation` armed a 90s deadline and then called `wait_for_mounted_build`, which armed *another* 90s inside the loop, so the outer budget never meant what it said and a failure could take ~180s. They now share one deadline.

The lifecycle probe returns early once it sees the document is still on the old build — precisely the failing case — so the dump carried no cache names. `caches.keys()` does not cross the worker's fetch boundary and so cannot keep the retiring worker alive, making it safe to include there. Had it been present, the question above would already be answered.

`test:sw` is 112 green; the new test fails without the guard and passes with it.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the service worker's handling of waiting states and adds tests to ensure correct behavior during worker transitions. It introduces new functions to manage incumbent workers and updates the logic for offline generation.

### Detailed summary
- Added comments to clarify behavior when a worker is waiting behind an incumbent.
- Introduced the `isWaitingBehindIncumbent` function to check if the current worker is waiting for another.
- Modified `extendOfflineGeneration` to prevent fills and prunes when waiting.
- Added a test to verify that a waiting successor does not run deferred fills.
- Updated `wait_for_mounted_build` to use `wait_for_mounted_build_by` for clearer deadline management.
- Enhanced health checks during worker retirement to provide more detailed logs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->