### PR TITLE
Resolve a view's event bindings at lowering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4752,6 +4752,7 @@ dependencies = [
  "tonk-core",
  "tonk-notation",
  "tonk-schema",
+ "tonk-template",
  "wasm-bindgen-test",
 ]
 
@@ -5255,6 +5256,8 @@ dependencies = [
  "dialog-common",
  "indexmap",
  "ipld-core",
+ "serde",
+ "serde_ipld_dagcbor",
  "serde_ipld_dagjson",
  "serde_json",
  "tokio",

--- a/rust/tonk-analyzer/Cargo.toml
+++ b/rust/tonk-analyzer/Cargo.toml
@@ -33,6 +33,7 @@ thiserror = { workspace = true }
 tonk-core = { workspace = true }
 tonk-notation = { workspace = true }
 tonk-schema = { workspace = true }
+tonk-template = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/rust/tonk-analyzer/src/analyzer.rs
+++ b/rust/tonk-analyzer/src/analyzer.rs
@@ -48,6 +48,7 @@ mod resolver_registry;
 mod rule;
 mod scan;
 mod scope;
+mod view;
 
 use std::collections::{HashMap, HashSet};
 
@@ -4931,6 +4932,75 @@ mod library_analysis_tests {
             "notebook.yaml on profile",
             &format!("{profile}\n{notebook}"),
         );
+    }
+
+    /// Every shipped library that binds an interaction must carry the
+    /// resolved bindings on its views.
+    ///
+    /// The inlining pass is silent when it succeeds, so
+    /// [`it_analyzes_the_shipped_libraries`] would pass just as well
+    /// if the pass stopped finding anything. This is the check that it
+    /// still reaches real templates: `on:` bindings exist in these
+    /// files, so `bindings` artifacts must too.
+    #[test]
+    fn it_inlines_the_bindings_the_shipped_libraries_make() {
+        let core = include_str!("../../tonk-core/assets/library/core.yaml");
+        for (name, body) in [
+            (
+                "notebook.yaml",
+                include_str!("../../tonk-core/assets/library/notebook.yaml"),
+            ),
+            (
+                "table.yaml",
+                include_str!("../../tonk-core/assets/library/table.yaml"),
+            ),
+            (
+                "prose.yaml",
+                include_str!("../../tonk-core/assets/library/prose.yaml"),
+            ),
+        ] {
+            let inlined = inlined_declarations(name, &format!("{core}\n{body}"));
+            assert!(
+                !inlined.is_empty(),
+                "{name} binds interactions, so its views must carry resolved bindings",
+            );
+        }
+        let profile = include_str!("../../tonk-core/assets/library/profile.yaml");
+        let inlined = inlined_declarations("profile.yaml", profile);
+        assert!(
+            inlined.contains(&"on/space-create".to_string()),
+            "profile.yaml's create form must carry its declaration inlined, got {inlined:?}",
+        );
+    }
+
+    /// Every `event!:` declaration name the document's views inlined.
+    fn inlined_declarations(name: &str, source: &str) -> Vec<String> {
+        use dialog_artifacts::Value as ArtifactValue;
+        use dialog_query::Term as QueryTerm;
+
+        let parsed = tonk_notation::parse(source);
+        let syntax = parsed
+            .syntax
+            .unwrap_or_else(|| panic!("{name} yields a syntax tree"));
+        let tree =
+            analyze_local(&syntax).unwrap_or_else(|error| panic!("{name} must analyze: {error:?}"));
+        let mut out = Vec::new();
+        for planned in tree.analysis.statements() {
+            let Statement::Assert(Application::Concept { query, .. }) = &planned.statement else {
+                continue;
+            };
+            let Some(QueryTerm::Constant(ArtifactValue::Bytes(bytes))) =
+                query.terms.get("bindings")
+            else {
+                continue;
+            };
+            let bindings = tonk_template::bindings::Bindings::decode(bytes)
+                .unwrap_or_else(|error| panic!("{name}'s artifact must decode: {error}"));
+            out.extend(bindings.events.into_keys());
+        }
+        out.sort();
+        out.dedup();
+        out
     }
 
     fn assert_analyzes(name: &str, source: &str) {

--- a/rust/tonk-analyzer/src/analyzer.rs
+++ b/rust/tonk-analyzer/src/analyzer.rs
@@ -4989,7 +4989,7 @@ mod library_analysis_tests {
             let Statement::Assert(Application::Concept { query, .. }) = &planned.statement else {
                 continue;
             };
-            let Some(QueryTerm::Constant(ArtifactValue::Bytes(bytes))) =
+            let Some(QueryTerm::Constant(ArtifactValue::Record(bytes))) =
                 query.terms.get("bindings")
             else {
                 continue;

--- a/rust/tonk-analyzer/src/analyzer/assertion.rs
+++ b/rust/tonk-analyzer/src/analyzer/assertion.rs
@@ -336,6 +336,34 @@ pub(crate) fn build_assertion_application(
                 }
             }
 
+            // A view's `on:<name>=<command>` bindings are resolved
+            // here, not at render time: the declaration and the
+            // command are both in scope, so an unresolvable reference
+            // fails the lowering instead of producing an inert
+            // element. The resolved table rides the view as one CBOR
+            // artifact, so the display decodes it rather than issuing
+            // a query per declaration name on every refresh.
+            if super::view::is_view(&resolved) {
+                user_fields.remove(super::view::BINDINGS_FIELD);
+                if let Some(bindings) = super::view::compile_bindings(assertion, scope)? {
+                    let encoded = bindings.encode().map_err(|reason| {
+                        AnalyzeError::at(
+                            AnalyzeErrorKind::InvalidViewBindings { reason },
+                            head_range,
+                        )
+                    })?;
+                    assert_terms.insert(
+                        super::view::BINDINGS_FIELD.into(),
+                        Term::Constant(Value::Bytes(encoded)),
+                    );
+                    retract_terms.insert(
+                        super::view::BINDINGS_FIELD.into(),
+                        Term::<dialog_query::Any>::blank(),
+                    );
+                    any_assert = true;
+                }
+            }
+
             if let Some((unknown, _)) = user_fields.into_iter().next() {
                 let unknown_range = assertion
                     .fields

--- a/rust/tonk-analyzer/src/analyzer/assertion.rs
+++ b/rust/tonk-analyzer/src/analyzer/assertion.rs
@@ -354,7 +354,7 @@ pub(crate) fn build_assertion_application(
                     })?;
                     assert_terms.insert(
                         super::view::BINDINGS_FIELD.into(),
-                        Term::Constant(Value::Bytes(encoded)),
+                        Term::Constant(Value::Record(encoded)),
                     );
                     retract_terms.insert(
                         super::view::BINDINGS_FIELD.into(),

--- a/rust/tonk-analyzer/src/analyzer/declaration.rs
+++ b/rust/tonk-analyzer/src/analyzer/declaration.rs
@@ -937,6 +937,11 @@ fn normalize_type_name(name: &str) -> Option<&'static str> {
         "boolean" | "Boolean" => Some("Boolean"),
         "entity" | "Entity" => Some("Entity"),
         "bytes" | "Bytes" => Some("Bytes"),
+        // Dialog's type for "one struct, one fact" — a value whose
+        // bytes are a serialized record rather than an opaque blob.
+        // Spellable here because the built-in `view` declares one and
+        // an author's concept must be able to say the same thing.
+        "record" | "Record" => Some("Record"),
         _ => None,
     }
 }

--- a/rust/tonk-analyzer/src/analyzer/error.rs
+++ b/rust/tonk-analyzer/src/analyzer/error.rs
@@ -350,6 +350,51 @@ pub enum AnalyzeErrorKind {
         /// The concept name that failed to resolve.
         name: String,
     },
+    /// A `on:<name>=<command>` binding in a view template names an
+    /// `event!:` declaration nothing declares. The binding would
+    /// install no listener and report nothing — the element would
+    /// simply be inert — so it fails the lowering instead.
+    #[error(
+        "`{attribute}` names the event declaration `{name}`, which no `event!:` declares          in this document or on the branch"
+    )]
+    UnknownEventDeclaration {
+        /// The attribute as written (`on:click`).
+        attribute: String,
+        /// The declaration it names (`on/click`).
+        name: String,
+    },
+    /// A `on:<name>=<command>` binding names a command that resolves
+    /// to no concept. Same failure mode as an unknown declaration: the
+    /// click would post nothing.
+    #[error("`{attribute}={command}` names no command")]
+    UnknownBoundCommand {
+        /// The attribute as written (`on:click`).
+        attribute: String,
+        /// The command name or URI the binding carries.
+        command: String,
+    },
+    /// The bound declaration cannot fill the bound command: a required
+    /// field has no source, or a source names a field the command does
+    /// not declare. The first posts a command no rule premise matches;
+    /// the second is a typo that silently does nothing.
+    #[error("`{attribute}={command}` cannot fill the command — {detail}")]
+    EventCommandMismatch {
+        /// The attribute as written (`on:click`).
+        attribute: String,
+        /// The command the binding posts.
+        command: String,
+        /// What is wrong, rendered: the required fields with no
+        /// source and the sources naming fields the command does not
+        /// declare. One string rather than two lists so the error
+        /// type stays small enough to return by value.
+        detail: String,
+    },
+    /// The resolved bindings could not be encoded.
+    #[error("view bindings could not be encoded: {reason}")]
+    InvalidViewBindings {
+        /// Underlying encoder message.
+        reason: String,
+    },
     /// A field in the body doesn't appear in the head concept's
     /// `with` map.
     #[error("field {field:?} is not part of concept {concept:?}")]
@@ -561,6 +606,10 @@ impl AnalyzeErrorKind {
             Self::InvalidConceptBody { .. } => "E_INVALID_CONCEPT_BODY",
             Self::ReservedName { .. } => "E_RESERVED_NAME",
             Self::UnknownConcept { .. } => "E_UNKNOWN_CONCEPT",
+            Self::UnknownEventDeclaration { .. } => "E_UNKNOWN_EVENT_DECLARATION",
+            Self::UnknownBoundCommand { .. } => "E_UNKNOWN_BOUND_COMMAND",
+            Self::EventCommandMismatch { .. } => "E_EVENT_COMMAND_MISMATCH",
+            Self::InvalidViewBindings { .. } => "E_INVALID_VIEW_BINDINGS",
             Self::UnknownField { .. } => "E_UNKNOWN_FIELD",
             Self::DuplicateConceptField { .. } => "E_DUPLICATE_CONCEPT_FIELD",
             Self::UnknownFormulaOperand { .. } => "E_UNKNOWN_FORMULA_OPERAND",

--- a/rust/tonk-analyzer/src/analyzer/graph.rs
+++ b/rust/tonk-analyzer/src/analyzer/graph.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 
 use dialog_artifacts::Entity;
 use dialog_common::ConditionalSync;
-use tonk_notation::{Effectful, Expression, FieldValue, HeadName, Syntax};
+use tonk_notation::{Effectful, Expression, Field, FieldValue, HeadName, Syntax};
 
 use tonk_schema::concept::QueryEnv;
 use tonk_schema::query_source::Source;
@@ -377,6 +377,16 @@ pub(crate) fn push(syntax: &Syntax) -> Result<Graph, AnalyzeError> {
             }
         }
 
+        // A `view!:` body's `show:` templates bind commands with
+        // `on:<name>=<command>`. Both halves are resolved at lowering
+        // (`super::view::compile_bindings`), so both must be in scope
+        // by then: the command as a concept, the declaration as a
+        // name. Gathered here for the same reason a rule's premise
+        // concepts are — the pass that needs them is synchronous.
+        if is_claim && matches!(&head.name, HeadName::Concept(n) if n == "view") {
+            collect_view_binding_needs(fields, &mut needs);
+        }
+
         // `rule!:` bodies reference concepts (head + premises) and,
         // on retract, the installed rule.
         if let Expression::Claim(c) = expression
@@ -401,6 +411,48 @@ pub(crate) fn push(syntax: &Syntax) -> Result<Graph, AnalyzeError> {
         declarations,
         pending_anchors,
     })
+}
+
+/// Gather what a `view!:` body's `on:<name>=<command>` bindings must
+/// have in scope by lowering: the command's concept (by name or, for a
+/// URI-spelled binding, by entity) and the declaration's name.
+///
+/// A need that resolves to nothing is not an error here — the binding
+/// pass is where an unresolvable reference gets a diagnostic with a
+/// template to point at.
+fn collect_view_binding_needs(fields: &[Field], needs: &mut Vec<Need>) {
+    for field in fields {
+        if field.name != "show" {
+            continue;
+        }
+        let FieldValue::Nested(entries) = &field.value else {
+            continue;
+        };
+        for entry in entries {
+            let FieldValue::Literal(tonk_notation::Scalar::String(template)) = &entry.value else {
+                continue;
+            };
+            for binding in tonk_template::bindings::scan(template) {
+                let range = entry.value_range;
+                // Both forms are prefetched rather than one guessed:
+                // a template writes the command as a bare name
+                // (`space/create`) or as a URI (`tonk:invite`), and
+                // the one that does not apply resolves to nothing,
+                // which costs a lookup and no correctness.
+                if let Ok(entity) = binding.command.parse::<Entity>() {
+                    needs.push(Need::ConceptByEntity { entity, range });
+                }
+                needs.push(Need::Concept {
+                    name: binding.command,
+                    range,
+                });
+                needs.push(Need::Symbol {
+                    name: binding.event_name,
+                    range,
+                });
+            }
+        }
+    }
 }
 
 /// Gather the attribute references a `concept!`'s `with:` and
