### PR TITLE
feat(commands): declare events as concepts, and give every command its own namespace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5385,6 +5385,7 @@ dependencies = [
  "tonk-notation",
  "tonk-router",
  "tonk-schema",
+ "tonk-template",
  "tonk-worker-api",
  "tower",
  "tower-service",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5258,6 +5258,7 @@ dependencies = [
  "serde_ipld_dagjson",
  "serde_json",
  "tokio",
+ "tonk-notation",
  "tonk-schema",
  "wasm-bindgen-test",
 ]

--- a/rust/dialog-reactor/src/command.rs
+++ b/rust/dialog-reactor/src/command.rs
@@ -124,6 +124,108 @@ where
     }
 }
 
+/// A command's decode surface: the shape it has **now**, plus one
+/// deprecated predecessor that converts into it.
+///
+/// A command is matched structurally — the set of attribute names a
+/// transient carries is its whole identity. That makes changing a
+/// command's shape a compatibility problem: a branch seeded before the
+/// change still asserts the old attributes, and a handler keyed on the
+/// new ones stops firing for it.
+///
+/// This is the seam that makes such a change survivable without the old
+/// shape becoming permanent. A handler declares
+/// `Migrated<Current, Legacy>`; the registry indexes it under the union
+/// of both attribute sets, so either shape reaches it, and
+/// [`decode`](Self::decode) hands the handler a `Current` either way —
+/// the legacy shape arriving through `Legacy: Into<Current>`.
+///
+/// The handler is therefore written against `Current` only. Retiring the
+/// legacy shape is deleting its concept, its `From` impl, and the second
+/// type parameter here: no handler body changes.
+///
+/// `Current` is tried first, so a transient that satisfies both shapes
+/// (one carrying every attribute of each) decodes as the current one.
+///
+/// ```no_run
+/// # use dialog_reactor::Migrated;
+/// # use dialog_artifacts::Entity;
+/// # use dialog_query::{Attribute, Concept};
+/// # #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+/// # #[domain("xyz.example.rename")] pub struct Name(pub String);
+/// # #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+/// # #[domain("dom.event.current-target")] pub struct Value(pub String);
+/// # #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+/// # pub struct Rename { pub this: Entity, pub name: Name }
+/// # #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+/// # pub struct LegacyRename { pub this: Entity, pub value: Value }
+/// impl From<LegacyRename> for Rename {
+///     fn from(old: LegacyRename) -> Self {
+///         Self { this: old.this, name: Name(old.value.0) }
+///     }
+/// }
+///
+/// let command: Migrated<Rename, LegacyRename> = Migrated::new();
+/// // Indexed under both `xyz.example.rename/name` and
+/// // `dom.event.current-target/value`.
+/// assert_eq!(command.trigger_attributes().len(), 2);
+/// ```
+pub struct Migrated<Current, Legacy> {
+    attributes: Vec<String>,
+    _shapes: std::marker::PhantomData<fn() -> (Current, Legacy)>,
+}
+
+impl<Current, Legacy> Migrated<Current, Legacy>
+where
+    Current: Decode,
+    Legacy: Decode + Into<Current>,
+{
+    /// Cache the union of both shapes' trigger attributes, so the
+    /// registry indexes the handler under everything either shape can
+    /// assert.
+    pub fn new() -> Self {
+        let mut attributes = Current::trigger_attributes();
+        for attribute in Legacy::trigger_attributes() {
+            if !attributes.contains(&attribute) {
+                attributes.push(attribute);
+            }
+        }
+        Self {
+            attributes: attributes,
+            _shapes: std::marker::PhantomData,
+        }
+    }
+
+    /// The attribute names that make a transient a candidate: every one
+    /// either shape carries.
+    pub fn trigger_attributes(&self) -> &[String] {
+        &self.attributes
+    }
+
+    /// Decode one transient entity's facts as `Current`, converting a
+    /// legacy shape when that is what arrived. `None` when the facts
+    /// satisfy neither.
+    pub fn decode(&self, facts: &EntityFacts) -> Option<Current> {
+        let this = facts_entity(facts)?;
+        Current::decode(this.clone(), facts).or_else(|| Legacy::decode(this, facts).map(Into::into))
+    }
+
+    /// Whether these facts decode as either shape.
+    pub fn matches(&self, facts: &EntityFacts) -> bool {
+        self.decode(facts).is_some()
+    }
+}
+
+impl<Current, Legacy> Default for Migrated<Current, Legacy>
+where
+    Current: Decode,
+    Legacy: Decode + Into<Current>,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// A `'static` boxed future for one command's execution, `Send` only
 /// off wasm — matches the reactor's
 /// [`ConditionalSync`](dialog_common::ConditionalSync) convention so a
@@ -250,6 +352,75 @@ where
     }
 }
 
+/// A registry entry for a command whose shape changed: runs the
+/// [`Provider<Current>`](dialog_capability::Provider) for either the
+/// current shape or the deprecated predecessor that converts into it.
+///
+/// The [`TypedCommand`] sibling for [`Migrated`]. The provider is
+/// implemented for `Current` alone — `Legacy` reaches it through
+/// `Into<Current>`, so nothing downstream of decode knows the old shape
+/// exists, and retiring it touches only the registration.
+pub struct MigratedCommand<Current, Legacy, Env> {
+    command: Migrated<Current, Legacy>,
+    _env: std::marker::PhantomData<fn() -> Env>,
+}
+
+impl<Current, Legacy, Env> MigratedCommand<Current, Legacy, Env>
+where
+    Current: Decode + Command<Input = Current> + 'static,
+    Legacy: Decode + Into<Current> + 'static,
+    Env: Provider<Current>,
+{
+    /// Register `Current`, also accepting `Legacy` on its behalf. The
+    /// `Env: Provider<Current>` bound is the same compile-time
+    /// capability gate [`TypedCommand::new`] applies — the legacy shape
+    /// grants no capability of its own.
+    pub fn new() -> Self {
+        Self {
+            command: Migrated::new(),
+            _env: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<Current, Legacy, Env> Default for MigratedCommand<Current, Legacy, Env>
+where
+    Current: Decode + Command<Input = Current> + 'static,
+    Legacy: Decode + Into<Current> + 'static,
+    Env: Provider<Current>,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Current, Legacy, Env> CommandHandler<Env> for MigratedCommand<Current, Legacy, Env>
+where
+    Current: Decode + Command<Input = Current, Output = ()> + ConditionalSync + 'static,
+    Legacy: Decode + Into<Current> + ConditionalSync + 'static,
+    Env: Provider<Current> + Clone + ConditionalSync + 'static,
+{
+    fn trigger_attributes(&self) -> &[String] {
+        self.command.trigger_attributes()
+    }
+
+    fn matches(&self, facts: &EntityFacts) -> bool {
+        self.command.matches(facts)
+    }
+
+    fn run(&self, facts: &EntityFacts, env: &Env) -> RunFuture {
+        // Decode (and convert) synchronously, as `TypedCommand` does —
+        // the caller still holds the lock.
+        let decoded = self.command.decode(facts);
+        let env = env.clone();
+        Box::pin(async move {
+            if let Some(command) = decoded {
+                env.execute(command).await;
+            }
+        })
+    }
+}
+
 /// Registry of command handlers, with a reverse index from trigger
 /// attribute name to the handlers it can fire. Mirrors the
 /// `dialog.effect/on` index the induce loop walks, but over
@@ -295,6 +466,20 @@ impl<Env> CommandRegistry<Env> {
         Env: Provider<C> + Clone + ConditionalSync + 'static,
     {
         self.register(Box::new(TypedCommand::<C, Env>::new()));
+        self
+    }
+
+    /// Register the command type `Current`, also accepting the
+    /// deprecated `Legacy` shape on its behalf and converting it. The
+    /// [`Self::command`] counterpart for a command whose shape changed;
+    /// see [`Migrated`]. Chainable.
+    pub fn migrated<Current, Legacy>(mut self) -> Self
+    where
+        Current: Decode + Command<Input = Current, Output = ()> + ConditionalSync + 'static,
+        Legacy: Decode + Into<Current> + ConditionalSync + 'static,
+        Env: Provider<Current> + Clone + ConditionalSync + 'static,
+    {
+        self.register(Box::new(MigratedCommand::<Current, Legacy, Env>::new()));
         self
     }
 
@@ -900,5 +1085,144 @@ mod tests {
                 _ => None,
             });
         assert_eq!(name.as_deref(), Some("pics"));
+    }
+
+    // --- migrated commands ----------------------------------------------
+    // A command's shape is the set of attributes it carries, so changing
+    // the shape breaks every branch seeded before the change. `Migrated`
+    // is how a handler accepts both without the old shape becoming
+    // permanent: the handler only ever sees `Current`.
+
+    /// The DOM-shaped predecessor of [`CreateRepo`]: same command, but
+    /// its field is the DOM read path the form used to post. Its own
+    /// module so the struct can be named `Value` — the attribute's last
+    /// segment IS the struct name, and the read path ends `name/value`.
+    pub mod form {
+        use dialog_query::Attribute;
+
+        #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        #[domain("dom.event.current-target.elements.name")]
+        pub struct Value(pub String);
+    }
+
+    #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct LegacyCreateRepo {
+        pub this: Entity,
+        pub name: form::Value,
+    }
+
+    impl From<LegacyCreateRepo> for CreateRepo {
+        fn from(legacy: LegacyCreateRepo) -> Self {
+            Self {
+                this: legacy.this,
+                name: RepoName(legacy.name.0),
+            }
+        }
+    }
+
+    fn legacy_create_repo_transient(of: &str, name: &str) -> Changes {
+        let mut changes = Changes::new();
+        the!("dom.event.current-target.elements.name/value")
+            .of(entity(of))
+            .is(name.to_string())
+            .assert(&mut changes);
+        changes
+    }
+
+    #[dialog_common::test]
+    fn a_migrated_command_is_indexed_under_both_shapes() {
+        let command: Migrated<CreateRepo, LegacyCreateRepo> = Migrated::new();
+        let attributes: Vec<&str> = command
+            .trigger_attributes()
+            .iter()
+            .map(String::as_str)
+            .collect();
+        assert!(attributes.contains(&"xyz.tonk.command/repo-name"));
+        assert!(attributes.contains(&"dom.event.current-target.elements.name/value"));
+    }
+
+    #[dialog_common::test]
+    fn a_migrated_command_decodes_the_current_shape() {
+        let command: Migrated<CreateRepo, LegacyCreateRepo> = Migrated::new();
+        let (_, facts) = facts_for(create_repo_transient("did:key:zCmd", "pictures"));
+        let decoded = command.decode(&facts).expect("the current shape decodes");
+        assert_eq!(decoded.name.0, "pictures");
+    }
+
+    #[dialog_common::test]
+    fn a_migrated_command_converts_the_legacy_shape() {
+        // The whole point: a branch seeded before the change still posts
+        // the DOM-shaped transient, and the handler still receives a
+        // `CreateRepo` — it never learns the old shape exists.
+        let command: Migrated<CreateRepo, LegacyCreateRepo> = Migrated::new();
+        let (_, facts) = facts_for(legacy_create_repo_transient("did:key:zCmd", "pictures"));
+        let decoded = command.decode(&facts).expect("the legacy shape converts");
+        assert_eq!(decoded.name.0, "pictures");
+    }
+
+    #[dialog_common::test]
+    fn a_migrated_command_prefers_the_current_shape() {
+        // A transient carrying both (a page mid-migration, or a branch
+        // reseeded while a tab held the old descriptor) decodes as the
+        // current shape rather than round-tripping through the
+        // conversion.
+        let command: Migrated<CreateRepo, LegacyCreateRepo> = Migrated::new();
+        let mut changes = create_repo_transient("did:key:zCmd", "current");
+        the!("dom.event.current-target.elements.name/value")
+            .of(entity("did:key:zCmd"))
+            .is("legacy".to_string())
+            .assert(&mut changes);
+        let (_, facts) = facts_for(changes);
+        assert_eq!(command.decode(&facts).expect("decodes").name.0, "current");
+    }
+
+    #[dialog_common::test]
+    fn a_migrated_command_rejects_facts_matching_neither_shape() {
+        let command: Migrated<CreateRepo, LegacyCreateRepo> = Migrated::new();
+        let mut changes = Changes::new();
+        noise_fact(&mut changes, "did:key:zCmd");
+        let (_, facts) = facts_for(changes);
+        assert!(!command.matches(&facts));
+    }
+
+    #[dialog_common::test]
+    fn the_registry_fires_a_migrated_handler_for_either_shape() {
+        // End to end through the registry: both transients reach the
+        // same registered handler.
+        let mut registry = CommandRegistry::<()>::new();
+        registry.register(Box::new(MigratedStub {
+            command: Migrated::<CreateRepo, LegacyCreateRepo>::new(),
+        }));
+
+        for changes in [
+            create_repo_transient("did:key:zCmd", "pictures"),
+            legacy_create_repo_transient("did:key:zCmd", "pictures"),
+        ] {
+            assert_eq!(
+                registry.match_transients(&changes).len(),
+                1,
+                "both shapes reach the migrated handler"
+            );
+        }
+    }
+
+    /// A handler that only knows `Migrated` — the shape every real
+    /// command handler takes once migrated.
+    struct MigratedStub {
+        command: Migrated<CreateRepo, LegacyCreateRepo>,
+    }
+
+    impl CommandHandler<()> for MigratedStub {
+        fn trigger_attributes(&self) -> &[String] {
+            self.command.trigger_attributes()
+        }
+
+        fn matches(&self, facts: &EntityFacts) -> bool {
+            self.command.matches(facts)
+        }
+
+        fn run(&self, _facts: &EntityFacts, _env: &()) -> RunFuture {
+            Box::pin(async {})
+        }
     }
 }

--- a/rust/dialog-reactor/src/command.rs
+++ b/rust/dialog-reactor/src/command.rs
@@ -191,7 +191,7 @@ where
             }
         }
         Self {
-            attributes: attributes,
+            attributes,
             _shapes: std::marker::PhantomData,
         }
     }
