### PR TITLE
fix(ui): hide local profiles from account switcher

### DIFF
--- a/rust/tonk-workspace/src/ui_hub_account.rs
+++ b/rust/tonk-workspace/src/ui_hub_account.rs
@@ -104,9 +104,10 @@ fn render_profiles(this: &HtmlElement, response: &ProfilesResponse) {
     }
 
     // The current account is the TAB itself, so the page holds only ways
-    // onward: one row per other account, wearing its switch verb.
+    // onward: one row per other linked account, wearing its switch verb.
+    // Provider-free profiles are local workspaces, not account-switch targets.
     for profile in &response.profiles {
-        if profile.active || profile.profile_name == response.active {
+        if profile.active || profile.profile_name == response.active || profile.provider.is_none() {
             continue;
         }
         let Ok(row) = document.create_element("button") else {
@@ -1273,7 +1274,7 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    fn it_renders_the_existing_profile_roster_in_the_account_menu() {
+    fn it_renders_only_existing_accounts_in_the_account_menu() {
         let host = account_element();
         let response = ProfilesResponse {
             active: "primary".into(),
@@ -1312,7 +1313,7 @@ mod tests {
             "the current account is the tab itself, not a row"
         );
         let switches = host.query_selector_all("button[data-profile]").unwrap();
-        assert_eq!(switches.length(), 2);
+        assert_eq!(switches.length(), 1);
         let second = switches.item(0).unwrap().text_content().unwrap();
         assert!(second.contains("grace@example.com"));
         assert!(
@@ -1320,12 +1321,10 @@ mod tests {
             "a roster row carries its switch verb"
         );
         assert!(
-            switches
-                .item(1)
+            host.query_selector("[data-profile=\"Local workspace\"]")
                 .unwrap()
-                .text_content()
-                .unwrap()
-                .contains("Local workspace")
+                .is_none(),
+            "a local fallback profile is not an account-switch target"
         );
         assert!(host.query_selector("[data-add-profile]").unwrap().is_some());
         assert!(


### PR DESCRIPTION
## What changed

- hide provider-free local workspace profiles from the account switcher
- keep local profiles in the worker roster so their retained data and signed-out fallback behavior are unchanged
- keep other provider-attached accounts available as switch targets

## Verification

- `cargo fmt --all -- --check`
- `nix develop path:. -c test:web:debug -E "package(tonk-workspace) & test(it_renders_only_existing_accounts_in_the_account_menu)"`
- `nix develop path:. -c test:web:debug -E "package(tonk-workspace)"` (78 passed)
- `git diff --check origin/staging...HEAD`

## Storybook impact

- [x] User-visible browser behavior changed. Existing account lifecycle coverage: `B2`, `LIFE-15`, and `LIFE-17`; the focused Wasm DOM regression covers the filtering rule.
- [ ] This fixes a user-visible bug. The regression test and Storybook now share this ID:
- [ ] No user-visible contract changed because:

No fixture recapture is needed because this change only removes a provider-free row from the state-driven account menu.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refining the handling of linked accounts in the account menu and updating related tests to ensure only existing accounts are rendered.

### Detailed summary
- Updated comment to clarify that the page shows rows for linked accounts.
- Added a condition to skip profiles with no provider in the profile check.
- Renamed test function to reflect that it only renders existing accounts.
- Adjusted test assertions to expect only one account button instead of two.
- Verified that local workspaces are not treated as account-switch targets in assertions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->