@@ -836,6 +888,11 @@ impl Graph {
             };
             scope.declare(&anchor.name, entity, anchor.range)?;
         }
+
+        // Pass 5 — `event!:` declarations. Indexed last so their
+        // bare-symbol sources resolve against a fully populated name
+        // table; read synchronously by the view-binding pass.
+        super::view::index_event_declarations(syntax, scope);
 
         Ok(Resolved { declared })
     }

--- a/rust/tonk-analyzer/src/analyzer/rule.rs
+++ b/rust/tonk-analyzer/src/analyzer/rule.rs
@@ -2478,7 +2478,7 @@ rule!:
 
     /// The notation analyzer's `Derived` lowering and the wire-path
     /// [`application_plan_from_predicate`] hash `(predicate, payload)`
-    /// the same way, so a `view!:` written in YAML and a `view`
+    /// the same way, so a `card!:` written in YAML and a `card`
     /// command issued over `/transact` with matching attributes
     /// converge on the same subject entity.
     #[dialog_common::test]
@@ -2492,13 +2492,13 @@ rule!:
         };
 
         let fixture = new_fixture().await;
-        let descriptor = one_text_field("xyz.tonk.view", "name");
-        fixture.declare("view", descriptor.clone()).await;
+        let descriptor = one_text_field("xyz.tonk.card", "name");
+        fixture.declare("card", descriptor.clone()).await;
 
-        // Notation path: a `view!:` with one literal field. No
+        // Notation path: a `card!:` with one literal field. No
         // `this:` and no `&anchor`, so the lowering falls into
         // `ThisIntent::Derived` and hashes `(predicate, body)`.
-        let doc = r#"view!:
+        let doc = r#"card!:
   name: Basic
 "#;
         let syntax = parse(doc).syntax.expect("parsed syntax");
@@ -2548,7 +2548,7 @@ rule!:
 
     /// Entity derivation includes reference fields, not just
     /// literals — so a concept identified by an entity *reference*
-    /// (e.g. a view's `model`) gets a distinct, correct entity.
+    /// (e.g. a card's `model`) gets a distinct, correct entity.
     ///
     /// Regression guard for a `body_digest` defect: it used to
     /// include only literal scalars and skip references, so two
@@ -2570,10 +2570,10 @@ rule!:
 
         let fixture = new_fixture().await;
 
-        // A `view` concept whose sole field, `model`, is an entity
+        // A `card` concept whose sole field, `model`, is an entity
         // reference, plus two distinct concepts it can point at.
-        let view = one_entity_field("xyz.tonk.view", "model");
-        fixture.declare("view", view.clone()).await;
+        let card = one_entity_field("xyz.tonk.card", "model");
+        fixture.declare("card", card.clone()).await;
         fixture
             .declare("counter", one_text_field("xyz.tonk.counter", "count"))
             .await;
@@ -2581,10 +2581,10 @@ rule!:
             .declare("greeting", one_text_field("xyz.tonk.greeting", "message"))
             .await;
 
-        // Helper: lower a `view!: { model: <name> }` document and
+        // Helper: lower a `card!: { model: <name> }` document and
         // pull the derived `this` entity out of the lone statement.
         async fn notation_this_for(fixture: &Fixture<impl FixtureEnv>, model_name: &str) -> Entity {
-            let doc = format!("view!:\n  model: {model_name}\n");
+            let doc = format!("card!:\n  model: {model_name}\n");
             let syntax = parse(&doc).syntax.expect("parsed syntax");
             let analysis = fixture
                 .analyze(&syntax)
@@ -2601,14 +2601,14 @@ rule!:
             }
         }
 
-        let view_of_counter = notation_this_for(&fixture, "counter").await;
-        let view_of_greeting = notation_this_for(&fixture, "greeting").await;
+        let card_of_counter = notation_this_for(&fixture, "counter").await;
+        let card_of_greeting = notation_this_for(&fixture, "greeting").await;
 
         // Facet 1 — distinctness. Today both drop `model` from the
-        // digest and collide on `derive_this(view, {})`.
+        // digest and collide on `derive_this(card, {})`.
         assert_ne!(
-            view_of_counter, view_of_greeting,
-            "views for different models must be different entities; \
+            card_of_counter, card_of_greeting,
+            "instances for different models must be different entities; \
              body_digest dropping the `model` reference makes them collide"
         );
 
@@ -2623,7 +2623,7 @@ rule!:
         parameters.insert("model".into(), Value::Entity(counter_concept));
         let wire_plan = application_plan_from_predicate(
             SourceApplication {
-                predicate: DurableConceptDescriptor::Durable(view),
+                predicate: DurableConceptDescriptor::Durable(card),
                 parameters,
                 name: None,
             }
@@ -2641,7 +2641,7 @@ rule!:
         };
 
         assert_eq!(
-            view_of_counter, wire_this,
+            card_of_counter, wire_this,
             "notation and wire paths must derive the same entity when the body \
              carries a `model` reference"
         );
@@ -2649,20 +2649,20 @@ rule!:
 
     /// A reference field that doesn't resolve is an error, not a
     /// silent skip. Dropping the unresolved `model` from the digest
-    /// would fold the view into the entity it would have had with
+    /// would fold the instance into the entity it would have had with
     /// no model at all — deriving the wrong subject. The anchor
     /// (`&broken`) routes derivation through `body_digest` in the
     /// resolve pass, so this exercises that path specifically.
     #[dialog_common::test]
     async fn it_rejects_unresolved_reference_in_derived_entity() {
         let fixture = new_fixture().await;
-        // Declare `view` (so the head concept resolves) but NOT the
+        // Declare `card` (so the head concept resolves) but NOT the
         // concept its `model` points at.
         fixture
-            .declare("view", one_entity_field("xyz.tonk.view", "model"))
+            .declare("card", one_entity_field("xyz.tonk.card", "model"))
             .await;
 
-        let doc = r#"view!: &broken
+        let doc = r#"card!: &broken
   model: nonexistent
 "#;
         let syntax = parse(doc).syntax.expect("parsed syntax");

--- a/rust/tonk-analyzer/src/analyzer/scope.rs
+++ b/rust/tonk-analyzer/src/analyzer/scope.rs
@@ -15,6 +15,7 @@ use super::error::{AnalyzeError, AnalyzeErrorKind};
 use super::rule::builtin_kind;
 use tonk_schema::resolution::{AttributeDefinition, ConceptDefinition};
 use tonk_schema::rule::Rule;
+use tonk_template::event::EventDescriptor;
 
 /// Layered name index built during analysis.
 ///
@@ -76,6 +77,15 @@ pub(crate) struct Scope {
     /// means the entity holds no concept (retracting from something
     /// absent).
     pub(crate) resolved_concepts: Mutex<HashMap<String, Option<ConceptDefinition>>>,
+    /// Declaration name (`on/click`) -> the `event!:` instance the
+    /// document declares under it, parsed once.
+    ///
+    /// An `event!:` block is an ordinary instance assertion, not a
+    /// meta head, so nothing else in the analyzer needs its *content*
+    /// — only the view-binding pass, which inlines it. Indexed here so
+    /// that pass reads it synchronously, the same way a concept body
+    /// reads an in-document attribute.
+    pub(crate) event_declarations: Mutex<HashMap<String, EventDescriptor>>,
 }
 
 impl Scope {
@@ -91,6 +101,7 @@ impl Scope {
             named_entities: Mutex::new(HashMap::new()),
             resolved_rules: Mutex::new(HashMap::new()),
             resolved_concepts: Mutex::new(HashMap::new()),
+            event_declarations: Mutex::new(HashMap::new()),
         }
     }
 
@@ -233,6 +244,16 @@ impl Scope {
         self.named_entities.lock().insert(name.to_owned(), entity);
     }
 
+    /// Sync concept-by-entity lookup — in-doc declarations and
+    /// branch concepts the resolve phase recorded. The form a
+    /// URI-spelled reference (`on:join=tonk:join`) needs.
+    pub(crate) fn concept_by_entity(&self, entity: &Entity) -> Option<ConceptDefinition> {
+        self.in_doc_concepts_by_entity
+            .lock()
+            .get(&entity.to_string())
+            .cloned()
+    }
+
     /// Sync attribute-by-name lookup — in-doc attributes only.
     pub(crate) fn attribute(&self, name: &str) -> Option<AttributeDefinition> {
         self.in_doc_attributes.lock().get(name).cloned()
@@ -337,5 +358,18 @@ impl Scope {
         self.resolved_concepts
             .lock()
             .insert(entity.to_string(), concept);
+    }
+
+    /// Record an `event!:` declaration the document makes, under the
+    /// name its anchor published (`on/click`).
+    pub(crate) fn record_event_declaration(&self, name: &str, descriptor: EventDescriptor) {
+        self.event_declarations
+            .lock()
+            .insert(name.to_owned(), descriptor);
+    }
+
+    /// Sync lookup of a declaration the document makes.
+    pub(crate) fn event_declaration(&self, name: &str) -> Option<EventDescriptor> {
+        self.event_declarations.lock().get(name).cloned()
     }
 }

--- a/rust/tonk-analyzer/src/analyzer/view.rs
+++ b/rust/tonk-analyzer/src/analyzer/view.rs
@@ -207,7 +207,7 @@ pub(crate) fn compile_bindings(
     if events.is_empty() {
         return Ok(None);
     }
-    Ok(Some(Bindings { events }))
+    Ok(Some(Bindings::new(events)))
 }
 
 /// The concept a binding's command half names — by bare name or by
@@ -351,7 +351,7 @@ view!:
             let Statement::Assert(Application::Concept { query, .. }) = statement else {
                 continue;
             };
-            if let Some(Term::Constant(Value::Bytes(bytes))) = query.terms.get("bindings") {
+            if let Some(Term::Constant(Value::Record(bytes))) = query.terms.get("bindings") {
                 return Some(Bindings::decode(bytes).expect("the artifact decodes"));
             }
         }
@@ -412,6 +412,25 @@ view!:
         let source = document("on:demo=demo/act", "{this}").replace("subject: \"{", "topic: \"{");
         let error = lower(&source).expect_err("an unfillable command must not lower");
         assert_eq!(error.kind.code(), "E_EVENT_COMMAND_MISMATCH", "{error}");
+    }
+
+    /// The `bindings` field's type is spellable in an author's own
+    /// `concept!:`, not only in the hand-built built-in.
+    ///
+    /// Lives with the view tests because the built-in is the reason
+    /// `record` entered the `as:` vocabulary: a type the analyzer
+    /// writes but cannot parse would be a schema only the compiler
+    /// could author.
+    #[dialog_common::test]
+    fn record_is_a_spellable_value_type() {
+        let source = r#"
+attribute!: &demo/blob
+  the: xyz.tonk.demo/blob
+  as: record
+  cardinality: one
+  description: A compiled artifact.
+"#;
+        lower(source).expect("`as: record` is a declarable value type");
     }
 
     /// A binding mentioned in an HTML comment is not a binding: the

--- a/rust/tonk-analyzer/src/analyzer/view.rs
+++ b/rust/tonk-analyzer/src/analyzer/view.rs
@@ -164,11 +164,10 @@ pub(crate) fn compile_bindings(
             let Some(template) = field_text(&entry.value) else {
                 continue;
             };
-            found.extend(
-                scan(&template)
-                    .into_iter()
-                    .map(|binding| (binding, entry.value_range)),
-            );
+            found.extend(scan(&template).into_iter().map(|binding| {
+                let range = attribute_range(entry.value_range, &template, &binding);
+                (binding, range)
+            }));
         }
     }
     if found.is_empty() {
@@ -208,6 +207,46 @@ pub(crate) fn compile_bindings(
         return Ok(None);
     }
     Ok(Some(Bindings::new(events)))
+}
+
+/// Where a binding's attribute is written, in the document's own
+/// coordinates.
+///
+/// A template is a block scalar: its value range starts at the first
+/// content character, and every content line carries that same
+/// indentation. So a position inside the template maps to the source
+/// by adding the range's start — line offset by line offset, and the
+/// indentation added to the column. That is exact for the block form,
+/// which is how every template in the corpus is written.
+///
+/// Anything else — a flow scalar whose escapes shift the columns, a
+/// computed position past the end of the value — falls back to the
+/// whole value. A range that is merely wide is a worse report; one
+/// that points outside the value is a wrong one.
+fn attribute_range(
+    value_range: lsp_types::Range,
+    template: &str,
+    binding: &EventBinding,
+) -> lsp_types::Range {
+    let Some(head) = template.get(..binding.offset) else {
+        return value_range;
+    };
+    let line = head.matches('\n').count() as u32;
+    // Every content line of a block scalar starts at the same column
+    // the value range does, so the same offset applies to all of them.
+    let column = head.rsplit('\n').next().unwrap_or(head).chars().count() as u32;
+    let start = lsp_types::Position {
+        line: value_range.start.line + line,
+        character: value_range.start.character + column,
+    };
+    let end = lsp_types::Position {
+        line: start.line,
+        character: start.character + binding.attribute.chars().count() as u32,
+    };
+    if (end.line, end.character) > (value_range.end.line, value_range.end.character) {
+        return value_range;
+    }
+    lsp_types::Range { start, end }
 }
 
 /// The concept a binding's command half names — by bare name or by