@@ -673,7 +673,7 @@ mod tests {
     /// fields off the matched concept.
     #[dialog_common::test]
     fn it_decodes_create_space_from_name_only_facts() {
-        use tonk_schema::command::CreateSpace;
+        use tonk_schema::command::{CreateSpace, legacy};
 
         let this = entity("did:key:zCreateSpace");
         let mut changes = Changes::new();
@@ -681,9 +681,13 @@ mod tests {
             .of(this.clone())
             .is("pictures".to_string())
             .assert(&mut changes);
-        let (this, facts) = facts_for(changes);
+        let (_, facts) = facts_for(changes);
 
-        let decoded = CreateSpace::decode(this, &facts)
+        // Through `Migrated`, exactly as the handler decodes it: the
+        // attribute here is the DOM read path an older descriptor still
+        // asserts, and it must arrive as the current shape.
+        let decoded = Migrated::<CreateSpace, legacy::CreateSpace>::new()
+            .decode(&facts)
             .expect("CreateSpace must decode from name-only facts (older descriptor / blank form)");
         assert_eq!(decoded.name.0, "pictures");
     }
@@ -692,7 +696,7 @@ mod tests {
     /// transient carrying only `data-remove` (the subject DID).
     #[dialog_common::test]
     fn it_decodes_remove_space_from_a_data_remove_fact() {
-        use tonk_schema::command::RemoveSpace;
+        use tonk_schema::command::{RemoveSpace, legacy};
 
         let this = entity("did:key:zRemoveSpace");
         let subject = entity("did:key:zSpaceSubject");
@@ -701,9 +705,10 @@ mod tests {
             .of(this.clone())
             .is(subject.clone())
             .assert(&mut changes);
-        let (this, facts) = facts_for(changes);
+        let (_, facts) = facts_for(changes);
 
-        let decoded = RemoveSpace::decode(this, &facts)
+        let decoded = Migrated::<RemoveSpace, legacy::RemoveSpace>::new()
+            .decode(&facts)
             .expect("RemoveSpace must decode from a data-remove-only transient");
         assert_eq!(decoded.subject.0, subject);
     }
@@ -715,7 +720,7 @@ mod tests {
     /// DID decode from the transient's raw facts.
     #[dialog_common::test]
     fn it_decodes_rename_repository_naming_its_target_space() {
-        use tonk_schema::command::RenameRepository;
+        use tonk_schema::command::{RenameRepository, legacy};
 
         let this = entity("did:key:zRenameRepository");
         let target_space = entity("did:key:zTargetSpace");
@@ -732,9 +737,10 @@ mod tests {
             .of(this.clone())
             .is(entity("tonk:repository"))
             .assert(&mut changes);
-        let (this, facts) = facts_for(changes);
+        let (_, facts) = facts_for(changes);
 
-        let decoded = RenameRepository::decode(this, &facts)
+        let decoded = Migrated::<RenameRepository, legacy::RenameRepository>::new()
+            .decode(&facts)
             .expect("RenameRepository must decode from its raw facts");
         assert_eq!(decoded.name.0, "Renamed");
         assert_eq!(
@@ -749,7 +755,7 @@ mod tests {
     /// would turn every banner rename into a space deletion.
     #[dialog_common::test]
     fn it_does_not_decode_a_rename_transient_as_remove_space() {
-        use tonk_schema::command::RemoveSpace;
+        use tonk_schema::command::{RemoveSpace, legacy};
 
         let mut changes = Changes::new();
         the!("dom.event.current-target.dataset/subject")
@@ -760,10 +766,10 @@ mod tests {
             .of(entity("did:key:zRename"))
             .is("new name".to_string())
             .assert(&mut changes);
-        let (this, facts) = facts_for(changes);
+        let (_, facts) = facts_for(changes);
 
         assert!(
-            RemoveSpace::decode(this, &facts).is_none(),
+            !Migrated::<RemoveSpace, legacy::RemoveSpace>::new().matches(&facts),
             "a rename-shaped transient must not decode as RemoveSpace"
         );
     }
@@ -777,13 +783,19 @@ mod tests {
     /// decoded as BOTH commands and both handlers fired. Command decoding
     /// matches on which attributes are PRESENT, never their values, so a
     /// shared marker value (`tonk:repository` vs `tonk:profile`) never
-    /// disambiguated anything. The fix is a DISTINCT ATTRIBUTE per command
-    /// — `dataset/rename-repository` here — the same pattern
-    /// `remove::Remove` already uses (see
-    /// `it_does_not_decode_a_rename_transient_as_remove_space` above).
+    /// disambiguated anything. The fix was a DISTINCT ATTRIBUTE per
+    /// command — the marker `dataset/rename-repository` this transient
+    /// still carries.
+    ///
+    /// The current shapes need no marker: each command's fields live in
+    /// its own `xyz.tonk.command.<verb>` namespace, so the shapes are
+    /// disjoint by construction (`tonk-worker/tests/command_migration.rs`
+    /// pins that). What this test still pins is that the DEPRECATED
+    /// shapes stay disjoint too — a branch seeded before the migration is
+    /// exactly where this bug would come back.
     #[dialog_common::test]
     fn it_does_not_decode_a_repo_rename_as_a_profile_rename() {
-        use tonk_schema::command::{ProfileRename, RenameRepository};
+        use tonk_schema::command::{ProfileRename, RenameRepository, legacy};
 
         let this = entity("did:key:zRepoRename");
         let target_space = entity("did:key:zTargetSpace");
@@ -800,14 +812,14 @@ mod tests {
             .of(this.clone())
             .is(entity("tonk:repository"))
             .assert(&mut changes);
-        let (this, facts) = facts_for(changes);
+        let (_, facts) = facts_for(changes);
 
         assert!(
-            RenameRepository::decode(this.clone(), &facts).is_some(),
+            Migrated::<RenameRepository, legacy::RenameRepository>::new().matches(&facts),
             "a repo-rename transient must decode as RenameRepository"
         );
         assert!(
-            ProfileRename::decode(this, &facts).is_none(),
+            !Migrated::<ProfileRename, legacy::ProfileRename>::new().matches(&facts),
             "a repo-rename transient must NOT also decode as ProfileRename — \
              that is the bug: renaming a space was also renaming the profile"
         );
@@ -818,7 +830,7 @@ mod tests {
     /// `RenameRepository`, which requires `space` regardless.
     #[dialog_common::test]
     fn it_does_not_decode_a_profile_rename_as_a_repo_rename() {
-        use tonk_schema::command::{ProfileRename, RenameRepository};
+        use tonk_schema::command::{ProfileRename, RenameRepository, legacy};
 
         let this = entity("did:key:zProfileRename");
         let mut changes = Changes::new();
@@ -830,14 +842,14 @@ mod tests {
             .of(this.clone())
             .is(entity("tonk:profile"))
             .assert(&mut changes);
-        let (this, facts) = facts_for(changes);
+        let (_, facts) = facts_for(changes);
 
         assert!(
-            ProfileRename::decode(this.clone(), &facts).is_some(),
+            Migrated::<ProfileRename, legacy::ProfileRename>::new().matches(&facts),
             "a profile-rename transient must decode as ProfileRename"
         );
         assert!(
-            RenameRepository::decode(this, &facts).is_none(),
+            !Migrated::<RenameRepository, legacy::RenameRepository>::new().matches(&facts),
             "a profile-rename transient must not decode as RenameRepository \
              (it carries no `space`)"
         );

--- a/rust/dialog-reactor/src/lib.rs
+++ b/rust/dialog-reactor/src/lib.rs
@@ -39,7 +39,10 @@ mod subscription;
 mod transaction;
 
 pub use branch::{BranchReference, BranchSession, BranchState};
-pub use command::{CommandHandler, CommandRegistry, Decode, EntityFacts, RunFuture, TypedCommand};
+pub use command::{
+    CommandHandler, CommandRegistry, Decode, EntityFacts, Migrated, MigratedCommand, RunFuture,
+    TypedCommand,
+};
 pub use env::{
     BranchOpenProvider, CommitProvider, GetPutProvider, LoadProvider, PullProvider, PushProvider,
     SelectProvider,

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -60,6 +60,121 @@ view!:
 
 
 # ============================================================
+# EVENTS
+# ============================================================
+
+# The `event` concept. An `event!:` declaration is the seam between a
+# host's input model and a command's domain shape: it names the platform
+# event to listen for, whether to suppress the platform's default
+# handling, and a `where:` map from COMMAND FIELD NAME to source.
+#
+# A template binds one with `on:<name>=<command>`, which resolves the
+# declaration named `on/<name>` — `/` is not legal in an HTML attribute
+# name but `:` is, so the identifier and the attribute differ by exactly
+# that substitution. Only the single `on:` prefix is reserved, so
+# `bind:base`, `xlink:href` and `xml:lang` are untouched.
+#
+# This replaces spelling the extraction inside the command's `with:`
+# map as `dom.event.*` identifiers. That form made a command's identity
+# its plumbing: two verbs reading the same DOM path were the same
+# concept (hence `sheet-name` / `rename-name` in table.yaml, contorted
+# only to stay distinct), and the command could not be reused by a host
+# with no DOM. Here the command stays domain-shaped and every platform
+# difference lives in one artifact whose whole job is platform
+# difference.
+#
+# `on<event>=` keeps working — the two attribute forms are distinct, so
+# templates migrate one at a time.
+concept!: &event
+  this: tonk:event
+  description: How a platform event fills a command's fields
+  with:
+    type:
+      description: The platform event name to listen for
+      the: xyz.tonk.event/type
+      cardinality: one
+      as: text
+    where:
+      description: Command field name to source
+      # A keyed collection's `the:` names a domain and the key supplies
+      # the name half, so each entry lands as its own fact
+      # (`xyz.tonk.event.where/<field>`) with cardinality one — a space
+      # can supersede one source without restating the map. Its own
+      # domain, so a field called `type` cannot collide with the `type:`
+      # attribute above.
+      the: xyz.tonk.event.where
+      cardinality: one
+      as: {[symbol]: text}
+  maybe:
+    prevent-default:
+      description: Suppress the platform's default handling
+      the: xyz.tonk.event/prevent-default
+      cardinality: one
+      as: boolean
+    stop-propagation:
+      description: Stop the event propagating further
+      the: xyz.tonk.event/stop-propagation
+      cardinality: one
+      as: boolean
+
+# A `where:` source is one of three forms, each syntactically distinct
+# so a typo cannot be mistaken for a different kind:
+#
+#   {field}   template interpolation, in the scope of the element the
+#             event fired on — a field of the enclosing repeat subject.
+#             `{this}` is the subject itself.
+#   .path     a property read off the live event, spelled the way the
+#             platform spells it (`.currentTarget.dataset.todo`). No
+#             case translation, so the old kebab/camel trap is gone.
+#   "text"    a literal, for defaults the interaction never supplies.
+#
+# A bare word is an error rather than a literal: `timeStamp` without its
+# dot would otherwise silently become the string "timeStamp", which is
+# the class of mistake this exists to catch.
+
+# Activation. `{this}` covers the whole `data-*` stash-and-recover
+# pattern: the renderer already stamps `data-this` on every repeat row,
+# so the subject needs no template attribute at all.
+event!: &on/click
+  type: "click"
+  where:
+    subject: "{this}"
+
+# Activation on a row, carrying a per-event nonce so two identical
+# clicks mint distinct entities. `time` is why a command that creates
+# something needs no hand-written nonce field.
+event!: &on/click-once
+  type: "click"
+  where:
+    subject: "{this}"
+    time: ".timeStamp"
+
+# Form submission. `prevent-default` lives here rather than in the
+# command, which is what keeps the command rule-consumable: an action
+# field in a command's `with:` map stores no value, so a rule premise
+# over it matches zero rows however successfully the command transacts.
+event!: &on/submit
+  type: "submit"
+  prevent-default: true
+  where:
+    subject: "{this}"
+
+# A native control's committed value.
+event!: &on/change
+  type: "change"
+  where:
+    subject: "{this}"
+    value: ".currentTarget.value"
+
+# A native control's checked state.
+event!: &on/toggle
+  type: "change"
+  where:
+    subject: "{this}"
+    checked: ".currentTarget.checked"
+
+
+# ============================================================
 # WORKSPACE
 # ============================================================
 

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -63,10 +63,16 @@ view!:
 # EVENTS
 # ============================================================
 
-# The `event` concept. An `event!:` declaration is the seam between a
-# host's input model and a command's domain shape: it names the platform
-# event to listen for, whether to suppress the platform's default
-# handling, and a `where:` map from COMMAND FIELD NAME to source.
+# `event` is a BUILT-IN concept (tonk-schema's registry, beside
+# `command` and `rule`), not a library one — an `event!:` declaration is
+# schema an author writes, so it must resolve on any branch rather than
+# only where this library has been seeded. What lives here are its
+# INSTANCES: the DOM event set. A terminal seeds its own.
+#
+# An `event!:` declaration is the seam between a host's input model and
+# a command's domain shape: it names the platform event to listen for,
+# whether to suppress the platform's default handling, and a `where:`
+# map from COMMAND FIELD NAME to source.
 #
 # A template binds one with `on:<name>=<command>`, which resolves the
 # declaration named `on/<name>` — `/` is not legal in an HTML attribute
@@ -85,38 +91,6 @@ view!:
 #
 # `on<event>=` keeps working — the two attribute forms are distinct, so
 # templates migrate one at a time.
-concept!: &event
-  this: tonk:event
-  description: How a platform event fills a command's fields
-  with:
-    type:
-      description: The platform event name to listen for
-      the: xyz.tonk.event/type
-      cardinality: one
-      as: text
-    where:
-      description: Command field name to source
-      # A keyed collection's `the:` names a domain and the key supplies
-      # the name half, so each entry lands as its own fact
-      # (`xyz.tonk.event.where/<field>`) with cardinality one — a space
-      # can supersede one source without restating the map. Its own
-      # domain, so a field called `type` cannot collide with the `type:`
-      # attribute above.
-      the: xyz.tonk.event.where
-      cardinality: one
-      as: {[symbol]: text}
-  maybe:
-    prevent-default:
-      description: Suppress the platform's default handling
-      the: xyz.tonk.event/prevent-default
-      cardinality: one
-      as: boolean
-    stop-propagation:
-      description: Stop the event propagating further
-      the: xyz.tonk.event/stop-propagation
-      cardinality: one
-      as: boolean
-
 # A `where:` source is one of three forms, each syntactically distinct
 # so a typo cannot be mistaken for a different kind:
 #

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -219,7 +219,7 @@ view!:
         <span class="blank-canvas__label">no template &middot; empty view</span>
         <h1 class="blank-canvas__title">your starting layout is in place</h1>
         <section class="blank-canvas__deeplink">
-          <tonk-page onmount=tonk:invite data-invite="tonk:invite"></tonk-page>
+          <tonk-page on:invite=tonk:invite></tonk-page>
           <tonk-origin>
             <tonk-display
               entity={subject}
@@ -248,21 +248,27 @@ view!:
 # `<tonk-sync-state>` element (which resolves the repo from its
 # `with` ancestor) stamps the real name into the form's
 # hidden `name` input on click — the one identifier notation can't read
-# from the event. `prevent-default` stops the page reloading.
+# from the event.
+#
+# It carries `create-space`'s attributes deliberately: the two ARE one
+# command as far as the worker is concerned (`CreateSpaceHandler` serves
+# both, keyed on the shared `name`). Two notation names, one shape.
+#
+# `prevent-default` used to be a field here. A side effect declared as a
+# command field stores no value, so a rule premise over it matches zero
+# rows however successfully the command transacted; it belongs on the
+# `event!:` declaration of whatever binds this.
 command!: &space/enable-sync
   description: A request to attach a sync remote to the current space.
   with:
     name:
       description: The space's local repository name, stamped into the hidden `name` input
-      the: dom.event.current-target.elements.name/value
+      the: xyz.tonk.command.create-space/name
       as: text
     remote:
       description: The sync URL, read from the form's `remote` input on submit
-      the: dom.event.current-target.elements.remote/value
+      the: xyz.tonk.command.create-space/remote
       as: text
-    prevent-default:
-      description: Stop the form submission from reloading the page
-      the: dom.event.do/prevent-default
 
 # Mint a repository invite. Clicking Share submits this transient; the
 # worker's `InviteHandler` generates a fresh membership keypair, delegates
@@ -271,27 +277,31 @@ command!: &space/enable-sync
 # private seed as a `tonk:credential` into the reactor's session overlay
 # (never replicated). The repository is not a field here — the handler
 # reads it from the command's origin (the branch the commit landed in).
-# `time` carries the submit event's timestamp so each click is a distinct
-# transient and reliably re-fires the handler (rotating the credential).
+#
+# How the share affordance's mount fills it. `<tonk-page>` raises `mount`
+# as a CustomEvent, so its `timeStamp` is what makes each dispatch
+# distinct.
+event!: &on/invite
+  type: "mount"
+  where:
+    time: ".timeStamp"
+
 command!: &tonk/invite
   this: tonk:invite
   description: Mint a repo invite — generates a membership keypair and delegation.
   with:
     time:
-      description: The submit event's timestamp; makes each click distinct.
-      the: dom.event/time-stamp
-      as: float
-    marker:
       description: |
-          Per-command marker read from the share form's `data-invite`. Gives
-          `tonk:invite` an attribute no other command carries, so a
-          `tonk:pause-sync` transient (otherwise an identical {this, time}
-          shape) does not also decode as an invite.
-      the: dom.event.current-target.dataset/invite
-      as: entity
-    prevent-default:
-      description: Stop the form submission from reloading the page
-      the: dom.event.do/prevent-default
+          The activation's timestamp; makes each dispatch distinct so a repeat
+          click reliably re-fires the handler and rotates the credential.
+
+          It used to be accompanied by a marker field read from a
+          `data-invite` attribute, whose whole job was to stop a
+          `tonk:pause-sync` transient — an identical {this, time} otherwise —
+          from also decoding as an invite. Each command now owns its
+          attribute namespace, so the two are disjoint and the marker is gone.
+      the: xyz.tonk.command.invite/time
+      as: float
 
 # Load the requesting tab's site for its current path. Asserted transiently by
 # `<tonk-site>` (via the regular transact API) instead of a `/site` fetch: the
@@ -674,23 +684,23 @@ concept!: &member
 # The role badge label comes from CSS `::after` keyed on `data-role`, so the
 # raw `tonk:founder` / `tonk:member` URI never shows; the raw {role} text is
 # kept (visually hidden) only to drive the attribute.
-# Removing a member. A single matched field, so the attribute is the
-# command's shape as well as its payload: `dataset/expel` is read by no
-# other command. Acts on the space it fires in. The worker's handler does
-# the chain work; the service refuses a removal minted under a member's
-# `/use` chain, so holding the space is what makes it take effect, not the
-# role on the roster. Promotion is not a form: the FAB dispatches it after
-# the page mints the admin hop under the passkey.
+# Removing a member. Acts on the space it fires in. The worker's handler
+# does the chain work; the service refuses a removal minted under a
+# member's `/use` chain, so holding the space is what makes it take
+# effect, not the role on the roster. Promotion is not a form: the FAB
+# dispatches it after the page mints the admin hop under the passkey.
+#
+# The field used to be read from a `data-expel` attribute, chosen for
+# being read by no other command — the attribute doubling as the command's
+# shape. `xyz.tonk.command.expel-member/member` is that distinctness by
+# construction, so the name can just say what it means.
 command!: &member/expel
   description: Remove a member from this space.
   with:
     member:
-      description: The DID of the member to remove, read from `data-expel`.
-      the: dom.event.current-target.dataset/expel
+      description: The DID of the member to remove.
+      the: xyz.tonk.command.expel-member/member
       as: entity
-    prevent-default:
-      description: Stop the form submission from reloading the page
-      the: dom.event.do/prevent-default
 
 view!:
   this: tonk:member
@@ -997,23 +1007,21 @@ concept!: &tonk/identity
       cardinality: one
       as: text
 
-# Rename the signed-in member (set their display name). The editable
-# chip input dispatches this on commit (blur/Enter); `name` reads the
-# input's value and `marker` reads the `data-rename` attribute so the
-# worker handler matches this transient distinctly from
-# `tonk/rename-repository`. No rule: a typed-Rust handler in
-# tonk-worker reacts (it must reach the profile meta branch).
+# Rename the signed-in member (set their display name). The editable chip
+# input dispatches this on commit (blur/Enter). No rule: a typed-Rust
+# handler in tonk-worker reacts (it must reach the profile meta branch).
+#
+# This and `tonk/rename-repository` both read `currentTarget.value`, and a
+# marker field read from `data-rename` is what used to keep the two
+# shapes disjoint — without it every space rename also renamed the
+# profile. Separate attribute namespaces do that now.
 command!: &profile/rename
   description: Rename the signed-in member (set their display name).
   with:
     name:
       description: The new name, read from the editable's value on commit.
-      the: dom.event.current-target/value
+      the: xyz.tonk.command.profile-rename/name
       as: text
-    marker:
-      description: Per-command marker (data-rename) distinguishing this from repo rename.
-      the: dom.event.current-target.dataset/rename
-      as: entity
 
 # The repository's name, as two extra facets of `tonk:repository`'s
 # dictionary. `label` — plain, non-editable text: the Hub card mounts

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -942,16 +942,26 @@ concept!: &tonk/agents
 # `subject` reads the repository identity stamped on the banner so the
 # rule below knows which repository to rename. The command is transient:
 # the rule fires once and the command is swept before the durable commit.
+# How the banner input's commit fills the rename. `subject` stays a
+# `data-*` read rather than `{this}`: the banner is not inside a repeat
+# row, and its subject is the repository rather than the view's own
+# entity, so the two are genuinely different values here.
+event!: &on/repository-rename
+  type: "change"
+  where:
+    subject: ".currentTarget.dataset.subject"
+    name: ".currentTarget.value"
+
 command!: &tonk/rename-repository
   description: Rename the repository.
   with:
     subject:
-      description: The repository's subject DID, stamped on the banner element.
-      the: dom.event.current-target.dataset/subject
+      description: The repository being renamed.
+      the: xyz.tonk.rename-repository/subject
       as: entity
     name:
-      description: The new name, read from the banner input's value on commit.
-      the: dom.event.current-target/value
+      description: The new name.
+      the: xyz.tonk.rename-repository/name
       as: text
 
 # Apply the rename: assert the new `tonk/repository` name against the
@@ -985,7 +995,7 @@ view!:
         class="workspace__title-input"
         value={name}
         data-subject={this}
-        onchange=tonk/rename-repository
+        on:repository-rename=tonk/rename-repository
         aria-label="Space name"
       ></tonk-editable>
 

--- a/rust/tonk-core/assets/library/notebook.yaml
+++ b/rust/tonk-core/assets/library/notebook.yaml
@@ -175,10 +175,10 @@ view!:
         data-subject={this}
         data-notebook={this}
         title={title}
-        onblockedit=block/edit
-        onplace=block/place
-        onremove=block/remove
-        ontitlechange=notebook/retitle
+        on:block-edit=block/edit
+        on:block-place=block/place
+        on:block-remove=block/remove
+        on:notebook-retitle=notebook/retitle
         style="display: block;"
       >
         <div class="notebook-data" hidden>
@@ -276,14 +276,14 @@ view!:
   this: tonk:notebook/index-route
   show:
     ui: |
-      <tonk-notebook-index class="notebook-index" onnotebookcreate=notebook/create>
+      <tonk-notebook-index class="notebook-index" on:notebook-create=notebook/create>
         <tonk-notebook
           draft
           with="{branch}@{repo}"
-          onblockedit=block/edit
-          onplace=block/place
-          onremove=block/remove
-          ontitlechange=notebook/retitle
+          on:block-edit=block/edit
+          on:block-place=block/place
+          on:block-remove=block/remove
+          on:notebook-retitle=notebook/retitle
           style="display: block;"
         ></tonk-notebook>
         <tonk-display with="{branch}@{repo}" model=tonk:notebook></tonk-display>
@@ -372,6 +372,54 @@ command!: &block/insert
 # notebook's first block is written by the ordinary insert path once the
 # author types into the body, so a notebook begins as a name and nothing
 # else.
+# ---------------------------------------------------------------------------
+# Events — how `<tonk-notebook>`'s CustomEvents fill the commands.
+#
+# The commands above used to give near-identical fields their own
+# attributes (`created-title` rather than `title`, `removed` rather than
+# `key`) purely so two transient commands would not decode from one
+# event. With each command's fields in its own namespace they cannot
+# collide, so the distinction lives here, in the source, where it is
+# about the element's payload rather than about the matcher.
+#
+# Detail keys are spelled the way the element spells them: the old
+# identifiers kebab-cased then camel-cased on the way to the DOM, so the
+# wire name was never written down.
+# ---------------------------------------------------------------------------
+
+event!: &on/notebook-create
+  type: "notebookcreate"
+  where:
+    title: ".detail.createdTitle"
+    body: ".detail.createdBody"
+
+event!: &on/notebook-retitle
+  type: "titlechange"
+  where:
+    subject: ".detail.notebook"
+    title: ".detail.title"
+
+event!: &on/block-edit
+  type: "blockedit"
+  where:
+    subject: ".currentTarget.dataset.subject"
+    source: ".detail.source"
+    notebook: ".detail.notebook"
+
+event!: &on/block-place
+  type: "place"
+  where:
+    subject: ".currentTarget.dataset.subject"
+    notebook: ".detail.notebook"
+    key: ".detail.key"
+
+event!: &on/block-remove
+  type: "remove"
+  where:
+    subject: ".currentTarget.dataset.subject"
+    notebook: ".detail.notebook"
+    key: ".detail.removed"
+
 command!: &notebook/create
   description: Create a notebook with a title.
   with:
@@ -381,7 +429,7 @@ command!: &notebook/create
         `detail/title`: a retitle carries that one, and two transient
         commands reading the same attribute both decode from one event, so
         every rename would also create a notebook.
-      the: dom.event.detail/created-title
+      the: xyz.tonk.notebook.create/title
       as: text
     body:
       description: |
@@ -390,7 +438,7 @@ command!: &notebook/create
         in `CreateNotebook`: a field the struct requires but the command
         does not declare is simply absent from the descriptor, so the decode
         fails and the binding falls through in silence.
-      the: dom.event.detail/created-body
+      the: xyz.tonk.notebook.create/body
       as: text
 
 # Rename a notebook from its document's own heading.
@@ -404,11 +452,11 @@ command!: &notebook/retitle
   with:
     subject:
       description: The notebook entity.
-      the: dom.event.detail/notebook
+      the: xyz.tonk.notebook.retitle/subject
       as: entity
     title:
       description: The heading text, without its `#` markers.
-      the: dom.event.detail/title
+      the: xyz.tonk.notebook.retitle/title
       as: text
 
 command!: &block/edit
@@ -416,11 +464,11 @@ command!: &block/edit
   with:
     subject:
       description: The block entity, stamped on the element's data-subject.
-      the: dom.event.current-target.dataset/subject
+      the: xyz.tonk.block.edit/subject
       as: entity
     source:
       description: The block's new markdown source.
-      the: dom.event.detail/source
+      the: xyz.tonk.block.edit/source
       as: text
     notebook:
       description: |
@@ -428,7 +476,7 @@ command!: &block/edit
         creating one: a block written with only its source does not match
         `tonk:notebook/block`, so it renders no row. Re-asserting it on an
         existing block is a no-op.
-      the: dom.event.detail/notebook
+      the: xyz.tonk.block.edit/notebook
       as: entity
 
 # Placement is per block: put this block into its notebook's sequence under
@@ -440,15 +488,15 @@ command!: &block/place
   with:
     subject:
       description: The block entity.
-      the: dom.event.current-target.dataset/subject
+      the: xyz.tonk.block.place/subject
       as: entity
     notebook:
       description: The notebook whose sequence the block joins.
-      the: dom.event.detail/notebook
+      the: xyz.tonk.block.place/notebook
       as: entity
     key:
       description: The block's position in the sequence.
-      the: dom.event.detail/key
+      the: xyz.tonk.block.place/key
       as: text
 
 command!: &block/remove
@@ -456,18 +504,18 @@ command!: &block/remove
   with:
     subject:
       description: The block entity.
-      the: dom.event.current-target.dataset/subject
+      the: xyz.tonk.block.remove/subject
       as: entity
     notebook:
       description: The notebook whose sequence the block leaves.
-      the: dom.event.detail/notebook
+      the: xyz.tonk.block.remove/notebook
       as: entity
     # Its own attribute, not `detail/key`: two transient commands with the
     # same shape would both decode from one event, and the retraction
     # would fire alongside every placement.
     key:
       description: The position the block held.
-      the: dom.event.detail/removed
+      the: xyz.tonk.block.remove/key
       as: text
 
 # An inserted block exists.

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -104,12 +104,22 @@ concept!: &space
 # worker's `create_space` handler decodes it and does the work (record the
 # replica, create + seed the repository, flip the status, navigate the
 # creator into the new space). `name` reads from the form on submit:
-# `event.currentTarget.elements.name.value` — the hidden
-# `<input name="name" value="Untitled">` inside `<form onsubmit=space/create>`.
-# `prevent-default` stops the page from reloading; without it the browser
-# falls through to a GET submit and reloads with the fields in the query
-# string. The command is transient: it fires the handler once and is swept
+# the hidden `<input name="name" value="Untitled">` inside the create
+# form. The command is transient: it fires the handler once and is swept
 # before the durable commit.
+#
+# How a submit fills it. `prevent-default` stops the page reloading;
+# without it the browser falls through to a GET submit and reloads with
+# the fields in the query string. It lives here rather than in the
+# command's `with:` map, where it used to be: a side effect declared as a
+# command field stores no value, so a rule premise over it matches zero
+# rows however successfully the command transacted.
+event!: &on/space-create
+  type: "submit"
+  prevent-default: true
+  where:
+    name: ".currentTarget.elements.name.value"
+
 command!: &space/create
   description: A request to create a new space.
   with:
@@ -122,11 +132,8 @@ command!: &space/create
         place on arrival. The sentinel must be non-empty — the event
         extractor omits blank fields, and with no `name` fact the
         transient would never trigger the handler.
-      the: dom.event.current-target.elements.name/value
+      the: xyz.tonk.command.create-space/name
       as: text
-    prevent-default:
-      description: Stop the form submission from reloading the page
-      the: dom.event.do/prevent-default
 
 # The device-local Remove Space command. A joined-space leave or local-only
 # delete submits this transient; the worker's `RemoveSpaceHandler` retracts
@@ -134,23 +141,35 @@ command!: &space/create
 # (stopping background sync), and deletes its local storage. An owned hosted
 # space does NOT submit it: `<ui-space-remove>` routes that verb through the
 # reviewed account-space deletion flow instead.
-# `subject` reads the form's `data-remove` attribute. Deliberately NOT
-# `data-subject`: `tonk/rename-repository` transients already carry
-# `dataset/subject`, and a remove command matched on that attribute
-# alone would also decode every rename. The distinct attribute doubles
-# as the command's unique shape, so no marker field is needed. The
-# command is transient: it fires the handler once and is swept before
+# The command is transient: it fires the handler once and is swept before
 # the durable commit.
+#
+# `subject` used to be read from a `data-remove` attribute, deliberately
+# NOT `data-subject`: `tonk/rename-repository` transients already carried
+# `dataset/subject`, and a remove matched on that attribute alone would
+# have decoded every rename — turning each rename into a deletion. The
+# distinct DOM attribute doubled as the command's unique shape.
+# `xyz.tonk.command.remove-space/subject` is that distinctness by
+# construction, so the field can be named for what it is and read from
+# the row it is rendered in.
+#
+# How the confirm's submit fills it. `{subject}` is a field of the row
+# being confirmed, not the row's own entity (`{this}` is the replica
+# record; `{subject}` is the space's DID), so the form stamps it and the
+# read resolves against the nearest element carrying it.
+event!: &on/space-remove
+  type: "submit"
+  prevent-default: true
+  where:
+    subject: "{subject}"
+
 command!: &space/remove
   description: A request to remove a space from this device (its list entry and local data).
   with:
     subject:
-      description: The subject DID of the space to remove, read from `data-remove`.
-      the: dom.event.current-target.dataset/remove
+      description: The subject DID of the space to remove.
+      the: xyz.tonk.command.remove-space/subject
       as: entity
-    prevent-default:
-      description: Stop the form submission from reloading the page
-      the: dom.event.do/prevent-default
 
 # Load the requesting tab's site for its current path. Mirrors core.yaml's
 # `&tonk/load` — seeded here too because the top-level `<tonk-site>` stamps onto
@@ -228,7 +247,7 @@ view!:
                 <button class="verb-remove" type="button" data-space-remove-open disabled>checking&hellip;</button>
               </span>
               <tonk-dialog data-space-remove-dialog heading="confirm leaving space">
-                <form id="remove-{subject}" class="remove-form" onsubmit=space/remove data-remove={subject}>
+                <form id="remove-{subject}" class="remove-form" on:space-remove=space/remove data-subject={subject}>
                   Leave {name}? This removes the space and its local data from this
                   device. You'll need another invite link to join again. Other
                   members keep access.
@@ -244,7 +263,7 @@ view!:
                carried: the worker resolves where a space syncs from the
                account's own registration, so a space created before anyone
                registers stays local until it is shared. -->
-          <form class="snew-form" onsubmit=space/create>
+          <form class="snew-form" on:space-create=space/create>
             <input type="hidden" name="name" value="Untitled">
             <button class="snew chrome" type="submit">create new space<span class="g" aria-hidden="true">+</span></button>
           </form>
@@ -291,23 +310,23 @@ concept!: &profile/name
 # in core.yaml because the FAB is sealed to the profile/meta branch: the
 # guest's `<tonk-display>` resolves the command's concept descriptor by a
 # phase-1 lookup against THIS branch (seeded from the lean profile.yaml), so
-# the command must be present here for the editable's `onchange=profile/rename`
-# to fire. The worker's globally-registered `ProfileRenameHandler` does the
+# the command must be present here for the editable's rename binding to
+# fire. The worker's globally-registered `ProfileRenameHandler` does the
 # work (persist `ProfileName`, restamp `MemberName` across every space's
-# roster, republish self-identity) — this descriptor only has to decode the
-# new name and the `tonk:profile` marker that distinguishes it from the repo
-# rename, which shares the same `dom.event.current-target` shape.
+# roster, republish self-identity) — this descriptor only has to decode
+# the new name.
+#
+# It used to carry a `tonk:profile` marker as well, because this and
+# `tonk/rename-repository` both read `currentTarget.value` and a shape
+# matched on that attribute alone made every space rename also rename the
+# profile. Each command's own attribute namespace keeps them disjoint now.
 command!: &profile/rename
   description: Rename the signed-in member (set their display name).
   with:
     name:
       description: The new name, read from the editable's value on commit.
-      the: dom.event.current-target/value
+      the: xyz.tonk.command.profile-rename/name
       as: text
-    marker:
-      description: Per-command marker (data-rename) distinguishing this from repo rename.
-      the: dom.event.current-target.dataset/rename
-      as: entity
 
 # Toggle auto-sync (pause ⇄ resume) for a space. Dispatched by the FAB's
 # `<ui-sync-status onpause=…>` cap on alt/option-click. Defined here on the
@@ -316,22 +335,22 @@ command!: &profile/rename
 # older spaces missing a `fab-pause` view no longer break it. The `space` field
 # names WHICH replica to flip; the worker's PauseSyncHandler reads it in place
 # of the dispatch origin. `time` makes each click a distinct transient so the
-# toggle reliably re-fires; `marker` keeps the shape distinct from `tonk:invite`.
+# toggle reliably re-fires.
+#
+# It used to carry a marker field too, whose only job was to keep this
+# shape distinct from `tonk:invite`'s identical {this, time}. Each
+# command now owns its attribute namespace, so the two cannot collide.
 command!: &tonk/pause-sync
   this: tonk:pause-sync
   description: Toggle auto-sync (pause ⇄ resume) for a space.
   with:
     time:
       description: The click's timestamp; makes each dispatch a distinct transient.
-      the: dom.event/time-stamp
+      the: xyz.tonk.command.pause-sync/time
       as: float
     space:
       description: The target space DID — the replica whose auto-sync is flipped.
       the: xyz.tonk.pause-sync/space
-      as: entity
-    marker:
-      description: Per-command marker keeping the shape distinct from tonk:invite.
-      the: dom.event.current-target.dataset/pause-sync
       as: entity
 
 # The FAB fallback seat — the nearest corner restored on the next page load,
@@ -351,7 +370,7 @@ concept!: &fab/dock
 # JOIN — redeem an invite at /join (runs on the profile meta branch)
 # ============================================================
 
-# Redeem an invite URL. Fired by `<tonk-page onmount=tonk:join>` on the
+# Redeem an invite URL. Fired by `<tonk-page on:join=tonk:join>` on the
 # /join view: the element reads the page location (the service worker can't
 # see the `#fragment`, where an open invite's seed rides) and delivers it in
 # the mount event's `detail` (a flat, URL-shaped record). The worker's
@@ -360,13 +379,20 @@ concept!: &fab/dock
 # or retract + durable replica on success). Lives here, not in core.yaml:
 # the join happens on the PROFILE meta branch (it records a replica), so
 # the command + view must resolve there.
+# How the page element's mount fills it: the complete href, fragment and
+# all, off the mount event's `detail`.
+event!: &on/join
+  type: "mount"
+  where:
+    url: ".detail.href"
+
 command!: &tonk/join
   this: tonk:join
   description: Redeem an invite URL and join its space.
   with:
     url:
-      description: The complete invite URL, including any fragment, from detail.href.
-      the: dom.event.detail/href
+      description: The complete invite URL, including any fragment.
+      the: xyz.tonk.command.join/url
       as: text
 
 # The in-flight join, overlay-only, at the fixed `tonk:join/status` entity.
@@ -607,7 +633,7 @@ view!:
 # missing"). Mirrors the Hub: `/join` → `tonk:join/route`, whose entity view
 # (on the site entity) mounts the no-entity `<tonk-display
 # model="tonk:join/status">` directory. That directory's chrome carries the
-# `<tonk-page onmount=tonk:join>` trigger, which reads the page location
+# `<tonk-page on:join=tonk:join>` trigger, which reads the page location
 # (the SW can't see the `#fragment` seed) and fires `tonk:join`.
 route!: &route/join
   this: id:tonk:route/join
@@ -731,14 +757,14 @@ view!:
             }
           </style>
           <a class="edge-mast" href="/" aria-label="Tonk home"><img src="/images/tonk-wordmark.svg" alt=""></a>
-          <tonk-page onmount=tonk:join></tonk-page>
+          <tonk-page on:join=tonk:join></tonk-page>
           <!-- `onmount`, not `onsubmit`: `<tonk-invite-link>` cancels the
                submit, resolves the pasted text (expanding a short link on
                its minting origin), and re-fires it as a bubbling `mount`
                carrying `detail.href` — the one read path `tonk:join`
                declares. Same command, same handler, whether the invite
                arrived in the address bar or in this box. -->
-          <form class="join-paste edge-wall edge-wall--no-access" onmount=tonk:join>
+          <form class="join-paste edge-wall edge-wall--no-access" on:join=tonk:join>
             <div class="edge-statement">you do not have access to this space</div>
             <label class="edge-field">
               <span class="edge-noun">share link</span>

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -144,24 +144,30 @@ command!: &space/create
 # The command is transient: it fires the handler once and is swept before
 # the durable commit.
 #
-# `subject` used to be read from a `data-remove` attribute, deliberately
-# NOT `data-subject`: `tonk/rename-repository` transients already carried
+# The COMMAND's field used to be `dataset/remove` too, deliberately NOT
+# `dataset/subject`: `tonk/rename-repository` transients already carried
 # `dataset/subject`, and a remove matched on that attribute alone would
 # have decoded every rename — turning each rename into a deletion. The
-# distinct DOM attribute doubled as the command's unique shape.
+# distinct DOM read path doubled as the command's unique shape.
 # `xyz.tonk.command.remove-space/subject` is that distinctness by
-# construction, so the field can be named for what it is and read from
-# the row it is rendered in.
+# construction, so the field is named for what it is. The DOM attribute
+# it is read FROM keeps its name: `<ui-space-remove>` locates this form
+# by it.
 #
-# How the confirm's submit fills it. `{subject}` is a field of the row
-# being confirmed, not the row's own entity (`{this}` is the replica
-# record; `{subject}` is the space's DID), so the form stamps it and the
-# read resolves against the nearest element carrying it.
+# How the confirm's submit fills it.
+#
+# The source is the form's `data-remove`, not a `{subject}` template
+# field, because that attribute is load-bearing for something else:
+# `<ui-space-remove>` finds this form by `form[data-remove]` to write the
+# confirm copy into it. Stamping a second attribute carrying the same DID
+# just to feed the command would be two names for one fact. Reading the
+# one that already exists is what an `event!:` declaration is for —
+# platform specifics live here so the command stays domain-shaped.
 event!: &on/space-remove
   type: "submit"
   prevent-default: true
   where:
-    subject: "{subject}"
+    subject: ".currentTarget.dataset.remove"
 
 command!: &space/remove
   description: A request to remove a space from this device (its list entry and local data).
@@ -247,7 +253,7 @@ view!:
                 <button class="verb-remove" type="button" data-space-remove-open disabled>checking&hellip;</button>
               </span>
               <tonk-dialog data-space-remove-dialog heading="confirm leaving space">
-                <form id="remove-{subject}" class="remove-form" on:space-remove=space/remove data-subject={subject}>
+                <form id="remove-{subject}" class="remove-form" on:space-remove=space/remove data-remove={subject}>
                   Leave {name}? This removes the space and its local data from this
                   device. You'll need another invite link to join again. Other
                   members keep access.

--- a/rust/tonk-core/assets/library/prose.yaml
+++ b/rust/tonk-core/assets/library/prose.yaml
@@ -41,16 +41,25 @@ concept!: &prose
 # element's `data-subject` so the rule knows which document to write.
 # ---------------------------------------------------------------------------
 
+# How `<tonk-prose>`'s change event fills the command. The element's
+# own payload key is `content`; the subject needs no `data-*` attribute
+# because `{this}` is the entity the view is rendering.
+event!: &on/prose-change
+  type: "change"
+  where:
+    subject: "{this}"
+    content: ".detail.content"
+
 command!: &prose/edit
   description: Edit a prose document.
   with:
     subject:
-      description: The document entity, stamped on the editor's data-subject.
-      the: dom.event.current-target.dataset/subject
+      description: The document being edited.
+      the: xyz.tonk.prose.edit/subject
       as: entity
     content:
-      description: The new content envelope, read from the change event.
-      the: dom.event.detail/content
+      description: The new content envelope.
+      the: xyz.tonk.prose.edit/content
       as: text
 
 # ---------------------------------------------------------------------------
@@ -73,8 +82,9 @@ rule!:
 # element's TEXT (between the tags), the way a <textarea> carries its value:
 # the store's `content` envelope is written via set_text_content, which is
 # newline- and markup-safe (an attribute value can be normalized in transit,
-# corrupting the multi-line envelope). `data-subject={this}` carries identity
-# for the command; `onchange=prose/edit` fires the command on each idle edit.
+# corrupting the multi-line envelope). `on:prose-change=prose/edit` fires the
+# command on each idle edit; identity comes from the declaration's `{this}`,
+# so the editor needs no `data-subject` to stash and read back.
 # ---------------------------------------------------------------------------
 
 view!:
@@ -82,8 +92,7 @@ view!:
   show:
     ui: |
       <tonk-prose
-        onchange=prose/edit
-        data-subject={this}
+        on:prose-change=prose/edit
         placeholder="Write something…"
         auto-focus
         style="display: block; min-height: 12rem;"

--- a/rust/tonk-core/assets/library/table.yaml
+++ b/rust/tonk-core/assets/library/table.yaml
@@ -172,30 +172,106 @@ concept!: &table/row-height
     height: row/height
 
 # ---------------------------------------------------------------------------
-# Commands — one per element event; field URIs are command-specific
-# (`dom.event.detail/edit-cell` ↔ detail.editCell) so one event can
-# never read as another. `time` is a component-minted monotonic nonce
-# that keeps otherwise-identical creates distinct.
+# Commands — domain-shaped, each in its own namespace so one can never
+# read as another. `time` is a component-minted monotonic nonce that
+# keeps otherwise-identical creates distinct. How the element's payload
+# fills them is the `event!:` declarations below.
 # ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Events — how `<tonk-table>`'s CustomEvents fill the commands.
+#
+# Detail keys are spelled the way the element spells them. The old
+# `dom.event.detail/edit-cell` identifier kebab-cased then camel-cased
+# on the way to `detail.editCell`, so the wire name was never written
+# down; here it is verbatim and there is no translation to get wrong.
+#
+# The keys are prefixed (`sheet-name`, `rename-name`) only because two
+# commands reading the same key used to be structurally the same
+# concept. With each command's fields in its own namespace that
+# constraint is gone, so they are read here under domain names and the
+# element's payload can be simplified independently.
+# ---------------------------------------------------------------------------
+
+event!: &on/table-create-sheet
+  type: "createsheet"
+  where:
+    table: ".detail.sheetTable"
+    name: ".detail.sheetName"
+    order: ".detail.sheetOrder"
+    time: ".detail.time"
+
+event!: &on/table-rename-sheet
+  type: "renamesheet"
+  where:
+    sheet: ".detail.renameSheet"
+    name: ".detail.renameName"
+
+event!: &on/table-create-cell
+  type: "createcell"
+  where:
+    sheet: ".detail.cellSheet"
+    at: ".detail.cellAt"
+    content: ".detail.cellContent"
+    time: ".detail.time"
+
+event!: &on/table-edit-cell
+  type: "editcell"
+  where:
+    cell: ".detail.editCell"
+    content: ".detail.editContent"
+
+event!: &on/table-clear-cell
+  type: "clearcell"
+  where:
+    cell: ".detail.clearCell"
+
+event!: &on/table-create-column
+  type: "createcolumn"
+  where:
+    sheet: ".detail.columnSheet"
+    at: ".detail.columnAt"
+    width: ".detail.columnWidth"
+    time: ".detail.time"
+
+event!: &on/table-resize-column
+  type: "resizecolumn"
+  where:
+    column: ".detail.resizeColumn"
+    width: ".detail.resizeWidth"
+
+event!: &on/table-create-row
+  type: "createrow"
+  where:
+    sheet: ".detail.rowSheet"
+    at: ".detail.rowAt"
+    height: ".detail.rowHeight"
+    time: ".detail.time"
+
+event!: &on/table-resize-row
+  type: "resizerow"
+  where:
+    row: ".detail.resizeRow"
+    height: ".detail.resizeHeight"
 
 command!: &table/create-sheet
   description: Create a sheet in workbook `table`.
   with:
     table:
       description: The workbook gaining the sheet
-      the: dom.event.detail/sheet-table
+      the: xyz.tonk.table.create-sheet/table
       as: entity
     name:
       description: The new sheet's name
-      the: dom.event.detail/sheet-name
+      the: xyz.tonk.table.create-sheet/name
       as: text
     order:
       description: Tab-strip order key, computed by the element
-      the: dom.event.detail/sheet-order
+      the: xyz.tonk.table.create-sheet/order
       as: text
     time:
       description: A monotonic integer nonce from the element
-      the: dom.event.detail/time
+      the: xyz.tonk.table.create-sheet/time
       as: unsigned-integer
 
 command!: &table/rename-sheet
@@ -203,11 +279,11 @@ command!: &table/rename-sheet
   with:
     sheet:
       description: The sheet being renamed
-      the: dom.event.detail/rename-sheet
+      the: xyz.tonk.table.rename-sheet/sheet
       as: entity
     name:
       description: The new name
-      the: dom.event.detail/rename-name
+      the: xyz.tonk.table.rename-sheet/name
       as: text
 
 command!: &table/create-cell
@@ -215,19 +291,19 @@ command!: &table/create-cell
   with:
     sheet:
       description: The sheet the cell is on
-      the: dom.event.detail/cell-sheet
+      the: xyz.tonk.table.create-cell/sheet
       as: entity
     at:
       description: A1-style address
-      the: dom.event.detail/cell-at
+      the: xyz.tonk.table.create-cell/at
       as: text
     content:
       description: The raw input
-      the: dom.event.detail/cell-content
+      the: xyz.tonk.table.create-cell/content
       as: text
     time:
       description: A monotonic integer nonce from the element
-      the: dom.event.detail/time
+      the: xyz.tonk.table.create-sheet/time
       as: unsigned-integer
 
 command!: &table/edit-cell
@@ -235,11 +311,11 @@ command!: &table/edit-cell
   with:
     cell:
       description: The edited cell
-      the: dom.event.detail/edit-cell
+      the: xyz.tonk.table.edit-cell/cell
       as: entity
     content:
       description: The new raw input
-      the: dom.event.detail/edit-content
+      the: xyz.tonk.table.edit-cell/content
       as: text
 
 command!: &table/clear-cell
@@ -247,7 +323,7 @@ command!: &table/clear-cell
   with:
     cell:
       description: The cleared cell
-      the: dom.event.detail/clear-cell
+      the: xyz.tonk.table.clear-cell/cell
       as: entity
 
 command!: &table/create-column
@@ -255,19 +331,19 @@ command!: &table/create-column
   with:
     sheet:
       description: The sheet the column is on
-      the: dom.event.detail/column-sheet
+      the: xyz.tonk.table.create-column/sheet
       as: entity
     at:
       description: Column letters
-      the: dom.event.detail/column-at
+      the: xyz.tonk.table.create-column/at
       as: text
     width:
       description: Width px, as decimal text
-      the: dom.event.detail/column-width
+      the: xyz.tonk.table.create-column/width
       as: text
     time:
       description: A monotonic integer nonce from the element
-      the: dom.event.detail/time
+      the: xyz.tonk.table.create-sheet/time
       as: unsigned-integer
 
 command!: &table/resize-column
@@ -275,11 +351,11 @@ command!: &table/resize-column
   with:
     column:
       description: The resized column
-      the: dom.event.detail/resize-column
+      the: xyz.tonk.table.resize-column/column
       as: entity
     width:
       description: The new width px, as decimal text
-      the: dom.event.detail/resize-width
+      the: xyz.tonk.table.resize-column/width
       as: text
 
 command!: &table/create-row
@@ -287,19 +363,19 @@ command!: &table/create-row
   with:
     sheet:
       description: The sheet the row is on
-      the: dom.event.detail/row-sheet
+      the: xyz.tonk.table.create-row/sheet
       as: entity
     at:
       description: The row number, as text
-      the: dom.event.detail/row-at
+      the: xyz.tonk.table.create-row/at
       as: text
     height:
       description: Height px, as decimal text
-      the: dom.event.detail/row-height
+      the: xyz.tonk.table.create-row/height
       as: text
     time:
       description: A monotonic integer nonce from the element
-      the: dom.event.detail/time
+      the: xyz.tonk.table.create-sheet/time
       as: unsigned-integer
 
 command!: &table/resize-row
@@ -307,11 +383,11 @@ command!: &table/resize-row
   with:
     row:
       description: The resized row
-      the: dom.event.detail/resize-row
+      the: xyz.tonk.table.resize-row/row
       as: entity
     height:
       description: The new height px, as decimal text
-      the: dom.event.detail/resize-height
+      the: xyz.tonk.table.resize-row/height
       as: text
 
 # ---------------------------------------------------------------------------
@@ -445,15 +521,15 @@ view!:
   show:
     ui: |
       <tonk-table subject={this}
-        oncreatesheet=table/create-sheet
-        onrenamesheet=table/rename-sheet
-        oncreatecell=table/create-cell
-        oneditcell=table/edit-cell
-        onclearcell=table/clear-cell
-        oncreatecolumn=table/create-column
-        onresizecolumn=table/resize-column
-        oncreaterow=table/create-row
-        onresizerow=table/resize-row
+        on:table-create-sheet=table/create-sheet
+        on:table-rename-sheet=table/rename-sheet
+        on:table-create-cell=table/create-cell
+        on:table-edit-cell=table/edit-cell
+        on:table-clear-cell=table/clear-cell
+        on:table-create-column=table/create-column
+        on:table-resize-column=table/resize-column
+        on:table-create-row=table/create-row
+        on:table-resize-row=table/resize-row
       >
         <div hidden>
           <tonk-display model=tonk:table/sheet></tonk-display>

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -1773,6 +1773,9 @@ async fn resolve_event_table(
                 }
                 declarations.insert(name.clone(), descriptor);
             }
+            // Only a missing `type:` can fail — a `where:` entry never
+            // does, so one odd source cannot cost a declaration its
+            // other bindings.
             Err(error) => {
                 web_sys::console::warn_1(&JsValue::from_str(&format!(
                     "<tonk-display>: `{name}` is not a usable event declaration: {error}"

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -1756,7 +1756,21 @@ async fn resolve_event_table(
             stop_propagation,
             sources,
         ) {
-            Ok(descriptor) => {
+            Ok(mut descriptor) => {
+                // A bare symbol is a named-entity reference, the same
+                // as anywhere else in the notation. Resolve them here,
+                // once, so the event-time path never does a lookup.
+                let mut resolved = std::collections::BTreeMap::new();
+                for reference in descriptor.references() {
+                    if let Some(entity) = resolve_event_entity(host, &reference).await {
+                        resolved.insert(reference, entity);
+                    }
+                }
+                for missing in descriptor.resolve_references(&resolved) {
+                    web_sys::console::warn_1(&JsValue::from_str(&format!(
+                        "<tonk-display>: `{name}` references `{missing}`, which names no entity"
+                    )));
+                }
                 declarations.insert(name.clone(), descriptor);
             }
             Err(error) => {

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -1688,6 +1688,126 @@ fn schedule_delegate_refresh(host: &Element, state: &Rc<RefCell<Inner>>) {
     });
 }
 
+/// Resolve the `event!:` declarations a template's `on:<name>`
+/// bindings reference into a dispatch table.
+///
+/// Each declaration is an *instance* of `tonk:event`, not a concept, so
+/// this is a name lookup followed by an entity read — not the phase-1
+/// descriptor path the command names take. Two reads per declaration:
+/// the required `type`/`where`, then the optional side-effect flags,
+/// which are separate because a declaration that omits them must still
+/// resolve.
+///
+/// A declaration that does not resolve is skipped with a warning rather
+/// than aborting the whole delegate, so one bad binding cannot silence
+/// the rest of a view.
+async fn resolve_event_table(
+    host: &Element,
+    event_names: &std::collections::BTreeSet<String>,
+) -> tonk_template::event::EventTable {
+    use tonk_template::event::event_descriptor;
+    use tonk_template::resolve::event_query;
+
+    let mut declarations = std::collections::BTreeMap::new();
+    for name in event_names {
+        let Some(entity) = resolve_event_entity(host, name).await else {
+            web_sys::console::warn_1(&JsValue::from_str(&format!(
+                "<tonk-display>: no `event!:` declaration named `{name}` \
+                 (bound as `{}`)",
+                tonk_template::event::attribute_for_event_name(name).unwrap_or_default(),
+            )));
+            continue;
+        };
+
+        let Ok(query) = event_query(&entity) else {
+            continue;
+        };
+        let Ok(body) = to_body(&query) else { continue };
+        let Ok(rows) = host_consumer::query(host, &body).await else {
+            continue;
+        };
+        let conclusions: Vec<Conclusion> =
+            serde_wasm_bindgen::from_value(rows.clone()).unwrap_or_default();
+        let folded = tonk_template::fold::select_rows(conclusions);
+        let Some(conclusion) = folded.first() else {
+            continue;
+        };
+
+        let event_type = conclusion.fields.get("type").and_then(ipld_text);
+        let sources: Vec<(String, String)> = conclusion
+            .fields
+            .get("where")
+            .and_then(|value| match value {
+                Ipld::Map(map) => Some(map),
+                _ => None,
+            })
+            .map(|map| {
+                map.iter()
+                    .filter_map(|(field, value)| ipld_text(value).map(|raw| (field.clone(), raw)))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let (prevent_default, stop_propagation) = resolve_event_flags(host, &entity).await;
+
+        match event_descriptor(
+            event_type.as_deref(),
+            prevent_default,
+            stop_propagation,
+            sources,
+        ) {
+            Ok(descriptor) => {
+                declarations.insert(name.clone(), descriptor);
+            }
+            Err(error) => {
+                web_sys::console::warn_1(&JsValue::from_str(&format!(
+                    "<tonk-display>: `{name}` is not a usable event declaration: {error}"
+                )));
+            }
+        }
+    }
+    tonk_template::event::EventTable::new(declarations)
+}
+
+/// Name -> entity for an event declaration.
+async fn resolve_event_entity(host: &Element, name: &str) -> Option<String> {
+    if name.contains(':') {
+        return Some(name.to_string());
+    }
+    let body = to_body(&name_query(name)).ok()?;
+    let result = host_consumer::query(host, &body).await.ok()?;
+    first_field(&result, "entity").ok().flatten()
+}
+
+/// Read the optional side-effect flags. Absent means `false`.
+async fn resolve_event_flags(host: &Element, entity: &str) -> (bool, bool) {
+    use tonk_template::resolve::event_flags_query;
+    let Ok(query) = event_flags_query(entity) else {
+        return (false, false);
+    };
+    let Ok(body) = to_body(&query) else {
+        return (false, false);
+    };
+    let Ok(rows) = host_consumer::query(host, &body).await else {
+        return (false, false);
+    };
+    let conclusions: Vec<Conclusion> =
+        serde_wasm_bindgen::from_value(rows.clone()).unwrap_or_default();
+    let Some(conclusion) = conclusions.first() else {
+        return (false, false);
+    };
+    let flag = |name: &str| matches!(conclusion.fields.get(name), Some(Ipld::Bool(true)));
+    (flag("prevent-default"), flag("stop-propagation"))
+}
+
+/// `Ipld::String` as text.
+fn ipld_text(value: &Ipld) -> Option<String> {
+    match value {
+        Ipld::String(text) => Some(text.clone()),
+        _ => None,
+    }
+}
+
 async fn refresh_delegate(host: &Element, state: &Rc<RefCell<Inner>>, delegate_generation: u64) {
     use crate::events::delegate::{Delegate, Descriptors};
 
@@ -1706,6 +1826,7 @@ async fn refresh_delegate(host: &Element, state: &Rc<RefCell<Inner>>, delegate_g
     // Collect distinct event types and concept names across slides.
     let mut event_types: BTreeSet<String> = BTreeSet::new();
     let mut concept_names: BTreeSet<String> = BTreeSet::new();
+    let mut event_names: BTreeSet<String> = BTreeSet::new();
     for el in &view_els {
         let Some(raw) = el.get_attribute("data-event-bindings") else {
             continue;
@@ -1727,9 +1848,18 @@ async fn refresh_delegate(host: &Element, state: &Rc<RefCell<Inner>>, delegate_g
                 }
             }
         }
+        if let Some(arr) = value.get("declarations").and_then(|v| v.as_array()) {
+            for item in arr {
+                if let Some(s) = item.as_str() {
+                    event_names.insert(s.to_owned());
+                }
+            }
+        }
     }
 
-    if event_types.is_empty() || concept_names.is_empty() {
+    // A template using only `on:<name>` bindings has no legacy event
+    // types, so the guard cannot require them.
+    if concept_names.is_empty() || (event_types.is_empty() && event_names.is_empty()) {
         // No bindings — drop any existing delegate so detached
         // listeners don't linger after a template-swap. Only do
         // this if no newer refresh has been scheduled in the
@@ -1783,7 +1913,8 @@ async fn refresh_delegate(host: &Element, state: &Rc<RefCell<Inner>>, delegate_g
 
     // Build the delegate before acquiring the borrow so its
     // `addEventListener` calls don't run inside the lock.
-    let delegate = Delegate::install(host.clone(), event_types.into_iter(), descriptors);
+    let table = resolve_event_table(host, &event_names).await;
+    let delegate = Delegate::install(host.clone(), event_types.into_iter(), descriptors, table);
     // Re-check the per-refresh generation: if a newer refresh has
     // started while we were resolving descriptors, drop our delegate
     // rather than overwrite the newer one. `delegate`'s `Drop` impl

--- a/rust/tonk-display/src/events.rs
+++ b/rust/tonk-display/src/events.rs
@@ -16,7 +16,14 @@
 //! - `delegate` (wasm-only) — installs per-event-type listeners
 //!   on the host that route fires to the bound concept,
 //!   extract, and POST the resulting `TransactRequest`.
+//! - `binding` (wasm-only) — the `on:<name>=<command>` form: reads
+//!   an `event!:` declaration's `where:` map against the live event
+//!   instead of the command's own `dom.event.*` identifiers. The
+//!   grammar, the dispatch table and the wire shape live in
+//!   `tonk_template::event`, shared with any other host.
 
+#[cfg(target_arch = "wasm32")]
+pub mod binding;
 #[cfg(target_arch = "wasm32")]
 pub mod delegate;
 #[cfg(target_arch = "wasm32")]

--- a/rust/tonk-display/src/events/binding.rs
+++ b/rust/tonk-display/src/events/binding.rs
@@ -1,0 +1,229 @@
+//! Resolve an `on:<name>=<command>` binding against a live event.
+//!
+//! The counterpart of [`super::extract`] for the `event!:` form. Where
+//! that walks the *command's* `dom.event.*` identifiers, this walks the
+//! *event declaration's* `where:` map — so the command stays
+//! domain-shaped and the platform knowledge lives in one artifact.
+//!
+//! Only the three source readers are here. The dispatch table, the
+//! source grammar and the wire shape live in `tonk_template::event`, so
+//! they are shared with any other host and tested natively.
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+use tonk_template::event::{Binding, Source};
+use wasm_bindgen::{JsCast, JsValue};
+use web_sys::{Element, Event};
+
+use super::extract::{ReadOutcome, coerce, read_path_and_coerce};
+use super::path::EventPath;
+
+/// The attribute the renderer stamps on a repeat row root, carrying the
+/// row's subject. `{this}` reads it.
+const SUBJECT_ATTRIBUTE: &str = "data-this";
+
+/// Build the transact body for `binding` fired by `event` on `bound`.
+///
+/// `descriptor` is the command's dialog descriptor. Returns `None` when
+/// a source failed to resolve, which the caller treats as "this binding
+/// does not apply" and falls through to the next ancestor — the same
+/// behaviour as the legacy path, so a typo on an inner binding cannot
+/// swallow an outer one's click.
+pub(super) fn build_body(
+    binding: &Binding<'_>,
+    descriptor: &Value,
+    event: &Event,
+    bound: &Element,
+) -> Option<Value> {
+    let with = descriptor.get("with").and_then(Value::as_object)?;
+    let event_js: &JsValue = event.as_ref();
+    let bound_js: &JsValue = bound.as_ref();
+
+    let mut parameters: BTreeMap<String, Value> = BTreeMap::new();
+    for (field, source) in &binding.event.sources {
+        // A source for a field the command does not declare is dropped
+        // rather than posted: `tonk_template::event::check` reports it
+        // at lowering, and an extra parameter would be a wire error.
+        let Some(entry) = with.get(field) else {
+            continue;
+        };
+        let as_type = entry.get("as").and_then(Value::as_str).unwrap_or("Text");
+
+        match read_source(source, event_js, bound_js, bound, as_type) {
+            ReadOutcome::Value(value) => {
+                parameters.insert(field.clone(), value);
+            }
+            // Present but empty — a blank control, or an attribute
+            // rendered from an absent field. "Not provided": omit it
+            // and still post, which is what `maybe:` on the command
+            // makes safe to consume from a rule.
+            ReadOutcome::Empty => {}
+            ReadOutcome::Unresolved => return None,
+        }
+    }
+
+    Some(tonk_template::event::transact_body(descriptor, parameters))
+}
+
+/// Read one source into an outcome.
+fn read_source(
+    source: &Source,
+    event_js: &JsValue,
+    bound_js: &JsValue,
+    bound: &Element,
+    as_type: &str,
+) -> ReadOutcome {
+    match source {
+        // `{field}` is interpolation in the scope of the element the
+        // event fired on. The renderer stamps the repeat subject as
+        // `data-this` on every row root and writes interpolated values
+        // into the DOM as it renders, so this reads back what the
+        // render pass already wrote — never a second query.
+        Source::Field(name) => read_field(name, bound, as_type),
+        // `.path` walks the live event, spelled the way the platform
+        // spells it. `currentTarget` means the bound element, not the
+        // host the delegated listener sits on.
+        Source::Property(segments) => read_path_and_coerce(
+            event_js,
+            bound_js,
+            &EventPath {
+                segments: segments.clone(),
+            },
+            as_type,
+        ),
+        Source::Literal(text) => match coerce(&JsValue::from_str(text), as_type) {
+            Some(value) => ReadOutcome::Value(value),
+            None => ReadOutcome::Unresolved,
+        },
+    }
+}
+
+/// Read a `{field}` against the bound element's row.
+///
+/// `{this}` is the enclosing repeat subject. Any other `{name}` reads
+/// the rendered `data-<name>` attribute, so a field the template did
+/// not surface is a genuine miss rather than a silent blank.
+fn read_field(name: &str, bound: &Element, as_type: &str) -> ReadOutcome {
+    let attribute = if name == "this" {
+        SUBJECT_ATTRIBUTE.to_string()
+    } else {
+        format!("data-{}", name.replace(['/', '.'], "-"))
+    };
+    let selector = format!("[{attribute}]");
+    let raw = match bound
+        .closest(&selector)
+        .ok()
+        .flatten()
+        .and_then(|holder| holder.get_attribute(&attribute))
+    {
+        Some(raw) => raw,
+        // `data-this` is stamped on repeat row roots only: a
+        // single-entity view has one conclusion and no element to
+        // clone, so there is no row to carry it. Fall back to the
+        // owning display's `entity`, which is the same subject by
+        // definition — otherwise `{this}` would work in a directory
+        // and silently fail in a detail view.
+        None if name == "this" => match host_entity(bound) {
+            Some(entity) => entity,
+            None => return ReadOutcome::Unresolved,
+        },
+        None => return ReadOutcome::Unresolved,
+    };
+    if raw.is_empty() {
+        return ReadOutcome::Empty;
+    }
+    match coerce(&JsValue::from_str(&raw), as_type) {
+        Some(value) => ReadOutcome::Value(value),
+        None => ReadOutcome::Unresolved,
+    }
+}
+
+/// The subject of the nearest `<tonk-display entity=...>` ancestor.
+fn host_entity(element: &Element) -> Option<String> {
+    let display = element.closest("tonk-display[entity]").ok().flatten()?;
+    display
+        .get_attribute("entity")
+        .filter(|entity| !entity.is_empty())
+}
+
+/// Every `on:`-prefixed attribute on `element`, as `(name, value)`.
+pub(super) fn on_attributes(element: &Element) -> Vec<(String, String)> {
+    let attrs = element.attributes();
+    let mut out = Vec::new();
+    for index in 0..attrs.length() {
+        let Some(attr) = attrs.item(index) else {
+            continue;
+        };
+        let name = attr.name();
+        if name.starts_with(tonk_template::event::ON_PREFIX) {
+            out.push((name, attr.value()));
+        }
+    }
+    out
+}
+
+/// True when `element` carries any `on:` binding attribute.
+pub(super) fn has_on_attribute(element: &Element) -> bool {
+    !on_attributes(element).is_empty()
+}
+
+/// Walk up from `event.target` trying each `on:`-bound ancestor until
+/// one produces a body, bounded by `host`.
+pub(super) fn resolve_binding(
+    event: &Event,
+    event_type: &str,
+    table: &tonk_template::event::EventTable,
+    descriptors: &super::delegate::Descriptors,
+    host: &Element,
+) -> Option<Value> {
+    let target = event.target()?.dyn_ref::<Element>()?.clone();
+    let mut cursor = Some(target);
+    while let Some(current) = cursor {
+        let bound = nearest_bound(&current)?;
+        // A binding outside the host belongs to another view.
+        if !host.contains(Some(bound.unchecked_ref())) {
+            return None;
+        }
+        if let Some(binding) = table.resolve(event_type, on_attributes(&bound))
+            && let Some(descriptor) = descriptors.get(&binding.command)
+            && let Some(body) = build_body(&binding, descriptor, event, &bound)
+        {
+            apply_side_effects(&binding, event);
+            return Some(body);
+        }
+        cursor = bound.parent_element();
+    }
+    None
+}
+
+/// The nearest ancestor of `element` (inclusive) carrying an `on:`
+/// attribute. There is no CSS selector for "any attribute with this
+/// prefix", so this walks rather than using `closest`.
+fn nearest_bound(element: &Element) -> Option<Element> {
+    let mut cursor = Some(element.clone());
+    while let Some(current) = cursor {
+        if has_on_attribute(&current) {
+            return Some(current);
+        }
+        cursor = current.parent_element();
+    }
+    None
+}
+
+/// Apply the declaration's side effects, and only for the binding that
+/// won — a losing binding must not suppress the platform's default.
+///
+/// These live on the event declaration rather than in the command's
+/// field map, which is what keeps the command rule-consumable: a
+/// `dom.event.do/*` field stores no value, so a rule premise over a
+/// command declaring one matches zero rows however successfully the
+/// command transacts.
+fn apply_side_effects(binding: &Binding<'_>, event: &Event) {
+    if binding.event.prevent_default {
+        event.prevent_default();
+    }
+    if binding.event.stop_propagation {
+        event.stop_propagation();
+    }
+}

--- a/rust/tonk-display/src/events/binding.rs
+++ b/rust/tonk-display/src/events/binding.rs
@@ -92,10 +92,16 @@ fn read_source(
             },
             as_type,
         ),
-        Source::Literal(text) => match coerce(&JsValue::from_str(text), as_type) {
-            Some(value) => ReadOutcome::Value(value),
-            None => ReadOutcome::Unresolved,
-        },
+        Source::Literal(text) | Source::Entity(text) => {
+            match coerce(&JsValue::from_str(text), as_type) {
+                Some(value) => ReadOutcome::Value(value),
+                None => ReadOutcome::Unresolved,
+            }
+        }
+        // Left unresolved by the host's name lookup — reported there,
+        // and treated as a binding that does not apply rather than
+        // posting a command with a name where an entity belongs.
+        Source::Reference(_) => ReadOutcome::Unresolved,
     }
 }
 

--- a/rust/tonk-display/src/events/delegate.rs
+++ b/rust/tonk-display/src/events/delegate.rs
@@ -29,7 +29,9 @@ use wasm_bindgen::closure::Closure;
 use wasm_bindgen_futures::spawn_local;
 use web_sys::{Element, Event};
 
+use super::binding;
 use super::extract::build_transact_body;
+use tonk_template::event::EventTable;
 
 /// Concept name → pre-parsed descriptor. Built once at mount time
 /// from the worker's phase-1 results; each click reads from this
@@ -68,16 +70,34 @@ impl Delegate {
         host: Element,
         event_types: impl IntoIterator<Item = String>,
         descriptors: Descriptors,
+        table: EventTable,
     ) -> Self {
         let descriptors = Rc::new(descriptors);
+        let table = Rc::new(table);
         let mut listeners: Vec<ListenerEntry> = Vec::new();
 
-        for event_type in event_types {
+        // One listener per distinct platform event type across both
+        // forms. The `on:` set comes from the resolved declarations
+        // rather than from attribute names, which is what lets two
+        // declarations read the same event differently.
+        let mut types: std::collections::BTreeSet<String> = event_types.into_iter().collect();
+        types.extend(table.event_types());
+
+        for event_type in types {
             let descriptors = Rc::clone(&descriptors);
+            let table = Rc::clone(&table);
             let attr_name = format!("data-on{event_type}");
+            let fired_type = event_type.clone();
             let host_for_handler = host.clone();
             let closure = Closure::wrap(Box::new(move |event: Event| {
-                handle_event(&event, &attr_name, descriptors.as_ref(), &host_for_handler);
+                handle_event(
+                    &event,
+                    &attr_name,
+                    &fired_type,
+                    descriptors.as_ref(),
+                    table.as_ref(),
+                    &host_for_handler,
+                );
             }) as Box<dyn FnMut(Event)>);
             let _ = host
                 .add_event_listener_with_callback(&event_type, closure.as_ref().unchecked_ref());
@@ -111,8 +131,22 @@ impl Drop for Delegate {
 /// side effects (`preventDefault`, `stopPropagation`) only fire for
 /// the binding that wins, because `build_transact_body` queues them
 /// and applies them only after the body is known-good.
-fn handle_event(event: &Event, attr_name: &str, descriptors: &Descriptors, host: &Element) {
-    let Some(body) = resolve_actionable_binding(event, attr_name, descriptors, host) else {
+fn handle_event(
+    event: &Event,
+    attr_name: &str,
+    event_type: &str,
+    descriptors: &Descriptors,
+    table: &EventTable,
+    host: &Element,
+) {
+    // The `on:<name>` form is tried first, then the legacy
+    // `on<event>=` form. An element can carry either; nothing carries
+    // both for one event type, so the order only decides which wins in
+    // a half-migrated template — and preferring the new form is what
+    // makes migrating one element at a time observable.
+    let body = binding::resolve_binding(event, event_type, table, descriptors, host)
+        .or_else(|| resolve_actionable_binding(event, attr_name, descriptors, host));
+    let Some(body) = body else {
         return;
     };
     let request_js = match serde_wasm_bindgen::to_value(&body) {

--- a/rust/tonk-display/src/events/extract.rs
+++ b/rust/tonk-display/src/events/extract.rs
@@ -188,7 +188,7 @@ pub fn build_transact_body(
 }
 
 /// The result of reading a `dom.event` path for one field.
-enum ReadOutcome {
+pub(super) enum ReadOutcome {
     /// The path resolved and the leaf coerced to a term value.
     Value(Value),
     /// The path resolved to a *present but empty* leaf — a blank
@@ -217,7 +217,7 @@ enum ReadOutcome {
 /// [`ReadOutcome::Empty`] — "field left blank", not a hard failure —
 /// while a missing intermediate step or an uncoercible value is
 /// [`ReadOutcome::Unresolved`].
-fn read_path_and_coerce(
+pub(super) fn read_path_and_coerce(
     event: &JsValue,
     binding: &JsValue,
     path: &EventPath,
@@ -285,7 +285,7 @@ fn read_path_and_coerce(
 /// concept attribute declared with any supported `as:` can be
 /// populated from a DOM event provided the JS path produces a
 /// shape that fits.
-fn coerce(value: &JsValue, as_type: &str) -> Option<Value> {
+pub(super) fn coerce(value: &JsValue, as_type: &str) -> Option<Value> {
     match as_type {
         "Text" | "String" | "text" | "string" => value.as_string().map(Value::String),
         "Entity" | "entity" => {

--- a/rust/tonk-display/src/events/preprocess.rs
+++ b/rust/tonk-display/src/events/preprocess.rs
@@ -37,6 +37,15 @@ pub struct Bindings {
     /// renderer to resolve descriptors up front so the listener
     /// can build assertions without an async hop on each click.
     pub concept_names: BTreeSet<String>,
+    /// Event declarations referenced by `on:<name>=<command>`
+    /// bindings, as declaration names (`on/click`).
+    ///
+    /// These carry no event *type* — that lives on the declaration,
+    /// which the renderer resolves alongside the command descriptors.
+    /// So the listener set is derived from resolved data rather than
+    /// from the attribute names, which is what lets two declarations
+    /// read the same platform event differently.
+    pub event_names: BTreeSet<String>,
 }
 
 /// Walk `fragment`, rewriting every `on<event>=<value>` attribute
@@ -72,6 +81,21 @@ fn rewrite_element(el: &Element, bindings: &mut Bindings) {
             continue;
         };
         let name = attr.name();
+        // The `on:<name>` form needs no rewrite: `on:click` is not one
+        // of HTML's event-handler content attributes, so the browser
+        // never tries to evaluate it as inline JS. It is left in place
+        // and read back at dispatch time.
+        if let Some(event_name) = tonk_template::event::event_name_for_attribute(&name) {
+            let command = attr.value().trim().to_string();
+            if !command.is_empty() {
+                // The command still needs its descriptor resolved, the
+                // same way the legacy form's does — only the field
+                // *sources* moved to the declaration.
+                bindings.concept_names.insert(command);
+                bindings.event_names.insert(event_name);
+            }
+            continue;
+        }
         if let Some(event_type) = strip_on_prefix(&name) {
             // Empty event type (just `on=`) is meaningless; skip.
             if !event_type.is_empty() {

--- a/rust/tonk-display/src/view.rs
+++ b/rust/tonk-display/src/view.rs
@@ -105,10 +105,14 @@ impl CustomElement for TonkView {
         // structural views (layout containers, etc.).
         if let Some(renderer) = &renderer {
             let bindings = renderer.event_bindings();
-            if !bindings.event_types.is_empty() || !bindings.concept_names.is_empty() {
+            if !bindings.event_types.is_empty()
+                || !bindings.concept_names.is_empty()
+                || !bindings.event_names.is_empty()
+            {
                 let json = serde_json::json!({
                     "events": bindings.event_types.iter().collect::<Vec<_>>(),
                     "concepts": bindings.concept_names.iter().collect::<Vec<_>>(),
+                    "declarations": bindings.event_names.iter().collect::<Vec<_>>(),
                 });
                 if let Ok(serialized) = serde_json::to_string(&json) {
                     let _ = host.set_attribute("data-event-bindings", &serialized);

--- a/rust/tonk-fab/src/element.rs
+++ b/rust/tonk-fab/src/element.rs
@@ -741,7 +741,7 @@ fn dispatch_pause(this: &HtmlElement) {
         .and_then(|w| w.performance())
         .map(|p| p.now())
         .unwrap_or_default();
-    transact(&pause_claim_json("tonk:pause-sync", &space, time));
+    transact(&pause_claim_json(&space, time));
 }
 
 /// Call `window.tonk.transact(request)` with a claim.

--- a/rust/tonk-fab/src/logic.rs
+++ b/rust/tonk-fab/src/logic.rs
@@ -515,13 +515,17 @@ pub fn promote_claim_json(space: &str, member: &str, chain: &str) -> Value {
 /// Build a `TransactRequest` JSON body for the `tonk:pause-sync` command.
 ///
 /// A transient command asserting the target `space` (the DID to pause) with a
-/// per-click `time` so each dispatch is a distinct transient, plus the `marker`
-/// (the command URI) that keeps the shape distinct from `tonk:invite`. `this`
-/// is omitted so the worker mints it from `(descriptor, parameters)`. Dispatched
+/// per-click `time` so each dispatch is a distinct transient. `this` is
+/// omitted so the worker mints it from `(descriptor, parameters)`.
+///
+/// It used to carry a third field, the command URI, whose only job was to
+/// keep this shape distinct from `tonk:invite`'s identical `{this, time}`.
+/// The two commands now have their own attribute namespaces, so the marker
+/// is gone. Dispatched
 /// routeless via `window.tonk.transact`, so it lands on the FAB portal's own
 /// `main@profile:tonk` context where the command lives; the worker's handler
 /// reads `space` to flip that replica — nothing space-side is required.
-pub fn pause_claim_json(command: &str, space: &str, time: f64) -> Value {
+pub fn pause_claim_json(space: &str, time: f64) -> Value {
     json!({
         "claims": [{
             "op": "assert",
@@ -531,16 +535,14 @@ pub fn pause_claim_json(command: &str, space: &str, time: f64) -> Value {
                     "concept": {
                         "description": "Toggle auto-sync (pause ⇄ resume) for a space.",
                         "with": {
-                            "time":   { "the": "dom.event/time-stamp", "as": "Float" },
-                            "space":  { "the": "xyz.tonk.pause-sync/space", "as": "Entity" },
-                            "marker": { "the": "dom.event.current-target.dataset/pause-sync", "as": "Entity" }
+                            "time":  { "the": "xyz.tonk.command.pause-sync/time", "as": "Float" },
+                            "space": { "the": "xyz.tonk.pause-sync/space", "as": "Entity" }
                         }
                     }
                 },
                 "parameters": {
                     "time": time,
-                    "space": space,
-                    "marker": command
+                    "space": space
                 }
             }
         }]
@@ -1046,7 +1048,7 @@ mod persist {
 
     #[test]
     fn pause_claim_carries_the_space_and_is_transient() {
-        let v = pause_claim_json("tonk:pause-sync", "did:key:zSpace", 123.0);
+        let v = pause_claim_json("did:key:zSpace", 123.0);
         let app = &v["claims"][0]["application"];
         assert_eq!(v["claims"][0]["op"], "assert");
         // A command is a one-timestep transient, not a durable fact.
@@ -1055,12 +1057,19 @@ mod persist {
         // from the dispatch origin — this is what lets pause dispatch from the
         // profile branch and depend on nothing seeded per-space.
         assert_eq!(app["parameters"]["space"], "did:key:zSpace");
-        assert_eq!(app["parameters"]["marker"], "tonk:pause-sync");
         assert_eq!(app["parameters"]["time"], 123.0);
         assert_eq!(
             app["predicate"]["concept"]["with"]["space"]["the"],
             "xyz.tonk.pause-sync/space"
         );
+        // The timestamp is in the command's own namespace, which is what
+        // separates this from `tonk:invite`'s identical `{this, time}`. No
+        // marker field does that job any more.
+        assert_eq!(
+            app["predicate"]["concept"]["with"]["time"]["the"],
+            "xyz.tonk.command.pause-sync/time"
+        );
+        assert!(app["parameters"].get("marker").is_none());
         // `this` is omitted so the worker mints it from (descriptor, params).
         assert!(app["parameters"].get("this").is_none());
     }
@@ -1558,9 +1567,8 @@ pub fn rename_repo_claim_json(space: &str, name: &str) -> Value {
                     "concept": {
                         "description": "Rename a space's repository from the FAB.",
                         "with": {
-                            "value":            { "the": "dom.event.current-target/value", "as": "Text" },
-                            "space":            { "the": "xyz.tonk.rename-repository/space", "as": "Entity" },
-                            "rename-repository": { "the": "dom.event.current-target.dataset/rename-repository", "as": "Entity" }
+                            "name":  { "the": "xyz.tonk.command.rename-repository/name", "as": "Text" },
+                            "space": { "the": "xyz.tonk.rename-repository/space", "as": "Entity" }
                         }
                     }
                 },
@@ -1580,7 +1588,7 @@ mod rename_repo {
         let text = claim.to_string();
         // The descriptor rides WITH the claim — nothing seeded is consulted.
         assert!(text.contains("xyz.tonk.rename-repository/space"));
-        assert!(text.contains("dom.event.current-target/value"));
+        assert!(text.contains("xyz.tonk.command.rename-repository/name"));
         assert!(text.contains("did:key:z6Mk"));
         assert!(text.contains("Renamed"));
     }
@@ -1662,7 +1670,7 @@ mod create_space {
 /// same "commit a blank, nothing changes" behaviour `ProfileRenameHandler`
 /// itself would otherwise have to special-case.
 pub fn profile_rename_claim_json(name: &str) -> Value {
-    let mut parameters = json!({ "marker": "tonk:profile" });
+    let mut parameters = json!({});
     if !name.is_empty() {
         parameters["name"] = json!(name);
     }
@@ -1675,8 +1683,7 @@ pub fn profile_rename_claim_json(name: &str) -> Value {
                     "concept": {
                         "description": "Rename the signed-in member (set their display name).",
                         "with": {
-                            "name":   { "the": "dom.event.current-target/value", "as": "Text" },
-                            "marker": { "the": "dom.event.current-target.dataset/rename", "as": "Entity" }
+                            "name": { "the": "xyz.tonk.command.profile-rename/name", "as": "Text" }
                         }
                     }
                 },
@@ -1703,14 +1710,14 @@ mod profile_rename {
         // and never on their values. `dialog-reactor`'s
         // `it_does_not_decode_a_repo_rename_as_a_profile_rename` pins the
         // invariant; this pins the claim this crate actually builds.
-        assert_eq!(with["name"]["the"], "dom.event.current-target/value");
-        assert_eq!(
-            with["marker"]["the"],
-            "dom.event.current-target.dataset/rename"
+        assert_eq!(with["name"]["the"], "xyz.tonk.command.profile-rename/name");
+        assert!(
+            with.get("marker").is_none(),
+            "the namespace separates the two renames; no marker is needed"
         );
         let params = &claim["claims"][0]["application"]["parameters"];
         assert_eq!(params["name"], "Ada");
-        assert_eq!(params["marker"], "tonk:profile");
+        assert!(params.get("marker").is_none());
     }
 
     #[test]
@@ -1744,16 +1751,14 @@ pub fn invite_claim_json(space: &str, time: f64) -> Value {
                     "concept": {
                         "description": "Mint a repo invite — generates a membership keypair and delegation.",
                         "with": {
-                            "time":   { "the": "dom.event/time-stamp", "as": "Float" },
-                            "space":  { "the": "xyz.tonk.invite/space", "as": "Entity" },
-                            "marker": { "the": "dom.event.current-target.dataset/invite", "as": "Entity" }
+                            "time":  { "the": "xyz.tonk.command.invite/time", "as": "Float" },
+                            "space": { "the": "xyz.tonk.invite/space", "as": "Entity" }
                         }
                     }
                 },
                 "parameters": {
                     "time": time,
-                    "space": space,
-                    "marker": "tonk:invite"
+                    "space": space
                 }
             }
         }]
@@ -1769,14 +1774,12 @@ pub fn invite_claim_json(space: &str, time: f64) -> Value {
 /// the assert incomplete, so the transient would commit and match nothing.
 pub fn enable_sync_claim_json(space: &str, remote: &str, share: bool, time: f64) -> Value {
     let mut with = json!({
-        "time":   { "the": "dom.event/time-stamp", "as": "Float" },
-        "space":  { "the": "xyz.tonk.enable-sync/space", "as": "Entity" },
-        "marker": { "the": "dom.event.current-target.dataset/enable-sync", "as": "Entity" }
+        "time":  { "the": "xyz.tonk.command.enable-sync/time", "as": "Float" },
+        "space": { "the": "xyz.tonk.enable-sync/space", "as": "Entity" }
     });
     let mut parameters = json!({
         "time": time,
-        "space": space,
-        "marker": "tonk:enable-sync"
+        "space": space
     });
     // An empty remote is omitted rather than sent as `""`: the handler
     // then resolves where this account syncs from its own recorded
@@ -1819,8 +1822,12 @@ mod invite {
         assert!(claim.to_string().contains("did:key:z6Mk"));
         let app = &claim["claims"][0]["application"];
         assert_eq!(app["parameters"]["space"], "did:key:z6Mk");
-        assert_eq!(app["parameters"]["marker"], "tonk:invite");
         assert_eq!(app["parameters"]["time"], 1.0);
+        assert_eq!(
+            app["predicate"]["concept"]["with"]["time"]["the"],
+            "xyz.tonk.command.invite/time"
+        );
+        assert!(app["parameters"].get("marker").is_none());
         assert!(app["parameters"].get("this").is_none());
     }
 }
@@ -2049,8 +2056,8 @@ mod enable_sync_claim {
         assert_eq!(app["parameters"]["space"], "did:key:z6Mk");
         assert_eq!(app["parameters"]["remote"], "https://tonk.network/ucan/");
         assert_eq!(app["parameters"]["share"], "tonk:share");
-        assert_eq!(app["parameters"]["marker"], "tonk:enable-sync");
         assert_eq!(app["parameters"]["time"], 7.0);
+        assert!(app["parameters"].get("marker").is_none());
         assert_eq!(
             app["predicate"]["concept"]["description"],
             "Attach a sync remote to a space, and share it."
@@ -2061,12 +2068,12 @@ mod enable_sync_claim {
         // above, then silently no-ops at runtime because the transient
         // commits and matches no handler. Pin every declared attribute name.
         let with = &app["predicate"]["concept"]["with"];
-        assert_eq!(with["time"]["the"], "dom.event/time-stamp");
+        assert_eq!(with["time"]["the"], "xyz.tonk.command.enable-sync/time");
         assert_eq!(with["space"]["the"], "xyz.tonk.enable-sync/space");
         assert_eq!(with["remote"]["the"], "xyz.tonk.enable-sync/remote");
-        assert_eq!(
-            with["marker"]["the"],
-            "dom.event.current-target.dataset/enable-sync"
+        assert!(
+            with.get("marker").is_none(),
+            "the namespace keeps this shape distinct; no marker is needed"
         );
         assert_eq!(with["share"]["the"], "xyz.tonk.enable-sync/share");
     }
@@ -2241,7 +2248,7 @@ mod wire_types {
             create_space_claim_json("N").to_string(),
             profile_rename_claim_json("N").to_string(),
             invite_claim_json("did:key:zX", 1.0).to_string(),
-            pause_claim_json("tonk:pause-sync", "did:key:zX", 1.0).to_string(),
+            pause_claim_json("did:key:zX", 1.0).to_string(),
             dock_claim_json(crate::logic::Dock::BottomRight).to_string(),
         ];
 

--- a/rust/tonk-fab/src/logic.rs
+++ b/rust/tonk-fab/src/logic.rs
@@ -1622,12 +1622,11 @@ mod create_space {
     fn it_uses_the_declared_form_attribute_uris_for_create_space() {
         let claim = create_space_claim_json("Untitled");
         let text = claim.to_string();
-        // Verbatim, kebab-cased as declared — the handler matches on these.
-        // Every control is read at `/value`: the segment after the control
-        // name is the JS property the browser's extractor would have read,
-        // so a descriptive leaf resolves to `undefined` there and the
-        // handler would never see the field here.
-        assert!(text.contains("dom.event.current-target.elements.name/value"));
+        // Verbatim as declared — the handler matches on this. The
+        // attribute is the command's own; the DOM read path that used to
+        // fill it is now only what a branch seeded before the migration
+        // still asserts, and the handler converts that separately.
+        assert!(text.contains("xyz.tonk.command.create-space/name"));
         let params = &claim["claims"][0]["application"]["parameters"];
         assert_eq!(params["name"], "Untitled");
     }

--- a/rust/tonk-fab/src/logic.rs
+++ b/rust/tonk-fab/src/logic.rs
@@ -1542,7 +1542,7 @@ mod profile_name {
 
 /// Build a `TransactRequest` body for `tonk/rename-repository`.
 ///
-/// A transient carrying the target `space` and the new `value`. Dispatched
+/// A transient carrying the target `space` and the new `name`. Dispatched
 /// routeless via `window.tonk.transact`, so it lands on the FAB's own
 /// `main@profile:tonk`; the worker's handler reads `space` to rename that
 /// repository — nothing space-side is required. `this` is omitted so the
@@ -1551,12 +1551,9 @@ mod profile_name {
 /// An empty `name` is omitted entirely: the extractor drops empty fields, so
 /// a blank would store no fact and the command would never fire.
 pub fn rename_repo_claim_json(space: &str, name: &str) -> Value {
-    let mut parameters = json!({
-        "space": space,
-        "rename-repository": "tonk:repository"
-    });
+    let mut parameters = json!({ "space": space });
     if !name.is_empty() {
-        parameters["value"] = json!(name);
+        parameters["name"] = json!(name);
     }
     json!({
         "claims": [{
@@ -1596,15 +1593,28 @@ mod rename_repo {
     #[test]
     fn it_omits_an_empty_name_rather_than_sending_a_blank() {
         // The extractor drops empty fields; a blank would store no fact and the
-        // handler would never fire. The descriptor's `with.value` mapping is
+        // handler would never fire. The descriptor's `with.name` mapping is
         // schema metadata and stays present regardless — what must be absent
-        // is the `value` PARAMETER, the thing that actually becomes a fact.
+        // is the `name` PARAMETER, the thing that actually becomes a fact.
         let claim = rename_repo_claim_json("did:key:z6Mk", "");
-        assert!(
-            claim["claims"][0]["application"]["parameters"]
-                .get("value")
-                .is_none()
-        );
+        let parameters = &claim["claims"][0]["application"]["parameters"];
+        assert!(parameters.get("name").is_none());
+        assert_eq!(parameters["space"], "did:key:z6Mk");
+    }
+
+    #[test]
+    fn it_sets_the_new_name_under_the_field_the_descriptor_declares() {
+        // Regression: the parameters carried `value` plus a
+        // `rename-repository` marker while the inlined descriptor declared
+        // `name` and `space`. The worker rejects a parameter the concept
+        // does not declare — `invalid claim: field "rename-repository" is
+        // not declared by this concept` — so every rename from the FAB
+        // failed with a 400 and the chip silently reverted.
+        let claim = rename_repo_claim_json("did:key:z6Mk", "Renamed");
+        let parameters = &claim["claims"][0]["application"]["parameters"];
+        assert_eq!(parameters["name"], "Renamed");
+        assert!(parameters.get("value").is_none());
+        assert!(parameters.get("rename-repository").is_none());
     }
 }
 

--- a/rust/tonk-notation/src/parse.rs
+++ b/rust/tonk-notation/src/parse.rs
@@ -930,7 +930,7 @@ fn walk_field_value(
 /// distinguish string literals that would otherwise look like
 /// symbols — `text/html` reads as a qualified symbol, so the MIME
 /// literal must be written `"text/html"`.
-fn classify_plain_value(text: &str) -> FieldValue {
+pub fn classify_plain_value(text: &str) -> FieldValue {
     if text == "_" {
         return FieldValue::Blank;
     }

--- a/rust/tonk-schema/src/builtin.rs
+++ b/rust/tonk-schema/src/builtin.rs
@@ -57,6 +57,7 @@ fn build_registry() -> Vec<(&'static str, ConceptDefinition)> {
         ("attribute", builtin::<AnonymousAttribute>("attribute")),
         ("concept", concept_descriptor()),
         ("command", command_descriptor()),
+        ("event", event_descriptor()),
         ("rule", rule_descriptor()),
         ("name", builtin::<Name>("name")),
         ("branch", builtin::<Branch>("branch")),
@@ -109,6 +110,69 @@ fn command_descriptor() -> ConceptDefinition {
             .parse()
             .expect("`db:command` is a valid entity URI"),
         descriptor: ConceptDescriptor::Durable(command_of_command_descriptor().clone()),
+    }
+}
+
+/// Built-in `event` concept — how a platform event fills a command's
+/// fields.
+///
+/// A peer of `command`: an `event!:` declaration is schema an author
+/// writes, so it must resolve on any branch rather than only where the
+/// standard library has been seeded. Its instances (`on/click`, and a
+/// terminal's own set) are ordinary data and stay in the library.
+///
+/// Hand-built rather than `derive(Concept)` for the same reason
+/// [`command_descriptor`] and [`rule_descriptor`] are: `where` is a
+/// keyed dictionary, which no Rust fixed-record shape expresses — the
+/// same reason the `view` concept is still declared in the library.
+fn event_descriptor() -> ConceptDefinition {
+    static DESCRIPTOR: std::sync::OnceLock<DialogConceptDescriptor> = std::sync::OnceLock::new();
+    let descriptor = DESCRIPTOR.get_or_init(|| {
+        serde_json::from_value(serde_json::json!({
+            "description": "How a platform event fills a command's fields.",
+            "with": {
+                "type": {
+                    "the": "xyz.tonk.event/type",
+                    "as": "Text",
+                    "cardinality": "one",
+                    "description": "The platform event name to listen for"
+                },
+                // A keyed collection: the `the` names a domain and the
+                // key supplies the name half, so each source lands as
+                // its own fact and a space can supersede one without
+                // restating the map. Its own domain, so a command field
+                // called `type` cannot collide with `type` above.
+                "where": {
+                    "the": { "domain": "xyz.tonk.event.where", "keyed": "dictionary" },
+                    "as": "Text",
+                    "cardinality": "one",
+                    "description": "Command field name to source"
+                },
+                // Optional: a declaration that suppresses neither must
+                // still resolve, so these cannot be required.
+                "prevent-default": {
+                    "the": "xyz.tonk.event/prevent-default",
+                    "as": "Boolean",
+                    "cardinality": "one",
+                    "optional": true,
+                    "description": "Suppress the platform's default handling"
+                },
+                "stop-propagation": {
+                    "the": "xyz.tonk.event/stop-propagation",
+                    "as": "Boolean",
+                    "cardinality": "one",
+                    "optional": true,
+                    "description": "Stop the event propagating further"
+                }
+            }
+        }))
+        .expect("event descriptor is well-formed")
+    });
+    ConceptDefinition {
+        entity: "db:event"
+            .parse()
+            .expect("`db:event` is a valid entity URI"),
+        descriptor: ConceptDescriptor::Durable(descriptor.clone()),
     }
 }
 

--- a/rust/tonk-schema/src/command.rs
+++ b/rust/tonk-schema/src/command.rs
@@ -20,7 +20,7 @@ use dialog_artifacts::Entity;
 use dialog_capability::Command;
 use dialog_query::Concept;
 
-use crate::domain::command::Value as SpaceName;
+pub mod legacy;
 
 /// `tonk:delete-account`: purge the account from every service and
 /// this device.
@@ -74,74 +74,24 @@ impl Command for AuthorizeDevice {
 pub struct AddPasskey {
     /// The command entity (a fresh id per click).
     pub this: Entity,
-    /// The per-command marker; see [`crate::domain::command::add_passkey`].
-    pub marker: crate::domain::command::add_passkey::AddPasskey,
+    /// The account to add a passkey to. The verb carries no data of its
+    /// own, so it needs one attribute simply to be nameable; see
+    /// [`crate::domain::command::current::add_passkey::Account`].
+    pub account: crate::domain::command::current::add_passkey::Account,
+}
+
+impl From<legacy::AddPasskey> for AddPasskey {
+    fn from(legacy: legacy::AddPasskey) -> Self {
+        Self {
+            account: crate::domain::command::current::add_passkey::Account(legacy.marker.0),
+            this: legacy.this,
+        }
+    }
 }
 
 impl Command for AddPasskey {
     type Input = Self;
     type Output = ();
-}
-
-/// Request to create a new space (repository) by local name.
-///
-/// Asserted transiently when the user submits the Add Space form (a
-/// `<form onsubmit=space/create>` defined in `profile.yaml`). The
-/// notation event layer reads `name` from the form's
-/// `elements.name.value` and POSTs the transient claim; the handler
-/// records the replica (`status: blank`) so the Hub shows it
-/// installing, then creates the repository, seeds the standard library,
-/// and flips the status to `initialized`.
-///
-/// `name`'s attribute is a `dom.event.*` read-path so the same concept
-/// the form asserts is the one the worker handler decodes — see
-/// [`crate::domain::command::Value`].
-///
-/// Deliberately a single matched field. A command concept must keep
-/// decoding against the descriptor an *older* version seeded — a profile
-/// branch is seeded once and not re-seeded across versions, so its
-/// `space/create` descriptor is frozen at the version that created it.
-/// Adding a required field here would make the command silently fail to
-/// match every such profile (the transient commits, no provider runs),
-/// breaking all space creation.
-///
-/// The optional sync remote is therefore *not* a field here: the worker's
-/// `CreateSpaceHandler` matches on `name` and reads the remote URL
-/// directly from the transient's facts. It can't be a `String`-typed
-/// concept field anyway — a URL round-trips through JSON and the worker's
-/// untagged `Value` deserialization picks `Entity` for any string with a
-/// `:`, so a `remote: String` field would never decode a URL. Reading the
-/// artifact directly tolerates both `String` and `Entity`. The same
-/// handler also serves the topbar's "Enable sync" form (which posts the
-/// same `name`+`remote` shape against an existing space).
-#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct CreateSpace {
-    /// The command entity (a fresh id per invocation, derived by the
-    /// worker from the predicate + payload).
-    pub this: Entity,
-    /// Local name for the new space, read from the form's `name` input.
-    /// The create wizard supplies it from a hidden input carrying the
-    /// `Untitled` sentinel (the user no longer types a name up front);
-    /// the worker's handler uniquifies that to "Untitled N" against the
-    /// existing space labels, and the user renames later.
-    pub name: SpaceName,
-}
-
-/// Create a notebook from the index's heading switcher, and drop the
-/// author into it.
-///
-/// The handler does both halves: it writes the notebook and then posts a
-/// `navigate` to the originating client. The navigation cannot happen in
-/// the page, because the notebook's entity is derived when the fact is
-/// written — the element that fired the command never learns it.
-#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct CreateNotebook {
-    /// The command entity, minted per invocation.
-    pub this: Entity,
-    /// The title typed into the heading.
-    pub title: crate::domain::command::notebook::CreatedTitle,
-    /// The draft's document, blocks and all.
-    pub body: crate::domain::command::notebook::CreatedBody,
 }
 
 /// Ask whether an address is already registered, so the form can route
@@ -159,8 +109,17 @@ pub struct CreateNotebook {
 pub struct CheckEmail {
     /// The command entity, minted per invocation.
     pub this: Entity,
-    /// The address to ask about, read from the form's `email` input.
-    pub email: crate::domain::command::email::Value,
+    /// The address to look up.
+    pub email: crate::domain::command::current::check_email::Email,
+}
+
+impl From<legacy::CheckEmail> for CheckEmail {
+    fn from(legacy: legacy::CheckEmail) -> Self {
+        Self {
+            email: crate::domain::command::current::check_email::Email(legacy.email.0),
+            this: legacy.this,
+        }
+    }
 }
 
 impl Command for CheckEmail {
@@ -168,35 +127,29 @@ impl Command for CheckEmail {
     type Output = ();
 }
 
-/// Register an account, from the form the registration overlay renders.
+/// Create the account for an address, once the lookup said it is free.
 ///
-/// The page asserts this and then watches facts: `AccountCustomer`
-/// appears once enrollment lands, and gains a provider at activation.
-/// Nothing is read back from a response, because a command answers with
-/// facts rather than a body.
-///
-/// The provider cannot finish this alone. Creating an account is a
-/// WebAuthn ceremony, which needs a `window` and a user gesture, and the
-/// service worker has neither; it asks the originating client to
-/// authorize with a passkey and continues from what comes back.
+/// The lookup ([`CheckEmail`]) and this were once the same shape
+/// `{this, email}` under one shared DOM read path, so every keystroke's
+/// lookup also decoded as a registration and the worker started a
+/// passkey ceremony while the user was still typing. A marker attribute
+/// patched that; the two now live in separate namespaces, so the shapes
+/// cannot collide and the marker is gone.
 #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RegisterAccount {
     /// The command entity, minted per invocation.
     pub this: Entity,
-    /// The address to register, read from the form's `email` input.
-    pub email: crate::domain::command::email::Value,
-    /// Per-command marker keeping this distinct from [`CheckEmail`],
-    /// which is otherwise the same shape.
-    ///
-    /// Without it every keystroke's lookup also decoded as a
-    /// registration, and a passkey prompt appeared while the user was
-    /// still typing their address.
-    pub marker: crate::domain::command::register::RegisterAccount,
+    /// The address to register.
+    pub email: crate::domain::command::current::register_account::Email,
 }
 
-impl RegisterAccount {
-    /// The value [`Self::marker`] carries.
-    pub const MARKER: &str = "tonk:register-account";
+impl From<legacy::RegisterAccount> for RegisterAccount {
+    fn from(legacy: legacy::RegisterAccount) -> Self {
+        Self {
+            email: crate::domain::command::current::register_account::Email(legacy.email.0),
+            this: legacy.this,
+        }
+    }
 }
 
 impl Command for RegisterAccount {
@@ -204,11 +157,85 @@ impl Command for RegisterAccount {
     type Output = ();
 }
 
+/// Request to create a new space (repository) by local name.
+///
+/// Asserted transiently when a create form submits. The handler records
+/// the replica (`status: blank`) so the Hub shows it installing, then
+/// creates the repository, seeds the standard library, flips the status
+/// to `initialized`, and navigates the creator into it.
+///
+/// Matched **name-only**, deliberately. An optional sync URL rides on
+/// the same transient and is read straight from its facts rather than
+/// declared here: a URL round-trips through JSON as `Value::Entity` (the
+/// untagged decode picks it for any `:`-bearing string), so a
+/// `String`-typed field would never decode one. That is a value
+/// representation problem, not a command shape problem, and it is left
+/// where it was.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CreateSpace {
+    /// The command entity (a fresh id per invocation).
+    pub this: Entity,
+    /// The space's local name. Nothing asks for one: every create
+    /// carries the `Untitled` sentinel, which the handler uniquifies
+    /// against the existing labels ("Untitled", "Untitled 2", …), and
+    /// the user renames the space in place on arrival.
+    pub name: crate::domain::command::current::create_space::Name,
+}
+
+impl From<legacy::CreateSpace> for CreateSpace {
+    fn from(legacy: legacy::CreateSpace) -> Self {
+        Self {
+            name: crate::domain::command::current::create_space::Name(legacy.name.0),
+            this: legacy.this,
+        }
+    }
+}
+
 /// `CreateSpace` is a [`dialog_capability::Command`]. Note the worker
 /// registers a custom `CreateSpaceHandler` (not a plain `Provider`) so it
 /// can read the optional remote from the facts; the `Command` impl is
 /// kept for the decode/`Decode` machinery.
 impl Command for CreateSpace {
+    type Input = Self;
+    type Output = ();
+}
+
+/// Create a notebook from the index's heading switcher, and drop the
+/// author into it.
+///
+/// The handler does both halves: it writes the notebook and then posts a
+/// `navigate` to the originating client. The navigation cannot happen in
+/// the page, because the notebook's entity is derived when the fact is
+/// written — the element that fired the command never learns it.
+///
+/// The fields are `title` and `body`. They were `created-title` and
+/// `created-body` only so a retitle's `detail/title` would not also
+/// decode as a create; the namespace does that now.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CreateNotebook {
+    /// The command entity, minted per invocation.
+    pub this: Entity,
+    /// The title typed into the heading.
+    pub title: crate::domain::command::current::create_notebook::Title,
+    /// The draft's document, blocks and all.
+    pub body: crate::domain::command::current::create_notebook::Body,
+}
+
+impl From<legacy::CreateNotebook> for CreateNotebook {
+    fn from(legacy: legacy::CreateNotebook) -> Self {
+        Self {
+            title: crate::domain::command::current::create_notebook::Title(legacy.title.0),
+            body: crate::domain::command::current::create_notebook::Body(legacy.body.0),
+            this: legacy.this,
+        }
+    }
+}
+
+/// `CreateNotebook` is a [`dialog_capability::Command`]; the worker
+/// registers a custom handler for it (the work needs the branch handle
+/// and the originating client, which the decoded command does not
+/// carry).
+impl Command for CreateNotebook {
     type Input = Self;
     type Output = ();
 }
@@ -249,47 +276,36 @@ impl Command for Load {
     type Output = ();
 }
 
-/// Request to mint a repository invite.
+/// Mint a repository invite: a membership keypair, a delegation of the
+/// space's access to its DID, and the private seed on the overlay.
 ///
-/// Asserted transiently when the FAB's share control is clicked
-/// (`<tonk-share>`, `tonk-fab`). The worker handler generates a fresh
-/// membership keypair, delegates the repository's access to its DID,
-/// asserts a durable [`Authorization`] (the public delegation chain) into
-/// storage, and asserts the private seed as a [`Credential`] into the
-/// reactor's session overlay (never replicated). The share view joins the
-/// two via `tonk:invitation` and assembles the final URL.
+/// The target space rides on the transient as a raw fact
+/// (`xyz.tonk.invite/space`) that the handler reads opportunistically,
+/// falling back to the dispatch origin — the FAB's share affordance is
+/// routeless, so it must name its target, while a space's own share form
+/// need not.
 ///
-/// Deliberately a minimal matched shape, like [`CreateSpace`]: a command
-/// concept must keep decoding against the descriptor an *older* seeded
-/// `core.yaml` carries, and every existing space's `tonk:invite` descriptor
-/// is frozen at `{this, time, marker}` (no `space` field). A required
-/// `space` field here would make those transients silently fail to match
-/// (the transient commits, no handler runs) — see `CreateSpace`'s doc and
-/// `docs/evolving-command-concepts.md`, which records the same mistake with
-/// `CreateSpace.remote`.
-///
-/// The FAB's newer profile-dispatched share affordance (routeless, so
-/// `CommandEnv::origin` is empty) still needs to name its target: it does
-/// so by asserting the `xyz.tonk.invite/space` attribute on the same
-/// transient WITHOUT it being a matched concept field — the worker's
-/// `InviteHandler` reads it opportunistically from the raw facts
-/// (`invite_space_from_facts`, mirroring `remote_from_facts`), falling back
-/// to the dispatch origin when it's absent. The timestamp makes each click
-/// a distinct transient so repeated Share clicks reliably re-fire the
-/// handler and rotate the credential.
+/// The timestamp makes each activation a distinct transient, so repeated
+/// Share clicks reliably re-fire the handler and rotate the credential.
+/// It used to be accompanied by a marker attribute, whose whole job was
+/// to stop a [`PauseSync`] transient — an identical `{this, time}`
+/// otherwise — from also decoding as an invite. Per-verb namespaces make
+/// the two disjoint, so the marker is gone.
 #[derive(Concept, Debug, Clone, PartialEq, PartialOrd)]
 pub struct Invite {
     /// The command entity (a fresh id per invocation).
     pub this: Entity,
-    /// The submit event's timestamp — distinguishes one click from the
-    /// next so the transient re-fires.
-    pub time: crate::domain::command::invite::TimeStamp,
-    /// Per-command marker (read from the share form's `data-invite`) that
-    /// gives `Invite` an attribute no other command carries — so a
-    /// `tonk:pause-sync` transient (identical `{this, time}` shape otherwise)
-    /// does NOT also decode as an invite. See
-    /// [`crate::domain::command::invite::Invite`].
-    pub marker: crate::domain::command::invite::Invite,
+    /// The activation's timestamp — one click from the next.
+    pub time: crate::domain::command::current::invite::Time,
+}
+
+impl From<legacy::Invite> for Invite {
+    fn from(legacy: legacy::Invite) -> Self {
+        Self {
+            time: crate::domain::command::current::invite::Time(legacy.time.0),
+            this: legacy.this,
+        }
+    }
 }
 
 /// `Invite` is a [`dialog_capability::Command`]; its handler lives in
@@ -300,29 +316,37 @@ impl Command for Invite {
     type Output = ();
 }
 
-/// Attach a sync remote to an existing space, and optionally mint an invite
-/// once it is attached.
+/// Attach a sync remote to an existing space, and optionally mint an
+/// invite once it is attached.
 ///
-/// Dispatched routelessly by the share control when a user accepts the offer
-/// to turn sync on. `space`, `remote` and the `share` marker ride on the
-/// transient as raw facts the handler reads directly — `remote` because a URL
-/// cannot be a `String`-typed field (see
+/// Dispatched routelessly by the share control when a user accepts the
+/// offer to turn sync on. `space`, `remote` and the `share` request ride
+/// on the transient as raw facts the handler reads directly — `remote`
+/// because a URL cannot be a `String`-typed field (see
 /// [`crate::domain::command::enable_sync::Remote`]), the other two for
 /// symmetry with it.
 ///
-/// This is deliberately NOT the `space/enable-sync` command seeded in
-/// `core.yaml`: that one shares `CreateSpace`'s trigger attribute, so a
-/// handler registered against it would fire alongside `CreateSpaceHandler`
-/// and mint a new space instead of attaching to the existing one.
+/// This used to need a marker attribute, and to be a second command
+/// distinct from the `space/enable-sync` form's, because that form
+/// shared [`CreateSpace`]'s trigger attribute and anything registered
+/// against it would have minted a new space instead of attaching to the
+/// existing one. Both commands now have their own namespace, so neither
+/// workaround is load-bearing.
 #[derive(Concept, Debug, Clone, PartialEq, PartialOrd)]
 pub struct EnableSync {
     /// The command entity (a fresh id per invocation).
     pub this: Entity,
-    /// The acceptance timestamp — distinguishes one click from the next.
-    pub time: crate::domain::command::enable_sync::TimeStamp,
-    /// Per-command marker that keeps this command's shape distinct from
-    /// every other transient's.
-    pub marker: crate::domain::command::enable_sync::EnableSync,
+    /// The acceptance's timestamp — one click from the next.
+    pub time: crate::domain::command::current::enable_sync::Time,
+}
+
+impl From<legacy::EnableSync> for EnableSync {
+    fn from(legacy: legacy::EnableSync) -> Self {
+        Self {
+            time: crate::domain::command::current::enable_sync::Time(legacy.time.0),
+            this: legacy.this,
+        }
+    }
 }
 
 /// `EnableSync` is a [`dialog_capability::Command`]; its handler lives in
@@ -336,28 +360,31 @@ impl Command for EnableSync {
 ///
 /// Dispatched when the FAB's sync cap is alt/option-clicked. Carries the
 /// target `space` (the DID to pause) and a timestamp so each click is a
-/// distinct transient (re-firing the handler); the handler reads the
-/// replica's current `auto-sync` preference for that space and flips it.
+/// distinct transient; the handler reads the replica's current
+/// `auto-sync` preference for that space and flips it.
 ///
-/// The `space` field is what lets this command live on and dispatch from the
-/// PROFILE branch: the handler reads the target space from the command rather
-/// than the dispatch origin, so the FAB's pause affordance needs no view or
-/// command seeded on each space's own branch.
+/// Naming the target rather than firing on it is what lets this live on
+/// and dispatch from the PROFILE branch, so the FAB's pause affordance
+/// needs nothing seeded per space.
 #[derive(Concept, Debug, Clone, PartialEq, PartialOrd)]
 pub struct PauseSync {
     /// The command entity (a fresh id per click).
     pub this: Entity,
-    /// The click event's timestamp — distinguishes one click from the next
-    /// so the transient re-fires.
-    pub time: crate::domain::command::invite::TimeStamp,
-    /// The target space DID — the replica to pause/resume. Read by the handler
-    /// in place of the dispatch origin.
+    /// The click's timestamp — one click from the next.
+    pub time: crate::domain::command::current::pause_sync::Time,
+    /// The target space DID — the replica to pause/resume, read in place
+    /// of the dispatch origin.
     pub space: crate::domain::command::pause_sync::Space,
-    /// Per-command marker that gives `PauseSync` an attribute no other command
-    /// carries — so this transient does NOT also decode as `tonk:invite` (which
-    /// shares the same `{this, time}` shape). See
-    /// [`crate::domain::command::pause_sync::PauseSync`].
-    pub marker: crate::domain::command::pause_sync::PauseSync,
+}
+
+impl From<legacy::PauseSync> for PauseSync {
+    fn from(legacy: legacy::PauseSync) -> Self {
+        Self {
+            time: crate::domain::command::current::pause_sync::Time(legacy.time.0),
+            space: legacy.space,
+            this: legacy.this,
+        }
+    }
 }
 
 /// `PauseSync` is a [`dialog_capability::Command`]; its handler lives in
@@ -369,23 +396,33 @@ impl Command for PauseSync {
 
 /// Rename a space's repository from the FAB.
 ///
-/// The space-side `tonk/rename-repository` rule (`core.yaml`) cannot consume a
-/// claim dispatched on the profile branch, so this carries its target `space`
-/// and is executed by a worker handler instead — the `PauseSync` pattern. That
-/// is what lets the FAB's name chip depend on nothing seeded per-space.
-#[derive(Concept, Debug, Clone, PartialEq, PartialOrd)]
+/// The space-side `tonk/rename-repository` rule (`core.yaml`) cannot
+/// consume a claim dispatched on the profile branch, so this carries its
+/// target `space` and is executed by a worker handler instead — the
+/// [`PauseSync`] pattern. That is what lets the FAB's name chip depend
+/// on nothing seeded per space.
+///
+/// It shared `currentTarget.value` with [`ProfileRename`], and a marker
+/// attribute is what kept the two shapes disjoint. They now have
+/// separate namespaces, so neither carries one.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RenameRepository {
     /// The command entity (a fresh id per commit).
     pub this: Entity,
-    /// The new name, read from the editable's value on commit.
-    pub name: crate::domain::command::rename_repository::Value,
+    /// The new repository name.
+    pub name: crate::domain::command::current::rename_repository::Name,
     /// The target space DID — the repository to rename.
     pub space: crate::domain::command::rename_repository::Space,
-    /// Per-command marker distinguishing this from `profile/rename`, which
-    /// shares the `{this, value}` shape. A DISTINCT ATTRIBUTE (not a
-    /// distinct marker value) is what keeps the shapes disjoint — see
-    /// `domain::command::rename_repository::RenameRepository`'s doc.
-    pub marker: crate::domain::command::rename_repository::RenameRepository,
+}
+
+impl From<legacy::RenameRepository> for RenameRepository {
+    fn from(legacy: legacy::RenameRepository) -> Self {
+        Self {
+            name: crate::domain::command::current::rename_repository::Name(legacy.name.0),
+            space: legacy.space,
+            this: legacy.this,
+        }
+    }
 }
 
 impl Command for RenameRepository {
@@ -393,22 +430,28 @@ impl Command for RenameRepository {
     type Output = ();
 }
 
-/// Request to rename the current profile (set the member display name).
+/// Rename the signed-in member (set their display name).
 ///
-/// Asserted transiently when the topbar identity chip's `<tonk-editable>`
-/// commits. Carries the new `name` (read from `currentTarget.value`) and
-/// a `marker` (`data-rename`) that distinguishes it from the declarative
-/// `tonk/rename-repository` transient, which shares the `current-target/
-/// value` attribute. The handler persists the override to the profile
-/// meta branch and re-stamps `MemberName` on the origin space.
+/// Asserted transiently when the topbar identity chip's
+/// `<tonk-editable>` commits. The handler persists the override to the
+/// profile meta branch and re-stamps `MemberName` on the origin space.
+///
+/// See [`RenameRepository`] for the marker these two used to need.
 #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProfileRename {
     /// The command entity (a fresh id per commit).
     pub this: Entity,
     /// The new display name.
-    pub name: crate::domain::command::rename::Value,
-    /// Per-command marker (`data-rename="tonk:profile"`).
-    pub marker: crate::domain::command::rename::Rename,
+    pub name: crate::domain::command::current::profile_rename::Name,
+}
+
+impl From<legacy::ProfileRename> for ProfileRename {
+    fn from(legacy: legacy::ProfileRename) -> Self {
+        Self {
+            name: crate::domain::command::current::profile_rename::Name(legacy.name.0),
+            this: legacy.this,
+        }
+    }
 }
 
 impl Command for ProfileRename {
@@ -417,28 +460,34 @@ impl Command for ProfileRename {
 }
 
 /// Request to remove a space from this device: retract its replica
-/// record from the profile meta branch (the Hub row's source of
-/// truth), detach it from the reactor/sync, and delete its local
-/// storage.
+/// record from the profile meta branch (the Hub row's source of truth),
+/// detach it from the reactor/sync, and delete its local storage.
 ///
-/// Asserted transiently when the user confirms a Hub row's delete
-/// overlay (`<form onsubmit=space/remove data-remove={subject}>` in
-/// `profile.yaml`). Removal is device-local: a synced space can be
-/// rejoined via an invite link; server-side data is untouched.
+/// Removal is device-local: a synced space can be rejoined via an invite
+/// link, and server-side data is untouched. An owned hosted space does
+/// NOT submit this — `<ui-space-remove>` routes that verb through the
+/// reviewed account-space deletion flow instead.
 ///
-/// Deliberately a single matched field, like [`CreateSpace`], so an
-/// older profile descriptor keeps decoding it. The field also doubles
-/// as the command's distinct shape: `dataset/remove` is read by no
-/// other command, whereas a `dataset/subject` field would also match
-/// every `tonk/rename-repository` transient (which carries
-/// `dataset/subject`) and turn each rename into a deletion — see
-/// [`crate::domain::command::remove::Remove`].
+/// The field is called `subject`, which is what it is. It used to be
+/// read from `data-remove` rather than the honest `data-subject` for one
+/// reason: a `dataset/subject` field would also have matched every
+/// [`RenameRepository`] transient and turned each rename into a
+/// deletion.
 #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RemoveSpace {
     /// The command entity (a fresh id per invocation).
     pub this: Entity,
-    /// The subject DID of the space to remove, from `data-remove`.
-    pub subject: crate::domain::command::remove::Remove,
+    /// The subject DID of the space to remove.
+    pub subject: crate::domain::command::current::remove_space::Subject,
+}
+
+impl From<legacy::RemoveSpace> for RemoveSpace {
+    fn from(legacy: legacy::RemoveSpace) -> Self {
+        Self {
+            subject: crate::domain::command::current::remove_space::Subject(legacy.subject.0),
+            this: legacy.this,
+        }
+    }
 }
 
 /// `RemoveSpace` is a [`dialog_capability::Command`]; the worker
@@ -525,20 +574,29 @@ impl Command for ResendActivation {
     type Output = ();
 }
 
-/// Remove a member from the space this command fires in.
+/// Revoke a member's access to a space.
 ///
-/// Asserted transiently by the roster row's expel form; the worker's
-/// handler revokes the hop that admits the member under the remover's
-/// own `/` chain, records it at the space's access service, and retracts
-/// the member's roster rows. The service refuses a revocation minted
-/// under a member's `/use` chain, so holding the space is what lets this
-/// take effect, not the role fact.
+/// Asserted transiently by the roster row's expel control; the handler
+/// revokes the hop that admits the member under the remover's own `/`
+/// chain, records it at the space's access service, and retracts the
+/// member's roster rows. The service refuses a revocation minted under a
+/// member's `/use` chain, so holding the space is what lets this take
+/// effect, not the role fact.
 #[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ExpelMember {
     /// The command entity (a fresh id per invocation).
     pub this: Entity,
-    /// The DID the member's membership is keyed on, from `data-expel`.
-    pub member: crate::domain::command::expel::Expel,
+    /// The DID the member's membership is keyed on.
+    pub member: crate::domain::command::current::expel_member::Member,
+}
+
+impl From<legacy::ExpelMember> for ExpelMember {
+    fn from(legacy: legacy::ExpelMember) -> Self {
+        Self {
+            member: crate::domain::command::current::expel_member::Member(legacy.member.0),
+            this: legacy.this,
+        }
+    }
 }
 
 impl Command for ExpelMember {
@@ -679,22 +737,28 @@ pub struct ShareBlocked {
     pub time: crate::domain::share::Time,
 }
 
-/// Request to redeem an invite URL and join its space.
+/// Redeem an invite URL and join its space.
 ///
-/// Asserted transiently when `<tonk-page>` fires its `mount` event on the
-/// `/join` view (`<tonk-page onmount=tonk/join>`). The element reads the
-/// complete page URL, including the fragment the service worker cannot see,
-/// and delivers it as `detail.href`.
-///
-/// The handler parses and claims that URL, driving the overlay-only
-/// `tonk:join/status` (pending → failed, or retract + durable space on
+/// Fired by the /join view's page element, which reads the page location
+/// (the service worker cannot see the `#fragment`, where an open
+/// invite's seed rides). The handler claims the invite and drives
+/// `tonk:join/status` (pending → failed, or retract + durable replica on
 /// success).
 #[derive(Concept, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Join {
     /// The command entity (a fresh id per invocation).
     pub this: Entity,
-    /// Complete invite URL from `detail.href`.
-    pub url: crate::domain::command::join::Href,
+    /// The complete invite URL, fragment included.
+    pub url: crate::domain::command::current::join::Url,
+}
+
+impl From<legacy::Join> for Join {
+    fn from(legacy: legacy::Join) -> Self {
+        Self {
+            url: crate::domain::command::current::join::Url(legacy.url.0),
+            this: legacy.this,
+        }
+    }
 }
 
 impl std::fmt::Debug for Join {

--- a/rust/tonk-schema/src/command/legacy.rs
+++ b/rust/tonk-schema/src/command/legacy.rs
@@ -1,0 +1,374 @@
+// The `#[derive(Concept)]` macro generates helper types without doc
+// comments; suppress `missing_docs` here.
+#![allow(missing_docs)]
+
+//! The shape commands used to have — kept only so a branch seeded
+//! before the change keeps working.
+//!
+//! A command is matched structurally: the set of attribute names a
+//! transient carries is its whole identity. A branch that was seeded
+//! with the old `command!:` descriptors still asserts these attributes,
+//! and its pages still hold those descriptors, so retiring them
+//! outright would break every space created before the migration.
+//!
+//! Nothing is written against these types. Each one has a
+//! `From<legacy::X> for X` conversion beside the current shape in
+//! [`super`], and each handler pairs the two through
+//! [`dialog_reactor::Migrated`], which decodes either and hands the
+//! handler the current shape. That is the whole compatibility surface:
+//! deleting this module, its `From` impls, and one type parameter per
+//! handler retires the old shape without touching a handler body.
+//!
+//! Two things these shapes have that the current ones do not, both
+//! consequences of naming a field after the DOM read path that filled
+//! it:
+//!
+//! - **`marker` fields.** Two verbs reading the same DOM path were the
+//!   same concept, so several commands carry an otherwise pointless
+//!   attribute purely to stay distinct from a sibling. Per-verb
+//!   namespaces make that distinction structural, so the current shapes
+//!   have none.
+//! - **`prevent-default`.** A side effect spelled as a field. It stores
+//!   no value, so a rule premise over it matches zero rows however
+//!   successfully the command transacted; it now lives on the `event!:`
+//!   declaration, where it is a property of the interaction rather than
+//!   of the command.
+//!
+//! [`dialog_reactor::Migrated`]: https://docs.rs/dialog-reactor
+
+use dialog_artifacts::Entity;
+use dialog_query::Concept;
+
+use crate::domain::command::Value as SpaceName;
+
+/// Request to create a new space (repository) by local name.
+///
+/// Asserted transiently when the user submits the Add Space form (a
+/// `<form onsubmit=space/create>` defined in `profile.yaml`). The
+/// notation event layer reads `name` from the form's
+/// `elements.name.value` and POSTs the transient claim; the handler
+/// records the replica (`status: blank`) so the Hub shows it
+/// installing, then creates the repository, seeds the standard library,
+/// and flips the status to `initialized`.
+///
+/// `name`'s attribute is a `dom.event.*` read-path so the same concept
+/// the form asserts is the one the worker handler decodes — see
+/// [`crate::domain::command::Value`].
+///
+/// Deliberately a single matched field. A command concept must keep
+/// decoding against the descriptor an *older* version seeded — a profile
+/// branch is seeded once and not re-seeded across versions, so its
+/// `space/create` descriptor is frozen at the version that created it.
+/// Adding a required field here would make the command silently fail to
+/// match every such profile (the transient commits, no provider runs),
+/// breaking all space creation.
+///
+/// The optional sync remote is therefore *not* a field here: the worker's
+/// `CreateSpaceHandler` matches on `name` and reads the remote URL
+/// directly from the transient's facts. It can't be a `String`-typed
+/// concept field anyway — a URL round-trips through JSON and the worker's
+/// untagged `Value` deserialization picks `Entity` for any string with a
+/// `:`, so a `remote: String` field would never decode a URL. Reading the
+/// artifact directly tolerates both `String` and `Entity`. The same
+/// handler also serves the topbar's "Enable sync" form (which posts the
+/// same `name`+`remote` shape against an existing space).
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CreateSpace {
+    /// The command entity (a fresh id per invocation, derived by the
+    /// worker from the predicate + payload).
+    pub this: Entity,
+    /// Local name for the new space, read from the form's `name` input.
+    /// The create wizard supplies it from a hidden input carrying the
+    /// `Untitled` sentinel (the user no longer types a name up front);
+    /// the worker's handler uniquifies that to "Untitled N" against the
+    /// existing space labels, and the user renames later.
+    pub name: SpaceName,
+}
+
+/// Create a notebook from the index's heading switcher, and drop the
+/// author into it.
+///
+/// The handler does both halves: it writes the notebook and then posts a
+/// `navigate` to the originating client. The navigation cannot happen in
+/// the page, because the notebook's entity is derived when the fact is
+/// written — the element that fired the command never learns it.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CreateNotebook {
+    /// The command entity, minted per invocation.
+    pub this: Entity,
+    /// The title typed into the heading.
+    pub title: crate::domain::command::notebook::CreatedTitle,
+    /// The draft's document, blocks and all.
+    pub body: crate::domain::command::notebook::CreatedBody,
+}
+
+/// Ask whether an address is already registered, so the form can route
+/// before anyone runs a ceremony.
+///
+/// Answers on the overlay as [`crate::EmailStatus`], not in a response
+/// body: the form subscribes to that row and renders the branch it
+/// names. Asserted as the user types, which is why the answer is
+/// overlay-only.
+///
+/// Creating an account with an address that already has one runs the
+/// whole WebAuthn ceremony and fails at the end, leaving an orphan
+/// passkey in the authenticator. Asking first is what avoids that.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CheckEmail {
+    /// The command entity, minted per invocation.
+    pub this: Entity,
+    /// The address to ask about, read from the form's `email` input.
+    pub email: crate::domain::command::email::Value,
+}
+
+/// Register an account, from the form the registration overlay renders.
+///
+/// The page asserts this and then watches facts: `AccountCustomer`
+/// appears once enrollment lands, and gains a provider at activation.
+/// Nothing is read back from a response, because a command answers with
+/// facts rather than a body.
+///
+/// The provider cannot finish this alone. Creating an account is a
+/// WebAuthn ceremony, which needs a `window` and a user gesture, and the
+/// service worker has neither; it asks the originating client to
+/// authorize with a passkey and continues from what comes back.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RegisterAccount {
+    /// The command entity, minted per invocation.
+    pub this: Entity,
+    /// The address to register, read from the form's `email` input.
+    pub email: crate::domain::command::email::Value,
+    /// Per-command marker keeping this distinct from [`CheckEmail`],
+    /// which is otherwise the same shape.
+    ///
+    /// Without it every keystroke's lookup also decoded as a
+    /// registration, and a passkey prompt appeared while the user was
+    /// still typing their address.
+    pub marker: crate::domain::command::register::RegisterAccount,
+}
+
+/// `tonk:add-passkey`: seal the account under a second passkey.
+///
+/// The worker asks the page for both ceremonies — the passkey that
+/// holds the account, and the new one — and re-seals the secret.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AddPasskey {
+    /// The command entity (a fresh id per click).
+    pub this: Entity,
+    /// The per-command marker; see [`crate::domain::command::add_passkey`].
+    pub marker: crate::domain::command::add_passkey::AddPasskey,
+}
+
+/// Request to mint a repository invite.
+///
+/// Asserted transiently when the FAB's share control is clicked
+/// (`<tonk-share>`, `tonk-fab`). The worker handler generates a fresh
+/// membership keypair, delegates the repository's access to its DID,
+/// asserts a durable [`Authorization`] (the public delegation chain) into
+/// storage, and asserts the private seed as a [`Credential`] into the
+/// reactor's session overlay (never replicated). The share view joins the
+/// two via `tonk:invitation` and assembles the final URL.
+///
+/// Deliberately a minimal matched shape, like [`CreateSpace`]: a command
+/// concept must keep decoding against the descriptor an *older* seeded
+/// `core.yaml` carries, and every existing space's `tonk:invite` descriptor
+/// is frozen at `{this, time, marker}` (no `space` field). A required
+/// `space` field here would make those transients silently fail to match
+/// (the transient commits, no handler runs) — see `CreateSpace`'s doc and
+/// `docs/evolving-command-concepts.md`, which records the same mistake with
+/// `CreateSpace.remote`.
+///
+/// The FAB's newer profile-dispatched share affordance (routeless, so
+/// `CommandEnv::origin` is empty) still needs to name its target: it does
+/// so by asserting the `xyz.tonk.invite/space` attribute on the same
+/// transient WITHOUT it being a matched concept field — the worker's
+/// `InviteHandler` reads it opportunistically from the raw facts
+/// (`invite_space_from_facts`, mirroring `remote_from_facts`), falling back
+/// to the dispatch origin when it's absent. The timestamp makes each click
+/// a distinct transient so repeated Share clicks reliably re-fire the
+/// handler and rotate the credential.
+#[derive(Concept, Debug, Clone, PartialEq, PartialOrd)]
+pub struct Invite {
+    /// The command entity (a fresh id per invocation).
+    pub this: Entity,
+    /// The submit event's timestamp — distinguishes one click from the
+    /// next so the transient re-fires.
+    pub time: crate::domain::command::invite::TimeStamp,
+    /// Per-command marker (read from the share form's `data-invite`) that
+    /// gives `Invite` an attribute no other command carries — so a
+    /// `tonk:pause-sync` transient (identical `{this, time}` shape otherwise)
+    /// does NOT also decode as an invite. See
+    /// [`crate::domain::command::invite::Invite`].
+    pub marker: crate::domain::command::invite::Invite,
+}
+
+/// Attach a sync remote to an existing space, and optionally mint an invite
+/// once it is attached.
+///
+/// Dispatched routelessly by the share control when a user accepts the offer
+/// to turn sync on. `space`, `remote` and the `share` marker ride on the
+/// transient as raw facts the handler reads directly — `remote` because a URL
+/// cannot be a `String`-typed field (see
+/// [`crate::domain::command::enable_sync::Remote`]), the other two for
+/// symmetry with it.
+///
+/// This is deliberately NOT the `space/enable-sync` command seeded in
+/// `core.yaml`: that one shares `CreateSpace`'s trigger attribute, so a
+/// handler registered against it would fire alongside `CreateSpaceHandler`
+/// and mint a new space instead of attaching to the existing one.
+#[derive(Concept, Debug, Clone, PartialEq, PartialOrd)]
+pub struct EnableSync {
+    /// The command entity (a fresh id per invocation).
+    pub this: Entity,
+    /// The acceptance timestamp — distinguishes one click from the next.
+    pub time: crate::domain::command::enable_sync::TimeStamp,
+    /// Per-command marker that keeps this command's shape distinct from
+    /// every other transient's.
+    pub marker: crate::domain::command::enable_sync::EnableSync,
+}
+
+/// Toggle background sync for a space's replica.
+///
+/// Dispatched when the FAB's sync cap is alt/option-clicked. Carries the
+/// target `space` (the DID to pause) and a timestamp so each click is a
+/// distinct transient (re-firing the handler); the handler reads the
+/// replica's current `auto-sync` preference for that space and flips it.
+///
+/// The `space` field is what lets this command live on and dispatch from the
+/// PROFILE branch: the handler reads the target space from the command rather
+/// than the dispatch origin, so the FAB's pause affordance needs no view or
+/// command seeded on each space's own branch.
+#[derive(Concept, Debug, Clone, PartialEq, PartialOrd)]
+pub struct PauseSync {
+    /// The command entity (a fresh id per click).
+    pub this: Entity,
+    /// The click event's timestamp — distinguishes one click from the next
+    /// so the transient re-fires.
+    pub time: crate::domain::command::invite::TimeStamp,
+    /// The target space DID — the replica to pause/resume. Read by the handler
+    /// in place of the dispatch origin.
+    pub space: crate::domain::command::pause_sync::Space,
+    /// Per-command marker that gives `PauseSync` an attribute no other command
+    /// carries — so this transient does NOT also decode as `tonk:invite` (which
+    /// shares the same `{this, time}` shape). See
+    /// [`crate::domain::command::pause_sync::PauseSync`].
+    pub marker: crate::domain::command::pause_sync::PauseSync,
+}
+
+/// Rename a space's repository from the FAB.
+///
+/// The space-side `tonk/rename-repository` rule (`core.yaml`) cannot consume a
+/// claim dispatched on the profile branch, so this carries its target `space`
+/// and is executed by a worker handler instead — the `PauseSync` pattern. That
+/// is what lets the FAB's name chip depend on nothing seeded per-space.
+#[derive(Concept, Debug, Clone, PartialEq, PartialOrd)]
+pub struct RenameRepository {
+    /// The command entity (a fresh id per commit).
+    pub this: Entity,
+    /// The new name, read from the editable's value on commit.
+    pub name: crate::domain::command::rename_repository::Value,
+    /// The target space DID — the repository to rename.
+    pub space: crate::domain::command::rename_repository::Space,
+    /// Per-command marker distinguishing this from `profile/rename`, which
+    /// shares the `{this, value}` shape. A DISTINCT ATTRIBUTE (not a
+    /// distinct marker value) is what keeps the shapes disjoint — see
+    /// `domain::command::rename_repository::RenameRepository`'s doc.
+    pub marker: crate::domain::command::rename_repository::RenameRepository,
+}
+
+/// Request to rename the current profile (set the member display name).
+///
+/// Asserted transiently when the topbar identity chip's `<tonk-editable>`
+/// commits. Carries the new `name` (read from `currentTarget.value`) and
+/// a `marker` (`data-rename`) that distinguishes it from the declarative
+/// `tonk/rename-repository` transient, which shares the `current-target/
+/// value` attribute. The handler persists the override to the profile
+/// meta branch and re-stamps `MemberName` on the origin space.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ProfileRename {
+    /// The command entity (a fresh id per commit).
+    pub this: Entity,
+    /// The new display name.
+    pub name: crate::domain::command::rename::Value,
+    /// Per-command marker (`data-rename="tonk:profile"`).
+    pub marker: crate::domain::command::rename::Rename,
+}
+
+/// Request to remove a space from this device: retract its replica
+/// record from the profile meta branch (the Hub row's source of
+/// truth), detach it from the reactor/sync, and delete its local
+/// storage.
+///
+/// Asserted transiently when the user confirms a Hub row's delete
+/// overlay (`<form onsubmit=space/remove data-remove={subject}>` in
+/// `profile.yaml`). Removal is device-local: a synced space can be
+/// rejoined via an invite link; server-side data is untouched.
+///
+/// Deliberately a single matched field, like [`CreateSpace`], so an
+/// older profile descriptor keeps decoding it. The field also doubles
+/// as the command's distinct shape: `dataset/remove` is read by no
+/// other command, whereas a `dataset/subject` field would also match
+/// every `tonk/rename-repository` transient (which carries
+/// `dataset/subject`) and turn each rename into a deletion — see
+/// [`crate::domain::command::remove::Remove`].
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RemoveSpace {
+    /// The command entity (a fresh id per invocation).
+    pub this: Entity,
+    /// The subject DID of the space to remove, from `data-remove`.
+    pub subject: crate::domain::command::remove::Remove,
+}
+
+/// Remove a member from the space this command fires in.
+///
+/// Asserted transiently by the roster row's expel form; the worker's
+/// handler revokes the hop that admits the member under the remover's
+/// own `/` chain, records it at the space's access service, and retracts
+/// the member's roster rows. The service refuses a revocation minted
+/// under a member's `/use` chain, so holding the space is what lets this
+/// take effect, not the role fact.
+#[derive(Concept, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ExpelMember {
+    /// The command entity (a fresh id per invocation).
+    pub this: Entity,
+    /// The DID the member's membership is keyed on, from `data-expel`.
+    pub member: crate::domain::command::expel::Expel,
+}
+
+/// Request to redeem an invite URL and join its space.
+///
+/// Asserted transiently when `<tonk-page>` fires its `mount` event on the
+/// `/join` view (`<tonk-page onmount=tonk/join>`). The element reads the
+/// complete page URL, including the fragment the service worker cannot see,
+/// and delivers it as `detail.href`.
+///
+/// The handler parses and claims that URL, driving the overlay-only
+/// `tonk:join/status` (pending → failed, or retract + durable space on
+/// success).
+#[derive(Concept, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Join {
+    /// The command entity (a fresh id per invocation).
+    pub this: Entity,
+    /// Complete invite URL from `detail.href`.
+    pub url: crate::domain::command::join::Href,
+}
+
+/// Redacted like the current shape's: the url carries the membership
+/// seed in its fragment, so it must never reach a log.
+impl std::fmt::Debug for Join {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("legacy::Join")
+            .field("this", &self.this)
+            .field("url", &"[redacted]")
+            .finish()
+    }
+}
+
+impl RegisterAccount {
+    /// The value [`Self::marker`] carries. The current shape needs no
+    /// marker — `xyz.tonk.command.register-account/email` cannot be
+    /// confused with the lookup's `…check-email/email` — so this is part
+    /// of the compatibility surface, not of the command.
+    pub const MARKER: &str = "tonk:register-account";
+}

--- a/rust/tonk-schema/src/domain.rs
+++ b/rust/tonk-schema/src/domain.rs
@@ -939,7 +939,12 @@ pub mod command {
             pub struct Name(pub String);
         }
 
-        /// `space/create-notebook` — write a notebook and go to it.
+        /// `notebook/create` — write a notebook and go to it.
+        ///
+        /// The domain is `xyz.tonk.notebook.create`, not
+        /// `xyz.tonk.command.create-notebook`: `notebook.yaml` declares
+        /// this command and the YAML is the schema of record, so the
+        /// struct follows it rather than the other way round.
         pub mod create_notebook {
             use dialog_query::Attribute;
 
@@ -948,13 +953,13 @@ pub mod command {
             /// retitle's `detail/title` would not also decode as a
             /// create.
             #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
-            #[domain("xyz.tonk.command.create-notebook")]
+            #[domain("xyz.tonk.notebook.create")]
             pub struct Title(pub String);
 
             /// The draft's whole document, so the new notebook keeps
             /// what was already written under the heading.
             #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
-            #[domain("xyz.tonk.command.create-notebook")]
+            #[domain("xyz.tonk.notebook.create")]
             pub struct Body(pub String);
         }
 

--- a/rust/tonk-schema/src/domain.rs
+++ b/rust/tonk-schema/src/domain.rs
@@ -890,6 +890,203 @@ pub mod command {
         #[domain("dom.event.detail")]
         pub struct Href(pub String);
     }
+
+    /// The **current** shape of every command's fields: one
+    /// `xyz.tonk.command.<verb>` namespace per verb.
+    ///
+    /// Everything above this is the shape commands used to have, and
+    /// the reason this module exists. A command is matched
+    /// structurally — the set of attributes a transient carries is its
+    /// whole identity — so spelling a field as the DOM read path that
+    /// produced it (`dom.event.current-target.dataset/subject`) made two
+    /// unrelated verbs reading the same DOM path the *same concept*.
+    ///
+    /// Every `marker` field above is that collision being patched by
+    /// hand: `Invite` carries one so a `PauseSync` transient (an
+    /// identical `{this, time}` otherwise) does not also decode as an
+    /// invite; `RenameRepository` and `ProfileRename` each carry one
+    /// because both read `currentTarget.value`; `RemoveSpace` reads
+    /// `dataset/remove` rather than the honest `dataset/subject` only
+    /// because the latter would make every rename decode as a deletion;
+    /// `EnableSync` is a whole second command because the first one
+    /// shared `CreateSpace`'s trigger attribute.
+    ///
+    /// Giving each verb its own namespace makes all of that structural:
+    /// `xyz.tonk.command.remove-space/subject` and
+    /// `xyz.tonk.command.rename-repository/space` cannot collide however
+    /// they were typed in, so nominal identity is a *byproduct* of the
+    /// naming rather than something a marker field has to reassert. Not
+    /// one of these modules needs a marker.
+    ///
+    /// This is the same rule the module header states for every other
+    /// concept — "each concept owns its own attribute namespace so its
+    /// descriptor never matches entities of another shape". Commands
+    /// were the exception, and the markers were the cost.
+    ///
+    /// Where a field was *already* domain-shaped (`xyz.tonk.invite/space`,
+    /// `xyz.tonk.pause-sync/space`, `xyz.tonk.enable-sync/remote`, the
+    /// whole of `promote` / `enroll` / `authorize_device`) the current
+    /// command reuses it rather than minting a synonym.
+    pub mod current {
+        /// `space/create` — make a new space, optionally with a remote.
+        pub mod create_space {
+            use dialog_query::Attribute;
+
+            /// The space's local name. The create wizard supplies the
+            /// `Untitled` sentinel, which the handler uniquifies.
+            #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+            #[domain("xyz.tonk.command.create-space")]
+            pub struct Name(pub String);
+        }
+
+        /// `space/create-notebook` — write a notebook and go to it.
+        pub mod create_notebook {
+            use dialog_query::Attribute;
+
+            /// The title typed into the heading switcher. Named `title`,
+            /// not `created-title`: the old name existed only so a
+            /// retitle's `detail/title` would not also decode as a
+            /// create.
+            #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+            #[domain("xyz.tonk.command.create-notebook")]
+            pub struct Title(pub String);
+
+            /// The draft's whole document, so the new notebook keeps
+            /// what was already written under the heading.
+            #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+            #[domain("xyz.tonk.command.create-notebook")]
+            pub struct Body(pub String);
+        }
+
+        /// `space/remove` — drop a space from this device.
+        pub mod remove_space {
+            use dialog_artifacts::Entity;
+            use dialog_query::Attribute;
+
+            /// The space to remove. Called what it is: the old
+            /// `dataset/remove` name was chosen only to avoid colliding
+            /// with a rename's `dataset/subject`.
+            #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+            #[domain("xyz.tonk.command.remove-space")]
+            pub struct Subject(pub Entity);
+        }
+
+        /// `tonk/invite` — mint a repo invite.
+        pub mod invite {
+            use dialog_query::Attribute;
+
+            /// The activation's timestamp, so repeated Share clicks are
+            /// distinct transients and each re-fires the handler
+            /// (rotating the credential).
+            #[derive(Attribute, Clone, PartialEq, PartialOrd)]
+            #[domain("xyz.tonk.command.invite")]
+            pub struct Time(pub f64);
+        }
+
+        /// `space/enable-sync` — attach a remote to an existing space.
+        pub mod enable_sync {
+            use dialog_query::Attribute;
+
+            /// The acceptance's timestamp — one click from the next.
+            #[derive(Attribute, Clone, PartialEq, PartialOrd)]
+            #[domain("xyz.tonk.command.enable-sync")]
+            pub struct Time(pub f64);
+        }
+
+        /// `tonk/pause-sync` — toggle a space's background sync.
+        pub mod pause_sync {
+            use dialog_query::Attribute;
+
+            /// The click's timestamp, so each toggle re-fires.
+            #[derive(Attribute, Clone, PartialEq, PartialOrd)]
+            #[domain("xyz.tonk.command.pause-sync")]
+            pub struct Time(pub f64);
+        }
+
+        /// `tonk/rename-repository` — rename a space's repository.
+        pub mod rename_repository {
+            use dialog_query::Attribute;
+
+            /// The new repository name.
+            #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+            #[domain("xyz.tonk.command.rename-repository")]
+            pub struct Name(pub String);
+        }
+
+        /// `profile/rename` — set the signed-in member's display name.
+        pub mod profile_rename {
+            use dialog_query::Attribute;
+
+            /// The new display name. Distinct from
+            /// [`rename_repository::Name`] by namespace alone, which is
+            /// what retires both commands' marker fields.
+            #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+            #[domain("xyz.tonk.command.profile-rename")]
+            pub struct Name(pub String);
+        }
+
+        /// `member/expel` — revoke a member's access to a space.
+        pub mod expel_member {
+            use dialog_artifacts::Entity;
+            use dialog_query::Attribute;
+
+            /// The DID the member's membership is keyed on.
+            #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+            #[domain("xyz.tonk.command.expel-member")]
+            pub struct Member(pub Entity);
+        }
+
+        /// `tonk/join` — redeem an invite URL.
+        pub mod join {
+            use dialog_query::Attribute;
+
+            /// The complete invite URL, fragment included.
+            #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+            #[domain("xyz.tonk.command.join")]
+            pub struct Url(pub String);
+        }
+
+        /// `account/check-email` — is this address already registered?
+        pub mod check_email {
+            use dialog_query::Attribute;
+
+            /// The address to look up.
+            #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+            #[domain("xyz.tonk.command.check-email")]
+            pub struct Email(pub String);
+        }
+
+        /// `account/register` — create the account.
+        pub mod register_account {
+            use dialog_query::Attribute;
+
+            /// The address to register. Distinct from
+            /// [`check_email::Email`] by namespace, which is why a
+            /// registration marker is no longer needed to stop every
+            /// keystroke's lookup from also running a passkey ceremony.
+            #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+            #[domain("xyz.tonk.command.register-account")]
+            pub struct Email(pub String);
+        }
+
+        /// `tonk/add-passkey` — seal the account under a second passkey.
+        pub mod add_passkey {
+            use dialog_artifacts::Entity;
+            use dialog_query::Attribute;
+
+            /// The account to add a passkey to.
+            ///
+            /// The one command here that keeps a single opaque field,
+            /// and the one place that is not a workaround: the verb
+            /// carries no data, so it needs one attribute simply to be
+            /// nameable. Unlike the markers above, it is not there to
+            /// separate this command from another that would otherwise
+            /// decode identically — the namespace already does that.
+            #[derive(Attribute, Clone, PartialEq, Eq, PartialOrd, Ord)]
+            #[domain("xyz.tonk.command.add-passkey")]
+            pub struct Account(pub Entity);
+        }
+    }
 }
 
 /// Attributes on the transient overlay row answering "is this address

--- a/rust/tonk-template/Cargo.toml
+++ b/rust/tonk-template/Cargo.toml
@@ -11,6 +11,7 @@ indexmap = { workspace = true }
 ipld-core = { workspace = true }
 serde_ipld_dagjson = { workspace = true }
 serde_json = { workspace = true }
+tonk-notation = { workspace = true }
 tonk-schema = { workspace = true }
 
 [dev-dependencies]

--- a/rust/tonk-template/src/event.rs
+++ b/rust/tonk-template/src/event.rs
@@ -1,0 +1,784 @@
+//! The `event` concept: how a platform event fills a command's fields.
+//!
+//! An `event!:` declaration is the seam between a host's input model
+//! and a command's domain shape. It carries the platform event name to
+//! listen for, whether to suppress the platform's default handling, and
+//! a `where:` map from **command field name** to **source**:
+//!
+//! ```yaml
+//! event!: &on/click
+//!   type: "click"
+//!   prevent-default: false
+//!   stop-propagation: false
+//!   where:
+//!     subject: "{this}"
+//!     time: .timeStamp
+//! ```
+//!
+//! ```html
+//! <button on:click=increment>+</button>
+//! ```
+//!
+//! Three things follow from putting the mapping here rather than in the
+//! command's `with:` map, which is what `dom.event.*` identifiers did:
+//!
+//! - **The command is domain-shaped.** `increment.subject` is
+//!   `io.gozala.increment/subject`, not a DOM path, so it means the same
+//!   thing to a rule regardless of which host produced it.
+//! - **The platform difference has one home.** A terminal declares its
+//!   own `on/activate` against the same command; the command and every
+//!   rule downstream are untouched.
+//! - **Completeness is checkable before anything runs** ([`check`]):
+//!   with the event and the command both in hand at view-lowering, a
+//!   required field with no source is a diagnostic instead of a button
+//!   that silently does nothing.
+//!
+//! This module is DOM-free so both the browser renderer and a native
+//! one share one parser and one checker, the same way they already
+//! share the binding planner.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+/// Where one command field's value comes from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Source {
+    /// `{field}` — the same interpolation a template uses, resolved in
+    /// the scope of the element the event fired on: a field of the
+    /// enclosing repeat subject's conclusion. `{this}` is the subject
+    /// itself.
+    Field(String),
+    /// `.a.b.c` — a property read off the live platform event. Segments
+    /// are taken verbatim, so a DOM source is written the way JS spells
+    /// it (`.currentTarget.dataset.todo`) with no case translation to
+    /// get wrong.
+    Property(Vec<String>),
+    /// `"text"` — a constant, for defaults the interaction never
+    /// supplies.
+    Literal(String),
+}
+
+/// Why a `where:` value could not be read as a [`Source`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SourceError {
+    /// Empty, or nothing but whitespace.
+    Empty,
+    /// `{` with no closing `}`, or text outside the braces.
+    MalformedField(String),
+    /// A `.` path with an empty segment (`.a..b`, `.`, `a.`).
+    MalformedProperty(String),
+    /// A bare word — neither `{field}`, nor `.path`, nor quoted.
+    ///
+    /// Rejected rather than guessed: `timeStamp` without its leading
+    /// dot would otherwise be silently taken as the literal string
+    /// `"timeStamp"`, which is exactly the class of typo this design
+    /// exists to catch.
+    Bare(String),
+}
+
+impl fmt::Display for SourceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SourceError::Empty => write!(f, "empty source"),
+            SourceError::MalformedField(raw) => {
+                write!(f, "`{raw}` is not a well-formed `{{field}}` reference")
+            }
+            SourceError::MalformedProperty(raw) => {
+                write!(f, "`{raw}` has an empty path segment")
+            }
+            SourceError::Bare(raw) => write!(
+                f,
+                "`{raw}` is a bare word — write `.{raw}` to read it off the event, \
+                 `{{{raw}}}` to read a field, or `\"{raw}\"` for a literal"
+            ),
+        }
+    }
+}
+
+/// Read one `where:` value.
+pub fn parse_source(raw: &str) -> Result<Source, SourceError> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Err(SourceError::Empty);
+    }
+
+    if let Some(rest) = raw.strip_prefix('{') {
+        let Some(name) = rest.strip_suffix('}') else {
+            return Err(SourceError::MalformedField(raw.to_string()));
+        };
+        let name = name.trim();
+        if name.is_empty() || name.contains('{') || name.contains('}') {
+            return Err(SourceError::MalformedField(raw.to_string()));
+        }
+        return Ok(Source::Field(name.to_string()));
+    }
+
+    if let Some(rest) = raw.strip_prefix('.') {
+        let segments: Vec<String> = rest.split('.').map(str::to_string).collect();
+        if segments.iter().any(String::is_empty) {
+            return Err(SourceError::MalformedProperty(raw.to_string()));
+        }
+        return Ok(Source::Property(segments));
+    }
+
+    // A quoted value is a literal. YAML usually strips the quotes
+    // before we see the string, so an already-unquoted literal is
+    // accepted only in that form; everything else is a bare word.
+    if let Some(inner) = raw
+        .strip_prefix('"')
+        .and_then(|rest| rest.strip_suffix('"'))
+        .or_else(|| {
+            raw.strip_prefix('\'')
+                .and_then(|rest| rest.strip_suffix('\''))
+        })
+    {
+        return Ok(Source::Literal(inner.to_string()));
+    }
+
+    Err(SourceError::Bare(raw.to_string()))
+}
+
+/// A parsed `event!:` declaration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EventDescriptor {
+    /// The platform event name to listen for (`click`, `submit`,
+    /// `createsheet`). Distinct from the declaration's own identifier,
+    /// so several declarations can read the same platform event
+    /// differently — which is how a site-specific binding is expressed
+    /// without a per-site override syntax.
+    pub event_type: String,
+    /// Suppress the platform's default handling.
+    pub prevent_default: bool,
+    /// Stop the event propagating further.
+    pub stop_propagation: bool,
+    /// Command field name -> source.
+    pub sources: BTreeMap<String, Source>,
+}
+
+/// Why an `event!:` declaration could not be read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EventError {
+    /// No `type:`, or it was not text.
+    MissingType,
+    /// A `where:` entry's value was unreadable.
+    Source {
+        /// The command field the entry was for.
+        field: String,
+        /// What was wrong with it.
+        error: SourceError,
+    },
+}
+
+impl fmt::Display for EventError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            EventError::MissingType => {
+                write!(f, "event declaration has no `type:`")
+            }
+            EventError::Source { field, error } => {
+                write!(f, "source for `{field}`: {error}")
+            }
+        }
+    }
+}
+
+/// Build a descriptor from an event instance's already-projected
+/// fields: `type`, `prevent-default`, `stop-propagation`, and the
+/// `where` dictionary.
+pub fn event_descriptor(
+    event_type: Option<&str>,
+    prevent_default: bool,
+    stop_propagation: bool,
+    where_entries: impl IntoIterator<Item = (String, String)>,
+) -> Result<EventDescriptor, EventError> {
+    let event_type = event_type
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or(EventError::MissingType)?;
+
+    let mut sources = BTreeMap::new();
+    for (field, raw) in where_entries {
+        let source = parse_source(&raw).map_err(|error| EventError::Source {
+            field: field.clone(),
+            error,
+        })?;
+        sources.insert(field, source);
+    }
+
+    Ok(EventDescriptor {
+        event_type: event_type.to_string(),
+        prevent_default,
+        stop_propagation,
+        sources,
+    })
+}
+
+/// A command field an event cannot fill.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Unfilled {
+    /// The field's name on the command.
+    pub field: String,
+}
+
+/// A source naming a field the command does not declare.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Unknown {
+    /// The name the `where:` entry used.
+    pub field: String,
+}
+
+/// The result of checking an event declaration against a command.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Mismatch {
+    /// Required (`with:`) fields with no source. These are the ones
+    /// that make an interaction silently do nothing today.
+    pub unfilled: Vec<Unfilled>,
+    /// Sources for fields the command does not have. Usually a typo,
+    /// and harmless at runtime, which is why it is worth reporting.
+    pub unknown: Vec<Unknown>,
+}
+
+impl Mismatch {
+    /// True when nothing is wrong.
+    pub fn is_empty(&self) -> bool {
+        self.unfilled.is_empty() && self.unknown.is_empty()
+    }
+}
+
+/// Check that `event` can fill `command`.
+///
+/// `required` is the command's `with:` field names, `optional` its
+/// `maybe:` ones. This is the check that turns the guide's documented
+/// "no warn, but the rule didn't fire" into a diagnostic: it needs only
+/// the two declarations, not a resolvable source, so it works even
+/// though a `.path` is opaque text.
+pub fn check(
+    event: &EventDescriptor,
+    required: &BTreeSet<String>,
+    optional: &BTreeSet<String>,
+) -> Mismatch {
+    let mut mismatch = Mismatch::default();
+
+    for field in required {
+        if !event.sources.contains_key(field) {
+            mismatch.unfilled.push(Unfilled {
+                field: field.clone(),
+            });
+        }
+    }
+    for field in event.sources.keys() {
+        if !required.contains(field) && !optional.contains(field) {
+            mismatch.unknown.push(Unknown {
+                field: field.clone(),
+            });
+        }
+    }
+    mismatch
+}
+
+/// The attribute prefix that marks an event binding in a template.
+pub const ON_PREFIX: &str = "on:";
+
+/// The namespace every event declaration lives under.
+pub const ON_NAMESPACE: &str = "on/";
+
+/// Map a template attribute name to the event declaration it names.
+///
+/// `on:click` -> `on/click`. `/` is not a legal character in an HTML
+/// attribute name (the spec excludes space, `"`, `'`, `>`, `/`, `=`)
+/// while `:` is, so the identifier and the attribute differ by exactly
+/// this substitution.
+///
+/// Only the single `on:` prefix is reserved, which leaves `bind:base`,
+/// `xlink:href` and `xml:lang` alone — an attribute merely containing a
+/// colon is not a binding.
+pub fn event_name_for_attribute(attribute: &str) -> Option<String> {
+    let rest = attribute.strip_prefix(ON_PREFIX)?;
+    if rest.is_empty() || rest.contains(':') {
+        return None;
+    }
+    Some(format!("{ON_NAMESPACE}{rest}"))
+}
+
+/// The template attribute that would name `event_name`, for
+/// diagnostics that want to point at the source.
+pub fn attribute_for_event_name(event_name: &str) -> Option<String> {
+    let rest = event_name.strip_prefix(ON_NAMESPACE)?;
+    if rest.is_empty() {
+        return None;
+    }
+    Some(format!("{ON_PREFIX}{rest}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn required(names: &[&str]) -> BTreeSet<String> {
+        names.iter().map(|n| (*n).to_string()).collect()
+    }
+
+    #[test]
+    fn a_braced_name_is_a_field_read() {
+        assert_eq!(parse_source("{this}"), Ok(Source::Field("this".into())));
+        assert_eq!(parse_source(" {title} "), Ok(Source::Field("title".into())));
+        assert_eq!(
+            parse_source("{dom.host/repo}"),
+            Ok(Source::Field("dom.host/repo".into()))
+        );
+    }
+
+    #[test]
+    fn a_leading_dot_is_a_property_read() {
+        assert_eq!(
+            parse_source(".timeStamp"),
+            Ok(Source::Property(vec!["timeStamp".into()]))
+        );
+        assert_eq!(
+            parse_source(".currentTarget.dataset.todo"),
+            Ok(Source::Property(vec![
+                "currentTarget".into(),
+                "dataset".into(),
+                "todo".into()
+            ]))
+        );
+    }
+
+    #[test]
+    fn property_segments_are_verbatim() {
+        // The old identifier form kebab-cased then camel-cased, so
+        // `name="like-seed"` had to be looked up as `likeSeed` and a
+        // kebab control name silently failed. Written as JS spells it,
+        // there is no transformation to get wrong.
+        assert_eq!(
+            parse_source(".currentTarget.elements.noteBody.value"),
+            Ok(Source::Property(vec![
+                "currentTarget".into(),
+                "elements".into(),
+                "noteBody".into(),
+                "value".into()
+            ]))
+        );
+    }
+
+    #[test]
+    fn a_quoted_value_is_a_literal() {
+        assert_eq!(
+            parse_source("\"Untitled\""),
+            Ok(Source::Literal("Untitled".into()))
+        );
+        assert_eq!(parse_source("''"), Ok(Source::Literal(String::new())));
+    }
+
+    #[test]
+    fn a_bare_word_is_rejected_rather_than_guessed() {
+        // The whole point: `timeStamp` (missing its dot) must not be
+        // silently accepted as the literal string "timeStamp".
+        let error = parse_source("timeStamp").expect_err("bare word");
+        assert_eq!(error, SourceError::Bare("timeStamp".into()));
+        assert!(error.to_string().contains(".timeStamp"), "{error}");
+    }
+
+    #[test]
+    fn malformed_sources_are_named() {
+        assert_eq!(
+            parse_source("{this"),
+            Err(SourceError::MalformedField("{this".into()))
+        );
+        assert_eq!(
+            parse_source(".a..b"),
+            Err(SourceError::MalformedProperty(".a..b".into()))
+        );
+        assert_eq!(parse_source("   "), Err(SourceError::Empty));
+    }
+
+    #[test]
+    fn a_descriptor_needs_a_type() {
+        assert_eq!(
+            event_descriptor(None, false, false, []),
+            Err(EventError::MissingType)
+        );
+        assert_eq!(
+            event_descriptor(Some("  "), false, false, []),
+            Err(EventError::MissingType)
+        );
+    }
+
+    #[test]
+    fn a_bad_source_names_its_field() {
+        let error = event_descriptor(
+            Some("click"),
+            false,
+            false,
+            [("time".to_string(), "timeStamp".to_string())],
+        )
+        .expect_err("bare source");
+        let EventError::Source { field, .. } = &error else {
+            panic!("expected a source error, got {error:?}");
+        };
+        assert_eq!(field, "time");
+        assert!(error.to_string().contains("time"), "{error}");
+    }
+
+    #[test]
+    fn a_required_field_with_no_source_is_reported() {
+        // The failure this design exists to catch: today the command
+        // posts without `subject`, the rule's premise matches nothing,
+        // and the click is a silent no-op.
+        let event = event_descriptor(
+            Some("click"),
+            false,
+            false,
+            [("time".to_string(), ".timeStamp".to_string())],
+        )
+        .expect("descriptor");
+        let mismatch = check(&event, &required(&["subject", "time"]), &BTreeSet::new());
+        assert_eq!(
+            mismatch.unfilled,
+            vec![Unfilled {
+                field: "subject".into()
+            }]
+        );
+        assert!(mismatch.unknown.is_empty());
+    }
+
+    #[test]
+    fn an_optional_field_needs_no_source() {
+        let event = event_descriptor(
+            Some("click"),
+            false,
+            false,
+            [("subject".to_string(), "{this}".to_string())],
+        )
+        .expect("descriptor");
+        let mismatch = check(&event, &required(&["subject"]), &required(&["time"]));
+        assert!(mismatch.is_empty(), "{mismatch:?}");
+    }
+
+    #[test]
+    fn a_source_for_an_unknown_field_is_reported() {
+        let event = event_descriptor(
+            Some("click"),
+            false,
+            false,
+            [
+                ("subject".to_string(), "{this}".to_string()),
+                ("tiem".to_string(), ".timeStamp".to_string()),
+            ],
+        )
+        .expect("descriptor");
+        let mismatch = check(&event, &required(&["subject"]), &required(&["time"]));
+        assert_eq!(
+            mismatch.unknown,
+            vec![Unknown {
+                field: "tiem".into()
+            }]
+        );
+    }
+
+    #[test]
+    fn only_the_on_prefix_is_reserved() {
+        assert_eq!(
+            event_name_for_attribute("on:click").as_deref(),
+            Some("on/click")
+        );
+        assert_eq!(
+            event_name_for_attribute("on:createsheet").as_deref(),
+            Some("on/createsheet")
+        );
+        // Not bindings: an attribute merely containing a colon.
+        assert_eq!(event_name_for_attribute("bind:base"), None);
+        assert_eq!(event_name_for_attribute("xlink:href"), None);
+        assert_eq!(event_name_for_attribute("xml:lang"), None);
+        // Nor the legacy form, which keeps working through its own path.
+        assert_eq!(event_name_for_attribute("onclick"), None);
+        // Nor a nested name: `on/` is one flat namespace for now.
+        assert_eq!(event_name_for_attribute("on:table:createsheet"), None);
+        assert_eq!(event_name_for_attribute("on:"), None);
+    }
+
+    #[test]
+    fn attribute_and_event_name_round_trip() {
+        for attribute in ["on:click", "on:submit", "on:createsheet"] {
+            let name = event_name_for_attribute(attribute).expect("event name");
+            assert_eq!(attribute_for_event_name(&name).as_deref(), Some(attribute));
+        }
+        assert_eq!(attribute_for_event_name("increment"), None);
+    }
+}
+
+/// The event declarations a mounted template binds, indexed for
+/// dispatch.
+///
+/// A fired event knows only its platform type, and several
+/// declarations may share one — that is how a site-specific binding is
+/// expressed. So dispatch is: for the fired type, which of this
+/// element's attributes names a declaration of that type?
+#[derive(Debug, Clone, Default)]
+pub struct EventTable {
+    /// Declaration name (`on/click`) -> descriptor.
+    declarations: BTreeMap<String, EventDescriptor>,
+}
+
+/// One resolved binding: which declaration fired, and what it asserts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Binding<'a> {
+    /// The declaration's name, e.g. `on/click`.
+    pub event_name: &'a str,
+    /// The declaration.
+    pub event: &'a EventDescriptor,
+    /// The command the attribute's value named.
+    pub command: String,
+}
+
+impl EventTable {
+    /// Index a set of resolved declarations.
+    pub fn new(declarations: BTreeMap<String, EventDescriptor>) -> Self {
+        Self { declarations }
+    }
+
+    /// Look up one declaration.
+    pub fn get(&self, event_name: &str) -> Option<&EventDescriptor> {
+        self.declarations.get(event_name)
+    }
+
+    /// Every distinct platform event type to install a listener for.
+    ///
+    /// This is what closes the "which events does a template subscribe
+    /// to?" question without scanning the DOM: it falls out of the
+    /// declarations the view resolved.
+    pub fn event_types(&self) -> BTreeSet<String> {
+        self.declarations
+            .values()
+            .map(|event| event.event_type.clone())
+            .collect()
+    }
+
+    /// Resolve the binding for a fired `event_type` against one
+    /// element's attributes.
+    ///
+    /// `attributes` yields `(name, value)` pairs. Only `on:`-prefixed
+    /// names resolving to a declaration of the fired type match, so an
+    /// element carrying both `on:click=a` and `on:keydown=b` dispatches
+    /// each to the right command, and `bind:base` is never considered.
+    ///
+    /// When several attributes on one element qualify, the
+    /// lexicographically first declaration name wins, so dispatch does
+    /// not depend on DOM attribute order.
+    pub fn resolve<'a, I, N, V>(&'a self, event_type: &str, attributes: I) -> Option<Binding<'a>>
+    where
+        I: IntoIterator<Item = (N, V)>,
+        N: AsRef<str>,
+        V: AsRef<str>,
+    {
+        let mut best: Option<Binding<'a>> = None;
+        for (name, value) in attributes {
+            let Some(event_name) = event_name_for_attribute(name.as_ref()) else {
+                continue;
+            };
+            let Some((key, event)) = self.declarations.get_key_value(&event_name) else {
+                continue;
+            };
+            if event.event_type != event_type {
+                continue;
+            }
+            let command = value.as_ref().trim();
+            if command.is_empty() {
+                continue;
+            }
+            let candidate = Binding {
+                event_name: key.as_str(),
+                event,
+                command: command.to_string(),
+            };
+            if best
+                .as_ref()
+                .is_none_or(|b| candidate.event_name < b.event_name)
+            {
+                best = Some(candidate);
+            }
+        }
+        best
+    }
+}
+
+/// Assemble the `TransactRequest` body for one fired binding.
+///
+/// `descriptor` is the command's dialog descriptor and `parameters` the
+/// already-resolved field values — resolving a [`Source`] needs the
+/// live event and the rendered row, so it stays with the host, and
+/// everything after it is shared.
+///
+/// The wire shape matches what the `dom.event.*` path did, so the
+/// worker sees no difference between a command posted the old way and
+/// the new one. That is what lets templates migrate one at a time.
+pub fn transact_body(
+    descriptor: &serde_json::Value,
+    parameters: BTreeMap<String, serde_json::Value>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "claims": [{
+            "op": "assert",
+            "application": {
+                "predicate": {
+                    "kind": "transient",
+                    "concept": descriptor.clone(),
+                },
+                "parameters": parameters,
+            },
+        }],
+    })
+}
+
+#[cfg(test)]
+mod dispatch_tests {
+    use super::*;
+
+    fn event(event_type: &str, sources: &[(&str, &str)]) -> EventDescriptor {
+        event_descriptor(
+            Some(event_type),
+            false,
+            false,
+            sources
+                .iter()
+                .map(|(field, raw)| ((*field).to_string(), (*raw).to_string())),
+        )
+        .expect("descriptor")
+    }
+
+    fn table() -> EventTable {
+        EventTable::new(BTreeMap::from([
+            (
+                "on/click".to_string(),
+                event("click", &[("subject", "{this}")]),
+            ),
+            (
+                "on/click-once".to_string(),
+                event("click", &[("subject", "{this}"), ("time", ".timeStamp")]),
+            ),
+            (
+                "on/submit".to_string(),
+                event("submit", &[("subject", "{this}")]),
+            ),
+        ]))
+    }
+
+    #[test]
+    fn listener_types_come_from_the_declarations() {
+        // Deduplicated: two declarations share "click".
+        assert_eq!(
+            table().event_types(),
+            BTreeSet::from(["click".to_string(), "submit".to_string()])
+        );
+    }
+
+    #[test]
+    fn an_attribute_dispatches_to_its_command() {
+        let table = table();
+        let binding = table
+            .resolve("click", [("on:click", "increment")])
+            .expect("binding");
+        assert_eq!(binding.event_name, "on/click");
+        assert_eq!(binding.command, "increment");
+    }
+
+    #[test]
+    fn a_different_type_on_the_same_element_does_not_match() {
+        let table = table();
+        assert!(
+            table
+                .resolve("submit", [("on:click", "increment")])
+                .is_none()
+        );
+        let binding = table
+            .resolve("submit", [("on:click", "increment"), ("on:submit", "save")])
+            .expect("binding");
+        assert_eq!(binding.command, "save");
+    }
+
+    #[test]
+    fn declarations_sharing_a_type_stay_distinct() {
+        // Two declarations both read "click"; the attribute picks.
+        let table = table();
+        let binding = table
+            .resolve("click", [("on:click-once", "publish")])
+            .expect("binding");
+        assert_eq!(binding.event_name, "on/click-once");
+        assert!(binding.event.sources.contains_key("time"));
+    }
+
+    #[test]
+    fn non_event_attributes_are_never_considered() {
+        let table = table();
+        assert!(
+            table
+                .resolve(
+                    "click",
+                    [
+                        ("bind:base", "data-base"),
+                        ("xlink:href", "#x"),
+                        ("xml:lang", "en"),
+                        ("onclick", "legacy"),
+                        ("data-this", "id:1"),
+                    ]
+                )
+                .is_none(),
+            "only `on:` names bind"
+        );
+    }
+
+    #[test]
+    fn an_unresolvable_declaration_does_not_bind() {
+        // `on:hover` names no declaration; it must not fall through to
+        // some other binding on the element.
+        let table = table();
+        assert!(
+            table
+                .resolve("click", [("on:hover", "increment")])
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn an_empty_command_does_not_bind() {
+        let table = table();
+        assert!(table.resolve("click", [("on:click", "  ")]).is_none());
+    }
+
+    #[test]
+    fn dispatch_does_not_depend_on_attribute_order() {
+        let table = table();
+        let forward = table
+            .resolve("click", [("on:click", "a"), ("on:click-once", "b")])
+            .expect("binding");
+        let reverse = table
+            .resolve("click", [("on:click-once", "b"), ("on:click", "a")])
+            .expect("binding");
+        assert_eq!(forward, reverse);
+    }
+
+    #[test]
+    fn the_wire_shape_matches_the_legacy_path() {
+        // Byte-identical to what the `dom.event.*` extractor built, so
+        // the worker cannot tell which form posted the command — which
+        // is what makes migrating one template at a time safe.
+        let descriptor = serde_json::json!({ "with": { "subject": {} } });
+        let body = transact_body(
+            &descriptor,
+            BTreeMap::from([("subject".to_string(), serde_json::json!("did:key:zCounter"))]),
+        );
+        assert_eq!(body["claims"][0]["op"], serde_json::json!("assert"));
+        assert_eq!(
+            body["claims"][0]["application"]["predicate"]["kind"],
+            serde_json::json!("transient")
+        );
+        assert_eq!(
+            body["claims"][0]["application"]["predicate"]["concept"],
+            descriptor
+        );
+        assert_eq!(
+            body["claims"][0]["application"]["parameters"]["subject"],
+            serde_json::json!("did:key:zCounter")
+        );
+    }
+}

--- a/rust/tonk-template/src/event.rs
+++ b/rust/tonk-template/src/event.rs
@@ -54,8 +54,24 @@ pub enum Source {
     /// get wrong.
     Property(Vec<String>),
     /// `"text"` — a constant, for defaults the interaction never
-    /// supplies.
+    /// supplies. Quotes are load-bearing: a bare word is a
+    /// [`Source::Reference`], not a string.
     Literal(String),
+    /// A bare lowercase identifier — a reference to the entity the
+    /// symbol currently names, resolved through the name table.
+    ///
+    /// This is what a bare symbol means everywhere else in the
+    /// notation (`FieldValue::Symbol`), so it means the same here. A
+    /// misspelling is still caught, but by the language's own
+    /// mechanism: an unresolvable name is a diagnostic, so `timeStamp`
+    /// with its dot dropped fails to resolve rather than becoming the
+    /// literal string `"timeStamp"`.
+    Reference(String),
+    /// A reference already resolved to an entity URI. Not written by
+    /// hand — [`EventDescriptor::resolve_references`] produces it once
+    /// the host has consulted the name table, so the event-time path
+    /// never performs a lookup.
+    Entity(String),
 }
 
 /// Why a `where:` value could not be read as a [`Source`].
@@ -67,13 +83,6 @@ pub enum SourceError {
     MalformedField(String),
     /// A `.` path with an empty segment (`.a..b`, `.`, `a.`).
     MalformedProperty(String),
-    /// A bare word — neither `{field}`, nor `.path`, nor quoted.
-    ///
-    /// Rejected rather than guessed: `timeStamp` without its leading
-    /// dot would otherwise be silently taken as the literal string
-    /// `"timeStamp"`, which is exactly the class of typo this design
-    /// exists to catch.
-    Bare(String),
 }
 
 impl fmt::Display for SourceError {
@@ -86,11 +95,6 @@ impl fmt::Display for SourceError {
             SourceError::MalformedProperty(raw) => {
                 write!(f, "`{raw}` has an empty path segment")
             }
-            SourceError::Bare(raw) => write!(
-                f,
-                "`{raw}` is a bare word — write `.{raw}` to read it off the event, \
-                 `{{{raw}}}` to read a field, or `\"{raw}\"` for a literal"
-            ),
         }
     }
 }
@@ -135,7 +139,14 @@ pub fn parse_source(raw: &str) -> Result<Source, SourceError> {
         return Ok(Source::Literal(inner.to_string()));
     }
 
-    Err(SourceError::Bare(raw.to_string()))
+    // A scheme-prefixed URI is a direct entity reference, no lookup —
+    // matching `FieldValue::Uri` and the rule `<tonk-display>` already
+    // applies to its `entity` attribute.
+    if raw.contains(':') {
+        return Ok(Source::Entity(raw.to_string()));
+    }
+
+    Ok(Source::Reference(raw.to_string()))
 }
 
 /// A parsed `event!:` declaration.
@@ -153,6 +164,43 @@ pub struct EventDescriptor {
     pub stop_propagation: bool,
     /// Command field name -> source.
     pub sources: BTreeMap<String, Source>,
+}
+
+impl EventDescriptor {
+    /// Every bare-symbol reference this declaration makes, for the
+    /// host to resolve through the name table.
+    pub fn references(&self) -> BTreeSet<String> {
+        self.sources
+            .values()
+            .filter_map(|source| match source {
+                Source::Reference(name) => Some(name.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Rewrite resolved references into [`Source::Entity`], so the
+    /// event-time path never performs a name lookup.
+    ///
+    /// Returns the names that did not resolve. They are left as
+    /// references rather than dropped or guessed, so the caller can
+    /// report them — an unresolvable name is the typo case, and it
+    /// should be loud.
+    pub fn resolve_references(&mut self, resolved: &BTreeMap<String, String>) -> Vec<String> {
+        let mut unresolved = Vec::new();
+        for source in self.sources.values_mut() {
+            let Source::Reference(name) = source else {
+                continue;
+            };
+            match resolved.get(name) {
+                Some(entity) => *source = Source::Entity(entity.clone()),
+                None => unresolved.push(name.clone()),
+            }
+        }
+        unresolved.sort();
+        unresolved.dedup();
+        unresolved
+    }
 }
 
 /// Why an `event!:` declaration could not be read.
@@ -371,12 +419,90 @@ mod tests {
     }
 
     #[test]
-    fn a_bare_word_is_rejected_rather_than_guessed() {
-        // The whole point: `timeStamp` (missing its dot) must not be
-        // silently accepted as the literal string "timeStamp".
-        let error = parse_source("timeStamp").expect_err("bare word");
-        assert_eq!(error, SourceError::Bare("timeStamp".into()));
-        assert!(error.to_string().contains(".timeStamp"), "{error}");
+    fn a_bare_symbol_is_a_named_entity_reference() {
+        // What a bare symbol means everywhere else in the notation
+        // (`FieldValue::Symbol`): the entity the name currently refers
+        // to. Quotes are what make a value a string.
+        assert_eq!(
+            parse_source("counter"),
+            Ok(Source::Reference("counter".into()))
+        );
+        assert_eq!(
+            parse_source("\"counter\""),
+            Ok(Source::Literal("counter".into()))
+        );
+    }
+
+    #[test]
+    fn a_uri_is_a_direct_entity_reference() {
+        // `FieldValue::Uri`: scheme-prefixed, no name-table lookup.
+        assert_eq!(
+            parse_source("did:key:zCounter"),
+            Ok(Source::Entity("did:key:zCounter".into()))
+        );
+        assert_eq!(
+            parse_source("tonk:invite"),
+            Ok(Source::Entity("tonk:invite".into()))
+        );
+    }
+
+    #[test]
+    fn a_dropped_dot_still_fails_but_as_an_unresolvable_name() {
+        // `timeStamp` is no longer an error at parse time — it is a
+        // reference. The typo is still caught, by the language's own
+        // mechanism: nothing names it, so resolution reports it.
+        let source = parse_source("timeStamp").expect("a reference");
+        assert_eq!(source, Source::Reference("timeStamp".into()));
+
+        let event = event_descriptor(
+            Some("click"),
+            false,
+            false,
+            [("time".to_string(), "timeStamp".to_string())],
+        )
+        .expect("descriptor");
+        assert_eq!(
+            event.references(),
+            BTreeSet::from(["timeStamp".to_string()])
+        );
+    }
+
+    #[test]
+    fn resolving_references_rewrites_them_to_entities() {
+        let mut event = event_descriptor(
+            Some("click"),
+            false,
+            false,
+            [("subject".to_string(), "counter".to_string())],
+        )
+        .expect("descriptor");
+        let unresolved = event.resolve_references(&BTreeMap::from([(
+            "counter".to_string(),
+            "did:key:zCounter".to_string(),
+        )]));
+        assert!(unresolved.is_empty());
+        assert_eq!(
+            event.sources.get("subject"),
+            Some(&Source::Entity("did:key:zCounter".into()))
+        );
+    }
+
+    #[test]
+    fn an_unresolvable_reference_is_reported_not_dropped() {
+        let mut event = event_descriptor(
+            Some("click"),
+            false,
+            false,
+            [("time".to_string(), "timeStamp".to_string())],
+        )
+        .expect("descriptor");
+        let unresolved = event.resolve_references(&BTreeMap::new());
+        assert_eq!(unresolved, vec!["timeStamp".to_string()]);
+        // Left as a reference rather than silently becoming a value.
+        assert_eq!(
+            event.sources.get("time"),
+            Some(&Source::Reference("timeStamp".into()))
+        );
     }
 
     #[test]
@@ -406,17 +532,24 @@ mod tests {
 
     #[test]
     fn a_bad_source_names_its_field() {
+        // A malformed source — not a bare word, which is a reference —
+        // reports which field it was for.
         let error = event_descriptor(
             Some("click"),
             false,
             false,
-            [("time".to_string(), "timeStamp".to_string())],
+            [("time".to_string(), ".a..b".to_string())],
         )
-        .expect_err("bare source");
-        let EventError::Source { field, .. } = &error else {
+        .expect_err("malformed source");
+        let EventError::Source {
+            field,
+            error: inner,
+        } = &error
+        else {
             panic!("expected a source error, got {error:?}");
         };
         assert_eq!(field, "time");
+        assert_eq!(inner, &SourceError::MalformedProperty(".a..b".into()));
         assert!(error.to_string().contains("time"), "{error}");
     }
 

--- a/rust/tonk-template/src/event.rs
+++ b/rust/tonk-template/src/event.rs
@@ -76,74 +76,48 @@ pub enum Source {
     Entity(String),
 }
 
-/// Why a `where:` value could not be read as a [`Source`].
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SourceError {
-    /// Empty, or nothing but whitespace.
-    Empty,
-    /// `{` with no closing `}`, or text outside the braces.
-    MalformedField(String),
-    /// A `.` path with an empty segment (`.a..b`, `.`, `a.`).
-    MalformedProperty(String),
-    /// A blank, a logic variable, or a nested mapping — meaningful in
-    /// a claim body, but not a place a value can come from.
-    Unusable(String),
-}
-
-impl fmt::Display for SourceError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            SourceError::Empty => write!(f, "empty source"),
-            SourceError::MalformedField(raw) => {
-                write!(f, "`{raw}` is not a well-formed `{{field}}` reference")
-            }
-            SourceError::MalformedProperty(raw) => {
-                write!(f, "`{raw}` has an empty path segment")
-            }
-            SourceError::Unusable(raw) => {
-                write!(f, "`{raw}` is not a value a command field can read")
-            }
-        }
-    }
-}
-
 /// Read one `where:` value.
 ///
-/// Two forms are this grammar's own — `{field}` and `.path` — and
-/// neither can be mistaken for anything else: a symbol must start with
-/// a lowercase letter, so `{` and `.` are already excluded. Everything
-/// else is handed to the notation's own classifier
-/// ([`tonk_notation::parse::classify_plain_value`]) rather than
-/// re-implemented, so a value means here exactly what it means in any
-/// other field position — and cannot drift from it.
-pub fn parse_source(raw: &str) -> Result<Source, SourceError> {
+/// **Total, like the classifier it delegates to.** The notation never
+/// rejects a scalar in a value position — everything that is not a
+/// symbol, a URI or a typed scalar is a string — so neither does this.
+/// Adding failure modes here would make syntax the language accepts
+/// invalid, and (worse) one odd value would take its whole declaration
+/// down with it.
+///
+/// Two forms are this grammar's own, recognised only when well formed:
+///
+/// - `{field}` — template interpolation, in the scope of the element
+///   the event fired on. `{this}` is the subject.
+/// - `.path` — a property read off the live event, spelled the way the
+///   platform spells it.
+///
+/// A symbol cannot begin with `{` or `.`, so neither form can shadow
+/// one. Anything else — including a malformed `{this` or `.a..b` — is
+/// handed to [`tonk_notation::parse::classify_plain_value`] and means
+/// exactly what it would mean in any other field position.
+pub fn parse_source(raw: &str) -> Source {
     let raw = raw.trim();
-    if raw.is_empty() {
-        return Err(SourceError::Empty);
+
+    if let Some(name) = raw
+        .strip_prefix('{')
+        .and_then(|rest| rest.strip_suffix('}'))
+        .map(str::trim)
+        .filter(|name| !name.is_empty() && !name.contains(['{', '}']))
+    {
+        return Source::Field(name.to_string());
     }
 
-    if let Some(rest) = raw.strip_prefix('{') {
-        let Some(name) = rest.strip_suffix('}') else {
-            return Err(SourceError::MalformedField(raw.to_string()));
-        };
-        let name = name.trim();
-        if name.is_empty() || name.contains('{') || name.contains('}') {
-            return Err(SourceError::MalformedField(raw.to_string()));
-        }
-        return Ok(Source::Field(name.to_string()));
-    }
-
-    if let Some(rest) = raw.strip_prefix('.') {
+    if let Some(segments) = raw.strip_prefix('.').and_then(|rest| {
         let segments: Vec<String> = rest.split('.').map(str::to_string).collect();
-        if segments.iter().any(String::is_empty) {
-            return Err(SourceError::MalformedProperty(raw.to_string()));
-        }
-        return Ok(Source::Property(segments));
+        (!segments.iter().any(String::is_empty)).then_some(segments)
+    }) {
+        return Source::Property(segments);
     }
 
     // An explicitly quoted value is a literal. YAML normally strips the
-    // quotes long before this, which is fine: the classifier below
-    // decides by charset, not by quoting.
+    // quotes long before this, which is fine: the classifier decides by
+    // charset, not by quoting.
     if let Some(inner) = raw
         .strip_prefix('"')
         .and_then(|rest| rest.strip_suffix('"'))
@@ -152,17 +126,18 @@ pub fn parse_source(raw: &str) -> Result<Source, SourceError> {
                 .and_then(|rest| rest.strip_suffix('\''))
         })
     {
-        return Ok(Source::Literal(inner.to_string()));
+        return Source::Literal(inner.to_string());
     }
 
     match tonk_notation::parse::classify_plain_value(raw) {
-        FieldValue::Symbol(name) => Ok(Source::Reference(name)),
-        FieldValue::Uri(uri) => Ok(Source::Entity(uri)),
-        FieldValue::Literal(scalar) => Ok(Source::Literal(scalar_text(&scalar))),
-        // A blank, a logic variable or a nested mapping is meaningful
-        // in a claim body but says nothing about where a value comes
-        // from, so it is a malformed source rather than a silent skip.
-        _ => Err(SourceError::Unusable(raw.to_string())),
+        FieldValue::Symbol(name) => Source::Reference(name),
+        FieldValue::Uri(uri) => Source::Entity(uri),
+        FieldValue::Literal(scalar) => Source::Literal(scalar_text(&scalar)),
+        // A blank, a logic variable or a nested mapping says nothing
+        // about where a value comes from. Carried through as its own
+        // text rather than rejected: the field simply will not coerce,
+        // which fails the one binding instead of the declaration.
+        _ => Source::Literal(raw.to_string()),
     }
 }
 
@@ -175,9 +150,9 @@ fn scalar_text(scalar: &Scalar) -> String {
         Scalar::UnsignedInteger(value) => value.to_string(),
         Scalar::Float(value) => value.to_string(),
         Scalar::Boolean(value) => value.to_string(),
-        // `null` reads as "no value", which the runtime treats the
-        // same way it treats a blank control: the field is omitted and
-        // the command still posts.
+        // `null` reads as "no value", which the runtime treats the way
+        // it treats a blank control: the field is omitted, the command
+        // still posts.
         Scalar::Null => String::new(),
     }
 }
@@ -237,17 +212,14 @@ impl EventDescriptor {
 }
 
 /// Why an `event!:` declaration could not be read.
+///
+/// One variant, because a declaration with no `type:` genuinely cannot
+/// install a listener. A `where:` entry never fails — see
+/// [`parse_source`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EventError {
     /// No `type:`, or it was not text.
     MissingType,
-    /// A `where:` entry's value was unreadable.
-    Source {
-        /// The command field the entry was for.
-        field: String,
-        /// What was wrong with it.
-        error: SourceError,
-    },
 }
 
 impl fmt::Display for EventError {
@@ -255,9 +227,6 @@ impl fmt::Display for EventError {
         match self {
             EventError::MissingType => {
                 write!(f, "event declaration has no `type:`")
-            }
-            EventError::Source { field, error } => {
-                write!(f, "source for `{field}`: {error}")
             }
         }
     }
@@ -277,14 +246,13 @@ pub fn event_descriptor(
         .filter(|value| !value.is_empty())
         .ok_or(EventError::MissingType)?;
 
-    let mut sources = BTreeMap::new();
-    for (field, raw) in where_entries {
-        let source = parse_source(&raw).map_err(|error| EventError::Source {
-            field: field.clone(),
-            error,
-        })?;
-        sources.insert(field, source);
-    }
+    let sources = where_entries
+        .into_iter()
+        .map(|(field, raw)| {
+            let source = parse_source(&raw);
+            (field, source)
+        })
+        .collect();
 
     Ok(EventDescriptor {
         event_type: event_type.to_string(),
@@ -401,11 +369,11 @@ mod tests {
 
     #[test]
     fn a_braced_name_is_a_field_read() {
-        assert_eq!(parse_source("{this}"), Ok(Source::Field("this".into())));
-        assert_eq!(parse_source(" {title} "), Ok(Source::Field("title".into())));
+        assert_eq!(parse_source("{this}"), Source::Field("this".into()));
+        assert_eq!(parse_source(" {title} "), Source::Field("title".into()));
         assert_eq!(
             parse_source("{dom.host/repo}"),
-            Ok(Source::Field("dom.host/repo".into()))
+            Source::Field("dom.host/repo".into())
         );
     }
 
@@ -413,15 +381,15 @@ mod tests {
     fn a_leading_dot_is_a_property_read() {
         assert_eq!(
             parse_source(".timeStamp"),
-            Ok(Source::Property(vec!["timeStamp".into()]))
+            Source::Property(vec!["timeStamp".into()])
         );
         assert_eq!(
             parse_source(".currentTarget.dataset.todo"),
-            Ok(Source::Property(vec![
+            Source::Property(vec![
                 "currentTarget".into(),
                 "dataset".into(),
                 "todo".into()
-            ]))
+            ])
         );
     }
 
@@ -433,12 +401,12 @@ mod tests {
         // there is no transformation to get wrong.
         assert_eq!(
             parse_source(".currentTarget.elements.noteBody.value"),
-            Ok(Source::Property(vec![
+            Source::Property(vec![
                 "currentTarget".into(),
                 "elements".into(),
                 "noteBody".into(),
                 "value".into()
-            ]))
+            ])
         );
     }
 
@@ -446,9 +414,9 @@ mod tests {
     fn a_quoted_value_is_a_literal() {
         assert_eq!(
             parse_source("\"Untitled\""),
-            Ok(Source::Literal("Untitled".into()))
+            Source::Literal("Untitled".into())
         );
-        assert_eq!(parse_source("''"), Ok(Source::Literal(String::new())));
+        assert_eq!(parse_source("''"), Source::Literal(String::new()));
     }
 
     #[test]
@@ -456,23 +424,20 @@ mod tests {
         // What a bare symbol means everywhere else in the notation
         // (`FieldValue::Symbol`): the entity the name currently refers
         // to.
-        assert_eq!(
-            parse_source("counter"),
-            Ok(Source::Reference("counter".into()))
-        );
+        assert_eq!(parse_source("counter"), Source::Reference("counter".into()));
         // Kebab and digits are in the symbol charset.
         assert_eq!(
             parse_source("person-name2"),
-            Ok(Source::Reference("person-name2".into()))
+            Source::Reference("person-name2".into())
         );
         // A `/`-qualified symbol is still a name lookup, not a URI.
         assert_eq!(
             parse_source("issue/title"),
-            Ok(Source::Reference("issue/title".into()))
+            Source::Reference("issue/title".into())
         );
         assert_eq!(
             parse_source("\"counter\""),
-            Ok(Source::Literal("counter".into()))
+            Source::Literal("counter".into())
         );
     }
 
@@ -483,14 +448,14 @@ mod tests {
         // distinction survives YAML stripping the quotes.
         for text in ["Untitled", "timeStamp", "two words", "9lives", "TEXT"] {
             assert!(
-                matches!(parse_source(text), Ok(Source::Literal(_))),
+                matches!(parse_source(text), Source::Literal(_)),
                 "`{text}` must classify as a literal, got {:?}",
                 parse_source(text)
             );
         }
         for text in ["untitled", "time-stamp", "a", "space/route/view"] {
             assert!(
-                matches!(parse_source(text), Ok(Source::Reference(_))),
+                matches!(parse_source(text), Source::Reference(_)),
                 "`{text}` must classify as a reference, got {:?}",
                 parse_source(text)
             );
@@ -501,8 +466,8 @@ mod tests {
     fn yaml_typed_scalars_are_literals() {
         // A plain `28` is an integer, not a symbol — the classifier
         // takes YAML's core schema before the symbol test.
-        assert_eq!(parse_source("28"), Ok(Source::Literal("28".into())));
-        assert_eq!(parse_source("true"), Ok(Source::Literal("true".into())));
+        assert_eq!(parse_source("28"), Source::Literal("28".into()));
+        assert_eq!(parse_source("true"), Source::Literal("true".into()));
     }
 
     #[test]
@@ -511,15 +476,15 @@ mod tests {
         // and a dotted domain with a name. No name-table lookup.
         assert_eq!(
             parse_source("did:key:zCounter"),
-            Ok(Source::Entity("did:key:zCounter".into()))
+            Source::Entity("did:key:zCounter".into())
         );
         assert_eq!(
             parse_source("tonk:invite"),
-            Ok(Source::Entity("tonk:invite".into()))
+            Source::Entity("tonk:invite".into())
         );
         assert_eq!(
             parse_source("io.gozala.issue/title"),
-            Ok(Source::Entity("io.gozala.issue/title".into()))
+            Source::Entity("io.gozala.issue/title".into())
         );
     }
 
@@ -562,16 +527,43 @@ mod tests {
     }
 
     #[test]
-    fn malformed_sources_are_named() {
+    fn parsing_a_source_never_fails() {
+        // The contract: the notation accepts any scalar in a value
+        // position, so this must too. A malformed `{field}` or `.path`
+        // is not an error — it is simply not that form, and falls
+        // through to the classifier like anything else. Rejecting here
+        // would make syntax the language accepts invalid, and would
+        // take a whole declaration down over one odd value.
+        assert_eq!(parse_source("{this"), Source::Literal("{this".into()));
+        assert_eq!(parse_source(".a..b"), Source::Literal(".a..b".into()));
+        assert_eq!(parse_source("{}"), Source::Literal("{}".into()));
+        assert_eq!(parse_source("   "), Source::Literal(String::new()));
+        assert_eq!(parse_source("_"), Source::Literal("_".into()));
+        assert_eq!(parse_source("?var"), Source::Literal("?var".into()));
+    }
+
+    #[test]
+    fn a_declaration_survives_an_odd_source() {
+        // One unusable value must not cost the other bindings on the
+        // same declaration.
+        let event = event_descriptor(
+            Some("click"),
+            false,
+            false,
+            [
+                ("subject".to_string(), "{this}".to_string()),
+                ("time".to_string(), "{oops".to_string()),
+            ],
+        )
+        .expect("descriptor");
         assert_eq!(
-            parse_source("{this"),
-            Err(SourceError::MalformedField("{this".into()))
+            event.sources.get("subject"),
+            Some(&Source::Field("this".into()))
         );
         assert_eq!(
-            parse_source(".a..b"),
-            Err(SourceError::MalformedProperty(".a..b".into()))
+            event.sources.get("time"),
+            Some(&Source::Literal("{oops".into()))
         );
-        assert_eq!(parse_source("   "), Err(SourceError::Empty));
     }
 
     #[test]
@@ -584,29 +576,6 @@ mod tests {
             event_descriptor(Some("  "), false, false, []),
             Err(EventError::MissingType)
         );
-    }
-
-    #[test]
-    fn a_bad_source_names_its_field() {
-        // A malformed source — not a bare word, which is a reference —
-        // reports which field it was for.
-        let error = event_descriptor(
-            Some("click"),
-            false,
-            false,
-            [("time".to_string(), ".a..b".to_string())],
-        )
-        .expect_err("malformed source");
-        let EventError::Source {
-            field,
-            error: inner,
-        } = &error
-        else {
-            panic!("expected a source error, got {error:?}");
-        };
-        assert_eq!(field, "time");
-        assert_eq!(inner, &SourceError::MalformedProperty(".a..b".into()));
-        assert!(error.to_string().contains("time"), "{error}");
     }
 
     #[test]

--- a/rust/tonk-template/src/event.rs
+++ b/rust/tonk-template/src/event.rs
@@ -40,6 +40,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
+use tonk_notation::syntax::{FieldValue, Scalar};
+
 /// Where one command field's value comes from.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Source {
@@ -83,6 +85,9 @@ pub enum SourceError {
     MalformedField(String),
     /// A `.` path with an empty segment (`.a..b`, `.`, `a.`).
     MalformedProperty(String),
+    /// A blank, a logic variable, or a nested mapping — meaningful in
+    /// a claim body, but not a place a value can come from.
+    Unusable(String),
 }
 
 impl fmt::Display for SourceError {
@@ -95,11 +100,22 @@ impl fmt::Display for SourceError {
             SourceError::MalformedProperty(raw) => {
                 write!(f, "`{raw}` has an empty path segment")
             }
+            SourceError::Unusable(raw) => {
+                write!(f, "`{raw}` is not a value a command field can read")
+            }
         }
     }
 }
 
 /// Read one `where:` value.
+///
+/// Two forms are this grammar's own — `{field}` and `.path` — and
+/// neither can be mistaken for anything else: a symbol must start with
+/// a lowercase letter, so `{` and `.` are already excluded. Everything
+/// else is handed to the notation's own classifier
+/// ([`tonk_notation::parse::classify_plain_value`]) rather than
+/// re-implemented, so a value means here exactly what it means in any
+/// other field position — and cannot drift from it.
 pub fn parse_source(raw: &str) -> Result<Source, SourceError> {
     let raw = raw.trim();
     if raw.is_empty() {
@@ -125,9 +141,9 @@ pub fn parse_source(raw: &str) -> Result<Source, SourceError> {
         return Ok(Source::Property(segments));
     }
 
-    // A quoted value is a literal. YAML usually strips the quotes
-    // before we see the string, so an already-unquoted literal is
-    // accepted only in that form; everything else is a bare word.
+    // An explicitly quoted value is a literal. YAML normally strips the
+    // quotes long before this, which is fine: the classifier below
+    // decides by charset, not by quoting.
     if let Some(inner) = raw
         .strip_prefix('"')
         .and_then(|rest| rest.strip_suffix('"'))
@@ -139,14 +155,31 @@ pub fn parse_source(raw: &str) -> Result<Source, SourceError> {
         return Ok(Source::Literal(inner.to_string()));
     }
 
-    // A scheme-prefixed URI is a direct entity reference, no lookup —
-    // matching `FieldValue::Uri` and the rule `<tonk-display>` already
-    // applies to its `entity` attribute.
-    if raw.contains(':') {
-        return Ok(Source::Entity(raw.to_string()));
+    match tonk_notation::parse::classify_plain_value(raw) {
+        FieldValue::Symbol(name) => Ok(Source::Reference(name)),
+        FieldValue::Uri(uri) => Ok(Source::Entity(uri)),
+        FieldValue::Literal(scalar) => Ok(Source::Literal(scalar_text(&scalar))),
+        // A blank, a logic variable or a nested mapping is meaningful
+        // in a claim body but says nothing about where a value comes
+        // from, so it is a malformed source rather than a silent skip.
+        _ => Err(SourceError::Unusable(raw.to_string())),
     }
+}
 
-    Ok(Source::Reference(raw.to_string()))
+/// A literal scalar as the text the runtime coerces to the field's
+/// declared type.
+fn scalar_text(scalar: &Scalar) -> String {
+    match scalar {
+        Scalar::String(text) => text.clone(),
+        Scalar::Integer(value) => value.to_string(),
+        Scalar::UnsignedInteger(value) => value.to_string(),
+        Scalar::Float(value) => value.to_string(),
+        Scalar::Boolean(value) => value.to_string(),
+        // `null` reads as "no value", which the runtime treats the
+        // same way it treats a blank control: the field is omitted and
+        // the command still posts.
+        Scalar::Null => String::new(),
+    }
 }
 
 /// A parsed `event!:` declaration.
@@ -422,10 +455,20 @@ mod tests {
     fn a_bare_symbol_is_a_named_entity_reference() {
         // What a bare symbol means everywhere else in the notation
         // (`FieldValue::Symbol`): the entity the name currently refers
-        // to. Quotes are what make a value a string.
+        // to.
         assert_eq!(
             parse_source("counter"),
             Ok(Source::Reference("counter".into()))
+        );
+        // Kebab and digits are in the symbol charset.
+        assert_eq!(
+            parse_source("person-name2"),
+            Ok(Source::Reference("person-name2".into()))
+        );
+        // A `/`-qualified symbol is still a name lookup, not a URI.
+        assert_eq!(
+            parse_source("issue/title"),
+            Ok(Source::Reference("issue/title".into()))
         );
         assert_eq!(
             parse_source("\"counter\""),
@@ -434,8 +477,38 @@ mod tests {
     }
 
     #[test]
+    fn the_symbol_charset_decides_symbol_from_string() {
+        // Symbols are lowercase, start with a letter, and hold no
+        // spaces. Anything else is a string — which is why the
+        // distinction survives YAML stripping the quotes.
+        for text in ["Untitled", "timeStamp", "two words", "9lives", "TEXT"] {
+            assert!(
+                matches!(parse_source(text), Ok(Source::Literal(_))),
+                "`{text}` must classify as a literal, got {:?}",
+                parse_source(text)
+            );
+        }
+        for text in ["untitled", "time-stamp", "a", "space/route/view"] {
+            assert!(
+                matches!(parse_source(text), Ok(Source::Reference(_))),
+                "`{text}` must classify as a reference, got {:?}",
+                parse_source(text)
+            );
+        }
+    }
+
+    #[test]
+    fn yaml_typed_scalars_are_literals() {
+        // A plain `28` is an integer, not a symbol — the classifier
+        // takes YAML's core schema before the symbol test.
+        assert_eq!(parse_source("28"), Ok(Source::Literal("28".into())));
+        assert_eq!(parse_source("true"), Ok(Source::Literal("true".into())));
+    }
+
+    #[test]
     fn a_uri_is_a_direct_entity_reference() {
-        // `FieldValue::Uri`: scheme-prefixed, no name-table lookup.
+        // `FieldValue::Uri`, both accepted shapes: scheme-prefixed,
+        // and a dotted domain with a name. No name-table lookup.
         assert_eq!(
             parse_source("did:key:zCounter"),
             Ok(Source::Entity("did:key:zCounter".into()))
@@ -444,26 +517,9 @@ mod tests {
             parse_source("tonk:invite"),
             Ok(Source::Entity("tonk:invite".into()))
         );
-    }
-
-    #[test]
-    fn a_dropped_dot_still_fails_but_as_an_unresolvable_name() {
-        // `timeStamp` is no longer an error at parse time — it is a
-        // reference. The typo is still caught, by the language's own
-        // mechanism: nothing names it, so resolution reports it.
-        let source = parse_source("timeStamp").expect("a reference");
-        assert_eq!(source, Source::Reference("timeStamp".into()));
-
-        let event = event_descriptor(
-            Some("click"),
-            false,
-            false,
-            [("time".to_string(), "timeStamp".to_string())],
-        )
-        .expect("descriptor");
         assert_eq!(
-            event.references(),
-            BTreeSet::from(["timeStamp".to_string()])
+            parse_source("io.gozala.issue/title"),
+            Ok(Source::Entity("io.gozala.issue/title".into()))
         );
     }
 
@@ -493,15 +549,15 @@ mod tests {
             Some("click"),
             false,
             false,
-            [("time".to_string(), "timeStamp".to_string())],
+            [("subject".to_string(), "counter".to_string())],
         )
         .expect("descriptor");
         let unresolved = event.resolve_references(&BTreeMap::new());
-        assert_eq!(unresolved, vec!["timeStamp".to_string()]);
+        assert_eq!(unresolved, vec!["counter".to_string()]);
         // Left as a reference rather than silently becoming a value.
         assert_eq!(
-            event.sources.get("time"),
-            Some(&Source::Reference("timeStamp".into()))
+            event.sources.get("subject"),
+            Some(&Source::Reference("counter".into()))
         );
     }
 

--- a/rust/tonk-template/src/lib.rs
+++ b/rust/tonk-template/src/lib.rs
@@ -31,6 +31,7 @@ use std::collections::BTreeMap;
 
 use ipld_core::ipld::Ipld;
 
+pub mod event;
 pub mod fold;
 pub mod resolve;
 

--- a/rust/tonk-template/src/resolve.rs
+++ b/rust/tonk-template/src/resolve.rs
@@ -42,6 +42,78 @@ pub fn view_query(model_entity: &str) -> Result<Query, serde_json::Error> {
     serde_json::from_value(json!({ "terms": terms, "predicate": view_predicate() }))
 }
 
+/// The `event` concept's shape, kept in step with the declaration
+/// pinned to `tonk:event` in the standard library.
+///
+/// `where` is a keyed collection like `view`'s `show`, so each source
+/// lands as its own fact (`xyz.tonk.event.where/<field>`) with
+/// cardinality one — a space can supersede one source without
+/// restating the map. Its own domain, so a command field called `type`
+/// cannot collide with the `type` attribute.
+pub fn event_predicate() -> Value {
+    json!({
+        "with": {
+            "type": {
+                "the": "xyz.tonk.event/type",
+                "as": "Text",
+                "cardinality": "one"
+            },
+            "where": {
+                "the": { "domain": "xyz.tonk.event.where", "keyed": "dictionary" },
+                "as": "Text",
+                "cardinality": "one"
+            }
+        }
+    })
+}
+
+/// Build the query that reads one `event!:` declaration: its `type`
+/// and every entry of its `where` map.
+///
+/// The optional `prevent-default` / `stop-propagation` markers are
+/// deliberately absent: they are `maybe:` fields, so pinning them here
+/// would make a declaration that omits them match nothing. They are
+/// read separately ([`event_flags_query`]).
+pub fn event_query(event_entity: &str) -> Result<Query, serde_json::Error> {
+    let mut terms: IndexMap<String, Value> = IndexMap::new();
+    terms.insert("this".into(), json!(event_entity));
+    terms.insert("type".into(), json!({ "?": { "name": "type" } }));
+    terms.insert("where".into(), json!({ "?": { "name": "where" } }));
+    terms.insert("where/key".into(), json!({ "?": { "name": "where/key" } }));
+    serde_json::from_value(json!({ "terms": terms, "predicate": event_predicate() }))
+}
+
+/// Build the query that reads a declaration's optional side-effect
+/// flags. Separate from [`event_query`] because an `event!:` that
+/// declares neither must still resolve.
+pub fn event_flags_query(event_entity: &str) -> Result<Query, serde_json::Error> {
+    let predicate = json!({
+        "with": {
+            "prevent-default": {
+                "the": "xyz.tonk.event/prevent-default",
+                "as": "Boolean",
+                "cardinality": "one"
+            },
+            "stop-propagation": {
+                "the": "xyz.tonk.event/stop-propagation",
+                "as": "Boolean",
+                "cardinality": "one"
+            }
+        }
+    });
+    let mut terms: IndexMap<String, Value> = IndexMap::new();
+    terms.insert("this".into(), json!(event_entity));
+    terms.insert(
+        "prevent-default".into(),
+        json!({ "?": { "name": "prevent-default" } }),
+    );
+    terms.insert(
+        "stop-propagation".into(),
+        json!({ "?": { "name": "stop-propagation" } }),
+    );
+    serde_json::from_value(json!({ "terms": terms, "predicate": predicate }))
+}
+
 /// Whether a `with:` entry declares a keyed collection: its `the` is a
 /// `{domain, keyed}` object rather than an attribute string.
 ///

--- a/rust/tonk-template/src/resolve.rs
+++ b/rust/tonk-template/src/resolve.rs
@@ -42,8 +42,13 @@ pub fn view_query(model_entity: &str) -> Result<Query, serde_json::Error> {
     serde_json::from_value(json!({ "terms": terms, "predicate": view_predicate() }))
 }
 
-/// The `event` concept's shape, kept in step with the declaration
-/// pinned to `tonk:event` in the standard library.
+/// The `event` concept's shape, kept in step with the built-in
+/// registered as `event` in `tonk_schema::builtin`.
+///
+/// A hand-mirrored copy for the same reason [`view_predicate`] is one:
+/// this crate builds wire queries as JSON and does not go through the
+/// descriptor types. The built-in is the source of truth; the parity
+/// test in `tonk-worker` is what keeps the two honest.
 ///
 /// `where` is a keyed collection like `view`'s `show`, so each source
 /// lands as its own fact (`xyz.tonk.event.where/<field>`) with

--- a/rust/tonk-ui/src/account_flow.rs
+++ b/rust/tonk-ui/src/account_flow.rs
@@ -2543,7 +2543,7 @@ mod tests {
                             "description": "Ask whether an address is registered.",
                             "with": {
                                 "email": {
-                                    "the": "dom.event.current-target.elements.email/value",
+                                    "the": "xyz.tonk.command.check-email/email",
                                     "as": "Text"
                                 }
                             }
@@ -6227,8 +6227,8 @@ mod tests {
                             "concept": {
                                 "description": "A request to create a new space from the wizard form.",
                                 "with": {
-                                    "name":     { "the": "dom.event.current-target.elements.name/value", "as": "Text" },
-                                    "remote":   { "the": "dom.event.current-target.elements.remote/value", "as": "Text" }
+                                    "name":   { "the": "xyz.tonk.command.create-space/name", "as": "Text" },
+                                    "remote": { "the": "xyz.tonk.command.create-space/remote", "as": "Text" }
                                 }
                             }
                         },

--- a/rust/tonk-ui/src/register_dialog.rs
+++ b/rust/tonk-ui/src/register_dialog.rs
@@ -1167,30 +1167,32 @@ pub(crate) fn is_plausible(email: &str) -> bool {
 
 /// The `account/check-email` claim, in the shape the command decodes.
 pub(crate) fn check_email_claim(email: &str) -> serde_json::Value {
-    claim("Ask whether an address is registered.", email)
+    claim(
+        "Ask whether an address is registered.",
+        "xyz.tonk.command.check-email/email",
+        email,
+    )
 }
 /// The `account/register` claim.
 #[cfg(test)]
 pub(crate) fn register_claim(email: &str) -> serde_json::Value {
-    let mut claim = claim("Register an account for this address.", email);
-    // The marker is what makes this a REGISTRATION and not a lookup.
-    // Both carry `{this, email}`, and decode does not consider concept
-    // identity — so without it every keystroke's `check-email` also
-    // decoded as `account/register`, and a passkey prompt appeared
-    // while the user was still typing.
-    claim["claims"][0]["application"]["predicate"]["concept"]["with"]["marker"] = serde_json::json!({
-        "the": "dom.event.current-target.dataset/register-account",
-        "as": "Entity"
-    });
-    claim["claims"][0]["application"]["parameters"]["marker"] =
-        serde_json::json!(tonk_schema::command::RegisterAccount::MARKER);
-    claim
+    claim(
+        "Register an account for this address.",
+        "xyz.tonk.command.register-account/email",
+        email,
+    )
 }
 
-/// The two commands read one field from the same read-path. A distinct
-/// description mints a distinct command entity, but that alone does not
-/// keep them apart at decode — see [`register_claim`].
-fn claim(description: &str, email: &str) -> serde_json::Value {
+/// One field, but under the asking command's own attribute — which is
+/// what keeps a lookup and a registration apart.
+///
+/// They were once the same shape `{this, email}` reading one shared DOM
+/// path, and decode does not consider concept identity, so every
+/// keystroke's `check-email` also decoded as `account/register` and a
+/// passkey prompt appeared while the user was still typing. A marker
+/// attribute patched that. Separate namespaces make the shapes disjoint,
+/// so there is nothing left to patch.
+fn claim(description: &str, attribute: &str, email: &str) -> serde_json::Value {
     serde_json::json!({
         "claims": [{
             "op": "assert",
@@ -1200,10 +1202,7 @@ fn claim(description: &str, email: &str) -> serde_json::Value {
                     "concept": {
                         "description": description,
                         "with": {
-                            "email": {
-                                "the": "dom.event.current-target.elements.email/value",
-                                "as": "Text"
-                            }
+                            "email": { "the": attribute, "as": "Text" }
                         }
                     }
                 },
@@ -2088,12 +2087,11 @@ fn profile_rename_claim(name: &str) -> serde_json::Value {
                     "concept": {
                         "description": "Rename the signed-in member (set their display name).",
                         "with": {
-                            "name":   { "the": "dom.event.current-target/value", "as": "Text" },
-                            "marker": { "the": "dom.event.current-target.dataset/rename", "as": "Entity" }
+                            "name": { "the": "xyz.tonk.command.profile-rename/name", "as": "Text" }
                         }
                     }
                 },
-                "parameters": { "name": name, "marker": "tonk:profile" }
+                "parameters": { "name": name }
             }
         }]
     })
@@ -2119,21 +2117,16 @@ pub(crate) fn enable_sync_claim(space: &str, time: f64) -> serde_json::Value {
                     "concept": {
                         "description": "Attach a sync remote to a space, and share it.",
                         "with": {
-                            "time": { "the": "dom.event/time-stamp", "as": "Float" },
+                            "time": { "the": "xyz.tonk.command.enable-sync/time", "as": "Float" },
                             "space": { "the": "xyz.tonk.enable-sync/space", "as": "Entity" },
-                            "share": { "the": "xyz.tonk.enable-sync/share", "as": "Entity" },
-                            "marker": {
-                                "the": "dom.event.current-target.dataset/enable-sync",
-                                "as": "Entity"
-                            }
+                            "share": { "the": "xyz.tonk.enable-sync/share", "as": "Entity" }
                         }
                     }
                 },
                 "parameters": {
                     "time": time,
                     "space": space,
-                    "share": "tonk:share",
-                    "marker": "tonk:enable-sync"
+                    "share": "tonk:share"
                 }
             }
         }]
@@ -2574,33 +2567,43 @@ mod tests {
 
     /// A lookup must not also decode as a registration.
     ///
-    /// `CheckEmail` and `RegisterAccount` are both `{this, email}`, and
-    /// decode does not consider concept identity — so before the marker,
-    /// every keystroke's lookup ALSO fired the register handler, and a
-    /// passkey prompt appeared while the user was still typing.
+    /// The two were both `{this, email}` reading one shared DOM path, and
+    /// decode does not consider concept identity — so every keystroke's
+    /// lookup ALSO fired the register handler, and a passkey prompt
+    /// appeared while the user was still typing. A marker attribute
+    /// patched that. What keeps them apart now is that each names its own
+    /// attribute, so the shapes are disjoint by construction and neither
+    /// claim carries a marker at all.
     #[dialog_common::test]
-    fn it_marks_a_registration_so_a_lookup_cannot_be_mistaken_for_one() {
+    fn a_lookup_cannot_be_mistaken_for_a_registration() {
         let lookup = check_email_claim("someone@example.com");
         let register = register_claim("someone@example.com");
 
-        let marker_of = |claim: &serde_json::Value| {
-            claim["claims"][0]["application"]["parameters"]["marker"].clone()
+        let attribute = |claim: &serde_json::Value| {
+            claim["claims"][0]["application"]["predicate"]["concept"]["with"]["email"]["the"]
+                .as_str()
+                .expect("the claim declares its email attribute")
+                .to_string()
         };
-        assert!(
-            marker_of(&lookup).is_null(),
-            "a lookup carries no marker: {lookup}",
-        );
+        assert_eq!(attribute(&lookup), "xyz.tonk.command.check-email/email");
         assert_eq!(
-            marker_of(&register),
-            serde_json::json!(tonk_schema::command::RegisterAccount::MARKER),
-            "a registration is the only one that does",
+            attribute(&register),
+            "xyz.tonk.command.register-account/email"
+        );
+        assert_ne!(
+            attribute(&lookup),
+            attribute(&register),
+            "one shared attribute is what made every keystroke a registration",
         );
 
-        // The declared field must be there too, or the marker never
-        // becomes a fact the handler can match on.
-        let declared =
-            &register["claims"][0]["application"]["predicate"]["concept"]["with"]["marker"];
-        assert_eq!(declared["as"], "Entity", "a `:`-bearing value is an entity");
+        for claim in [&lookup, &register] {
+            assert!(
+                claim["claims"][0]["application"]["parameters"]
+                    .get("marker")
+                    .is_none(),
+                "the namespace does the separating; no marker is needed: {claim}",
+            );
+        }
     }
 
     use super::*;

--- a/rust/tonk-ui/src/register_dialog.rs
+++ b/rust/tonk-ui/src/register_dialog.rs
@@ -2664,19 +2664,21 @@ mod tests {
         );
     }
 
-    /// Both claims name the read-path the commands decode, and differ
-    /// so each mints its own command entity.
+    /// Each claim names the attribute its own command decodes, and the
+    /// two are different attributes — which is what keeps a lookup from
+    /// also decoding as a registration.
     #[dialog_common::test]
     fn it_builds_claims_the_commands_decode() {
         let check = check_email_claim("jsmith@example.com").to_string();
-        assert!(check.contains("dom.event.current-target.elements.email/value"));
+        assert!(check.contains("xyz.tonk.command.check-email/email"));
         assert!(check.contains("jsmith@example.com"));
 
         let register = register_claim("jsmith@example.com").to_string();
-        assert!(register.contains("dom.event.current-target.elements.email/value"));
-        assert_ne!(
-            check, register,
-            "the descriptions differ, so the two commands are distinct transients",
+        assert!(register.contains("xyz.tonk.command.register-account/email"));
+        assert!(
+            !register.contains("xyz.tonk.command.check-email/email"),
+            "a registration must not carry the lookup's attribute",
         );
+        assert_ne!(check, register, "the two commands are distinct transients",);
     }
 }

--- a/rust/tonk-worker-api/src/lib.rs
+++ b/rust/tonk-worker-api/src/lib.rs
@@ -80,6 +80,11 @@ pub use sync::{
 /// The inline `with:` block must stay identical to the descriptor in
 /// `profile.yaml`, or the transient mints a different entity and no
 /// handler fires.
+///
+/// The attribute is the command's own (`xyz.tonk.command.create-space/name`),
+/// not the DOM read path that used to fill it. A branch seeded before that
+/// change still asserts the old path; the worker's handler accepts both and
+/// converts (`tonk_schema::command::legacy::CreateSpace`).
 pub fn create_space_claim_json(name: &str) -> Value {
     json!({
         "claims": [{
@@ -90,7 +95,7 @@ pub fn create_space_claim_json(name: &str) -> Value {
                     "concept": {
                         "description": "A request to create a new space.",
                         "with": {
-                            "name": { "the": "dom.event.current-target.elements.name/value", "as": "Text" }
+                            "name": { "the": "xyz.tonk.command.create-space/name", "as": "Text" }
                         }
                     }
                 },

--- a/rust/tonk-worker/Cargo.toml
+++ b/rust/tonk-worker/Cargo.toml
@@ -121,6 +121,7 @@ getrandom = { workspace = true, features = ["wasm_js"] }
 getrandom_0_3 = { workspace = true }
 
 [dev-dependencies]
+tonk-template = { workspace = true }
 anyhow = { workspace = true }
 dialog-common = { workspace = true, features = ["helpers"] }
 dialog-operator = { workspace = true, features = ["helpers"] }

--- a/rust/tonk-worker/src/router.rs
+++ b/rust/tonk-worker/src/router.rs
@@ -1466,14 +1466,19 @@ pub mod tests {
             "claims": [{
                 "op": "assert",
                 "application": {
+                    // Deliberately the DEPRECATED shape — the DOM read paths,
+                    // the marker that used to keep `tonk:invite` apart from
+                    // pause-sync, and `prevent-default` as a field. A branch
+                    // seeded before the migration still posts exactly this, so
+                    // this request is the backwards-compatibility test: it must
+                    // keep reaching the handler through
+                    // `tonk_schema::command::legacy::Invite`.
                     "parameters": { "time": 1, "marker": "tonk:invite" },
                     "predicate": { "kind": "transient", "concept": {
                         "description": "Mint a repo invite — generates a membership keypair and delegation.",
                         "with": {
                             "time": { "as": "Float", "cardinality": "one", "description": "",
                                 "the": "dom.event/time-stamp" },
-                            // Per-command marker — distinguishes `tonk:invite`
-                            // from other same-shape commands (e.g. pause-sync).
                             "marker": { "as": "Entity", "cardinality": "one", "description": "",
                                 "the": "dom.event.current-target.dataset/invite" },
                             "prevent-default": { "cardinality": "one", "description": "",
@@ -1604,6 +1609,8 @@ pub mod tests {
                         "time": 1,
                         "marker": "tonk:enable-sync"
                     },
+                    // Also the DEPRECATED shape, for the same reason as the
+                    // invite request above.
                     "predicate": { "kind": "transient", "concept": {
                         "description": "Attach a remote and mint an invite.",
                         "with": {

--- a/rust/tonk-worker/src/router/ceremony.rs
+++ b/rust/tonk-worker/src/router/ceremony.rs
@@ -85,15 +85,19 @@ pub(crate) async fn ask_for_passkey(
 /// `tonk:add-passkey`: seal the account under a second passkey.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) struct AddPasskeyHandler {
-    attributes: Vec<String>,
+    /// Decodes the current shape, and the deprecated one a
+    /// branch seeded before the migration still asserts.
+    command: crate::reactor::Migrated<
+        tonk_schema::command::AddPasskey,
+        tonk_schema::command::legacy::AddPasskey,
+    >,
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl AddPasskeyHandler {
     pub(crate) fn new() -> Self {
-        use crate::reactor::Decode as _;
         Self {
-            attributes: tonk_schema::command::AddPasskey::trigger_attributes(),
+            command: crate::reactor::Migrated::new(),
         }
     }
 }
@@ -101,16 +105,11 @@ impl AddPasskeyHandler {
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl crate::reactor::CommandHandler<crate::router::CommandEnv> for AddPasskeyHandler {
     fn trigger_attributes(&self) -> &[String] {
-        &self.attributes
+        self.command.trigger_attributes()
     }
 
     fn matches(&self, facts: &crate::reactor::EntityFacts) -> bool {
-        use crate::reactor::Decode as _;
-        facts
-            .first()
-            .map(|artifact| artifact.of.clone())
-            .and_then(|entity| tonk_schema::command::AddPasskey::decode(entity, facts))
-            .is_some()
+        self.command.matches(facts)
     }
 
     fn run(

--- a/rust/tonk-worker/src/router/email_status.rs
+++ b/rust/tonk-worker/src/router/email_status.rs
@@ -79,38 +79,40 @@ pub(crate) fn state_for_status(status: u16) -> &'static str {
 /// Runs `account/check-email`.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) struct CheckEmailHandler {
-    attributes: Vec<String>,
+    /// Decodes the current shape, and the deprecated one a
+    /// branch seeded before the migration still asserts.
+    command: crate::reactor::Migrated<
+        tonk_schema::command::CheckEmail,
+        tonk_schema::command::legacy::CheckEmail,
+    >,
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl CheckEmailHandler {
     pub(crate) fn new() -> Self {
-        use crate::reactor::Decode as _;
         Self {
-            attributes: tonk_schema::command::CheckEmail::trigger_attributes(),
+            command: crate::reactor::Migrated::new(),
         }
     }
-}
 
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-fn decode_email(facts: &crate::reactor::EntityFacts) -> Option<String> {
-    use crate::reactor::Decode as _;
-    facts
-        .first()
-        .map(|artifact| artifact.of.clone())
-        .and_then(|entity| tonk_schema::command::CheckEmail::decode(entity, facts))
-        .map(|command| command.email.0)
-        .filter(|email| !email.trim().is_empty())
+    /// The address to look up, or `None` when these facts are not a
+    /// lookup (or carry a blank address).
+    fn email(&self, facts: &crate::reactor::EntityFacts) -> Option<String> {
+        self.command
+            .decode(facts)
+            .map(|command| command.email.0)
+            .filter(|email| !email.trim().is_empty())
+    }
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl crate::reactor::CommandHandler<crate::router::CommandEnv> for CheckEmailHandler {
     fn trigger_attributes(&self) -> &[String] {
-        &self.attributes
+        self.command.trigger_attributes()
     }
 
     fn matches(&self, facts: &crate::reactor::EntityFacts) -> bool {
-        decode_email(facts).is_some()
+        self.email(facts).is_some()
     }
 
     fn run(
@@ -118,7 +120,7 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for CheckEmailHan
         facts: &crate::reactor::EntityFacts,
         env: &crate::router::CommandEnv,
     ) -> crate::reactor::RunFuture {
-        let email = decode_email(facts);
+        let email = self.email(facts);
         let env = env.clone();
 
         Box::pin(async move {
@@ -264,38 +266,40 @@ pub(crate) async fn record(tonk: &crate::worker::TonkState, email: &str, answer:
 /// dialog the user might never finish.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) struct RegisterAccountHandler {
-    attributes: Vec<String>,
+    /// Decodes the current shape, and the deprecated one a
+    /// branch seeded before the migration still asserts.
+    command: crate::reactor::Migrated<
+        tonk_schema::command::RegisterAccount,
+        tonk_schema::command::legacy::RegisterAccount,
+    >,
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl RegisterAccountHandler {
     pub(crate) fn new() -> Self {
-        use crate::reactor::Decode as _;
         Self {
-            attributes: tonk_schema::command::RegisterAccount::trigger_attributes(),
+            command: crate::reactor::Migrated::new(),
         }
     }
-}
 
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-fn decode_registration(facts: &crate::reactor::EntityFacts) -> Option<String> {
-    use crate::reactor::Decode as _;
-    facts
-        .first()
-        .map(|artifact| artifact.of.clone())
-        .and_then(|entity| tonk_schema::command::RegisterAccount::decode(entity, facts))
-        .map(|command| command.email.0)
-        .filter(|email| split_address(email).is_some())
+    /// The address to register, or `None` when these facts are not a
+    /// registration (or carry an unparseable address).
+    fn email(&self, facts: &crate::reactor::EntityFacts) -> Option<String> {
+        self.command
+            .decode(facts)
+            .map(|command| command.email.0)
+            .filter(|email| split_address(email).is_some())
+    }
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl crate::reactor::CommandHandler<crate::router::CommandEnv> for RegisterAccountHandler {
     fn trigger_attributes(&self) -> &[String] {
-        &self.attributes
+        self.command.trigger_attributes()
     }
 
     fn matches(&self, facts: &crate::reactor::EntityFacts) -> bool {
-        decode_registration(facts).is_some()
+        self.email(facts).is_some()
     }
 
     fn run(
@@ -305,7 +309,7 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for RegisterAccou
     ) -> crate::reactor::RunFuture {
         use tonk_common::log;
 
-        let email = decode_registration(facts);
+        let email = self.email(facts);
         let env = env.clone();
 
         Box::pin(async move {

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -1394,15 +1394,17 @@ const JOIN_STATUS_URI: &str = "tonk:join/status";
 /// [`Join`]: tonk_schema::command::Join
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) struct JoinHandler {
-    attributes: Vec<String>,
+    /// Decodes the current shape, and the deprecated one a
+    /// branch seeded before the migration still asserts.
+    command:
+        crate::reactor::Migrated<tonk_schema::command::Join, tonk_schema::command::legacy::Join>,
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl JoinHandler {
     pub(crate) fn new() -> Self {
-        use crate::reactor::Decode as _;
         Self {
-            attributes: tonk_schema::command::Join::trigger_attributes(),
+            command: crate::reactor::Migrated::new(),
         }
     }
 }
@@ -1410,16 +1412,11 @@ impl JoinHandler {
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl crate::reactor::CommandHandler<crate::router::CommandEnv> for JoinHandler {
     fn trigger_attributes(&self) -> &[String] {
-        &self.attributes
+        self.command.trigger_attributes()
     }
 
     fn matches(&self, facts: &crate::reactor::EntityFacts) -> bool {
-        use crate::reactor::Decode as _;
-        facts
-            .first()
-            .map(|artifact| artifact.of.clone())
-            .and_then(|this| tonk_schema::command::Join::decode(this, facts))
-            .is_some()
+        self.command.matches(facts)
     }
 
     fn run(
@@ -1427,14 +1424,9 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for JoinHandler {
         facts: &crate::reactor::EntityFacts,
         env: &crate::router::CommandEnv,
     ) -> crate::reactor::RunFuture {
-        use crate::reactor::Decode as _;
-
         // Decode the full location synchronously while the caller holds the
         // lock; hand the owned value to the `'static` future.
-        let command = facts
-            .first()
-            .map(|artifact| artifact.of.clone())
-            .and_then(|entity| tonk_schema::command::Join::decode(entity, facts));
+        let command = self.command.decode(facts);
         let env = env.clone();
 
         Box::pin(async move {

--- a/rust/tonk-worker/src/router/members.rs
+++ b/rust/tonk-worker/src/router/members.rs
@@ -375,15 +375,19 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for PromoteMember
 /// command fires in.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) struct ExpelMemberHandler {
-    attributes: Vec<String>,
+    /// Decodes the current shape, and the deprecated one a
+    /// branch seeded before the migration still asserts.
+    command: crate::reactor::Migrated<
+        tonk_schema::command::ExpelMember,
+        tonk_schema::command::legacy::ExpelMember,
+    >,
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl ExpelMemberHandler {
     pub(crate) fn new() -> Self {
-        use crate::reactor::Decode as _;
         Self {
-            attributes: tonk_schema::command::ExpelMember::trigger_attributes(),
+            command: crate::reactor::Migrated::new(),
         }
     }
 }
@@ -391,7 +395,7 @@ impl ExpelMemberHandler {
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl crate::reactor::CommandHandler<crate::router::CommandEnv> for ExpelMemberHandler {
     fn trigger_attributes(&self) -> &[String] {
-        &self.attributes
+        self.command.trigger_attributes()
     }
 
     fn matches(&self, facts: &crate::reactor::EntityFacts) -> bool {
@@ -715,7 +719,6 @@ mod tests {
     /// promote and an expel never decode as each other.
     #[dialog_common::test]
     async fn it_decodes_each_member_command_by_its_own_attribute() {
-        use crate::reactor::Decode as _;
         use tonk_schema::command::{ExpelMember, PromoteMember};
         let promote = PromoteMember::trigger_attributes();
         let expel = ExpelMember::trigger_attributes();

--- a/rust/tonk-worker/src/router/members.rs
+++ b/rust/tonk-worker/src/router/members.rs
@@ -719,6 +719,7 @@ mod tests {
     /// promote and an expel never decode as each other.
     #[dialog_common::test]
     async fn it_decodes_each_member_command_by_its_own_attribute() {
+        use crate::reactor::Decode as _;
         use tonk_schema::command::{ExpelMember, PromoteMember};
         let promote = PromoteMember::trigger_attributes();
         let expel = ExpelMember::trigger_attributes();

--- a/rust/tonk-worker/src/router/repository.rs
+++ b/rust/tonk-worker/src/router/repository.rs
@@ -296,11 +296,17 @@ pub async fn put_repository(
     Ok((StatusCode::CREATED, Json(info)))
 }
 
-/// The form-event attribute carrying the optional sync URL — the
-/// `remote` input on the `space/create` and `space/enable-sync` forms.
-/// Kept in sync with those notation commands' `remote` field `the:`.
+/// The attribute carrying the optional sync URL on a `space/create` or
+/// `space/enable-sync` transient. Kept in step with those notation
+/// commands' `remote` field `the:`.
 #[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
-const REMOTE_ATTR: &str = "dom.event.current-target.elements.remote/value";
+const REMOTE_ATTR: &str = "xyz.tonk.command.create-space/remote";
+
+/// The same field before the command took its own namespace: the DOM
+/// read path that filled it. Still asserted by any branch seeded before
+/// the migration, so both are read.
+#[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
+const LEGACY_REMOTE_ATTR: &str = "dom.event.current-target.elements.remote/value";
 
 /// Read the optional remote URL from a transient's facts, tolerating
 /// both `Value::String` and `Value::Entity`.
@@ -311,13 +317,23 @@ const REMOTE_ATTR: &str = "dom.event.current-target.elements.remote/value";
 /// decodes a URL (that's the bug a `remote: String` field hit). Reading
 /// the artifact directly sidesteps the concept decode and accepts either
 /// representation. Empty/whitespace → `None` (a local-only space).
+///
+/// This is why `remote` is still not a field on [`CreateSpace`] even
+/// after the command took its own namespace: the obstacle is how a URL
+/// is *represented*, not how the command is *shaped*, and the two are
+/// separate problems.
+///
+/// [`CreateSpace`]: tonk_schema::command::CreateSpace
 #[cfg(any(all(target_arch = "wasm32", target_os = "unknown"), test))]
 fn remote_from_facts(facts: &crate::reactor::EntityFacts) -> Option<String> {
     use dialog_artifacts::Value;
 
     facts
         .iter()
-        .find(|artifact| artifact.the.to_string() == REMOTE_ATTR)
+        .find(|artifact| {
+            let the = artifact.the.to_string();
+            the == REMOTE_ATTR || the == LEGACY_REMOTE_ATTR
+        })
         .and_then(|artifact| match &artifact.is {
             Value::String(url) => Some(url.clone()),
             Value::Entity(uri) => Some(uri.to_string()),
@@ -506,7 +522,12 @@ async fn existing_space_labels(state: &AppState) -> Vec<String> {
 /// [`CreateSpace`]: tonk_schema::command::CreateSpace
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) struct CreateSpaceHandler {
-    attributes: Vec<String>,
+    /// Decodes the current shape, and the deprecated one a
+    /// branch seeded before the migration still asserts.
+    command: crate::reactor::Migrated<
+        tonk_schema::command::CreateSpace,
+        tonk_schema::command::legacy::CreateSpace,
+    >,
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -514,9 +535,8 @@ impl CreateSpaceHandler {
     /// Cache `CreateSpace`'s trigger attributes (its `name` field) so the
     /// registry indexes this handler under them.
     pub(crate) fn new() -> Self {
-        use crate::reactor::Decode as _;
         Self {
-            attributes: tonk_schema::command::CreateSpace::trigger_attributes(),
+            command: crate::reactor::Migrated::new(),
         }
     }
 }
@@ -524,16 +544,11 @@ impl CreateSpaceHandler {
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl crate::reactor::CommandHandler<crate::router::CommandEnv> for CreateSpaceHandler {
     fn trigger_attributes(&self) -> &[String] {
-        &self.attributes
+        self.command.trigger_attributes()
     }
 
     fn matches(&self, facts: &crate::reactor::EntityFacts) -> bool {
-        use crate::reactor::Decode as _;
-        facts
-            .first()
-            .map(|artifact| artifact.of.clone())
-            .and_then(|this| tonk_schema::command::CreateSpace::decode(this, facts))
-            .is_some()
+        self.command.matches(facts)
     }
 
     fn run(
@@ -541,15 +556,9 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for CreateSpaceHa
         facts: &crate::reactor::EntityFacts,
         env: &crate::router::CommandEnv,
     ) -> crate::reactor::RunFuture {
-        use crate::reactor::Decode as _;
-
         // Decode synchronously (the caller still holds the lock), then
         // hand owned values + an env clone to the `'static` future.
-        let name = facts
-            .first()
-            .map(|artifact| artifact.of.clone())
-            .and_then(|entity| tonk_schema::command::CreateSpace::decode(entity, facts))
-            .map(|command| command.name.0);
+        let name = self.command.decode(facts).map(|command| command.name.0);
         // The optional remote is read from the facts directly (tolerating
         // the URL's `Value::Entity` representation), not via a concept.
         let remote = remote_from_facts(facts);
@@ -714,7 +723,12 @@ fn invite_space_from_facts(facts: &crate::reactor::EntityFacts) -> Option<String
 /// [`Credential`]: tonk_schema::command::Credential
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) struct InviteHandler {
-    attributes: Vec<String>,
+    /// Decodes the current shape, and the deprecated one a
+    /// branch seeded before the migration still asserts.
+    command: crate::reactor::Migrated<
+        tonk_schema::command::Invite,
+        tonk_schema::command::legacy::Invite,
+    >,
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -722,9 +736,8 @@ impl InviteHandler {
     /// Cache `Invite`'s trigger attributes (its `time` field) so the
     /// registry indexes this handler under them.
     pub(crate) fn new() -> Self {
-        use crate::reactor::Decode as _;
         Self {
-            attributes: tonk_schema::command::Invite::trigger_attributes(),
+            command: crate::reactor::Migrated::new(),
         }
     }
 }
@@ -732,16 +745,11 @@ impl InviteHandler {
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl crate::reactor::CommandHandler<crate::router::CommandEnv> for InviteHandler {
     fn trigger_attributes(&self) -> &[String] {
-        &self.attributes
+        self.command.trigger_attributes()
     }
 
     fn matches(&self, facts: &crate::reactor::EntityFacts) -> bool {
-        use crate::reactor::Decode as _;
-        facts
-            .first()
-            .map(|artifact| artifact.of.clone())
-            .and_then(|this| tonk_schema::command::Invite::decode(this, facts))
-            .is_some()
+        self.command.matches(facts)
     }
 
     fn run(
@@ -749,7 +757,6 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for InviteHandler
         facts: &crate::reactor::EntityFacts,
         env: &crate::router::CommandEnv,
     ) -> crate::reactor::RunFuture {
-        use crate::reactor::Decode as _;
         use tonk_schema::prelude::DidExt as _;
 
         // Read the target space off the facts opportunistically (NOT a
@@ -768,10 +775,9 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for InviteHandler
         // The triggering click's timestamp, echoed onto a refusal so a
         // later resubscribe can tell this refusal from a replay of an
         // older one — see `publish_share_blocked`.
-        let time = facts
-            .first()
-            .map(|artifact| artifact.of.clone())
-            .and_then(|entity| tonk_schema::command::Invite::decode(entity, facts))
+        let time = self
+            .command
+            .decode(facts)
             .map(|command| command.time.0)
             .unwrap_or_default();
         let env = env.clone();
@@ -814,15 +820,19 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for InviteHandler
 /// subscription it already holds — the same path an ordinary mint takes.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) struct EnableSyncHandler {
-    attributes: Vec<String>,
+    /// Decodes the current shape, and the deprecated one a
+    /// branch seeded before the migration still asserts.
+    command: crate::reactor::Migrated<
+        tonk_schema::command::EnableSync,
+        tonk_schema::command::legacy::EnableSync,
+    >,
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl EnableSyncHandler {
     pub(crate) fn new() -> Self {
-        use crate::reactor::Decode as _;
         Self {
-            attributes: tonk_schema::command::EnableSync::trigger_attributes(),
+            command: crate::reactor::Migrated::new(),
         }
     }
 }
@@ -830,16 +840,11 @@ impl EnableSyncHandler {
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl crate::reactor::CommandHandler<crate::router::CommandEnv> for EnableSyncHandler {
     fn trigger_attributes(&self) -> &[String] {
-        &self.attributes
+        self.command.trigger_attributes()
     }
 
     fn matches(&self, facts: &crate::reactor::EntityFacts) -> bool {
-        use crate::reactor::Decode as _;
-        facts
-            .first()
-            .map(|artifact| artifact.of.clone())
-            .and_then(|this| tonk_schema::command::EnableSync::decode(this, facts))
-            .is_some()
+        self.command.matches(facts)
     }
 
     fn run(
@@ -847,13 +852,11 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for EnableSyncHan
         facts: &crate::reactor::EntityFacts,
         env: &crate::router::CommandEnv,
     ) -> crate::reactor::RunFuture {
-        use crate::reactor::Decode as _;
         use tonk_schema::prelude::DidExt as _;
 
-        let time = facts
-            .first()
-            .map(|artifact| artifact.of.clone())
-            .and_then(|entity| tonk_schema::command::EnableSync::decode(entity, facts))
+        let time = self
+            .command
+            .decode(facts)
             .map(|command| command.time.0)
             .unwrap_or_default();
         let space = text_fact(facts, ENABLE_SYNC_SPACE_ATTR);
@@ -1453,7 +1456,12 @@ fn long_invite_url(
 /// [`ReplicaSyncEnabled`]: tonk_schema::ReplicaSyncEnabled
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) struct PauseSyncHandler {
-    attributes: Vec<String>,
+    /// Decodes the current shape, and the deprecated one a
+    /// branch seeded before the migration still asserts.
+    command: crate::reactor::Migrated<
+        tonk_schema::command::PauseSync,
+        tonk_schema::command::legacy::PauseSync,
+    >,
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -1461,9 +1469,8 @@ impl PauseSyncHandler {
     /// Cache `PauseSync`'s trigger attributes (its `time` field) so the
     /// registry indexes this handler under them.
     pub(crate) fn new() -> Self {
-        use crate::reactor::Decode as _;
         Self {
-            attributes: tonk_schema::command::PauseSync::trigger_attributes(),
+            command: crate::reactor::Migrated::new(),
         }
     }
 }
@@ -1471,16 +1478,11 @@ impl PauseSyncHandler {
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl crate::reactor::CommandHandler<crate::router::CommandEnv> for PauseSyncHandler {
     fn trigger_attributes(&self) -> &[String] {
-        &self.attributes
+        self.command.trigger_attributes()
     }
 
     fn matches(&self, facts: &crate::reactor::EntityFacts) -> bool {
-        use crate::reactor::Decode as _;
-        facts
-            .first()
-            .map(|artifact| artifact.of.clone())
-            .and_then(|this| tonk_schema::command::PauseSync::decode(this, facts))
-            .is_some()
+        self.command.matches(facts)
     }
 
     fn run(
@@ -1488,17 +1490,15 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for PauseSyncHand
         facts: &crate::reactor::EntityFacts,
         env: &crate::router::CommandEnv,
     ) -> crate::reactor::RunFuture {
-        use crate::reactor::Decode as _;
         use tonk_schema::prelude::DidExt as _;
 
         // Decode synchronously to read the target space off the command — the
         // handler flips THAT space's replica, not the dispatch origin's, so the
         // command can be dispatched from the profile branch. The repo key is
         // the space DID's suffix; a space's content branch is always `main`.
-        let target = facts
-            .first()
-            .map(|artifact| artifact.of.clone())
-            .and_then(|entity| tonk_schema::command::PauseSync::decode(entity, facts))
+        let target = self
+            .command
+            .decode(facts)
             .and_then(|command| {
                 command
                     .space
@@ -1550,7 +1550,12 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for PauseSyncHand
 /// [`MemberName`]: tonk_schema::MemberName
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) struct ProfileRenameHandler {
-    attributes: Vec<String>,
+    /// Decodes the current shape, and the deprecated one a
+    /// branch seeded before the migration still asserts.
+    command: crate::reactor::Migrated<
+        tonk_schema::command::ProfileRename,
+        tonk_schema::command::legacy::ProfileRename,
+    >,
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -1558,9 +1563,8 @@ impl ProfileRenameHandler {
     /// Cache `ProfileRename`'s trigger attributes (its `name` field) so
     /// the registry indexes this handler under them.
     pub(crate) fn new() -> Self {
-        use crate::reactor::Decode as _;
         Self {
-            attributes: tonk_schema::command::ProfileRename::trigger_attributes(),
+            command: crate::reactor::Migrated::new(),
         }
     }
 }
@@ -1568,16 +1572,11 @@ impl ProfileRenameHandler {
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl crate::reactor::CommandHandler<crate::router::CommandEnv> for ProfileRenameHandler {
     fn trigger_attributes(&self) -> &[String] {
-        &self.attributes
+        self.command.trigger_attributes()
     }
 
     fn matches(&self, facts: &crate::reactor::EntityFacts) -> bool {
-        use crate::reactor::Decode as _;
-        facts
-            .first()
-            .map(|artifact| artifact.of.clone())
-            .and_then(|this| tonk_schema::command::ProfileRename::decode(this, facts))
-            .is_some()
+        self.command.matches(facts)
     }
 
     fn run(
@@ -1585,15 +1584,9 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for ProfileRename
         facts: &crate::reactor::EntityFacts,
         env: &crate::router::CommandEnv,
     ) -> crate::reactor::RunFuture {
-        use crate::reactor::Decode as _;
-
         // Decode synchronously (the caller still holds the lock), then
         // hand the owned new name + an env clone to the `'static` future.
-        let name = facts
-            .first()
-            .map(|artifact| artifact.of.clone())
-            .and_then(|entity| tonk_schema::command::ProfileRename::decode(entity, facts))
-            .map(|command| command.name.0);
+        let name = self.command.decode(facts).map(|command| command.name.0);
         let key = env.origin().repo.clone();
         let env = env.clone();
 
@@ -1683,7 +1676,12 @@ pub(crate) fn rename_outcome(result: Result<(), RepositoryError>) -> RenameOutco
 /// [`RenameRepository`]: tonk_schema::command::RenameRepository
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) struct RenameRepositoryHandler {
-    attributes: Vec<String>,
+    /// Decodes the current shape, and the deprecated one a
+    /// branch seeded before the migration still asserts.
+    command: crate::reactor::Migrated<
+        tonk_schema::command::RenameRepository,
+        tonk_schema::command::legacy::RenameRepository,
+    >,
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -1691,9 +1689,8 @@ impl RenameRepositoryHandler {
     /// Cache `RenameRepository`'s trigger attributes so the registry indexes
     /// this handler under them.
     pub(crate) fn new() -> Self {
-        use crate::reactor::Decode as _;
         Self {
-            attributes: tonk_schema::command::RenameRepository::trigger_attributes(),
+            command: crate::reactor::Migrated::new(),
         }
     }
 }
@@ -1701,16 +1698,11 @@ impl RenameRepositoryHandler {
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl crate::reactor::CommandHandler<crate::router::CommandEnv> for RenameRepositoryHandler {
     fn trigger_attributes(&self) -> &[String] {
-        &self.attributes
+        self.command.trigger_attributes()
     }
 
     fn matches(&self, facts: &crate::reactor::EntityFacts) -> bool {
-        use crate::reactor::Decode as _;
-        facts
-            .first()
-            .map(|artifact| artifact.of.clone())
-            .and_then(|this| tonk_schema::command::RenameRepository::decode(this, facts))
-            .is_some()
+        self.command.matches(facts)
     }
 
     fn run(
@@ -1718,16 +1710,12 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for RenameReposit
         facts: &crate::reactor::EntityFacts,
         env: &crate::router::CommandEnv,
     ) -> crate::reactor::RunFuture {
-        use crate::reactor::Decode as _;
         use tonk_schema::prelude::DidExt as _;
 
         // Decode synchronously to read the target space off the command — the
         // handler renames THAT repository, not the dispatch origin's, so the
         // command can be dispatched from the profile branch.
-        let decoded = facts
-            .first()
-            .map(|artifact| artifact.of.clone())
-            .and_then(|entity| tonk_schema::command::RenameRepository::decode(entity, facts));
+        let decoded = self.command.decode(facts);
         let env = env.clone();
 
         Box::pin(async move {
@@ -1831,15 +1819,19 @@ async fn run_rename_repository(
 /// join redirects.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) struct CreateNotebookHandler {
-    attributes: Vec<String>,
+    /// Decodes the current shape, and the deprecated one a
+    /// branch seeded before the migration still asserts.
+    command: crate::reactor::Migrated<
+        tonk_schema::command::CreateNotebook,
+        tonk_schema::command::legacy::CreateNotebook,
+    >,
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl CreateNotebookHandler {
     pub(crate) fn new() -> Self {
-        use crate::reactor::Decode as _;
         Self {
-            attributes: tonk_schema::command::CreateNotebook::trigger_attributes(),
+            command: crate::reactor::Migrated::new(),
         }
     }
 }
@@ -1847,16 +1839,11 @@ impl CreateNotebookHandler {
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl crate::reactor::CommandHandler<crate::router::CommandEnv> for CreateNotebookHandler {
     fn trigger_attributes(&self) -> &[String] {
-        &self.attributes
+        self.command.trigger_attributes()
     }
 
     fn matches(&self, facts: &crate::reactor::EntityFacts) -> bool {
-        use crate::reactor::Decode as _;
-        facts
-            .first()
-            .map(|artifact| artifact.of.clone())
-            .and_then(|this| tonk_schema::command::CreateNotebook::decode(this, facts))
-            .is_some()
+        self.command.matches(facts)
     }
 
     fn run(
@@ -1864,12 +1851,7 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for CreateNoteboo
         facts: &crate::reactor::EntityFacts,
         env: &crate::router::CommandEnv,
     ) -> crate::reactor::RunFuture {
-        use crate::reactor::Decode as _;
-
-        let decoded = facts
-            .first()
-            .map(|artifact| artifact.of.clone())
-            .and_then(|entity| tonk_schema::command::CreateNotebook::decode(entity, facts));
+        let decoded = self.command.decode(facts);
         let env = env.clone();
 
         Box::pin(async move {
@@ -2063,7 +2045,12 @@ fn yaml_block_scalar(source: &str) -> String {
 /// [`RemoveSpace`]: tonk_schema::command::RemoveSpace
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) struct RemoveSpaceHandler {
-    attributes: Vec<String>,
+    /// Decodes the current shape, and the deprecated one a
+    /// branch seeded before the migration still asserts.
+    command: crate::reactor::Migrated<
+        tonk_schema::command::RemoveSpace,
+        tonk_schema::command::legacy::RemoveSpace,
+    >,
 }
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -2071,9 +2058,8 @@ impl RemoveSpaceHandler {
     /// Cache `RemoveSpace`'s trigger attributes (its `subject` field) so
     /// the registry indexes this handler under them.
     pub(crate) fn new() -> Self {
-        use crate::reactor::Decode as _;
         Self {
-            attributes: tonk_schema::command::RemoveSpace::trigger_attributes(),
+            command: crate::reactor::Migrated::new(),
         }
     }
 }
@@ -2081,16 +2067,11 @@ impl RemoveSpaceHandler {
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl crate::reactor::CommandHandler<crate::router::CommandEnv> for RemoveSpaceHandler {
     fn trigger_attributes(&self) -> &[String] {
-        &self.attributes
+        self.command.trigger_attributes()
     }
 
     fn matches(&self, facts: &crate::reactor::EntityFacts) -> bool {
-        use crate::reactor::Decode as _;
-        facts
-            .first()
-            .map(|artifact| artifact.of.clone())
-            .and_then(|this| tonk_schema::command::RemoveSpace::decode(this, facts))
-            .is_some()
+        self.command.matches(facts)
     }
 
     fn run(
@@ -2098,15 +2079,9 @@ impl crate::reactor::CommandHandler<crate::router::CommandEnv> for RemoveSpaceHa
         facts: &crate::reactor::EntityFacts,
         env: &crate::router::CommandEnv,
     ) -> crate::reactor::RunFuture {
-        use crate::reactor::Decode as _;
-
         // Decode synchronously (the caller still holds the lock), then
         // hand the owned subject + an env clone to the `'static` future.
-        let subject = facts
-            .first()
-            .map(|artifact| artifact.of.clone())
-            .and_then(|entity| tonk_schema::command::RemoveSpace::decode(entity, facts))
-            .map(|command| command.subject.0);
+        let subject = self.command.decode(facts).map(|command| command.subject.0);
         let env = env.clone();
 
         Box::pin(async move {
@@ -4996,7 +4971,7 @@ mod space_config_tests {
 /// sides against the seeded document. Native.
 #[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod form_attribute_tests {
-    use super::REMOTE_ATTR;
+    use super::{LEGACY_REMOTE_ATTR, REMOTE_ATTR};
 
     /// The document the worker seeds onto a profile branch, embedded for
     /// the same reason `tests/standard_library.rs` embeds it: CI runs from
@@ -5015,17 +4990,19 @@ mod form_attribute_tests {
     /// remote would wire one anyway, which is the behaviour
     /// `it_creates_a_local_only_space_from_the_hub_wizard` refuses.
     ///
-    /// `REMOTE_ATTR` stays readable so a frozen older descriptor that
-    /// still declares the field keeps working; it is simply no longer
-    /// where the answer comes from.
+    /// Both spellings stay readable so a frozen older descriptor that
+    /// still declares the field keeps working; neither is where the
+    /// answer comes from any more.
     #[test]
     fn it_declares_no_remote_on_the_create_form() {
-        assert!(
-            !PROFILE_LIBRARY.contains(REMOTE_ATTR),
-            "profile.yaml declares `the: {REMOTE_ATTR}` again — a space \
-             would wire a remote at creation instead of earning one when \
-             it is shared",
-        );
+        for attribute in [REMOTE_ATTR, LEGACY_REMOTE_ATTR] {
+            assert!(
+                !PROFILE_LIBRARY.contains(attribute),
+                "profile.yaml declares `the: {attribute}` again — a space \
+                 would wire a remote at creation instead of earning one \
+                 when it is shared",
+            );
+        }
     }
 }
 
@@ -5088,6 +5065,21 @@ mod remote_from_facts_tests {
         the!("dom.event.current-target.elements.remote/value")
             .of(of)
             .is(url)
+            .assert(&mut changes);
+        assert_eq!(remote_from_facts(&artifacts(changes)).as_deref(), Some(URL));
+    }
+
+    /// The attribute the app posts now. The two cases above use the DOM
+    /// read path a branch seeded before the migration still asserts, so
+    /// between them both spellings are covered.
+    #[test]
+    fn it_reads_the_commands_own_remote_attribute() {
+        let of: Entity = "did:key:zCreate".parse().expect("entity");
+        let mut changes = Changes::new();
+        name_fact(&mut changes, &of);
+        the!("xyz.tonk.command.create-space/remote")
+            .of(of)
+            .is(URL.to_string())
             .assert(&mut changes);
         assert_eq!(remote_from_facts(&artifacts(changes)).as_deref(), Some(URL));
     }

--- a/rust/tonk-worker/tests/command_migration.rs
+++ b/rust/tonk-worker/tests/command_migration.rs
@@ -1,0 +1,267 @@
+//! Every migrated command must still decode the shape a branch seeded
+//! before the migration asserts.
+//!
+//! A command is matched structurally: the set of attribute names a
+//! transient carries is its whole identity. Each command here changed
+//! that set — its fields moved out of the DOM read paths that used to
+//! fill them and into the command's own `xyz.tonk.command.<verb>`
+//! namespace, and the marker fields that existed only to stop two
+//! commands decoding as each other went away with them.
+//!
+//! `core.yaml` is seeded once at repo creation and never re-seeded, so
+//! every existing space still holds the old descriptors and still posts
+//! the old attributes. If those stopped decoding, the transient would
+//! commit, no handler would run, and the UI would look successful — the
+//! exact silent failure this suite exists to prevent.
+//!
+//! What makes that survivable without the old shape becoming permanent
+//! is [`dialog_reactor::Migrated`]: the handler is written against the
+//! current shape alone, and the legacy one reaches it through a `From`
+//! impl. Retiring the old shape is deleting `tonk_schema::command::legacy`,
+//! those `From` impls, and one type parameter per handler.
+//!
+//! Native-only, mirroring `standard_library.rs`: this needs no running
+//! system.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use dialog_artifacts::{Artifact, Entity};
+use dialog_reactor::{EntityFacts, Migrated};
+use tonk_schema::command;
+
+fn entity(source: &str) -> Entity {
+    source.parse().expect("entity URI")
+}
+
+/// One transient entity's facts, from `(attribute, value)` pairs.
+///
+/// Built as raw artifacts rather than through a typed concept: the whole
+/// point is to post attribute names no current type declares.
+fn facts(pairs: Vec<(&str, Value)>) -> EntityFacts {
+    let this = entity("did:key:zCommand");
+    pairs
+        .into_iter()
+        .map(|(attribute, value)| Artifact {
+            the: attribute.parse().expect("attribute name"),
+            of: this.clone(),
+            is: match value {
+                Value::Text(source) => dialog_artifacts::Value::String(source),
+                Value::Entity(source) => dialog_artifacts::Value::Entity(entity(&source)),
+                Value::Float(number) => dialog_artifacts::Value::Float(number),
+            },
+            cause: None,
+        })
+        .collect()
+}
+
+enum Value {
+    Text(String),
+    Entity(String),
+    Float(f64),
+}
+
+fn text(value: &str) -> Value {
+    Value::Text(value.to_string())
+}
+
+fn uri(value: &str) -> Value {
+    Value::Entity(value.to_string())
+}
+
+#[dialog_common::test]
+fn a_legacy_create_space_still_decodes() {
+    let command: Migrated<command::CreateSpace, command::legacy::CreateSpace> = Migrated::new();
+    let decoded = command
+        .decode(&facts(vec![(
+            "dom.event.current-target.elements.name/value",
+            text("Untitled"),
+        )]))
+        .expect("a name-only transient from an older profile descriptor");
+    assert_eq!(decoded.name.0, "Untitled");
+}
+
+#[dialog_common::test]
+fn a_current_create_space_decodes() {
+    let command: Migrated<command::CreateSpace, command::legacy::CreateSpace> = Migrated::new();
+    let decoded = command
+        .decode(&facts(vec![(
+            "xyz.tonk.command.create-space/name",
+            text("Untitled"),
+        )]))
+        .expect("the shape the app posts now");
+    assert_eq!(decoded.name.0, "Untitled");
+}
+
+#[dialog_common::test]
+fn a_legacy_remove_space_still_decodes() {
+    let command: Migrated<command::RemoveSpace, command::legacy::RemoveSpace> = Migrated::new();
+    let decoded = command
+        .decode(&facts(vec![(
+            "dom.event.current-target.dataset/remove",
+            uri("did:key:zSpace"),
+        )]))
+        .expect("the Hub's confirm form on an older profile branch");
+    assert_eq!(decoded.subject.0.to_string(), "did:key:zSpace");
+}
+
+#[dialog_common::test]
+fn a_legacy_invite_still_decodes_without_its_marker_meaning_anything() {
+    let command: Migrated<command::Invite, command::legacy::Invite> = Migrated::new();
+    let decoded = command
+        .decode(&facts(vec![
+            ("dom.event/time-stamp", Value::Float(17.0)),
+            (
+                "dom.event.current-target.dataset/invite",
+                uri("tonk:invite"),
+            ),
+        ]))
+        .expect("a share click on an older space branch");
+    assert_eq!(decoded.time.0, 17.0);
+}
+
+#[dialog_common::test]
+fn a_legacy_pause_sync_still_decodes() {
+    let command: Migrated<command::PauseSync, command::legacy::PauseSync> = Migrated::new();
+    let decoded = command
+        .decode(&facts(vec![
+            ("dom.event/time-stamp", Value::Float(3.0)),
+            ("xyz.tonk.pause-sync/space", uri("did:key:zSpace")),
+            (
+                "dom.event.current-target.dataset/pause-sync",
+                uri("tonk:pause-sync"),
+            ),
+        ]))
+        .expect("an alt-click dispatched by an older FAB bundle");
+    assert_eq!(decoded.space.0.to_string(), "did:key:zSpace");
+    assert_eq!(decoded.time.0, 3.0);
+}
+
+#[dialog_common::test]
+fn a_legacy_profile_rename_still_decodes() {
+    let command: Migrated<command::ProfileRename, command::legacy::ProfileRename> = Migrated::new();
+    let decoded = command
+        .decode(&facts(vec![
+            ("dom.event.current-target/value", text("Ada")),
+            (
+                "dom.event.current-target.dataset/rename",
+                uri("tonk:profile"),
+            ),
+        ]))
+        .expect("the identity chip on an older profile branch");
+    assert_eq!(decoded.name.0, "Ada");
+}
+
+#[dialog_common::test]
+fn a_legacy_rename_repository_still_decodes() {
+    let command: Migrated<command::RenameRepository, command::legacy::RenameRepository> =
+        Migrated::new();
+    let decoded = command
+        .decode(&facts(vec![
+            ("dom.event.current-target/value", text("Pictures")),
+            ("xyz.tonk.rename-repository/space", uri("did:key:zSpace")),
+            (
+                "dom.event.current-target.dataset/rename-repository",
+                uri("tonk:rename-repository"),
+            ),
+        ]))
+        .expect("the FAB's name chip on an older bundle");
+    assert_eq!(decoded.name.0, "Pictures");
+    assert_eq!(decoded.space.0.to_string(), "did:key:zSpace");
+}
+
+#[dialog_common::test]
+fn a_legacy_expel_member_still_decodes() {
+    let command: Migrated<command::ExpelMember, command::legacy::ExpelMember> = Migrated::new();
+    let decoded = command
+        .decode(&facts(vec![(
+            "dom.event.current-target.dataset/expel",
+            uri("did:key:zMember"),
+        )]))
+        .expect("a roster row on an older space branch");
+    assert_eq!(decoded.member.0.to_string(), "did:key:zMember");
+}
+
+#[dialog_common::test]
+fn a_legacy_join_still_decodes() {
+    let command: Migrated<command::Join, command::legacy::Join> = Migrated::new();
+    let decoded = command
+        .decode(&facts(vec![(
+            "dom.event.detail/href",
+            text("https://tonk.test/join#seed"),
+        )]))
+        .expect("the /join page on an older profile branch");
+    assert_eq!(decoded.url.0, "https://tonk.test/join#seed");
+}
+
+/// The pair the marker fields existed for.
+///
+/// `Invite` and `PauseSync` were both `{this, time}` reading one shared
+/// `dom.event/time-stamp`, so each carried an extra attribute purely to
+/// stay distinct. In the current shapes each `time` is in its own
+/// namespace, and this is what says so: neither command decodes the
+/// other's transient, with not a marker in sight.
+#[dialog_common::test]
+fn an_invite_and_a_pause_no_longer_need_a_marker_to_stay_apart() {
+    let invite: Migrated<command::Invite, command::legacy::Invite> = Migrated::new();
+    let pause: Migrated<command::PauseSync, command::legacy::PauseSync> = Migrated::new();
+
+    let an_invite = facts(vec![("xyz.tonk.command.invite/time", Value::Float(1.0))]);
+    let a_pause = facts(vec![
+        ("xyz.tonk.command.pause-sync/time", Value::Float(1.0)),
+        ("xyz.tonk.pause-sync/space", uri("did:key:zSpace")),
+    ]);
+
+    assert!(invite.matches(&an_invite));
+    assert!(pause.matches(&a_pause));
+    assert!(!pause.matches(&an_invite), "an invite is not a pause");
+    assert!(!invite.matches(&a_pause), "a pause is not an invite");
+}
+
+/// The other pair: a rename of the space and a rename of the person both
+/// read `currentTarget.value`, and before the marker every space rename
+/// also renamed the profile.
+#[dialog_common::test]
+fn the_two_renames_no_longer_need_a_marker_to_stay_apart() {
+    let repository: Migrated<command::RenameRepository, command::legacy::RenameRepository> =
+        Migrated::new();
+    let profile: Migrated<command::ProfileRename, command::legacy::ProfileRename> = Migrated::new();
+
+    let a_repository_rename = facts(vec![
+        ("xyz.tonk.command.rename-repository/name", text("Pictures")),
+        ("xyz.tonk.rename-repository/space", uri("did:key:zSpace")),
+    ]);
+    let a_profile_rename = facts(vec![("xyz.tonk.command.profile-rename/name", text("Ada"))]);
+
+    assert!(repository.matches(&a_repository_rename));
+    assert!(profile.matches(&a_profile_rename));
+    assert!(
+        !profile.matches(&a_repository_rename),
+        "renaming a space must not rename the person",
+    );
+    assert!(!repository.matches(&a_profile_rename));
+}
+
+/// And the pair that made a passkey prompt appear mid-keystroke.
+#[dialog_common::test]
+fn a_lookup_no_longer_decodes_as_a_registration() {
+    let lookup: Migrated<command::CheckEmail, command::legacy::CheckEmail> = Migrated::new();
+    let registration: Migrated<command::RegisterAccount, command::legacy::RegisterAccount> =
+        Migrated::new();
+
+    let asking = facts(vec![(
+        "xyz.tonk.command.check-email/email",
+        text("ada@example.com"),
+    )]);
+    let registering = facts(vec![(
+        "xyz.tonk.command.register-account/email",
+        text("ada@example.com"),
+    )]);
+
+    assert!(lookup.matches(&asking));
+    assert!(registration.matches(&registering));
+    assert!(
+        !registration.matches(&asking),
+        "asking whether an address is free must not create the account",
+    );
+    assert!(!lookup.matches(&registering));
+}

--- a/rust/tonk-worker/tests/fab_drift.rs
+++ b/rust/tonk-worker/tests/fab_drift.rs
@@ -90,7 +90,7 @@ fn it_builds_pause_claims_carrying_every_attribute_the_handler_triggers_on() {
         "the command must declare trigger attributes"
     );
 
-    let claim = logic::pause_claim_json("tonk:pause-sync", "did:key:z6Mk", 1.0).to_string();
+    let claim = logic::pause_claim_json("did:key:z6Mk", 1.0).to_string();
     for attribute in &triggers {
         assert!(
             claim.contains(attribute.as_str()),

--- a/rust/tonk-worker/tests/fab_drift.rs
+++ b/rust/tonk-worker/tests/fab_drift.rs
@@ -106,3 +106,84 @@ fn it_reads_the_repo_name_attribute_the_schema_writes() {
     let body = logic::repo_name_query_body("did:key:z6Mk").expect("builds");
     assert!(body.contains("xyz.tonk.repo/name"));
 }
+
+/// Every hand-built claim must declare each field it sets.
+///
+/// This is the invariant the worker enforces server-side: a parameter the
+/// inlined concept does not declare is rejected outright —
+/// `invalid claim: field "…" is not declared by this concept` — so the
+/// whole transact fails with a 400 and the interaction silently does
+/// nothing.
+///
+/// The per-command checks above cannot see it. They assert that the
+/// claim's JSON *text* contains each attribute the handler triggers on,
+/// which the descriptor half alone satisfies; a `parameters` map that has
+/// drifted from that descriptor passes every one of them. Renaming a space
+/// shipped broken exactly that way: the descriptor was migrated to
+/// `{name, space}` while the parameters kept sending `value` and a
+/// `rename-repository` marker from the pre-namespace shape.
+#[dialog_common::test]
+fn every_hand_built_claim_declares_the_fields_it_sets() {
+    use tonk_fab::logic::Dock;
+
+    let space = "did:key:z6Mk";
+    let claims = [
+        ("dock", logic::dock_claim_json(Dock::TopLeft)),
+        ("collapsed", logic::collapsed_claim_json(true)),
+        (
+            "promote",
+            logic::promote_claim_json(space, "did:key:z6Mm", "chain"),
+        ),
+        ("pause", logic::pause_claim_json(space, 1.0)),
+        (
+            "rename-repo",
+            logic::rename_repo_claim_json(space, "Renamed"),
+        ),
+        (
+            "rename-repo (blank)",
+            logic::rename_repo_claim_json(space, ""),
+        ),
+        ("profile-rename", logic::profile_rename_claim_json("Ada")),
+        ("invite", logic::invite_claim_json(space, 1.0)),
+        (
+            "enable-sync",
+            logic::enable_sync_claim_json(space, "https://example.test/ucan/", true, 1.0),
+        ),
+        // The remote and share halves are conditional on both sides, so the
+        // bare form is checked too — dropping one from `with` but not from
+        // `parameters` is the same defect in a branch the full form hides.
+        (
+            "enable-sync (bare)",
+            logic::enable_sync_claim_json(space, "", false, 1.0),
+        ),
+    ];
+
+    for (label, claim) in claims {
+        let application = &claim["claims"][0]["application"];
+        let declared = application["predicate"]["concept"]["with"]
+            .as_object()
+            .unwrap_or_else(|| panic!("{label}: the claim must inline a `with` map"));
+        let parameters = application["parameters"]
+            .as_object()
+            .unwrap_or_else(|| panic!("{label}: the claim must carry parameters"));
+
+        assert!(
+            !parameters.is_empty(),
+            "{label}: a claim that sets nothing would assert nothing",
+        );
+        for field in parameters.keys() {
+            // `this` is the one parameter that is not a concept field: the
+            // worker mints it from `(descriptor, parameters)` when absent,
+            // and pins it when present.
+            if field == "this" {
+                continue;
+            }
+            assert!(
+                declared.contains_key(field),
+                "{label}: parameter `{field}` is not declared by the inlined \
+                 concept ({:?}) — the worker rejects this claim with a 400",
+                declared.keys().collect::<Vec<_>>(),
+            );
+        }
+    }
+}

--- a/rust/tonk-worker/tests/standard_library.rs
+++ b/rust/tonk-worker/tests/standard_library.rs
@@ -834,14 +834,23 @@ fn parse_event_declarations(
         let (mut event_type, mut prevent, mut stop) = (None, false, false);
         let mut sources: Vec<(String, String)> = Vec::new();
         let mut in_where = false;
-        for body in lines.by_ref() {
+        // Peek; never consume the terminator. `for body in lines.by_ref()`
+        // eats the line it breaks on, so a declaration ending on the NEXT
+        // `event!:` header swallows it and that declaration is never seen.
+        // A blank line between them used to terminate first, which hid the
+        // bug for exactly as long as every pair had one.
+        while let Some(body) = lines.peek().copied() {
+            let trimmed = body.trim();
+            // Blank lines occur inside `description: |` blocks and do not
+            // end a declaration.
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                lines.next();
+                continue;
+            }
             if !body.starts_with("  ") {
                 break;
             }
-            let trimmed = body.trim();
-            if trimmed.is_empty() || trimmed.starts_with('#') {
-                continue;
-            }
+            lines.next();
             if trimmed == "where:" {
                 in_where = true;
                 continue;
@@ -907,14 +916,20 @@ fn parse_command_fields(
         // is indexed under both.
         let mut this: Option<String> = None;
         let mut section: Option<bool> = None;
-        for body in lines.by_ref() {
+        // Peek, and skip blanks — see `parse_event_declarations`. Ending a
+        // declaration on the first blank line truncated the field list of
+        // any command whose field carries a multi-paragraph description,
+        // so every check built on this quietly measured less than it read.
+        while let Some(body) = lines.peek().copied() {
+            let trimmed = body.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                lines.next();
+                continue;
+            }
             if !body.starts_with("  ") {
                 break;
             }
-            let trimmed = body.trim();
-            if trimmed.is_empty() || trimmed.starts_with('#') {
-                continue;
-            }
+            lines.next();
             if let Some(uri) = trimmed.strip_prefix("this: ") {
                 this = Some(uri.trim().to_string());
                 continue;
@@ -1068,4 +1083,163 @@ fn the_event_query_predicate_matches_the_builtin() {
         query_with.contains_key("type") && query_with.contains_key("where"),
         "the query must pin both required fields",
     );
+}
+
+/// A command with a Rust handler must match on attributes its notation
+/// declaration actually carries.
+///
+/// The two halves are written in different files and nothing but this
+/// connects them: the YAML `command!:` declares what a transient carries,
+/// and the Rust concept declares what the handler decodes. When they
+/// drift the transient still commits, the handler never runs, and the UI
+/// looks like it worked. `notebook.yaml` says it in its own words — "a
+/// field the struct requires but the command does not declare is simply
+/// absent from the descriptor, so the decode fails and the binding falls
+/// through in silence".
+///
+/// That is not hypothetical: moving `notebook/create` into its own
+/// namespace in the YAML without moving `CreateNotebook` with it silently
+/// broke notebook creation on any freshly seeded branch, and nothing
+/// failed.
+///
+/// The invariant is containment, not equality. A concept may deliberately
+/// match on FEWER attributes than the command declares — `CreateSpace` is
+/// matched name-only so a frozen older descriptor still decodes it, and
+/// reads the optional remote from the raw facts. What is never sound is
+/// the other direction: an attribute the handler requires that no
+/// declaration produces.
+#[dialog_common::test]
+fn every_handled_command_matches_attributes_its_declaration_carries() {
+    use dialog_reactor::Decode as _;
+
+    let mut declared = std::collections::BTreeMap::new();
+    for document in [
+        STANDARD_LIBRARY,
+        PROFILE_LIBRARY,
+        TABLE_LIBRARY,
+        NOTEBOOK_LIBRARY,
+        PROSE_LIBRARY,
+        ISSUE_LIBRARY,
+    ] {
+        for (name, attributes) in parse_command_attributes(document) {
+            declared
+                .entry(name)
+                .or_insert_with(std::collections::BTreeSet::new)
+                .extend(attributes);
+        }
+    }
+
+    // Every notation command the worker decodes in typed Rust. A command
+    // consumed by a `rule!:` has no Rust concept and is not listed.
+    //
+    // `tonk/rename-repository` is deliberately absent, and the reason is
+    // worth stating: the name belongs to TWO different commands. The one
+    // `core.yaml` declares carries `{subject, name}` and is consumed by a
+    // space-side `rule!:`. `tonk_schema::command::RenameRepository`
+    // carries `{space, name}` and is dispatched from the profile branch by
+    // the FAB, which inlines its own descriptor because the space-side
+    // rule cannot consume a claim made on the profile branch. They share a
+    // notation name and nothing else, so pairing them here would compare
+    // two unrelated things. The FAB's claim is pinned against the struct
+    // in `fab_drift.rs` instead, which is where that pairing lives.
+    let handled: Vec<(&str, Vec<String>)> = vec![
+        (
+            "space/create",
+            tonk_schema::command::CreateSpace::trigger_attributes(),
+        ),
+        (
+            "space/enable-sync",
+            tonk_schema::command::CreateSpace::trigger_attributes(),
+        ),
+        (
+            "space/remove",
+            tonk_schema::command::RemoveSpace::trigger_attributes(),
+        ),
+        (
+            "tonk/invite",
+            tonk_schema::command::Invite::trigger_attributes(),
+        ),
+        (
+            "tonk/pause-sync",
+            tonk_schema::command::PauseSync::trigger_attributes(),
+        ),
+        (
+            "profile/rename",
+            tonk_schema::command::ProfileRename::trigger_attributes(),
+        ),
+        (
+            "member/expel",
+            tonk_schema::command::ExpelMember::trigger_attributes(),
+        ),
+        (
+            "tonk/join",
+            tonk_schema::command::Join::trigger_attributes(),
+        ),
+        (
+            "tonk/load",
+            tonk_schema::command::Load::trigger_attributes(),
+        ),
+        (
+            "notebook/create",
+            tonk_schema::command::CreateNotebook::trigger_attributes(),
+        ),
+    ];
+
+    for (name, required) in handled {
+        let carries = declared
+            .get(name)
+            .unwrap_or_else(|| panic!("no `command!: &{name}` in any shipped library"));
+        let missing: Vec<&String> = required
+            .iter()
+            .filter(|attribute| !carries.contains(*attribute))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "`{name}`: the handler matches on {missing:?}, which its notation \
+             declaration does not carry — the transient would commit and the \
+             handler would never run. Declared: {carries:?}",
+        );
+    }
+}
+
+/// Every `the:` a `command!:` declaration names, keyed by command name.
+fn parse_command_attributes(
+    document: &str,
+) -> std::collections::BTreeMap<String, std::collections::BTreeSet<String>> {
+    let mut out = std::collections::BTreeMap::new();
+    let mut lines = document.lines().peekable();
+    while let Some(line) = lines.next() {
+        let Some(name) = line.trim_start().strip_prefix("command!: &") else {
+            continue;
+        };
+        let name = name
+            .split_whitespace()
+            .next()
+            .unwrap_or_default()
+            .to_string();
+        let mut attributes = std::collections::BTreeSet::new();
+        // Peek, and skip blanks — see `parse_event_declarations`.
+        while let Some(body) = lines.peek().copied() {
+            // A blank line does not end the declaration: `description: |`
+            // block scalars contain them, and treating one as the end
+            // silently truncated the scan — which is how this gate first
+            // reported that `tonk/invite` declared no attributes at all.
+            if body.trim().is_empty() {
+                lines.next();
+                continue;
+            }
+            if !body.starts_with("  ") {
+                break;
+            }
+            lines.next();
+            // Exactly a field's own `the:`, six spaces in. Prose inside a
+            // block scalar is indented deeper and must not be read as a
+            // declaration however it happens to begin.
+            if let Some(attribute) = body.strip_prefix("      the: ") {
+                attributes.insert(attribute.trim().to_string());
+            }
+        }
+        out.insert(name, attributes);
+    }
+    out
 }

--- a/rust/tonk-worker/tests/standard_library.rs
+++ b/rust/tonk-worker/tests/standard_library.rs
@@ -30,6 +30,15 @@ const STANDARD_LIBRARY: &str = include_str!("../../tonk-core/assets/library/core
 /// command and its form).
 const PROFILE_LIBRARY: &str = include_str!("../../tonk-core/assets/library/profile.yaml");
 
+/// The component libraries. Each is seeded the same way and lowers the
+/// same way, so each belongs in the lowering gate — until now only
+/// `core.yaml` and `profile.yaml` were covered, which meant a broken
+/// `table.yaml` reached the seed before anything complained.
+const TABLE_LIBRARY: &str = include_str!("../../tonk-core/assets/library/table.yaml");
+const NOTEBOOK_LIBRARY: &str = include_str!("../../tonk-core/assets/library/notebook.yaml");
+const PROSE_LIBRARY: &str = include_str!("../../tonk-core/assets/library/prose.yaml");
+const ISSUE_LIBRARY: &str = include_str!("../../tonk-core/assets/library/issue.yaml");
+
 /// Light-DOM markup mounted by the Hub account custom element. The profile
 /// library supplies its geometry, so their visual contract is checked here
 /// together.
@@ -650,4 +659,94 @@ fn it_declares_mobile_target_and_input_floors_for_hub_and_join() {
             "mobile Hub/join CSS must contain `{contract}`"
         );
     }
+}
+
+/// Lower a component library the way the seed reaches it: on top of
+/// the standard library, whose `view` / `event` / `command` concepts it
+/// references. `analyze_local` resolves names within one document, so
+/// the concatenation is what stands in for "core is already seeded".
+fn assert_component_library_lowers(label: &str, document: &str) {
+    assert_library_lowers(label, &format!("{STANDARD_LIBRARY}\n{document}"));
+}
+
+#[dialog_common::test]
+fn it_lowers_the_table_library() {
+    assert_component_library_lowers("table library (table.yaml)", TABLE_LIBRARY);
+}
+
+#[dialog_common::test]
+fn it_lowers_the_notebook_library() {
+    assert_component_library_lowers("notebook library (notebook.yaml)", NOTEBOOK_LIBRARY);
+}
+
+#[dialog_common::test]
+fn it_lowers_the_prose_library() {
+    assert_component_library_lowers("prose library (prose.yaml)", PROSE_LIBRARY);
+}
+
+#[dialog_common::test]
+fn it_lowers_the_issue_library() {
+    assert_component_library_lowers("issue library (issue.yaml)", ISSUE_LIBRARY);
+}
+
+/// Every `on:<name>` binding in a library names a declaration the same
+/// library defines.
+///
+/// The dangling case is exactly the one the design exists to catch: a
+/// binding whose declaration does not resolve produces no listener and
+/// no diagnostic, so the element is simply inert. Cheap to check by
+/// scanning, and it fails at build time rather than on a click.
+#[dialog_common::test]
+fn every_on_binding_names_a_declared_event() {
+    for (label, document) in [
+        ("core.yaml", STANDARD_LIBRARY),
+        ("profile.yaml", PROFILE_LIBRARY),
+        ("table.yaml", TABLE_LIBRARY),
+        ("notebook.yaml", NOTEBOOK_LIBRARY),
+        ("prose.yaml", PROSE_LIBRARY),
+        ("issue.yaml", ISSUE_LIBRARY),
+    ] {
+        // Declarations are anchored `event!: &on/<name>`; every library
+        // resolves against the core one too, which is always seeded.
+        let mut declared: Vec<String> = collect_anchors(STANDARD_LIBRARY);
+        declared.extend(collect_anchors(document));
+
+        for attribute in collect_on_attributes(document) {
+            let event_name = tonk_template::event::event_name_for_attribute(&attribute)
+                .unwrap_or_else(|| panic!("{label}: `{attribute}` is not a usable binding name"));
+            assert!(
+                declared.contains(&event_name),
+                "{label}: `{attribute}` names `{event_name}`, which no `event!:` declares",
+            );
+        }
+    }
+}
+
+/// `event!: &on/<name>` anchors declared in a document.
+fn collect_anchors(document: &str) -> Vec<String> {
+    document
+        .lines()
+        .filter_map(|line| {
+            let rest = line.trim().strip_prefix("event!: &")?;
+            Some(rest.split_whitespace().next()?.to_string())
+        })
+        .collect()
+}
+
+/// `on:<name>=` attribute names appearing in any template.
+fn collect_on_attributes(document: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for (index, _) in document.match_indices("on:") {
+        // Only an attribute position counts — preceded by whitespace.
+        if index > 0 && !document.as_bytes()[index - 1].is_ascii_whitespace() {
+            continue;
+        }
+        let rest = &document[index..];
+        let Some(end) = rest.find('=') else { continue };
+        let name = &rest[..end];
+        if !name.contains(char::is_whitespace) {
+            out.push(name.to_string());
+        }
+    }
+    out
 }

--- a/rust/tonk-worker/tests/standard_library.rs
+++ b/rust/tonk-worker/tests/standard_library.rs
@@ -902,6 +902,10 @@ fn parse_command_fields(
             std::collections::BTreeSet::new(),
             std::collections::BTreeSet::new(),
         );
+        // A command with a `this:` is bound by that URI in templates, not
+        // by its YAML anchor (`<tonk-page on:invite=tonk:invite>`), so it
+        // is indexed under both.
+        let mut this: Option<String> = None;
         let mut section: Option<bool> = None;
         for body in lines.by_ref() {
             if !body.starts_with("  ") {
@@ -909,6 +913,10 @@ fn parse_command_fields(
             }
             let trimmed = body.trim();
             if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
+            if let Some(uri) = trimmed.strip_prefix("this: ") {
+                this = Some(uri.trim().to_string());
                 continue;
             }
             match trimmed {
@@ -930,6 +938,9 @@ fn parse_command_fields(
                     }
                 }
             }
+        }
+        if let Some(uri) = this {
+            out.insert(uri, (required.clone(), optional.clone()));
         }
         out.insert(name, (required, optional));
     }

--- a/rust/tonk-worker/tests/standard_library.rs
+++ b/rust/tonk-worker/tests/standard_library.rs
@@ -959,3 +959,102 @@ fn parse_bindings(document: &str) -> Vec<(String, String)> {
     }
     out
 }
+
+/// An `event!:` declaration lowers with no library seeded at all.
+///
+/// This is what makes `event` a built-in rather than a library concept:
+/// like `command!:` and `rule!:`, a declaration is schema an author
+/// writes, so it has to resolve on a bare branch. Declared in the
+/// standard library instead, it would work only where that library had
+/// been seeded — and a lean repo, the profile meta-branch, or a `tonk
+/// eval` fixture would all fail to parse one.
+#[dialog_common::test]
+fn an_event_declaration_lowers_without_the_library() {
+    let document = r#"event!: &on/tap
+  type: "click"
+  prevent-default: true
+  where:
+    subject: "{this}"
+    time: ".timeStamp"
+
+command!: &bump
+  with:
+    subject:
+      description: The thing being bumped
+      the: io.gozala.bump/subject
+      as: entity
+      cardinality: one
+  maybe:
+    time:
+      description: A per-event nonce
+      the: io.gozala.bump/time
+      as: float
+      cardinality: one
+"#;
+    assert_library_lowers("a bare `event!:` document", document);
+}
+
+/// The optional side-effect flags really are optional: a declaration
+/// that suppresses neither must lower. Every declaration in the
+/// library omits them, so a regression here would break all of them at
+/// once.
+#[dialog_common::test]
+fn an_event_declaration_may_omit_the_side_effect_flags() {
+    let document = r#"event!: &on/plain
+  type: "click"
+  where:
+    subject: "{this}"
+"#;
+    assert_library_lowers("an `event!:` with no flags", document);
+}
+
+/// The wire predicate `tonk-template` builds matches the built-in.
+///
+/// Two hand-maintained copies of one shape: the built-in descriptor is
+/// the source of truth and the query builder mirrors it, because that
+/// crate emits JSON rather than descriptor types. Drift would show up
+/// as an event declaration that resolves but reads back empty, which is
+/// the silent class of failure again — so it is asserted rather than
+/// trusted to a comment.
+#[dialog_common::test]
+fn the_event_query_predicate_matches_the_builtin() {
+    let builtin = tonk_schema::builtin::lookup_concept("event").expect("`event` is a built-in");
+    // `.concept()` unwraps the durability tag; the wire predicate has
+    // no such wrapper.
+    let serialized =
+        serde_json::to_value(builtin.descriptor.concept()).expect("descriptor serializes");
+    let builtin_with = serialized
+        .get("with")
+        .and_then(serde_json::Value::as_object)
+        .expect("the built-in has a `with` map");
+
+    let predicate = tonk_template::resolve::event_predicate();
+    let query_with = predicate
+        .get("with")
+        .and_then(serde_json::Value::as_object)
+        .expect("the predicate has a `with` map");
+
+    // The query pins only the required fields — the optional flags are
+    // read separately, since pinning them would make a declaration that
+    // omits them match nothing.
+    for field in query_with.keys() {
+        let ours = &query_with[field];
+        let theirs = builtin_with
+            .get(field)
+            .unwrap_or_else(|| panic!("the built-in has no `{field}` field"));
+        assert_eq!(
+            ours.get("the"),
+            theirs.get("the"),
+            "`{field}`: the query and the built-in disagree on `the`",
+        );
+        assert_eq!(
+            ours.get("cardinality"),
+            theirs.get("cardinality"),
+            "`{field}`: the query and the built-in disagree on cardinality",
+        );
+    }
+    assert!(
+        query_with.contains_key("type") && query_with.contains_key("where"),
+        "the query must pin both required fields",
+    );
+}

--- a/rust/tonk-worker/tests/standard_library.rs
+++ b/rust/tonk-worker/tests/standard_library.rs
@@ -750,3 +750,212 @@ fn collect_on_attributes(document: &str) -> Vec<String> {
     }
     out
 }
+
+/// Every `on:<name>=<command>` binding in a library resolves to a
+/// declaration that can fill the command's required fields.
+///
+/// This is the check the whole `event!:` design exists to make
+/// possible, run against the real libraries: a required field with no
+/// source posts a command the rule's premise cannot match, so the
+/// interaction silently does nothing. Before, the only way to find that
+/// was to click the button in a browser.
+#[dialog_common::test]
+fn every_binding_can_fill_its_command() {
+    let libraries = [
+        ("core.yaml", STANDARD_LIBRARY),
+        ("profile.yaml", PROFILE_LIBRARY),
+        ("table.yaml", TABLE_LIBRARY),
+        ("notebook.yaml", NOTEBOOK_LIBRARY),
+        ("prose.yaml", PROSE_LIBRARY),
+        ("issue.yaml", ISSUE_LIBRARY),
+    ];
+
+    // Declarations and commands resolve across the seed, so index them
+    // all before checking any binding.
+    let mut events = std::collections::BTreeMap::new();
+    let mut commands = std::collections::BTreeMap::new();
+    for (_, document) in libraries {
+        events.extend(parse_event_declarations(document));
+        commands.extend(parse_command_fields(document));
+    }
+    assert!(
+        !events.is_empty() && !commands.is_empty(),
+        "the scan found nothing — it has drifted from the library's shape"
+    );
+
+    let mut checked = 0usize;
+    for (label, document) in libraries {
+        for (attribute, command_name) in parse_bindings(document) {
+            let event_name = tonk_template::event::event_name_for_attribute(&attribute)
+                .unwrap_or_else(|| panic!("{label}: `{attribute}` is not a usable binding name"));
+            let event = events
+                .get(&event_name)
+                .unwrap_or_else(|| panic!("{label}: no `event!:` declares `{event_name}`"));
+            let (required, optional) = commands.get(&command_name).unwrap_or_else(|| {
+                panic!("{label}: `{attribute}={command_name}` names no command")
+            });
+
+            let mismatch = tonk_template::event::check(event, required, optional);
+            assert!(
+                mismatch.is_empty(),
+                "{label}: `{attribute}={command_name}` — unfilled {:?}, unknown {:?}",
+                mismatch
+                    .unfilled
+                    .iter()
+                    .map(|u| &u.field)
+                    .collect::<Vec<_>>(),
+                mismatch
+                    .unknown
+                    .iter()
+                    .map(|u| &u.field)
+                    .collect::<Vec<_>>(),
+            );
+            checked += 1;
+        }
+    }
+    assert!(checked > 0, "no `on:` bindings were checked");
+}
+
+/// `event!: &on/<name>` blocks, as name -> descriptor.
+fn parse_event_declarations(
+    document: &str,
+) -> std::collections::BTreeMap<String, tonk_template::event::EventDescriptor> {
+    let mut out = std::collections::BTreeMap::new();
+    let mut lines = document.lines().peekable();
+    while let Some(line) = lines.next() {
+        let Some(name) = line.trim_start().strip_prefix("event!: &") else {
+            continue;
+        };
+        let name = name
+            .split_whitespace()
+            .next()
+            .unwrap_or_default()
+            .to_string();
+        let (mut event_type, mut prevent, mut stop) = (None, false, false);
+        let mut sources: Vec<(String, String)> = Vec::new();
+        let mut in_where = false;
+        for body in lines.by_ref() {
+            if !body.starts_with("  ") {
+                break;
+            }
+            let trimmed = body.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
+            if trimmed == "where:" {
+                in_where = true;
+                continue;
+            }
+            let Some((key, value)) = trimmed.split_once(':') else {
+                continue;
+            };
+            let value = value.trim().trim_matches('"').to_string();
+            if in_where && body.starts_with("    ") {
+                sources.push((key.trim().to_string(), format!("\"{value}\"")));
+                continue;
+            }
+            in_where = false;
+            match key.trim() {
+                "type" => event_type = Some(value),
+                "prevent-default" => prevent = value == "true",
+                "stop-propagation" => stop = value == "true",
+                _ => {}
+            }
+        }
+        // The scan re-quotes every source so `parse_source` sees the
+        // form YAML would have delivered; a `.path` must survive that.
+        let sources = sources.into_iter().map(|(field, raw)| {
+            let inner = raw.trim_matches('"').to_string();
+            (field, inner)
+        });
+        let descriptor =
+            tonk_template::event::event_descriptor(event_type.as_deref(), prevent, stop, sources)
+                .unwrap_or_else(|e| panic!("`{name}` is not a usable declaration: {e}"));
+        out.insert(name, descriptor);
+    }
+    out
+}
+
+/// `command!: &<name>` blocks, as name -> (required, optional) fields.
+#[allow(clippy::type_complexity)]
+fn parse_command_fields(
+    document: &str,
+) -> std::collections::BTreeMap<
+    String,
+    (
+        std::collections::BTreeSet<String>,
+        std::collections::BTreeSet<String>,
+    ),
+> {
+    let mut out = std::collections::BTreeMap::new();
+    let mut lines = document.lines().peekable();
+    while let Some(line) = lines.next() {
+        let Some(name) = line.trim_start().strip_prefix("command!: &") else {
+            continue;
+        };
+        let name = name
+            .split_whitespace()
+            .next()
+            .unwrap_or_default()
+            .to_string();
+        let (mut required, mut optional) = (
+            std::collections::BTreeSet::new(),
+            std::collections::BTreeSet::new(),
+        );
+        let mut section: Option<bool> = None;
+        for body in lines.by_ref() {
+            if !body.starts_with("  ") {
+                break;
+            }
+            let trimmed = body.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
+            match trimmed {
+                "with:" => section = Some(true),
+                "maybe:" => section = Some(false),
+                _ => {
+                    // A field name is exactly four spaces in and ends
+                    // with `:` — deeper lines are its own body.
+                    if let Some(is_required) = section
+                        && body.starts_with("    ")
+                        && !body.starts_with("      ")
+                        && let Some(field) = trimmed.strip_suffix(':')
+                    {
+                        if is_required {
+                            required.insert(field.to_string());
+                        } else {
+                            optional.insert(field.to_string());
+                        }
+                    }
+                }
+            }
+        }
+        out.insert(name, (required, optional));
+    }
+    out
+}
+
+/// `on:<name>=<command>` pairs appearing in any template.
+fn parse_bindings(document: &str) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for (index, _) in document.match_indices("on:") {
+        if index > 0 && !document.as_bytes()[index - 1].is_ascii_whitespace() {
+            continue;
+        }
+        let rest = &document[index..];
+        let Some(end) = rest.find('=') else { continue };
+        let attribute = &rest[..end];
+        if attribute.contains(char::is_whitespace) {
+            continue;
+        }
+        let value: String = rest[end + 1..]
+            .chars()
+            .take_while(|c| !c.is_whitespace() && *c != '>' && *c != '"')
+            .collect();
+        if !value.is_empty() {
+            out.push((attribute.to_string(), value));
+        }
+    }
+    out
+}

--- a/rust/tonk-workspace/src/ui_account_settings.rs
+++ b/rust/tonk-workspace/src/ui_account_settings.rs
@@ -671,9 +671,9 @@ fn add_passkey(this: &HtmlElement) {
         &claim(
             "Seal the account under another passkey.",
             serde_json::json!({
-                "marker": { "the": "dom.event.current-target.dataset/add-passkey", "as": "Entity" }
+                "account": { "the": "xyz.tonk.command.add-passkey/account", "as": "Entity" }
             }),
-            serde_json::json!({ "marker": "tonk:add-passkey" }),
+            serde_json::json!({ "account": "tonk:add-passkey" }),
         ),
     );
 }


### PR DESCRIPTION
## What changed

Commands no longer have to be modelled in terms of how the view looks.

A command's fields used to be plumbing. To know which todo a click referred to,
the command declared `the: dom.event.current-target.dataset/todo` — its identity
*was* its DOM read path. Side effects were fields too, so `prevent-default` sat
in the `with:` map, where it stores no value and a rule premise over it matches
zero rows however successfully the command transacted.

Two halves, and the second only became possible because of the first.

### 1. `event!:` — the seam between an input model and a command

An event declaration names the platform event, optional `prevent-default` /
`stop-propagation`, and a `where:` map from *command field name* to *source*:

```yaml
event!: on/click
type: click
where:
  subject: "{this}"

command!: todo/toggle
with:
  subject: db.entity
```

Templates bind it as `on:click=todo/toggle`. `/` in the event name maps to `:`
in the attribute (`tonk/load` → `tonk:load=…`), and names live under the `on`
namespace so they don't take global ones. At runtime the display resolves each
referenced declaration — a name lookup plus an entity read per name — into an
event table keyed by DOM event type, and maps an event straight to facts.

(An earlier version of this description claimed the analyzer inlined those
descriptors at lowering. It does not, on this branch: resolution is per-name and
happens on every delegate refresh, and a dangling reference produces no listener
and no diagnostic. Moving it to lowering — so the resolved table rides the view
as a compiled artifact and a bad reference fails the build — is #905, stacked on
this PR.)

A source is `{field}` (a template field in the enclosing repeat clone; `{this}`
is the clone's entity), `.dotted.path` (a property read off the event), a bare
symbol (a named entity), a URI, or a literal. Classification is delegated to
`tonk_notation::parse::classify_plain_value`, so these are the notation's rules
rather than a second set, and parsing is total — nothing that parses today stops.

### 2. Per-command namespaces, and the markers go

Changing a command's shape used to be impossible: a command is matched
*structurally*, so a branch seeded before the change still asserts the old
attributes and a handler keyed on the new ones stops firing.
`dialog_reactor::Migrated<Current, Legacy>` is the seam that makes it
survivable. A handler declares it instead of a bare attribute list; the registry
indexes under the union of both attribute sets, and `decode` returns `Current`
either way, the old shape arriving through `Legacy: Into<Current>`. Handler
bodies are written against `Current` alone. Retiring a legacy shape is deleting
`tonk_schema::command::legacy`, its `From` impls, and one type parameter — no
handler changes. (`MigratedCommand` / `registry.migrated::<C, L>()` is the same
thing for the `Provider` path.)

With shapes able to change, each of the thirteen commands took its own
`xyz.tonk.command.<verb>` namespace. **Every marker field in the codebase then
became unnecessary**, because nominal identity is a byproduct of the naming
rather than something a hand-written attribute has to reassert:

- `Invite.marker` existed only so a `PauseSync` transient — an identical
  `{this, time}` — didn't also decode as an invite.
- `RenameRepository` and `ProfileRename` each carried one because both read
  `currentTarget.value`; without them every space rename also renamed the person.
- `RemoveSpace.subject` was read from `data-remove` rather than the honest
  `data-subject`, because `dataset/subject` would have made every rename decode
  as a deletion.
- `RegisterAccount.MARKER` existed because every keystroke's `check-email` also
  decoded as a registration and raised a passkey prompt mid-typing.

All four pairs are now disjoint by construction and tested as such. Every
`dom.event.*` read path is gone from the shipped libraries (61 → 0), and
`prevent-default` moved onto the `event!:` declarations.

**Not a breaking change.** `onclick=todo/toggle` keeps working; the delegate
tries the new form first and falls through. Old branches keep working through
`Migrated`. The legacy path is one deletable module, not a permanent tier.

## Verification

```console
cargo test --workspace --exclude wbg-pool --exclude tonk-baseline --exclude tonk-cli
cargo test --no-run --workspace --exclude tonk-cli                                  # native test targets
cargo test --no-run --workspace --exclude tonk-cli --target wasm32-unknown-unknown  # wasm test targets
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --all --check
```

Three gates carry this change:

- `standard_library.rs` lowers every shipped library, then checks that no
  template binds an undeclared event, that every declaration fills exactly its
  command's fields, and — new here —
  `every_handled_command_matches_attributes_its_declaration_carries`: for each
  notation command with a Rust handler, the handler's trigger attributes must be
  a subset of what its `command!:` declaration carries. Containment rather than
  equality, because `CreateSpace` is matched name-only on purpose; the unsound
  direction is an attribute the handler needs that no declaration produces.
- `command_migration.rs` — every migrated command still decodes the shape an
  older branch asserts, and the four marker pairs above no longer decode as each
  other.
- `fab_drift.rs` — the hand-built claims the FAB dispatches carry the attributes
  their handlers index on.

## Things a reviewer should look at sceptically

- **`notebook/create` was silently dead** on freshly seeded branches for part of
  this PR's history: an earlier commit moved its attributes in the YAML without
  moving `CreateNotebook` with them, so the transient committed and the handler
  never ran. That is the bug the new gate exists to prevent, and it is the third
  instance in this PR of one shape — a Rust symbol coupled to a notation
  declaration by a bare string with nothing checking they agree.
- **The DOM-attribute half of that coupling is still unguarded.** Removing
  `data-remove` from the remove-confirm form would have shipped an empty
  leave-space dialog, because `<ui-space-remove>` locates the form by
  `form[data-remove]`; only an e2e test that happened to share the selector
  caught it. Nothing prevents the next template edit from doing the same. The
  audit done here (every `data-*` any Rust element queries, every event `type:`
  against the DOM event it replaced) was manual.
- **The binding references themselves are unguarded at runtime too.** A
  `on:<name>=<command>` naming a declaration or command that does not resolve
  installs no listener and reports nothing. #905 makes that a lowering error.
- **`#enable-sync-form` is already broken on `staging`** — `<tonk-sync-state>`
  looks it up and no library defines it, so the stamping step silently no-ops.
  Filed separately; not fixed here.
- **`remote` on `space/create` is still read from raw facts.** A URL round-trips
  as `Value::Entity`, so a `String`-typed field never decodes one. That is a
  value-representation problem, not a command-shape one, and mixing it in would
  have made this unreviewable.
- `space/enable-sync` and `member/expel` have no live template binding left in
  the libraries; their forms moved into Rust elements or were removed. Their
  descriptors are migrated but no `event!:` was invented for bindings nobody
  writes.

## Storybook impact

- [x] No user-visible contract changed because: every existing `onclick=`
  binding behaves identically, old branches keep decoding through `Migrated`,
  and the migrated libraries produce the same commands from the same
  interactions. The change is in how a command is *declared*, not in what the
  user sees or does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WyWgReUaivze37mfWSNA4D

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the command and event handling structure in the `tonk` project to improve clarity and maintainability. It introduces new namespaces for commands, updates event declarations, and enhances the handling of event attributes.

### Detailed summary
- Added `tonk-notation` as a workspace dependency.
- Introduced `event` module in `tonk-template`.
- Updated event handling to use specific namespaces (e.g., `xyz.tonk.command.*`).
- Modified claims to ensure distinct attributes for different commands.
- Improved event declaration structure and added new events in YAML files.
- Enhanced the `handle_event` function to differentiate between legacy and new event formats.
- Updated tests to reflect changes in claim structures and event handling.

> The following files were skipped due to too many changes: `rust/tonk-schema/src/domain.rs`, `rust/tonk-display/src/events/binding.rs`, `rust/tonk-worker/tests/command_migration.rs`, `rust/tonk-core/assets/library/profile.yaml`, `rust/tonk-core/assets/library/core.yaml`, `rust/tonk-fab/src/logic.rs`, `rust/dialog-reactor/src/command.rs`, `rust/tonk-schema/src/command/legacy.rs`, `rust/tonk-worker/tests/standard_library.rs`, `rust/tonk-worker/src/router/repository.rs`, `rust/tonk-template/src/event.rs`, `rust/tonk-schema/src/command.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->