@@ -412,6 +451,30 @@ view!:
         let source = document("on:demo=demo/act", "{this}").replace("subject: \"{", "topic: \"{");
         let error = lower(&source).expect_err("an unfillable command must not lower");
         assert_eq!(error.kind.code(), "E_EVENT_COMMAND_MISMATCH", "{error}");
+    }
+
+    /// The report points at the attribute, not at the template.
+    ///
+    /// A block scalar is many lines wide; underlining all of it says
+    /// "something in here is wrong" when the analyzer knows exactly
+    /// which eight characters are.
+    #[dialog_common::test]
+    fn a_dangling_binding_is_reported_where_it_is_written() {
+        let source = document("on:missing=demo/act", "{this}");
+        let error = lower(&source).expect_err("a dangling declaration must not lower");
+        let range = error.range.expect("the report is placed");
+        let line = source
+            .lines()
+            .nth(range.start.line as usize)
+            .expect("the line is in the document");
+        let start = range.start.character as usize;
+        let end = range.end.character as usize;
+        assert_eq!(
+            &line[start..end],
+            "on:missing",
+            "the range covers the attribute alone, in `{line}`",
+        );
+        assert_eq!(range.start.line, range.end.line, "one line, not the block");
     }
 
     /// The `bindings` field's type is spellable in an author's own

--- a/rust/tonk-analyzer/src/analyzer/view.rs
+++ b/rust/tonk-analyzer/src/analyzer/view.rs
@@ -1,0 +1,433 @@
+//! View bindings, resolved at lowering.
+//!
+//! A `show:` template binds an interaction with `on:<name>=<command>`.
+//! Both halves used to be resolved at render time — one query per
+//! declaration name to rebuild the event descriptor, one per command
+//! name to fetch its shape — and a name that resolved to nothing
+//! produced no listener and no diagnostic. The element was inert, and
+//! the only way to find out was to click it.
+//!
+//! Both halves are knowable here: the analyzer has the template text
+//! and the document's `event!:` / `command!:` declarations in scope.
+//! So this module scans the templates, resolves each binding, fails
+//! the lowering on anything that does not resolve, and encodes the
+//! result as the view's `bindings` field — the same move `concept!:`
+//! makes when it inlines its attributes' descriptors rather than
+//! leaving names for the runtime to chase.
+//!
+//! What is *not* inlined is the command's descriptor. The display
+//! already resolves a concept from a name for every model it renders,
+//! so carrying a second copy here would duplicate work rather than
+//! remove it. What the analyzer contributes for commands is the check.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use tonk_notation::{Application as SyntaxApplication, Field, FieldValue, HeadName, Scalar};
+use tonk_schema::resolution::ConceptDefinition;
+use tonk_template::bindings::{Bindings, EventBinding, scan};
+use tonk_template::event::{EventDescriptor, event_descriptor};
+
+use super::error::{AnalyzeError, AnalyzeErrorKind};
+use super::scope::Scope;
+
+/// The field a view's compiled bindings are stored under, and the
+/// keyed field its templates live under.
+pub(crate) const BINDINGS_FIELD: &str = "bindings";
+const SHOW_FIELD: &str = "show";
+
+/// The built-in `view` concept's entity. A head resolving to it is a
+/// view however it was spelled, and nothing else is.
+const VIEW_ENTITY: &str = "db:view";
+
+/// True when this resolved head is the built-in `view`.
+pub(crate) fn is_view(concept: &ConceptDefinition) -> bool {
+    concept.entity.to_string() == VIEW_ENTITY
+}
+
+/// Index every `event!:` declaration the document makes, so the
+/// binding pass reads them synchronously.
+///
+/// Bare-symbol sources are resolved to entities here, once, using the
+/// same name table every other reference goes through — so the
+/// event-time path never performs a lookup, and a misspelled source is
+/// caught at lowering rather than dropped silently at click time.
+pub(crate) fn index_event_declarations(syntax: &tonk_notation::Syntax, scope: &Scope) {
+    use tonk_notation::Expression;
+
+    for expression in &syntax.expressions {
+        let Expression::Claim(claim) = expression else {
+            continue;
+        };
+        let Some(anchor) = &claim.anchor else {
+            continue;
+        };
+        if !matches!(&claim.inner.predicate.name, HeadName::Concept(name) if name == "event") {
+            continue;
+        }
+        let Some(mut descriptor) = parse_event_declaration(&claim.inner.fields) else {
+            continue;
+        };
+        let resolved: BTreeMap<String, String> = descriptor
+            .references()
+            .into_iter()
+            .filter_map(|name| scope.symbol(&name).map(|entity| (name, entity.to_string())))
+            .collect();
+        // Names left unresolved stay `Source::Reference`. They are not
+        // this pass's to report — the binding pass reaches them only
+        // if a template actually binds this declaration, and that is
+        // where the diagnostic has a template to point at.
+        let _ = descriptor.resolve_references(&resolved);
+        scope.record_event_declaration(&anchor.name, descriptor);
+    }
+}
+
+/// Read an `event!:` body into a descriptor. `None` when the body
+/// carries no usable `type:` — the one thing a declaration cannot do
+/// without.
+fn parse_event_declaration(fields: &[Field]) -> Option<EventDescriptor> {
+    let mut event_type = None;
+    let mut prevent_default = false;
+    let mut stop_propagation = false;
+    let mut sources: Vec<(String, String)> = Vec::new();
+
+    for field in fields {
+        match field.name.as_str() {
+            "type" => event_type = field_text(&field.value),
+            "prevent-default" => prevent_default = field_flag(&field.value),
+            "stop-propagation" => stop_propagation = field_flag(&field.value),
+            "where" => {
+                if let FieldValue::Nested(entries) = &field.value {
+                    for entry in entries {
+                        if let Some(text) = field_text(&entry.value) {
+                            sources.push((entry.name.clone(), text));
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    event_descriptor(
+        event_type.as_deref(),
+        prevent_default,
+        stop_propagation,
+        sources,
+    )
+    .ok()
+}
+
+/// A field value as the source text `parse_source` classifies.
+///
+/// A bare symbol stays a bare symbol and a URI stays a URI, so the
+/// classification a source gets here is the one it would get anywhere
+/// else in the notation.
+fn field_text(value: &FieldValue) -> Option<String> {
+    match value {
+        FieldValue::Literal(Scalar::String(text)) => Some(text.clone()),
+        FieldValue::Literal(Scalar::Integer(number)) => Some(number.to_string()),
+        FieldValue::Literal(Scalar::UnsignedInteger(number)) => Some(number.to_string()),
+        FieldValue::Literal(Scalar::Float(number)) => Some(number.to_string()),
+        FieldValue::Literal(Scalar::Boolean(flag)) => Some(flag.to_string()),
+        FieldValue::Symbol(name) => Some(name.clone()),
+        FieldValue::Uri(uri) => Some(uri.clone()),
+        _ => None,
+    }
+}
+
+/// A field value as a flag. Anything that is not an explicit `true`
+/// reads as `false`, matching the runtime's "absent means no".
+fn field_flag(value: &FieldValue) -> bool {
+    matches!(value, FieldValue::Literal(Scalar::Boolean(true)))
+}
+
+/// Resolve every binding a view's `show:` templates make, into the
+/// artifact the view stores.
+///
+/// `Ok(None)` means the templates bind nothing, so the view carries no
+/// `bindings` field at all — which is also what a view lowered before
+/// this pass existed looks like, and what the display's fallback
+/// handles.
+pub(crate) fn compile_bindings(
+    assertion: &SyntaxApplication,
+    scope: &Scope,
+) -> Result<Option<Bindings>, AnalyzeError> {
+    let mut found: Vec<(EventBinding, lsp_types::Range)> = Vec::new();
+    for field in &assertion.fields {
+        if field.name != SHOW_FIELD {
+            continue;
+        }
+        let FieldValue::Nested(entries) = &field.value else {
+            continue;
+        };
+        for entry in entries {
+            let Some(template) = field_text(&entry.value) else {
+                continue;
+            };
+            found.extend(
+                scan(&template)
+                    .into_iter()
+                    .map(|binding| (binding, entry.value_range)),
+            );
+        }
+    }
+    if found.is_empty() {
+        return Ok(None);
+    }
+
+    let mut events: BTreeMap<String, EventDescriptor> = BTreeMap::new();
+    for (binding, range) in found {
+        // Every binding's command must resolve, inlined or not: an
+        // `on:` that posts nothing is the failure this pass exists to
+        // catch, and it is checkable wherever the command lives.
+        let command = resolve_command(&binding, scope, range)?;
+
+        let Some(descriptor) = scope.event_declaration(&binding.event_name) else {
+            // Not declared in this document. A declaration seeded by
+            // an earlier one (a component library binding a core
+            // event) still resolves as a name, and the display's
+            // per-name query reads it at render time — so this is a
+            // binding that is not inlined, not a broken one. Only a
+            // name that resolves to nothing at all is an error.
+            if scope.symbol(&binding.event_name).is_some() {
+                continue;
+            }
+            return Err(AnalyzeError::at(
+                AnalyzeErrorKind::UnknownEventDeclaration {
+                    attribute: binding.attribute.clone(),
+                    name: binding.event_name.clone(),
+                },
+                range,
+            ));
+        };
+        check_fills(&binding, &descriptor, &command, range)?;
+        events.insert(binding.event_name, descriptor);
+    }
+
+    if events.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(Bindings { events }))
+}
+
+/// The concept a binding's command half names — by bare name or by
+/// URI, the two forms a template writes.
+fn resolve_command(
+    binding: &EventBinding,
+    scope: &Scope,
+    range: lsp_types::Range,
+) -> Result<ConceptDefinition, AnalyzeError> {
+    let unknown = || {
+        AnalyzeError::at(
+            AnalyzeErrorKind::UnknownBoundCommand {
+                attribute: binding.attribute.clone(),
+                command: binding.command.clone(),
+            },
+            range,
+        )
+    };
+    if let Some(concept) = scope.concept(&binding.command) {
+        return Ok(concept);
+    }
+    // A URI-spelled command (`on:invite=tonk:invite`) names the
+    // concept's entity rather than its published name.
+    let entity = binding.command.parse().map_err(|_| unknown())?;
+    scope
+        .resolved_concept(&entity)
+        .flatten()
+        .or_else(|| scope.concept_by_entity(&entity))
+        .ok_or_else(unknown)
+}
+
+/// The declaration must fill the command it is bound to.
+///
+/// This is the check the whole `event!:` split exists to make
+/// possible: a required field with no source posts a command no rule
+/// premise matches, and before this the only symptom was a button that
+/// did nothing.
+fn check_fills(
+    binding: &EventBinding,
+    descriptor: &EventDescriptor,
+    command: &ConceptDefinition,
+    range: lsp_types::Range,
+) -> Result<(), AnalyzeError> {
+    let concept = command.descriptor.concept();
+    let mut required: BTreeSet<String> = BTreeSet::new();
+    let mut optional: BTreeSet<String> = BTreeSet::new();
+    for (name, attribute) in concept.with().iter() {
+        if attribute.is_optional() {
+            optional.insert(name.to_string());
+        } else {
+            required.insert(name.to_string());
+        }
+    }
+    let mismatch = tonk_template::event::check(descriptor, &required, &optional);
+    if mismatch.is_empty() {
+        return Ok(());
+    }
+    let mut detail = Vec::new();
+    if !mismatch.unfilled.is_empty() {
+        let fields: Vec<&str> = mismatch.unfilled.iter().map(|u| u.field.as_str()).collect();
+        detail.push(format!("nothing fills {}", fields.join(", ")));
+    }
+    if !mismatch.unknown.is_empty() {
+        let fields: Vec<&str> = mismatch.unknown.iter().map(|u| u.field.as_str()).collect();
+        detail.push(format!(
+            "the declaration sources {}, which the command does not declare",
+            fields.join(", ")
+        ));
+    }
+    Err(AnalyzeError::at(
+        AnalyzeErrorKind::EventCommandMismatch {
+            attribute: binding.attribute.clone(),
+            command: binding.command.clone(),
+            detail: detail.join("; "),
+        },
+        range,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use dialog_artifacts::Value;
+    use dialog_query::Term;
+    use tonk_schema::transact::{Application, Statement};
+    use tonk_template::bindings::Bindings;
+
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    /// A command, the declaration that fills it, and a view binding
+    /// the two. `$binding` is what the template's `on:` attribute
+    /// carries, so a test can break exactly one half.
+    fn document(binding: &str, source: &str) -> String {
+        format!(
+            r#"
+command!: &demo/act
+  description: A demo command.
+  with:
+    subject:
+      description: What was acted on.
+      the: xyz.tonk.demo.act/subject
+      as: entity
+
+event!: &on/demo
+  type: "click"
+  where:
+    subject: "{source}"
+
+view!:
+  this: tonk:demo
+  show:
+    ui: |
+      <button {binding}>go</button>
+"#
+        )
+    }
+
+    /// Lower a document, returning the analyzer's verdict.
+    fn lower(source: &str) -> Result<Vec<Statement>, crate::analyzer::AnalyzeError> {
+        let parsed = tonk_notation::parse(source);
+        assert!(
+            parsed.diagnostics.is_empty(),
+            "the fixture must parse: {:#?}",
+            parsed.diagnostics
+        );
+        let syntax = parsed.syntax.expect("a syntax tree");
+        let tree = crate::analyzer::analyze_local(&syntax)?;
+        Ok(tree
+            .analysis
+            .statements()
+            .into_iter()
+            .map(|planned| planned.statement)
+            .collect())
+    }
+
+    /// The `bindings` artifact the lowered document carries, if any.
+    fn bindings(statements: &[Statement]) -> Option<Bindings> {
+        for statement in statements {
+            let Statement::Assert(Application::Concept { query, .. }) = statement else {
+                continue;
+            };
+            if let Some(Term::Constant(Value::Bytes(bytes))) = query.terms.get("bindings") {
+                return Some(Bindings::decode(bytes).expect("the artifact decodes"));
+            }
+        }
+        None
+    }
+
+    #[dialog_common::test]
+    fn it_inlines_the_declaration_a_binding_names() {
+        let statements = lower(&document("on:demo=demo/act", "{this}")).expect("lowers");
+        let bindings = bindings(&statements).expect("the view carries its bindings");
+        let descriptor = bindings
+            .events
+            .get("on/demo")
+            .expect("`on/demo` is inlined under the name the binding uses");
+        assert_eq!(descriptor.event_type, "click");
+        assert_eq!(
+            descriptor.sources.get("subject"),
+            Some(&tonk_template::event::Source::Field("this".into())),
+            "the `where:` source rides along, so nothing is queried per name at render time",
+        );
+    }
+
+    #[dialog_common::test]
+    fn a_view_that_binds_nothing_carries_no_artifact() {
+        let source = r#"
+view!:
+  this: tonk:demo
+  show:
+    ui: |
+      <p>nothing to click</p>
+"#;
+        let statements = lower(source).expect("lowers");
+        assert!(
+            bindings(&statements).is_none(),
+            "a view with no bindings must not grow an empty artifact",
+        );
+    }
+
+    #[dialog_common::test]
+    fn a_binding_naming_no_declaration_fails_the_lowering() {
+        let error = lower(&document("on:missing=demo/act", "{this}"))
+            .expect_err("a dangling declaration reference must not lower");
+        assert_eq!(error.kind.code(), "E_UNKNOWN_EVENT_DECLARATION", "{error}");
+    }
+
+    #[dialog_common::test]
+    fn a_binding_naming_no_command_fails_the_lowering() {
+        let error = lower(&document("on:demo=demo/nope", "{this}"))
+            .expect_err("a dangling command reference must not lower");
+        assert_eq!(error.kind.code(), "E_UNKNOWN_BOUND_COMMAND", "{error}");
+    }
+
+    #[dialog_common::test]
+    fn a_declaration_that_cannot_fill_its_command_fails_the_lowering() {
+        // The declaration sources `topic`, which the command does not
+        // declare, and leaves `subject` — which it requires —
+        // unfilled. Both halves of the mismatch, one diagnostic.
+        let source = document("on:demo=demo/act", "{this}").replace("subject: \"{", "topic: \"{");
+        let error = lower(&source).expect_err("an unfillable command must not lower");
+        assert_eq!(error.kind.code(), "E_EVENT_COMMAND_MISMATCH", "{error}");
+    }
+
+    /// A binding mentioned in an HTML comment is not a binding: the
+    /// parser drops comment content, so treating it as one would fail
+    /// the lowering over prose.
+    #[dialog_common::test]
+    fn a_binding_named_in_a_comment_is_not_one() {
+        let source = r#"
+view!:
+  this: tonk:demo
+  show:
+    ui: |
+      <!-- bind it with on:nowhere=nothing -->
+      <p>prose</p>
+"#;
+        let statements = lower(source).expect("lowers");
+        assert!(bindings(&statements).is_none());
+    }
+}

--- a/rust/tonk-cli/tests/common.rs
+++ b/rust/tonk-cli/tests/common.rs
@@ -378,6 +378,15 @@ concept!: &note
 /// a `view` concept that uses it. Pasted at the top of any test
 /// that needs `view!` heads. Shared with [`tonk_cli::guide`] so the
 /// agent-facing reference matches what the tests exercise.
+/// An author's own HTML-page concept, plus the `text/html` attribute
+/// it stores its body under.
+///
+/// Deliberately NOT named `view`: `view` is a built-in concept, and a
+/// built-in shadows a branch declaration of the same name, so a
+/// document written after this one is seeded would resolve `view!:` to
+/// the built-in's `show:` shape rather than to this. The listing these
+/// fixtures exercise keys off the `text/html` attribute and the `show`
+/// dictionary, never off a concept name, so the name is free.
 pub const VIEW_DECL: &str = r#"
 attribute!: &html-body
   description: "HTML body of a tonk-authored view"
@@ -385,8 +394,8 @@ attribute!: &html-body
   as:          text
   cardinality: many
 
-concept!: &view
-  description: "An HTML view, served via the host route"
+concept!: &page
+  description: "An HTML page, served via the host route"
   with:
     body: html-body
 "#;

--- a/rust/tonk-cli/tests/site.rs
+++ b/rust/tonk-cli/tests/site.rs
@@ -993,7 +993,7 @@ mod when_authoring_an_html_view {
     /// 1. `attribute! the: text/html` is accepted by parse +
     ///    analyzer (the dialog layer permits `text/html` even
     ///    though the domain is dotless).
-    /// 2. A `view!` head whose body field references that
+    /// 2. A `page!` head whose body field references that
     ///    attribute lands as a literal `(text/html, ?, body)`
     ///    claim — i.e. the URI on the wire really is `text/html`,
     ///    not a synthesised concept-namespace URI.
@@ -1004,7 +1004,7 @@ mod when_authoring_an_html_view {
         let test = common::TestSite::new().await?;
         test.eval_inline(VIEW_DECL).await?;
         test.eval_inline(
-            r#"view!: &my-view
+            r#"page!: &my-view
   body: "<h1>hi</h1>"
 "#,
         )
@@ -1029,7 +1029,7 @@ mod when_authoring_an_html_view {
         // Re-asserting the same body is a no-op: same content →
         // same entity, same claim. The claim count must stay 1.
         test.eval_inline(
-            r#"view!: &my-view
+            r#"page!: &my-view
   body: "<h1>hi</h1>"
 "#,
         )
@@ -1210,13 +1210,13 @@ mod when_listing_views {
         let test = common::TestSite::new().await?;
         test.eval_inline(VIEW_DECL).await?;
         test.eval_inline(
-            r#"view!: &todo-list
+            r#"page!: &todo-list
   body: "<ul><li>buy milk</li></ul>"
 "#,
         )
         .await?;
         test.eval_inline(
-            r#"view!: &welcome
+            r#"page!: &welcome
   body: "<h1>hi</h1>"
 "#,
         )
@@ -1237,7 +1237,7 @@ mod when_listing_views {
         let test = common::TestSite::new().await?;
         test.eval_inline(VIEW_DECL).await?;
         test.eval_inline(
-            r#"view!: &welcome
+            r#"page!: &welcome
   body: "<h1>hi</h1>"
 "#,
         )

--- a/rust/tonk-core/assets/library/core.yaml
+++ b/rust/tonk-core/assets/library/core.yaml
@@ -18,25 +18,16 @@
 # VIEW
 # ============================================================
 
-# The `view` concept. Shape matches what `<tonk-display>` queries
-# (resolve.rs `view_predicate`): the instance's `this` IS the model
-# entity, and `show` is its presentations keyed by facet (`ui` for
-# the detail view, `directory` for the entity-set view, `label`,
-# `title`, or any facet a `view=` attribute names). Each entry lands
-# as `<model> xyz.tonk.view/<facet> <template>`; cardinality is one
-# per entry, so re-asserting a facet supersedes its template. Pinned
-# to the stable `tonk:view` URI so <tonk-display> can refer to the
-# built-in view concept directly, without a name-resolution
-# round-trip.
-concept!: &view
-  this: tonk:view
-  description: A model's presentations, keyed by facet (ui, directory, label, title, ...)
-  with:
-    show:
-      description: HTML templates keyed by facet
-      the: xyz.tonk.view
-      cardinality: one
-      as: {[symbol]: text}
+# `view` is a BUILT-IN concept (tonk-schema's registry, beside
+# `concept`, `command`, `event` and `rule`). It is declared there
+# rather than here because the analyzer has to understand a view
+# structurally: a `show:` template can bind `on:<name>=<command>`,
+# and those are resolved at lowering into the view's `bindings`
+# rather than re-queried per name on every refresh.
+#
+# An in-document declaration SHADOWS a builtin, so declaring it
+# here again would silently restore runtime resolution. What lives
+# in the libraries are its INSTANCES: the `view!:` blocks below.
 
 # The default directory view: `this: tonk:_` matches any model whose
 # own `show` dictionary has no `directory` entry. `tonk:_` is the

--- a/rust/tonk-core/assets/library/profile.yaml
+++ b/rust/tonk-core/assets/library/profile.yaml
@@ -191,20 +191,16 @@ command!: &tonk/load
       the: xyz.tonk.site/path
       as: text
 
-# The `view` concept — the shape `<tonk-display>` queries: the
-# instance's `this` IS the model entity, `show` its templates keyed
-# by facet (`ui`, `directory`, `label`, `title`, …). The `view!:`
-# instances below are instances of it, so its concept must be present
-# on this branch too. Kept in step with core.yaml's declaration.
-concept!: &view
-  this: tonk:view
-  description: A model's presentations, keyed by facet (ui, directory, label, title, ...)
-  with:
-    show:
-      description: HTML templates keyed by facet
-      the: xyz.tonk.view
-      cardinality: one
-      as: {[symbol]: text}
+# `view` is a BUILT-IN concept (tonk-schema's registry, beside
+# `concept`, `command`, `event` and `rule`). It is declared there
+# rather than here because the analyzer has to understand a view
+# structurally: a `show:` template can bind `on:<name>=<command>`,
+# and those are resolved at lowering into the view's `bindings`
+# rather than re-queried per name on every refresh.
+#
+# An in-document declaration SHADOWS a builtin, so declaring it
+# here again would silently restore runtime resolution. What lives
+# in the libraries are its INSTANCES: the `view!:` blocks below.
 
 # The Hub directory view: the picker shown at `/`. One card per space,
 # linking to its `/space/{subject}` page. A space is identified by its

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -1712,6 +1712,10 @@ async fn resolve_inlined_bindings(
         return empty;
     };
     let conclusions: Vec<Conclusion> = serde_wasm_bindgen::from_value(rows).unwrap_or_default();
+    // `Ipld::Bytes`, even though the field is declared `Record`: the
+    // wire projection flattens both to the same shape, which is why
+    // the payload names its own format rather than relying on the
+    // value's type tag to have survived.
     let Some(Ipld::Bytes(bytes)) = conclusions
         .first()
         .and_then(|conclusion| conclusion.fields.get("bindings"))

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -2882,6 +2882,290 @@ mod tests {
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test_configure!(run_in_browser);
 
+    /// A `<tonk-display>` stand-in mounted in the document, optionally
+    /// with a `tonk-query` host behind it.
+    ///
+    /// Every wasm test in this crate shares one page, so a fixture that
+    /// leaves an element or a `body` listener behind changes what the
+    /// *next* test sees — a `tonk-query` listener especially, since it
+    /// claims queries for whoever dispatches them. Both are torn down
+    /// on drop.
+    #[cfg(target_arch = "wasm32")]
+    struct StubHost {
+        host: Element,
+        listener: Option<Closure<dyn FnMut(web_sys::Event)>>,
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    impl Drop for StubHost {
+        fn drop(&mut self) {
+            if let Some(listener) = self.listener.take()
+                && let Some(body) = window()
+                    .and_then(|w| w.document())
+                    .and_then(|document| document.body())
+            {
+                let _ = body.remove_event_listener_with_callback(
+                    "tonk-query",
+                    listener.as_ref().unchecked_ref(),
+                );
+            }
+            if let Some(parent) = self.host.parent_node() {
+                let _ = parent.remove_child(&self.host);
+            }
+        }
+    }
+
+    /// A host element in the document that nothing answers queries for.
+    #[cfg(target_arch = "wasm32")]
+    fn unclaimed_host() -> StubHost {
+        let document = window().expect("window").document().expect("document");
+        let host = document.create_element("div").expect("host");
+        document
+            .body()
+            .expect("body")
+            .append_child(&host)
+            .expect("append");
+        StubHost {
+            host,
+            listener: None,
+        }
+    }
+
+    /// A host whose queries are all claimed and answered with `rows`,
+    /// running `before` first.
+    ///
+    /// The listener runs *synchronously* inside `dispatch_event`, which
+    /// is what makes `before` useful: it executes at the exact moment
+    /// the display is mid-query, so a hook that takes a state borrow
+    /// there stands in for a frame handler firing during the round
+    /// trip.
+    #[cfg(target_arch = "wasm32")]
+    fn stub_query_host(rows: Vec<Conclusion>, before: impl Fn(&CustomEvent) + 'static) -> StubHost {
+        let mut stub = unclaimed_host();
+        let callback = Closure::wrap(Box::new(move |event: web_sys::Event| {
+            let Some(event) = event.dyn_ref::<CustomEvent>() else {
+                return;
+            };
+            before(event);
+            event.prevent_default();
+            let detail = event.detail();
+            let value = serde_wasm_bindgen::to_value(&rows).expect("rows serialize");
+            let _ = Reflect::set(&detail, &"result".into(), &Promise::resolve(&value));
+        }) as Box<dyn FnMut(web_sys::Event)>);
+        let body = window()
+            .expect("window")
+            .document()
+            .expect("document")
+            .body()
+            .expect("body");
+        body.add_event_listener_with_callback("tonk-query", callback.as_ref().unchecked_ref())
+            .expect("listener installs");
+        stub.listener = Some(callback);
+        stub
+    }
+
+    /// One event declaration, as the analyzer would have inlined it.
+    #[cfg(target_arch = "wasm32")]
+    fn one_inlined_declaration() -> BTreeMap<String, tonk_template::event::EventDescriptor> {
+        BTreeMap::from([(
+            "on/click".to_string(),
+            tonk_template::event::EventDescriptor {
+                event_type: "click".into(),
+                prevent_default: false,
+                stop_propagation: false,
+                sources: BTreeMap::from([(
+                    "subject".to_string(),
+                    tonk_template::event::Source::Field("this".into()),
+                )]),
+            },
+        )])
+    }
+
+    /// A declaration the artifact carries costs no query at all.
+    ///
+    /// This is the claim the whole change rests on, so it is asserted
+    /// the strictest way available: no `tonk-query` host is installed,
+    /// so *any* query the table tried to make would fail to be claimed
+    /// and the declaration would be dropped with a warning. It resolves
+    /// anyway, which it can only do from the artifact.
+    #[cfg(target_arch = "wasm32")]
+    #[dialog_common::test]
+    async fn it_resolves_an_inlined_declaration_without_querying() {
+        let stub = unclaimed_host();
+        let names = BTreeSet::from(["on/click".to_string()]);
+        let table = resolve_event_table(&stub.host, &names, one_inlined_declaration()).await;
+
+        let descriptor = table
+            .get("on/click")
+            .expect("the artifact answers without a host to query");
+        assert_eq!(descriptor.event_type, "click");
+        assert_eq!(
+            descriptor.sources.get("subject"),
+            Some(&tonk_template::event::Source::Field("this".into())),
+            "the `where:` source rides the artifact, not a per-name read",
+        );
+    }
+
+    /// A declaration the artifact does NOT carry still goes to the
+    /// branch — the fallback a view seeded before this field existed
+    /// depends on.
+    ///
+    /// Same no-host setup, so the fallback cannot succeed; what is
+    /// asserted is that it was *attempted*, which is the difference
+    /// between falling back and silently ignoring the binding.
+    #[cfg(target_arch = "wasm32")]
+    #[dialog_common::test]
+    async fn it_falls_back_for_a_declaration_the_artifact_omits() {
+        let stub = unclaimed_host();
+        let names = BTreeSet::from(["on/elsewhere".to_string()]);
+        let table = resolve_event_table(&stub.host, &names, one_inlined_declaration()).await;
+
+        assert!(
+            table.get("on/elsewhere").is_none(),
+            "an uncovered name is resolved against the branch, which no host answered",
+        );
+    }
+
+    /// The stored artifact is read back through the view-bindings query.
+    #[cfg(target_arch = "wasm32")]
+    #[dialog_common::test]
+    async fn it_decodes_the_stored_bindings_artifact() {
+        let encoded = tonk_template::bindings::Bindings::new(one_inlined_declaration())
+            .encode()
+            .expect("artifact encodes");
+        let stub = stub_query_host(
+            vec![Conclusion {
+                this: "tonk:demo".into(),
+                fields: BTreeMap::from([("bindings".to_string(), Ipld::Bytes(encoded))]),
+            }],
+            |_| {},
+        );
+
+        let events = resolve_inlined_bindings(&stub.host, "tonk:demo").await;
+        assert_eq!(
+            events.get("on/click").map(|d| d.event_type.as_str()),
+            Some("click"),
+        );
+    }
+
+    /// Bytes that are not this artifact resolve to nothing rather than
+    /// to an empty table read as authoritative — the display falls back
+    /// to per-name resolution, which is what an older view needs.
+    #[cfg(target_arch = "wasm32")]
+    #[dialog_common::test]
+    async fn it_ignores_a_bindings_value_it_cannot_decode() {
+        let stub = stub_query_host(
+            vec![Conclusion {
+                this: "tonk:demo".into(),
+                fields: BTreeMap::from([(
+                    "bindings".to_string(),
+                    Ipld::Bytes(vec![0xde, 0xad, 0xbe, 0xef]),
+                )]),
+            }],
+            |_| {},
+        );
+
+        assert!(
+            resolve_inlined_bindings(&stub.host, "tonk:demo")
+                .await
+                .is_empty()
+        );
+    }
+
+    /// Drive one delegate refresh, returning `(queries seen, whether
+    /// the state was free to borrow on every one of them)`.
+    ///
+    /// `model_entity` decides whether the refresh reaches the bindings
+    /// query at all, which is what lets the caller tell the two runs
+    /// apart by count rather than by inspecting a query body — the
+    /// bodies arrive as JS `Map`s, which `JSON.stringify` renders as
+    /// `{}`.
+    #[cfg(target_arch = "wasm32")]
+    async fn refresh_with(model_entity: Option<&str>) -> (usize, bool) {
+        let document = window().expect("window").document().expect("document");
+        let state = Rc::new(RefCell::new(Inner::new()));
+
+        // A slide whose template binds one command, so the refresh
+        // installs a delegate rather than bailing early.
+        let view_el = document.create_element("div").expect("view element");
+        view_el
+            .set_attribute(
+                "data-event-bindings",
+                r#"{"events":[],"concepts":["demo/act"],"declarations":["on/click"]}"#,
+            )
+            .expect("bindings attribute");
+        let item = document.create_element("div").expect("item");
+        item.append_child(&view_el).ok();
+        {
+            let mut inner = state.borrow_mut();
+            inner.model_entity = model_entity.map(str::to_owned);
+            inner.slides.insert(
+                "tonk:demo".into(),
+                Slide {
+                    display: String::new(),
+                    item,
+                    view_el,
+                },
+            );
+        }
+
+        // Observed rather than asserted by panicking: an exception
+        // raised inside a DOM listener is swallowed by `dispatch_event`
+        // and would only make that one query answer nothing, which the
+        // fallback path treats as an ordinary miss. A panic here would
+        // therefore be invisible.
+        let queries = Rc::new(std::cell::Cell::new(0usize));
+        let borrow_was_free = Rc::new(std::cell::Cell::new(true));
+        let stub = {
+            let state = state.clone();
+            let queries = queries.clone();
+            let borrow_was_free = borrow_was_free.clone();
+            stub_query_host(Vec::new(), move |_| {
+                queries.set(queries.get() + 1);
+                if state.try_borrow_mut().is_err() {
+                    borrow_was_free.set(false);
+                }
+            })
+        };
+
+        let generation = state.borrow().delegate_generation;
+        refresh_delegate(&stub.host, &state, generation).await;
+        (queries.get(), borrow_was_free.get())
+    }
+
+    /// The state must not be borrowed while the bindings query is in
+    /// flight.
+    ///
+    /// Regression: `match state.borrow().model_entity.clone() { … }`
+    /// keeps the scrutinee's `Ref` alive for the whole match, so the
+    /// `RefCell` stayed borrowed across the awaited query and any frame
+    /// handler that fired meanwhile panicked. The window is open only
+    /// while that one query is in flight, which is why the defect
+    /// surfaced as browser jobs failing in one CI run and passing in
+    /// the next.
+    ///
+    /// A refresh with no resolved model makes every other query but
+    /// skips the bindings one, so the count difference proves the run
+    /// with a model actually reached it. Without that, a refresh that
+    /// stopped querying bindings at all would leave this passing
+    /// vacuously.
+    #[cfg(target_arch = "wasm32")]
+    #[dialog_common::test]
+    async fn it_does_not_hold_the_state_borrow_across_the_bindings_query() {
+        let (without_model, free_without) = refresh_with(None).await;
+        let (with_model, free_with) = refresh_with(Some("tonk:demo")).await;
+
+        assert_eq!(
+            with_model,
+            without_model + 1,
+            "a resolved model must add exactly the bindings query, or this pins nothing",
+        );
+        assert!(
+            free_without && free_with,
+            "the state was still borrowed while a query was in flight",
+        );
+    }
+
     /// A model nested inside a DIFFERENT model is not recursion.
     ///
     /// Nesting is the normal case — a board of tiles, a workspace of

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -1979,9 +1979,18 @@ async fn refresh_delegate(host: &Element, state: &Rc<RefCell<Inner>>, delegate_g
         }
     }
 
+    // Snapshot the model entity in its own statement, so the `Ref`
+    // is dropped before the query below awaits. A `match
+    // state.borrow()… { … }` keeps the scrutinee's temporary alive
+    // for the whole match, which would hold the `RefCell` borrowed
+    // across the await and panic any frame handler that fires
+    // meanwhile — the same reason the view elements above are
+    // snapshotted rather than read through a live borrow.
+    let model_entity = state.borrow().model_entity.clone();
+
     // Build the delegate before acquiring the borrow so its
     // `addEventListener` calls don't run inside the lock.
-    let inlined = match state.borrow().model_entity.clone() {
+    let inlined = match model_entity {
         Some(model_entity) => resolve_inlined_bindings(host, &model_entity).await,
         None => std::collections::BTreeMap::new(),
     };

--- a/rust/tonk-display/src/element.rs
+++ b/rust/tonk-display/src/element.rs
@@ -1688,15 +1688,57 @@ fn schedule_delegate_refresh(host: &Element, state: &Rc<RefCell<Inner>>) {
     });
 }
 
+/// Read the bindings the analyzer resolved onto this view.
+///
+/// A view lowered by a current analyzer carries every declaration its
+/// templates bind, already resolved, as one CBOR artifact — so the
+/// per-name reads below are skipped entirely. An empty result means
+/// the view predates the field (or binds nothing), and the caller
+/// falls back to resolving by name.
+async fn resolve_inlined_bindings(
+    host: &Element,
+    model_entity: &str,
+) -> std::collections::BTreeMap<String, tonk_template::event::EventDescriptor> {
+    use tonk_template::resolve::view_bindings_query;
+
+    let empty = std::collections::BTreeMap::new();
+    let Ok(query) = view_bindings_query(model_entity) else {
+        return empty;
+    };
+    let Ok(body) = to_body(&query) else {
+        return empty;
+    };
+    let Ok(rows) = host_consumer::query(host, &body).await else {
+        return empty;
+    };
+    let conclusions: Vec<Conclusion> = serde_wasm_bindgen::from_value(rows).unwrap_or_default();
+    let Some(Ipld::Bytes(bytes)) = conclusions
+        .first()
+        .and_then(|conclusion| conclusion.fields.get("bindings"))
+    else {
+        return empty;
+    };
+    match tonk_template::bindings::Bindings::decode(bytes) {
+        Ok(bindings) => bindings.events,
+        Err(error) => {
+            web_sys::console::warn_1(&JsValue::from_str(&format!(
+                "<tonk-display>: this view's compiled bindings did not decode ({error}); \
+                 resolving each declaration by name instead"
+            )));
+            empty
+        }
+    }
+}
+
 /// Resolve the `event!:` declarations a template's `on:<name>`
 /// bindings reference into a dispatch table.
 ///
-/// Each declaration is an *instance* of `tonk:event`, not a concept, so
-/// this is a name lookup followed by an entity read — not the phase-1
-/// descriptor path the command names take. Two reads per declaration:
-/// the required `type`/`where`, then the optional side-effect flags,
-/// which are separate because a declaration that omits them must still
-/// resolve.
+/// `inlined` is what the analyzer already resolved onto the view; a
+/// name it covers costs no reads at all. Anything left over is an
+/// *instance* of `tonk:event` read the old way — a name lookup
+/// followed by an entity read, two reads per declaration (the required
+/// `type`/`where`, then the optional side-effect flags, separate
+/// because a declaration that omits them must still resolve).
 ///
 /// A declaration that does not resolve is skipped with a warning rather
 /// than aborting the whole delegate, so one bad binding cannot silence
@@ -1704,12 +1746,17 @@ fn schedule_delegate_refresh(host: &Element, state: &Rc<RefCell<Inner>>) {
 async fn resolve_event_table(
     host: &Element,
     event_names: &std::collections::BTreeSet<String>,
+    inlined: std::collections::BTreeMap<String, tonk_template::event::EventDescriptor>,
 ) -> tonk_template::event::EventTable {
     use tonk_template::event::event_descriptor;
     use tonk_template::resolve::event_query;
 
     let mut declarations = std::collections::BTreeMap::new();
     for name in event_names {
+        if let Some(descriptor) = inlined.get(name) {
+            declarations.insert(name.clone(), descriptor.clone());
+            continue;
+        }
         let Some(entity) = resolve_event_entity(host, name).await else {
             web_sys::console::warn_1(&JsValue::from_str(&format!(
                 "<tonk-display>: no `event!:` declaration named `{name}` \
@@ -1930,7 +1977,11 @@ async fn refresh_delegate(host: &Element, state: &Rc<RefCell<Inner>>, delegate_g
 
     // Build the delegate before acquiring the borrow so its
     // `addEventListener` calls don't run inside the lock.
-    let table = resolve_event_table(host, &event_names).await;
+    let inlined = match state.borrow().model_entity.clone() {
+        Some(model_entity) => resolve_inlined_bindings(host, &model_entity).await,
+        None => std::collections::BTreeMap::new(),
+    };
+    let table = resolve_event_table(host, &event_names, inlined).await;
     let delegate = Delegate::install(host.clone(), event_types.into_iter(), descriptors, table);
     // Re-check the per-refresh generation: if a newer refresh has
     // started while we were resolving descriptors, drop our delegate

--- a/rust/tonk-fab/tests/responsive_overflow.rs
+++ b/rust/tonk-fab/tests/responsive_overflow.rs
@@ -111,7 +111,15 @@ async fn set_parent_width(
         .style()
         .set_property("width", &format!("{width}px"))
         .expect("set parent width");
-    for _ in 0..50 {
+    // Same budget as `wait_for_width` above, and for the same reason:
+    // the settle is driven by a `ResizeObserver` callback, which a
+    // loaded CI browser can defer well past the naive
+    // 50-poll (~500ms) window this used to allow. The whole suite
+    // shares one browser, so the delay is not bounded by anything this
+    // test controls. Waiting longer costs nothing when the layout
+    // settles promptly — the loop returns on the first matching poll —
+    // and only the failing case pays.
+    for _ in 0..500 {
         let wrapper = shadow_element(fab, ".w");
         if wrapper.class_list().contains("compact") == compact
             && visible(&shadow_element(fab, "[data-cell=share]")) == share_visible

--- a/rust/tonk-schema/src/builtin.rs
+++ b/rust/tonk-schema/src/builtin.rs
@@ -58,6 +58,7 @@ fn build_registry() -> Vec<(&'static str, ConceptDefinition)> {
         ("concept", concept_descriptor()),
         ("command", command_descriptor()),
         ("event", event_descriptor()),
+        ("view", view_descriptor()),
         ("rule", rule_descriptor()),
         ("name", builtin::<Name>("name")),
         ("branch", builtin::<Branch>("branch")),
@@ -125,6 +126,58 @@ fn command_descriptor() -> ConceptDefinition {
 /// [`command_descriptor`] and [`rule_descriptor`] are: `where` is a
 /// keyed dictionary, which no Rust fixed-record shape expresses — the
 /// same reason the `view` concept is still declared in the library.
+/// `view` — a model's presentations, keyed by facet.
+///
+/// Built in rather than declared in a library because the analyzer has
+/// to understand a view structurally: a `show:` template can bind
+/// `on:<name>=<command>`, and resolving those at lowering (rather than
+/// re-querying per name on every refresh) means the analyzer must know
+/// which instances are views and where their templates live. A library
+/// `concept!: &view` shadows a builtin inside its own document, so the
+/// declaration moves here and the libraries keep only `view!:`
+/// instances — the same split `event` already has.
+///
+/// `bindings` is what lowering writes: the resolved `event!:` and
+/// `command!:` descriptors for every `on:` binding the templates carry,
+/// as one CBOR artifact. Optional, so a view seeded before this existed
+/// carries none and the display falls back to resolving at runtime.
+fn view_descriptor() -> ConceptDefinition {
+    static DESCRIPTOR: std::sync::OnceLock<DialogConceptDescriptor> = std::sync::OnceLock::new();
+    let descriptor = DESCRIPTOR.get_or_init(|| {
+        serde_json::from_value(serde_json::json!({
+            "description": "A model's presentations, keyed by facet (ui, directory, label, title, ...)",
+            "with": {
+                // Keyed collection: the facet supplies the key half, so
+                // one facet can be superseded without restating the map.
+                "show": {
+                    "the": { "domain": "xyz.tonk.view", "keyed": "dictionary" },
+                    "as": "Text",
+                    "cardinality": "one",
+                    "description": "HTML templates keyed by facet"
+                },
+                // One compiled artifact, not a queryable map: the
+                // bindings are resolved together and mean nothing
+                // apart, so there is no per-key supersession to model.
+                // CBOR rather than JSON text because this is a build
+                // product the display decodes, never something a person
+                // reads or a rule matches on.
+                "bindings": {
+                    "the": "xyz.tonk.view/bindings",
+                    "as": "Bytes",
+                    "cardinality": "one",
+                    "optional": true,
+                    "description": "CBOR of the event + command descriptors resolved at lowering"
+                }
+            }
+        }))
+        .expect("view descriptor is valid")
+    });
+    ConceptDefinition {
+        entity: "db:view".parse().expect("`db:view` is a valid entity URI"),
+        descriptor: ConceptDescriptor::Durable(descriptor.clone()),
+    }
+}
+
 fn event_descriptor() -> ConceptDefinition {
     static DESCRIPTOR: std::sync::OnceLock<DialogConceptDescriptor> = std::sync::OnceLock::new();
     let descriptor = DESCRIPTOR.get_or_init(|| {

--- a/rust/tonk-schema/src/builtin.rs
+++ b/rust/tonk-schema/src/builtin.rs
@@ -158,15 +158,24 @@ fn view_descriptor() -> ConceptDefinition {
                 // One compiled artifact, not a queryable map: the
                 // bindings are resolved together and mean nothing
                 // apart, so there is no per-key supersession to model.
-                // CBOR rather than JSON text because this is a build
-                // product the display decodes, never something a person
-                // reads or a rule matches on.
+                // dag-cbor rather than JSON text because this is a
+                // build product the display decodes, never something a
+                // person reads or a rule matches on.
+                //
+                // `Record`, not `Bytes`: dialog's type for "one struct,
+                // one fact" — the same one a revision record uses, and
+                // what keeps this distinguishable from an opaque blob
+                // in storage and in a `Value` match. The tag says
+                // "structured", not *which* structure, and it flattens
+                // to plain bytes on every wire projection, so the
+                // payload also names its own format
+                // (`tonk_template::bindings::KIND`).
                 "bindings": {
                     "the": "xyz.tonk.view/bindings",
-                    "as": "Bytes",
+                    "as": "Record",
                     "cardinality": "one",
                     "optional": true,
-                    "description": "CBOR of the event + command descriptors resolved at lowering"
+                    "description": "dag-cbor of the event descriptors resolved at lowering"
                 }
             }
         }))

--- a/rust/tonk-template/Cargo.toml
+++ b/rust/tonk-template/Cargo.toml
@@ -9,6 +9,8 @@ edition.workspace = true
 [dependencies]
 indexmap = { workspace = true }
 ipld-core = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_ipld_dagcbor = { workspace = true }
 serde_ipld_dagjson = { workspace = true }
 serde_json = { workspace = true }
 tonk-notation = { workspace = true }

--- a/rust/tonk-template/src/bindings.rs
+++ b/rust/tonk-template/src/bindings.rs
@@ -38,6 +38,12 @@ pub struct EventBinding {
     /// The command it posts — a bare name (`space/create`) or a URI
     /// (`tonk:invite`).
     pub command: String,
+    /// Byte offset of the attribute name within the template, so a
+    /// diagnostic can underline `on:click` rather than the whole
+    /// template. When one binding is written twice, this is the first
+    /// of them — the report has to point somewhere, and the earliest
+    /// occurrence is the one an author reads first.
+    pub offset: usize,
 }
 
 /// What every bindings artifact says it is, in its own `kind` field.
@@ -144,8 +150,14 @@ pub fn scan(template: &str) -> Vec<EventBinding> {
         index = scan_tag(template, after, &mut out);
     }
 
+    // The derived order puts the offset last, so a repeated binding's
+    // occurrences land next to each other and `dedup_by` — which keeps
+    // the first of a run — keeps the earliest place it is written.
     out.sort();
-    out.dedup();
+    out.dedup_by(|left, right| {
+        (&left.attribute, &left.event_name, &left.command)
+            == (&right.attribute, &right.event_name, &right.command)
+    });
     out
 }
 
@@ -230,6 +242,7 @@ fn scan_tag(template: &str, mut index: usize, out: &mut Vec<EventBinding>) -> us
             attribute: name.to_owned(),
             event_name,
             command: command.to_owned(),
+            offset: name_start,
         });
     }
     bytes.len()
@@ -269,6 +282,25 @@ mod tests {
         let found = scan(r##"<use xlink:href="#x" bind:base=a on:click=go />"##);
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].event_name, "on/click");
+    }
+
+    /// The offset points at the attribute name, which is what a
+    /// diagnostic underlines. A repeated binding keeps the first one.
+    #[dialog_common::test]
+    fn it_records_where_each_attribute_is_written() {
+        let template =
+            "<p>hi</p>\n<button on:click=demo/act>go</button>\n<a on:click=demo/act>x</a>";
+        let found = scan(template);
+        assert_eq!(found.len(), 1, "the repeat is one binding, not two");
+        assert_eq!(
+            &template[found[0].offset..found[0].offset + found[0].attribute.len()],
+            "on:click",
+        );
+        assert_eq!(
+            found[0].offset,
+            template.find("on:click").expect("it is in there"),
+            "the earliest occurrence is the one reported",
+        );
     }
 
     #[dialog_common::test]

--- a/rust/tonk-template/src/bindings.rs
+++ b/rust/tonk-template/src/bindings.rs
@@ -1,0 +1,261 @@
+//! Compile-time event bindings: what a view's templates bind, and the
+//! declarations those bindings resolved to.
+//!
+//! A template binds an interaction with `on:<name>=<command>`. Until
+//! now both halves were resolved at *render* time: the display scanned
+//! the rendered fragment for `on:` attributes, then issued one query
+//! per declaration name to rebuild the [`EventDescriptor`] and one per
+//! command name to fetch its descriptor. A dangling reference produced
+//! no listener and no diagnostic — the element was simply inert.
+//!
+//! Both halves are knowable at lowering: the analyzer has the template
+//! text and the document's `event!:` / `command!:` declarations in
+//! scope. So the scan moves here ([`scan`], DOM-free so it runs in the
+//! analyzer), the resolution happens once, and the result is stored on
+//! the view as one CBOR artifact ([`Bindings`]) the display decodes
+//! instead of re-querying.
+//!
+//! What stays at runtime is resolving a *command* concept from its
+//! name — the descriptor is the same one the display already resolves
+//! for every model, so inlining it here would duplicate rather than
+//! remove work. What the analyzer contributes for commands is the
+//! check: a name that resolves to nothing fails the lowering.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::event::{EventDescriptor, event_name_for_attribute};
+
+/// One `on:<name>=<command>` binding found in a template.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct EventBinding {
+    /// The attribute as written (`on:click`), for diagnostics that
+    /// point back at the template.
+    pub attribute: String,
+    /// The declaration it names (`on/click`).
+    pub event_name: String,
+    /// The command it posts — a bare name (`space/create`) or a URI
+    /// (`tonk:invite`).
+    pub command: String,
+}
+
+/// The bindings a view's templates make, resolved at lowering.
+///
+/// A struct rather than a bare map so the artifact can grow a field
+/// without a format break. Encoded as dag-cbor, which is canonical:
+/// re-lowering an unchanged view yields byte-identical output, so the
+/// claim does not churn.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Bindings {
+    /// Declaration name (`on/click`) -> the descriptor it resolved to,
+    /// with every bare-symbol source already rewritten to an entity.
+    pub events: BTreeMap<String, EventDescriptor>,
+}
+
+impl Bindings {
+    /// True when there is nothing to store.
+    pub fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
+    /// Encode as dag-cbor.
+    pub fn encode(&self) -> Result<Vec<u8>, String> {
+        serde_ipld_dagcbor::to_vec(self).map_err(|error| error.to_string())
+    }
+
+    /// Decode from dag-cbor.
+    pub fn decode(bytes: &[u8]) -> Result<Self, String> {
+        serde_ipld_dagcbor::from_slice(bytes).map_err(|error| error.to_string())
+    }
+}
+
+/// Every `on:<name>=<command>` binding a template's raw HTML makes, in
+/// document order, deduplicated.
+///
+/// A text scan rather than a DOM walk, because the analyzer has no DOM
+/// and the browser's `preprocess` walk is not available to it. It
+/// mirrors that walk on the two points that matter: only attribute
+/// positions inside a tag count, and an HTML comment carries none —
+/// the parser drops comment content, so a binding mentioned in prose
+/// inside `<!-- -->` must not become a dangling reference here.
+pub fn scan(template: &str) -> Vec<EventBinding> {
+    let bytes = template.as_bytes();
+    let mut out: Vec<EventBinding> = Vec::new();
+    let mut index = 0usize;
+
+    while index < bytes.len() {
+        if bytes[index] != b'<' {
+            index += 1;
+            continue;
+        }
+        if template[index..].starts_with("<!--") {
+            index = match template[index + 4..].find("-->") {
+                Some(offset) => index + 4 + offset + 3,
+                None => bytes.len(),
+            };
+            continue;
+        }
+        // `<` that opens no tag (a stray less-than in text) is not a
+        // tag start; only a name or a closing slash follows one.
+        let after = index + 1;
+        if after >= bytes.len() || !(bytes[after].is_ascii_alphabetic() || bytes[after] == b'/') {
+            index += 1;
+            continue;
+        }
+        index = scan_tag(template, after, &mut out);
+    }
+
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Read one tag's attributes starting just after its `<`. Returns the
+/// offset just past the tag's `>` (or the end of input).
+fn scan_tag(template: &str, mut index: usize, out: &mut Vec<EventBinding>) -> usize {
+    let bytes = template.as_bytes();
+    // Skip the tag name (and a closing tag's slash).
+    while index < bytes.len() && !bytes[index].is_ascii_whitespace() && bytes[index] != b'>' {
+        index += 1;
+    }
+
+    while index < bytes.len() {
+        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+            index += 1;
+        }
+        if index >= bytes.len() || bytes[index] == b'>' {
+            return (index + 1).min(bytes.len());
+        }
+        // A self-closing `/` before `>` is not an attribute name.
+        if bytes[index] == b'/' {
+            index += 1;
+            continue;
+        }
+
+        let name_start = index;
+        while index < bytes.len()
+            && !bytes[index].is_ascii_whitespace()
+            && !matches!(bytes[index], b'=' | b'>' | b'/')
+        {
+            index += 1;
+        }
+        let name = &template[name_start..index];
+
+        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+            index += 1;
+        }
+        if index >= bytes.len() || bytes[index] != b'=' {
+            // A valueless attribute — nothing to bind.
+            continue;
+        }
+        index += 1;
+        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+            index += 1;
+        }
+        if index >= bytes.len() {
+            return bytes.len();
+        }
+
+        let value_start;
+        let value_end;
+        match bytes[index] {
+            quote @ (b'"' | b'\'') => {
+                index += 1;
+                value_start = index;
+                while index < bytes.len() && bytes[index] != quote {
+                    index += 1;
+                }
+                value_end = index;
+                index = (index + 1).min(bytes.len());
+            }
+            _ => {
+                value_start = index;
+                while index < bytes.len()
+                    && !bytes[index].is_ascii_whitespace()
+                    && bytes[index] != b'>'
+                {
+                    index += 1;
+                }
+                value_end = index;
+            }
+        }
+
+        let Some(event_name) = event_name_for_attribute(name) else {
+            continue;
+        };
+        let command = template[value_start..value_end].trim();
+        if command.is_empty() {
+            continue;
+        }
+        out.push(EventBinding {
+            attribute: name.to_owned(),
+            event_name,
+            command: command.to_owned(),
+        });
+    }
+    bytes.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::Source;
+
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    #[dialog_common::test]
+    fn it_finds_a_bare_and_a_quoted_binding() {
+        let found = scan(
+            r#"<form on:submit=space/create><button on:click="tonk:invite">go</button></form>"#,
+        );
+        assert_eq!(
+            found
+                .iter()
+                .map(|b| (b.event_name.as_str(), b.command.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("on/click", "tonk:invite"), ("on/submit", "space/create"),],
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_ignores_a_binding_named_inside_a_comment() {
+        let found = scan("<!-- bind it with on:click=nope --><div on:click=yes></div>");
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].command, "yes");
+    }
+
+    #[dialog_common::test]
+    fn it_leaves_colon_attributes_that_are_not_bindings_alone() {
+        let found = scan(r##"<use xlink:href="#x" bind:base=a on:click=go />"##);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].event_name, "on/click");
+    }
+
+    #[dialog_common::test]
+    fn it_round_trips_through_dag_cbor() {
+        let mut events = BTreeMap::new();
+        events.insert(
+            "on/click".to_string(),
+            EventDescriptor {
+                event_type: "click".into(),
+                prevent_default: true,
+                stop_propagation: false,
+                sources: BTreeMap::from([
+                    ("subject".to_string(), Source::Field("this".into())),
+                    (
+                        "time".to_string(),
+                        Source::Property(vec!["timeStamp".into()]),
+                    ),
+                ]),
+            },
+        );
+        let bindings = Bindings { events };
+        let bytes = bindings.encode().expect("encodes");
+        assert_eq!(Bindings::decode(&bytes).expect("decodes"), bindings);
+        // Canonical: the same input encodes to the same bytes, so
+        // re-lowering an unchanged view does not churn the claim.
+        assert_eq!(bindings.encode().expect("encodes"), bytes);
+    }
+}

--- a/rust/tonk-template/src/bindings.rs
+++ b/rust/tonk-template/src/bindings.rs
@@ -40,20 +40,50 @@ pub struct EventBinding {
     pub command: String,
 }
 
+/// What every bindings artifact says it is, in its own `kind` field.
+///
+/// The value is stored as a `Record` — dialog's type for "one struct,
+/// one fact", the same one a revision record uses — so it is already
+/// distinguishable from a `Bytes` blob at the storage layer. But that
+/// tag says only "structured"; it does not say *which* structure, and
+/// it is flattened to plain bytes on every wire projection
+/// (`Ipld::Bytes`, base64 in the claim API). So the payload identifies
+/// itself too: a decoder handed some other CBOR fails loudly instead
+/// of quietly reading an empty binding table, and a future format
+/// change is a version bump rather than a silent misparse.
+pub const KIND: &str = "tonk/view-bindings@1";
+
 /// The bindings a view's templates make, resolved at lowering.
 ///
 /// A struct rather than a bare map so the artifact can grow a field
 /// without a format break. Encoded as dag-cbor, which is canonical:
 /// re-lowering an unchanged view yields byte-identical output, so the
 /// claim does not churn.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Bindings {
+    /// Always [`KIND`]. Private so it cannot be set to anything else;
+    /// checked on decode.
+    kind: String,
     /// Declaration name (`on/click`) -> the descriptor it resolved to,
     /// with every bare-symbol source already rewritten to an entity.
     pub events: BTreeMap<String, EventDescriptor>,
 }
 
+impl Default for Bindings {
+    fn default() -> Self {
+        Self::new(BTreeMap::new())
+    }
+}
+
 impl Bindings {
+    /// An artifact carrying `events`.
+    pub fn new(events: BTreeMap<String, EventDescriptor>) -> Self {
+        Self {
+            kind: KIND.to_owned(),
+            events,
+        }
+    }
+
     /// True when there is nothing to store.
     pub fn is_empty(&self) -> bool {
         self.events.is_empty()
@@ -64,9 +94,17 @@ impl Bindings {
         serde_ipld_dagcbor::to_vec(self).map_err(|error| error.to_string())
     }
 
-    /// Decode from dag-cbor.
+    /// Decode from dag-cbor, refusing anything that is not this format.
     pub fn decode(bytes: &[u8]) -> Result<Self, String> {
-        serde_ipld_dagcbor::from_slice(bytes).map_err(|error| error.to_string())
+        let decoded: Self =
+            serde_ipld_dagcbor::from_slice(bytes).map_err(|error| error.to_string())?;
+        if decoded.kind != KIND {
+            return Err(format!(
+                "expected `{KIND}`, got `{}`",
+                decoded.kind.escape_debug()
+            ));
+        }
+        Ok(decoded)
     }
 }
 
@@ -251,11 +289,33 @@ mod tests {
                 ]),
             },
         );
-        let bindings = Bindings { events };
+        let bindings = Bindings::new(events);
         let bytes = bindings.encode().expect("encodes");
         assert_eq!(Bindings::decode(&bytes).expect("decodes"), bindings);
         // Canonical: the same input encodes to the same bytes, so
         // re-lowering an unchanged view does not churn the claim.
         assert_eq!(bindings.encode().expect("encodes"), bytes);
+    }
+
+    /// Some other CBOR is refused, not read as an empty table.
+    ///
+    /// The `Record` type tag says "structured", not "these bindings",
+    /// and it does not survive the wire at all — so the payload has to
+    /// say what it is, or a decoder handed the wrong artifact silently
+    /// installs no listeners.
+    #[dialog_common::test]
+    fn it_refuses_cbor_that_is_not_a_bindings_artifact() {
+        #[derive(serde::Serialize)]
+        struct Impostor {
+            kind: &'static str,
+            events: BTreeMap<String, EventDescriptor>,
+        }
+        let bytes = serde_ipld_dagcbor::to_vec(&Impostor {
+            kind: "tonk/view-bindings@2",
+            events: BTreeMap::new(),
+        })
+        .expect("encodes");
+        let error = Bindings::decode(&bytes).expect_err("a foreign kind is refused");
+        assert!(error.contains("tonk/view-bindings@2"), "{error}");
     }
 }

--- a/rust/tonk-template/src/event.rs
+++ b/rust/tonk-template/src/event.rs
@@ -40,10 +40,12 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
+use serde::{Deserialize, Serialize};
 use tonk_notation::syntax::{FieldValue, Scalar};
 
 /// Where one command field's value comes from.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum Source {
     /// `{field}` — the same interpolation a template uses, resolved in
     /// the scope of the element the event fired on: a field of the
@@ -158,7 +160,8 @@ fn scalar_text(scalar: &Scalar) -> String {
 }
 
 /// A parsed `event!:` declaration.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct EventDescriptor {
     /// The platform event name to listen for (`click`, `submit`,
     /// `createsheet`). Distinct from the declaration's own identifier,

--- a/rust/tonk-template/src/lib.rs
+++ b/rust/tonk-template/src/lib.rs
@@ -31,6 +31,7 @@ use std::collections::BTreeMap;
 
 use ipld_core::ipld::Ipld;
 
+pub mod bindings;
 pub mod event;
 pub mod fold;
 pub mod resolve;

--- a/rust/tonk-template/src/resolve.rs
+++ b/rust/tonk-template/src/resolve.rs
@@ -211,6 +211,33 @@ pub fn view_predicate() -> Value {
     })
 }
 
+/// Build the query that reads a view's compiled bindings — the
+/// `event!:` declarations its templates bind, resolved at lowering.
+///
+/// Separate from [`view_query`] for the same reason
+/// [`event_flags_query`] is separate from [`event_query`]: `bindings`
+/// is optional, so pinning it in the view query would make a view that
+/// binds nothing — or one lowered before the field existed — match
+/// nothing, and the display would render no template at all.
+///
+/// An empty result is the fallback signal: resolve the declarations by
+/// name, the way every view was resolved before lowering did it.
+pub fn view_bindings_query(model_entity: &str) -> Result<Query, serde_json::Error> {
+    let predicate = json!({
+        "with": {
+            "bindings": {
+                "the": "xyz.tonk.view/bindings",
+                "as": "Bytes",
+                "cardinality": "one"
+            }
+        }
+    });
+    let mut terms: IndexMap<String, Value> = IndexMap::new();
+    terms.insert("this".into(), json!(model_entity));
+    terms.insert("bindings".into(), json!({ "?": { "name": "bindings" } }));
+    serde_json::from_value(json!({ "terms": terms, "predicate": predicate }))
+}
+
 /// Build the live **directory** subscription query: like
 /// [`entity_query`] but with `this` left as a variable instead of
 /// pinned, so the query matches *every* instance of the model. The

--- a/rust/tonk-template/src/resolve.rs
+++ b/rust/tonk-template/src/resolve.rs
@@ -227,7 +227,7 @@ pub fn view_bindings_query(model_entity: &str) -> Result<Query, serde_json::Erro
         "with": {
             "bindings": {
                 "the": "xyz.tonk.view/bindings",
-                "as": "Bytes",
+                "as": "Record",
                 "cardinality": "one"
             }
         }

--- a/rust/tonk-worker/tests/standard_library.rs
+++ b/rust/tonk-worker/tests/standard_library.rs
@@ -1085,6 +1085,69 @@ fn the_event_query_predicate_matches_the_builtin() {
     );
 }
 
+/// The wire query the display builds for a view must describe the same
+/// concept the analyzer lowers against.
+///
+/// `view` is a built-in now, so the two can drift the way `event`'s
+/// pair could: the display's predicate is hand-mirrored JSON, and a
+/// `the` or a cardinality that disagrees resolves nothing at render
+/// time with no error anywhere. The `bindings` field is checked
+/// through its own query for the same reason the event flags are —
+/// it is optional, so pinning it in the view query would make a view
+/// that carries none match nothing.
+#[dialog_common::test]
+fn the_view_queries_match_the_builtin() {
+    let builtin = tonk_schema::builtin::lookup_concept("view").expect("`view` is a built-in");
+    let serialized =
+        serde_json::to_value(builtin.descriptor.concept()).expect("descriptor serializes");
+    let builtin_with = serialized
+        .get("with")
+        .and_then(serde_json::Value::as_object)
+        .expect("the built-in has a `with` map");
+
+    let predicate = tonk_template::resolve::view_predicate();
+    let query_with = predicate
+        .get("with")
+        .and_then(serde_json::Value::as_object)
+        .expect("the predicate has a `with` map");
+    assert!(
+        query_with.contains_key("show") && !query_with.contains_key("bindings"),
+        "the view query pins `show` only; `bindings` is optional and read separately",
+    );
+
+    // The bindings query carries its own copy of the field, so check
+    // it against the built-in too.
+    let bindings_query = tonk_template::resolve::view_bindings_query("tonk:demo")
+        .expect("the bindings query builds");
+    let bindings_query =
+        serde_json::to_value(&bindings_query).expect("the bindings query serializes");
+    let bindings_with = bindings_query
+        .get("predicate")
+        .and_then(|predicate| predicate.get("with"))
+        .and_then(serde_json::Value::as_object)
+        .expect("the bindings query has a `with` map");
+
+    for (field, ours) in query_with.iter().chain(bindings_with.iter()) {
+        let theirs = builtin_with
+            .get(field)
+            .unwrap_or_else(|| panic!("the built-in has no `{field}` field"));
+        assert_eq!(
+            ours.get("the"),
+            theirs.get("the"),
+            "`{field}`: the query and the built-in disagree on `the`",
+        );
+        assert_eq!(
+            ours.get("cardinality"),
+            theirs.get("cardinality"),
+            "`{field}`: the query and the built-in disagree on cardinality",
+        );
+    }
+    assert!(
+        bindings_with.contains_key("bindings"),
+        "the bindings query must pin the field it exists to read",
+    );
+}
+
 /// A command with a Rust handler must match on attributes its notation
 /// declaration actually carries.
 ///


### PR DESCRIPTION
Stacked on #904 — review that first; this PR's diff is the commits on top of it. #906 is stacked on this one.

## What changed

A `show:` template binds an interaction with `on:<name>=<command>`. Both halves were resolved at **render** time: one query per declaration name to rebuild the event descriptor, one per command name to fetch its shape. A name that resolved to nothing produced no listener and no diagnostic — the element was simply inert, and the only way to find out was to click it.

Both halves are knowable at **lowering**: the analyzer has the template text and the document's `event!:` / `command!:` declarations in scope. So it now scans the templates, resolves each binding, fails the lowering on anything that does not resolve, and stores the result on the view as one dag-cbor artifact the display decodes — the same move `concept!:` already makes when it inlines its attributes' descriptors instead of leaving names for the runtime to chase.

The change proper:

1. **`view` becomes a built-in concept.** It has to be, for the analyzer to recognise a view structurally. Adds an optional `bindings` field at `xyz.tonk.view/bindings`.
2. **The libraries stop declaring `concept!: &view`.** An in-document declaration shadows a builtin, so leaving them in would silently keep runtime resolution.
3. **The inlining pass.**
   - `tonk-template::bindings` — a DOM-free scan for `on:` attributes (HTML comments and non-binding colon attributes excluded, matching the browser's DOM walk) plus the `Bindings` artifact. dag-cbor is canonical, so re-lowering an unchanged view yields byte-identical output and the claim does not churn.
   - `tonk-analyzer::view` — indexes the document's `event!:` declarations (resolving bare-symbol sources to entities once, so the event-time path never looks a name up), resolves every binding, and emits the `bindings` term.
   - `tonk-display` — reads the artifact once per refresh and skips per-name resolution for every declaration it covers.
4. **The field is a `Record`, and the payload identifies itself** — see below.

Then the fallout, each its own commit so the diff explains itself:

5. **The CLI site fixtures stop declaring a concept named `view`** — the fallout of (1), see **Compatibility**.
6. **The display stops holding its state borrow across the bindings query** — the one real defect this PR shipped, see below.
7. **Tests for the display half**, which had none.
8. **A `tonk-fab` settle budget raised to match its own file's other one** — see **Verification**.
9. **The new diagnostics point at the `on:` attribute rather than the whole template** — see below.

Three new diagnostics, all at build time instead of at click time:

| code | what it catches |
| --- | --- |
| `E_UNKNOWN_EVENT_DECLARATION` | `on:<name>` names a declaration nothing declares |
| `E_UNKNOWN_BOUND_COMMAND` | the command half resolves to no concept |
| `E_EVENT_COMMAND_MISMATCH` | the declaration cannot fill the command — a required field with no source, or a source naming a field the command does not declare |

The last one is the check the whole `event!:` split exists to make possible. It previously lived only in a `tonk-worker` test that string-scanned the shipped YAML; it now runs on every document the analyzer sees.

What is deliberately **not** inlined is the command's descriptor. The display already resolves a concept from a name for every model it renders, so a second copy would duplicate work rather than remove it — the analyzer's contribution for commands is the check.

### Where those diagnostics point

All three initially reported against the `show:` entry's whole value range. A template is a block scalar many lines wide, so an editor underlined the entire thing to say "one of these attributes is wrong" — when the analyzer knows exactly which eight characters are.

Commit (9) narrows them. `bindings::scan` now records each binding's byte offset within the template, and the analyzer maps that offset into the document's own coordinates: every content line of a block scalar starts at the value range's column, so the line offset adds to the line and the indentation adds to the column. A computed position that would fall outside the value — a multi-line flow scalar whose escapes shift the columns — falls back to the whole range, since a report that is merely wide beats one that points at the wrong text.

### What this does *not* check

Worth stating plainly, because it is easy to read the above as "command dispatch is verified now". It is not. These checks cover **notation**: `on:` bindings inside a `show:` template, resolved against the `event!:` / `command!:` declarations in scope when a document is lowered.

`tonk-fab` dispatches commands by a second, parallel path that no document describes. It hand-builds each claim as JSON in Rust and inlines its own descriptor, deliberately — `core.yaml` is seeded once at repo creation and frozen, so the FAB is built to consult nothing seeded (see the header of `fab_drift.rs`). Nothing the analyzer does can see those claims, because there is no document to lower.

That gap is not theoretical: renaming a space was broken on this stack the whole time, and #904 now carries the fix (`6e1a35d`). The descriptor half of the FAB's rename claim was migrated to the new namespace and the parameters half was not, so every rename failed with `invalid claim: field "rename-repository" is not declared by this concept` and the chip reverted with no other symptom. It was found by using the preview, not by any check here.

The durable fix is to stop hand-writing those claims: `tonk-fab` already depends on `tonk-schema`, and the command structs are `#[derive(Concept)]`, so both halves could be derived from the struct and could not disagree. That is a rewrite of every FAB claim builder and is not in this stack.

**`{field}` interpolations are unchecked *here*.** A `show:` template interpolating `{name}` where `name` is not a field of the view's model renders nothing, silently — the same class of failure this PR fixes for `on:` bindings, on the other half of the template. **#906, stacked on this PR, closes it**, along with the equivalent check on a bound declaration's `where:` sources. It is a separate PR because making it usable turns on getting three renderer exclusions right — `<style>` / `<script>` bodies, comments, and portal documents — and without them the check rejects the library it exists to protect. No shipped library has such a miss today; that PR catches the next one.

### The borrow this shipped, and what it cost

Commit (3) added an awaited query to `refresh_delegate`, reading the model entity like this:

```rust
let inlined = match state.borrow().model_entity.clone() {
    Some(model_entity) => resolve_inlined_bindings(host, &model_entity).await,
    None => BTreeMap::new(),
};
```

A `match` keeps its scrutinee's temporaries alive for the whole match, so the `Ref` was held across the await. Any view frame, entity frame, or disconnect landing in that window calls `state.borrow_mut()` and panics. The window is open only while that one query is in flight, so it failed by timing — which is why two browser jobs failed on one head and passed on another carrying the same code, and why "the artifacts are identical to a head where this passed" was the wrong thing to conclude from. Commit (6) snapshots the entity in its own statement, the shape the view-element snapshot ten lines above already uses.

Commit (7) pins it, along with the rest of the display path. Getting that regression test to actually fail on the old code took two attempts: asserting it by panicking inside the stub host proves nothing, because an exception raised in a DOM listener is swallowed by `dispatch_event` and only makes that query answer nothing, which the fallback treats as an ordinary miss. It now observes the borrow with `try_borrow_mut`, and tells the bindings query apart from the others by running the refresh twice — with and without a resolved model — and requiring exactly one more query, since the bodies arrive as JS `Map`s that `JSON.stringify` renders as `{}`. Verified in both directions.

### Why `Record`, and why the payload still tags itself

The field started as `Bytes`. That was the wrong type: dialog has `Record` for exactly this shape — one struct serialized as one atomic fact — and already uses it that way for `RevisionRecord`, whose read path matches on `Value::Record(bytes)` to tell it apart from an opaque blob. The type byte is carried in the key encoding, so the distinction survives storage and any `Value` match.

It survives nothing past that. `Record` says "structured", not *which* structure, and every wire projection flattens it into the shape a `Bytes` takes — `Ipld::Bytes` to the display, base64 in the claim API — while `Value`'s `#[serde(untagged)]` repr resolves any byte payload back to `Bytes` regardless of which variant produced it. So the artifact names its own format: `Bindings` carries `kind: "tonk/view-bindings@1"` and `decode` refuses anything else rather than quietly reading it as an empty binding table. Belt and braces, but the failure it prevents is the silent one.

`record` also joins the `as:` vocabulary (`text`, `bytes`, `entity`, …). The built-in `view` declares one, and a value type the compiler can write but an author cannot spell would be a schema only the compiler could author.

### Compatibility

- A binding whose declaration lives in an already-seeded document (a component library binding a `core.yaml` event) still resolves as a *name*, so it is not inlined and not an error. Only a name that resolves to nothing at all fails. A view carrying no `bindings` at all — one seeded before this existed — falls back to the old per-name path unchanged.
- **`view` is now effectively reserved.** A built-in shadows a *branch* declaration of the same name (as `event` and `command` already do), so an author who declares their own concept literally named `view` loses to the built-in in any later document. Existing spaces are unaffected: the built-in's `show` field is byte-identical to what the library declared, so their views resolve exactly as before and simply gain an optional field. Only a *differently shaped* author `view` breaks — which is what commit (5) fixes in the CLI's own fixtures, and what commit (1)'s fallout was in three `rule.rs` entity-derivation tests that used `view` as an incidental fixture name (now `card`). Note the asymmetry, which predates this PR: an *in-document* `concept!: &view` still shadows the built-in, so the reservation only bites across documents.

## Verification

CI's own invocation, which is `cargo nextest`, not `cargo test`:

```console
cargo fmt --all
cargo nextest run --workspace --exclude tonk-ui --exclude tonk-core \
    --features integration-tests --no-fail-fast \
    -E 'not test(it_suggests_sudo_when_the_target_directory_is_not_writable)'
# → 2005 tests run: 2005 passed, 4 skipped
```

Browser tests were run locally too, against a real Chrome — `tonk-display` 191/191 twice, `tonk-analyzer` 173/173, `tonk-template` 42/42.

The one filtered test is `tonk-cli`'s `it_suggests_sudo_when_the_target_directory_is_not_writable`, which cannot pass in a container running as root — nothing is unwritable. It passes on CI's unprivileged runner.

Two things worth flagging, because each is why a separate commit exists:

- `cargo test` stops launching further test **binaries** after one fails, so that root-only failure in `tonk-cli`'s lib tests silently prevented the `tonk-cli::site` integration binary from running at all. Every local `cargo test --workspace` was green only up to that point. `nextest --no-fail-fast` runs every binary regardless, and is what surfaced the three `site` failures behind commit (5).
- Commit (8) touches a crate this PR is otherwise unrelated to, so it deserves scrutiny. `tonk-fab`'s `set_parent_width` polled 50× at 10ms for a `ResizeObserver`-driven layout to settle, while `wait_for_width` ten lines above polls 500× at 10ms for the same kind of wait. The evidence that the short budget is marginal rather than the code broken: the identical `tonk-fab` binary — the crate links none of the code this branch changes beyond a static descriptor in `tonk-schema`, unchanged between these heads — passed `Tests (web, debug)` on `43e220c` at 1.875s and failed it on `9a508c8` at 2.378s, against 1.853s on the base. Same binary, three runs, both outcomes. Waiting longer costs nothing when the layout settles promptly: the loop returns on the first matching poll.

New tests:

- `tonk-template::bindings` — bare vs. quoted attribute values, a binding named inside an HTML comment, `xlink:`/`bind:` left alone, dag-cbor round-trip and byte-stability, a foreign `kind` refused rather than read as empty, and each binding's recorded offset landing on its attribute name (with a repeated binding keeping the first occurrence).
- `tonk-analyzer::view` — a binding is inlined with its `where:` source intact; a view binding nothing grows no artifact; each of the three diagnostics fires; a dangling binding's report covers the attribute alone rather than the block scalar; `as: record` is declarable.
- `tonk-analyzer::library_analysis_tests::it_inlines_the_bindings_the_shipped_libraries_make` — the pass is silent when it succeeds, so this asserts it still reaches real templates: every shipped library that binds an interaction must produce a decodable artifact, and `profile.yaml`'s create form must carry `on/space-create`.
- `tonk-display::element` — the artifact resolves with **no** query host installed (so it cannot have queried); a name it omits still goes to the branch; the stored artifact decodes back; foreign bytes resolve to nothing; and the state is not borrowed while the bindings query is in flight. The fixtures tear down their host element and their `body` listener on drop, since every wasm test in the crate shares one page and a stray `tonk-query` listener claims queries for whoever dispatches them.
- `tonk-worker::the_view_queries_match_the_builtin` — the display's hand-mirrored view predicate and the built-in cannot drift on `the` or cardinality (the parity `event` already had).

## Storybook impact

- [x] No user-visible contract changed because: this moves work from render time to lowering time. Every binding that worked before still works, resolved from a stored artifact instead of a per-name query; a view without the artifact takes the unchanged fallback path. What is new is that a *broken* binding in a template now fails the build instead of rendering an inert element — no working screen or journey changes. (The rename fix carried in from #904 restores a screen that was broken, and is described there.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WyWgReUaivze37mfWSNA4D

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for event bindings in the `tonk` framework, enabling views to declare and resolve events more effectively, improving the handling of user interactions.

### Detailed summary
- Added `bindings` module to handle event bindings.
- Introduced `EventBinding` struct for storing binding details.
- Updated `EventDescriptor` to include serialization support.
- Enhanced the `view` concept to include a `bindings` field.
- Modified the analyzer to index `event!:` declarations.
- Implemented logic to resolve bindings at lowering time.
- Updated tests to verify the functionality of inlined event declarations.

> The following files were skipped due to too many changes: `rust/tonk-analyzer/src/analyzer/view.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->