### PR TITLE
Check a template's `{field}` interpolations at lowering

### DIFF
--- a/rust/tonk-analyzer/src/analyzer.rs
+++ b/rust/tonk-analyzer/src/analyzer.rs
@@ -4973,6 +4973,73 @@ mod library_analysis_tests {
         );
     }
 
+    /// The interpolation checks reach the shipped libraries' own
+    /// templates, not just the fixtures.
+    ///
+    /// Both checks are silent when they succeed, so
+    /// [`it_analyzes_the_shipped_libraries`] passes just as happily if
+    /// they never resolve a model and skip every view. This introduces
+    /// the exact typo each check exists to catch, into a real library,
+    /// and requires the lowering to fail.
+    ///
+    /// The substitution is applied to the *target* file before it is
+    /// concatenated with its prelude, because `core.yaml` contains the
+    /// same strings and comes first: mutating the joined text would
+    /// silently break the wrong file.
+    #[test]
+    fn the_interpolation_checks_reach_the_shipped_libraries() {
+        let core = include_str!("../../tonk-core/assets/library/core.yaml");
+        let notebook = include_str!("../../tonk-core/assets/library/notebook.yaml");
+        let profile = include_str!("../../tonk-core/assets/library/profile.yaml");
+        let prose = include_str!("../../tonk-core/assets/library/prose.yaml");
+
+        for (name, prelude, target, from, to, expected) in [
+            (
+                "notebook.yaml template",
+                core,
+                notebook,
+                "{title}",
+                "{titel}",
+                "E_UNKNOWN_TEMPLATE_FIELD",
+            ),
+            (
+                "profile.yaml template",
+                "",
+                profile,
+                "{provider}",
+                "{provideer}",
+                "E_UNKNOWN_TEMPLATE_FIELD",
+            ),
+            // The only bound declaration in the libraries that sources
+            // a command field from an interpolation rather than a DOM
+            // property path. The rest read `.detail.*` / `.currentTarget.*`,
+            // which this check does not look at.
+            (
+                "prose.yaml event source",
+                core,
+                prose,
+                "subject: \"{this}\"",
+                "subject: \"{nope}\"",
+                "E_UNKNOWN_EVENT_SOURCE_FIELD",
+            ),
+        ] {
+            let broken = target.replacen(from, to, 1);
+            assert_ne!(
+                broken, target,
+                "{name} no longer contains {from:?}; point this gate at a live interpolation",
+            );
+            let source = format!("{prelude}\n{broken}");
+            let parsed = tonk_notation::parse(&source);
+            let syntax = parsed
+                .syntax
+                .unwrap_or_else(|| panic!("{name} yields a syntax tree"));
+            let error = analyze_local(&syntax)
+                .err()
+                .unwrap_or_else(|| panic!("{name} with {to:?} must not lower"));
+            assert_eq!(error.kind.code(), expected, "{name}: {error}");
+        }
+    }
+
     /// Every `event!:` declaration name the document's views inlined.
     fn inlined_declarations(name: &str, source: &str) -> Vec<String> {
         use dialog_artifacts::Value as ArtifactValue;

--- a/rust/tonk-analyzer/src/analyzer/error.rs
+++ b/rust/tonk-analyzer/src/analyzer/error.rs
@@ -389,6 +389,41 @@ pub enum AnalyzeErrorKind {
         /// type stays small enough to return by value.
         detail: String,
     },
+    /// A `show:` template interpolates a name the model concept does
+    /// not declare. The renderer resolves `{name}` against the row it
+    /// is rendering and a miss renders nothing at all — no gap, no
+    /// warning — so a typo is invisible until someone notices a value
+    /// missing from the page.
+    #[error("`{{{field}}}` is not a field of `{model}` — it renders as nothing. {known}")]
+    UnknownTemplateField {
+        /// The name between the braces, as written.
+        field: String,
+        /// The concept the view renders.
+        model: String,
+        /// The fields it does declare, rendered. One string rather
+        /// than a list so the error type stays small enough to return
+        /// by value.
+        known: String,
+    },
+    /// A bound `event!:` sources a command field from a `{name}` the
+    /// view's model does not declare. The interpolation is resolved in
+    /// the same scope a template's is, so the same miss applies: the
+    /// command is posted with that field empty.
+    ///
+    /// Only reported for a field the command actually declares. A
+    /// source the command has no field for fills nothing either way,
+    /// and is already the subject of `E_EVENT_COMMAND_MISMATCH`.
+    #[error("`{attribute}` sources `{{{field}}}` into {detail}")]
+    UnknownEventSourceField {
+        /// The attribute as written (`on:click`).
+        attribute: String,
+        /// The name between the braces, as written.
+        field: String,
+        /// The command field it fills and the model that does not
+        /// declare it, rendered. One string rather than two so the
+        /// error type stays small enough to return by value.
+        detail: String,
+    },
     /// The resolved bindings could not be encoded.
     #[error("view bindings could not be encoded: {reason}")]
     InvalidViewBindings {
@@ -609,6 +644,8 @@ impl AnalyzeErrorKind {
             Self::UnknownEventDeclaration { .. } => "E_UNKNOWN_EVENT_DECLARATION",
             Self::UnknownBoundCommand { .. } => "E_UNKNOWN_BOUND_COMMAND",
             Self::EventCommandMismatch { .. } => "E_EVENT_COMMAND_MISMATCH",
+            Self::UnknownTemplateField { .. } => "E_UNKNOWN_TEMPLATE_FIELD",
+            Self::UnknownEventSourceField { .. } => "E_UNKNOWN_EVENT_SOURCE_FIELD",
             Self::InvalidViewBindings { .. } => "E_INVALID_VIEW_BINDINGS",
             Self::UnknownField { .. } => "E_UNKNOWN_FIELD",
             Self::DuplicateConceptField { .. } => "E_DUPLICATE_CONCEPT_FIELD",

--- a/rust/tonk-analyzer/src/analyzer/graph.rs
+++ b/rust/tonk-analyzer/src/analyzer/graph.rs
@@ -377,14 +377,15 @@ pub(crate) fn push(syntax: &Syntax) -> Result<Graph, AnalyzeError> {
             }
         }
 
-        // A `view!:` body's `show:` templates bind commands with
-        // `on:<name>=<command>`. Both halves are resolved at lowering
-        // (`super::view::compile_bindings`), so both must be in scope
-        // by then: the command as a concept, the declaration as a
-        // name. Gathered here for the same reason a rule's premise
-        // concepts are — the pass that needs them is synchronous.
+        // A `view!:` body is resolved at lowering
+        // (`super::view::compile_bindings`), so everything that pass
+        // consults must be in scope by then: the model it renders, the
+        // command each `on:<name>=<command>` posts, and each
+        // declaration's name. Gathered here for the same reason a
+        // rule's premise concepts are — the pass that needs them is
+        // synchronous.
         if is_claim && matches!(&head.name, HeadName::Concept(n) if n == "view") {
-            collect_view_binding_needs(fields, &mut needs);
+            collect_view_needs(fields, &mut needs);
         }
 
         // `rule!:` bodies reference concepts (head + premises) and,
@@ -413,13 +414,52 @@ pub(crate) fn push(syntax: &Syntax) -> Result<Graph, AnalyzeError> {
     })
 }
 
-/// Gather what a `view!:` body's `on:<name>=<command>` bindings must
-/// have in scope by lowering: the command's concept (by name or, for a
-/// URI-spelled binding, by entity) and the declaration's name.
+/// Gather what a `view!:` body must have in scope by lowering.
+///
+/// Two things, and missing either is silent rather than loud:
+///
+/// * The **model** the view renders, named by its `this:`. The
+///   interpolation check reads its declared fields, and a model it
+///   cannot resolve is one it skips — so a view whose concept lives on
+///   the branch rather than in the document would go unchecked if the
+///   need were not registered here. Every test that lowers a
+///   self-contained document passes either way, which is exactly what
+///   makes the omission hard to see.
+/// * Each `on:<name>=<command>` binding's halves: the command's
+///   concept (by name or, for a URI-spelled binding, by entity) and
+///   the declaration's name.
 ///
 /// A need that resolves to nothing is not an error here — the binding
 /// pass is where an unresolvable reference gets a diagnostic with a
 /// template to point at.
+fn collect_view_needs(fields: &[Field], needs: &mut Vec<Need>) {
+    collect_view_model_needs(fields, needs);
+    collect_view_binding_needs(fields, needs);
+}
+
+/// The concept a view's `this:` names, in both spellings a reference
+/// takes — a published name and a URI — for the same reason the
+/// command half prefetches both: the one that does not apply resolves
+/// to nothing, which costs a lookup and no correctness.
+fn collect_view_model_needs(fields: &[Field], needs: &mut Vec<Need>) {
+    for field in fields {
+        if field.name != "this" {
+            continue;
+        }
+        let name = match &field.value {
+            FieldValue::Symbol(name) => name.clone(),
+            FieldValue::Uri(uri) => uri.clone(),
+            FieldValue::Literal(tonk_notation::Scalar::String(text)) => text.clone(),
+            _ => continue,
+        };
+        let range = field.value_range;
+        if let Ok(entity) = name.parse::<Entity>() {
+            needs.push(Need::ConceptByEntity { entity, range });
+        }
+        needs.push(Need::Concept { name, range });
+    }
+}
+
 fn collect_view_binding_needs(fields: &[Field], needs: &mut Vec<Need>) {
     for field in fields {
         if field.name != "show" {
@@ -910,6 +950,112 @@ mod tests {
     wasm_bindgen_test_configure!(run_in_browser);
 
     /// A resolver that counts how many external lookups it served,
+    /// A view whose model lives on the *branch* is still checked.
+    ///
+    /// This is the case every self-contained fixture misses. The
+    /// interpolation check resolves the view's `this:` through
+    /// `Scope`, and `Scope` only holds what the resolve phase was
+    /// asked to prefetch — so a view whose concept is not in the
+    /// document went unchecked until `collect_view_model_needs`
+    /// registered the need. Every test that lowers the concept and the
+    /// view together passes either way, which is exactly what made the
+    /// omission invisible: it reproduces only against a real branch.
+    #[dialog_common::test]
+    async fn a_view_whose_model_is_on_the_branch_is_still_checked() {
+        // Only the view and its declaration are written here. The
+        // model and the command it posts stand in for facts already
+        // seeded on the branch, served by the resolver below.
+        let syntax = parse(
+            r#"
+event!: &on/click
+  type: "click"
+  where:
+    subject: "{this}"
+
+view!: &counter/view
+  this: counter/model
+  show:
+    ui: |
+      <form>
+        <button on:click=counter/+1>+</button>
+        <h1>{counter}</h1>
+      </form>
+"#,
+        )
+        .syntax
+        .expect("the fixture parses");
+
+        let scope = Scope::new();
+        let graph = push(&syntax).expect("push");
+        let resolved = graph
+            .resolve(&syntax, &scope, &Branch)
+            .await
+            .expect("resolve");
+        let error = super::super::expand(&syntax, &scope, resolved)
+            .expect_err("`{counter}` is not a field of the branch's `counter/model`");
+        assert_eq!(error.kind.code(), "E_UNKNOWN_TEMPLATE_FIELD", "{error}");
+    }
+
+    /// A branch carrying the counter model and the command it posts.
+    struct Branch;
+
+    impl Branch {
+        /// One concept, from the JSON shape a resolved descriptor takes.
+        fn definition(entity: &str, descriptor: &str) -> ConceptDefinition {
+            ConceptDefinition {
+                entity: entity.parse().expect("an entity"),
+                descriptor: tonk_core::claim::ConceptDescriptor::Durable(
+                    serde_json::from_str(descriptor).expect("a descriptor"),
+                ),
+            }
+        }
+    }
+
+    impl Resolve for Branch {
+        async fn concept(&self, name: &str) -> Result<Option<ConceptDefinition>, ResolveError> {
+            Ok(match name {
+                "counter/model" => Some(Self::definition(
+                    "tonk:counter-model",
+                    r#"{"with":{"count":{"the":"xyz.tonk.counter/count",
+                       "as":"SignedInteger","cardinality":"one"}}}"#,
+                )),
+                "counter/+1" => Some(Self::definition(
+                    "tonk:counter-increment",
+                    r#"{"with":{"subject":{"the":"xyz.tonk.counter.increment/subject",
+                       "as":"Entity","cardinality":"one"}}}"#,
+                )),
+                _ => None,
+            })
+        }
+        async fn concept_by_entity(
+            &self,
+            _: &Entity,
+        ) -> Result<Option<ConceptDefinition>, ResolveError> {
+            Ok(None)
+        }
+        async fn attribute(&self, _: &str) -> Result<Option<AttributeDefinition>, ResolveError> {
+            Ok(None)
+        }
+        async fn attribute_by_entity(
+            &self,
+            _: &Entity,
+        ) -> Result<Option<AttributeDefinition>, ResolveError> {
+            Ok(None)
+        }
+        async fn attribute_by_id(
+            &self,
+            _: &str,
+        ) -> Result<Option<AttributeDefinition>, ResolveError> {
+            Ok(None)
+        }
+        async fn named_entity(&self, _: &str) -> Result<Option<Entity>, ResolveError> {
+            Ok(None)
+        }
+        async fn rule(&self, _: &Entity) -> Result<Option<Rule>, StoredRuleError> {
+            Ok(None)
+        }
+    }
+
     /// answering each with `None`. `AtomicUsize` keeps it `Sync` so
     /// it satisfies `Graph::resolve`'s `ConditionalSync` bound on
     /// native. Used to assert a self-contained document drives zero

--- a/rust/tonk-analyzer/src/analyzer/view.rs
+++ b/rust/tonk-analyzer/src/analyzer/view.rs
@@ -801,6 +801,62 @@ view!:
         );
     }
 
+    /// The document that prompted this check, verbatim.
+    ///
+    /// The fixtures above are minimal by construction, which is
+    /// exactly what lets a check pass them and still miss the real
+    /// thing. This is the shape actually written by hand: an anchored
+    /// view, a command whose name carries a `+`, a binding and an
+    /// interpolation in one template — and `{counter}` where the
+    /// model declares `count`. Without the check it lowers clean and
+    /// the renderer emits `<!--tonk-iter:counter-->`, cloning the
+    /// element zero times: the value is simply absent from the page.
+    #[dialog_common::test]
+    fn the_counter_document_that_prompted_this_check_fails_the_lowering() {
+        let source = r#"
+concept!: &counter/model
+  description: A counter.
+  with:
+    count:
+      description: How many.
+      the: xyz.tonk.counter/count
+      as: signed-integer
+      cardinality: one
+
+command!: &counter/+1
+  description: Add one.
+  with:
+    subject:
+      description: Which counter.
+      the: xyz.tonk.counter.increment/subject
+      as: entity
+
+event!: &on/click
+  type: "click"
+  where:
+    subject: "{this}"
+
+view!: &counter/view
+  this: counter/model
+  show:
+    ui: |
+      <form>
+        <button on:click=counter/+1>+</button>
+        <h1>{counter}</h1>
+      </form>
+"#;
+        let error = lower(source).expect_err("`{counter}` is not a field of `counter/model`");
+        assert_eq!(error.kind.code(), "E_UNKNOWN_TEMPLATE_FIELD", "{error}");
+        assert!(
+            error.to_string().contains("`count`"),
+            "the report names the field that was meant: {error}",
+        );
+
+        // The same document with the typo fixed must still lower, so
+        // the test cannot pass by rejecting the shape wholesale.
+        lower(&source.replace("{counter}", "{count}")).expect("`{count}` is declared");
+    }
+
     /// A portal document is mounted verbatim, so its braces are not
     /// interpolations and its `on:` attributes are not bindings. The
     /// display decides this from the same `type` entry.

--- a/rust/tonk-analyzer/src/analyzer/view.rs
+++ b/rust/tonk-analyzer/src/analyzer/view.rs
@@ -19,13 +19,31 @@
 //! already resolves a concept from a name for every model it renders,
 //! so carrying a second copy here would duplicate work rather than
 //! remove it. What the analyzer contributes for commands is the check.
+//!
+//! The other half of a template gets the same treatment. A `{field}`
+//! interpolation is resolved against the row being rendered, and a
+//! name that resolves to nothing renders as nothing — no gap, no
+//! warning, just a value missing from the page. Since the view names
+//! the concept it renders, the analyzer knows the legal names, so it
+//! checks them here too: in the templates, and in the `where:` sources
+//! of every declaration a template binds, which interpolate in the
+//! same scope.
+//!
+//! Both checks work by *mirroring the renderer*, which is where the
+//! subtlety lives. The renderer will not read a `<style>` or
+//! `<script>` body (their braces are CSS and JS), will not read an
+//! HTML comment, and will not interpolate a portal document at all.
+//! Miss any of those and the check rejects the library it is meant to
+//! protect. That is why the scan is shared with the binding scan
+//! ([`tonk_template::scan`]) rather than written twice.
 
 use std::collections::{BTreeMap, BTreeSet};
 
 use tonk_notation::{Application as SyntaxApplication, Field, FieldValue, HeadName, Scalar};
 use tonk_schema::resolution::ConceptDefinition;
 use tonk_template::bindings::{Bindings, EventBinding, scan};
-use tonk_template::event::{EventDescriptor, event_descriptor};
+use tonk_template::event::{EventDescriptor, Source, event_descriptor};
+use tonk_template::fields::{self, FieldReference};
 
 use super::error::{AnalyzeError, AnalyzeErrorKind};
 use super::scope::Scope;
@@ -141,8 +159,19 @@ fn field_flag(value: &FieldValue) -> bool {
     matches!(value, FieldValue::Literal(Scalar::Boolean(true)))
 }
 
-/// Resolve every binding a view's `show:` templates make, into the
-/// artifact the view stores.
+/// Check a view's `show:` templates and resolve the bindings they
+/// make into the artifact the view stores.
+///
+/// Three things are read out of one walk of the templates, because
+/// they are three readings of the same text:
+///
+/// * every `{field}` must be one the model declares, or ambient
+///   ([`check_interpolations`]);
+/// * every `on:<name>` must name a declaration, and its command must
+///   resolve and be fillable;
+/// * a bound declaration's own `{field}` sources are interpolations in
+///   the same scope, so they get the same check
+///   ([`check_event_sources`]).
 ///
 /// `Ok(None)` means the templates bind nothing, so the view carries no
 /// `bindings` field at all — which is also what a view lowered before
@@ -152,6 +181,23 @@ pub(crate) fn compile_bindings(
     assertion: &SyntaxApplication,
     scope: &Scope,
 ) -> Result<Option<Bindings>, AnalyzeError> {
+    // A portal view's templates are full HTML documents mounted into
+    // a `<tonk-portal>` verbatim — the display checks the same `type`
+    // entry and takes a different path entirely. Nothing interpolates
+    // them and nothing delegates their events, so a `{` in one is a
+    // brace and an `on:` in one is an attribute. Reading either as a
+    // reference would fail the lowering over a document the renderer
+    // never looks inside.
+    if is_portal(assertion) {
+        return Ok(None);
+    }
+
+    // The concept the view renders. Without it neither interpolation
+    // check has anything to check against, so both are skipped: a view
+    // whose `this:` is a variable, or names something that is not a
+    // concept, is not one this pass can reason about.
+    let model = model_concept(assertion, scope);
+
     let mut found: Vec<(EventBinding, lsp_types::Range)> = Vec::new();
     for field in &assertion.fields {
         if field.name != SHOW_FIELD {
@@ -164,8 +210,16 @@ pub(crate) fn compile_bindings(
             let Some(template) = field_text(&entry.value) else {
                 continue;
             };
+            if let Some(model) = &model {
+                check_interpolations(&template, entry.value_range, model)?;
+            }
             found.extend(scan(&template).into_iter().map(|binding| {
-                let range = attribute_range(entry.value_range, &template, &binding);
+                let range = offset_range(
+                    entry.value_range,
+                    &template,
+                    binding.offset,
+                    binding.attribute.chars().count(),
+                );
                 (binding, range)
             }));
         }
@@ -200,6 +254,9 @@ pub(crate) fn compile_bindings(
             ));
         };
         check_fills(&binding, &descriptor, &command, range)?;
+        if let Some(model) = &model {
+            check_event_sources(&binding, &descriptor, &command, model, range)?;
+        }
         events.insert(binding.event_name, descriptor);
     }
 
@@ -209,8 +266,8 @@ pub(crate) fn compile_bindings(
     Ok(Some(Bindings::new(events)))
 }
 
-/// Where a binding's attribute is written, in the document's own
-/// coordinates.
+/// Where something inside a template is written, in the document's
+/// own coordinates.
 ///
 /// A template is a block scalar: its value range starts at the first
 /// content character, and every content line carries that same
@@ -223,12 +280,13 @@ pub(crate) fn compile_bindings(
 /// computed position past the end of the value — falls back to the
 /// whole value. A range that is merely wide is a worse report; one
 /// that points outside the value is a wrong one.
-fn attribute_range(
+fn offset_range(
     value_range: lsp_types::Range,
     template: &str,
-    binding: &EventBinding,
+    offset: usize,
+    width: usize,
 ) -> lsp_types::Range {
-    let Some(head) = template.get(..binding.offset) else {
+    let Some(head) = template.get(..offset) else {
         return value_range;
     };
     let line = head.matches('\n').count() as u32;
@@ -241,12 +299,157 @@ fn attribute_range(
     };
     let end = lsp_types::Position {
         line: start.line,
-        character: start.character + binding.attribute.chars().count() as u32,
+        character: start.character + width as u32,
     };
     if (end.line, end.character) > (value_range.end.line, value_range.end.character) {
         return value_range;
     }
     lsp_types::Range { start, end }
+}
+
+/// Whether the view's `show:` declares a portal document: a `type`
+/// entry reading `text/html`.
+///
+/// The same entry the display checks — see `handle_view_frame` in
+/// `tonk-display` — so the two agree on which templates are markup to
+/// read and which are documents to hand over untouched.
+fn is_portal(assertion: &SyntaxApplication) -> bool {
+    use tonk_template::resolve::TYPE_FACET;
+
+    assertion
+        .fields
+        .iter()
+        .filter(|field| field.name == SHOW_FIELD)
+        .filter_map(|field| match &field.value {
+            FieldValue::Nested(entries) => Some(entries),
+            _ => None,
+        })
+        .flatten()
+        .any(|entry| {
+            entry.name == TYPE_FACET
+                && field_text(&entry.value).as_deref() == Some(PORTAL_CONTENT_TYPE)
+        })
+}
+
+/// The `type` value that marks a portal document.
+const PORTAL_CONTENT_TYPE: &str = "text/html";
+
+/// The concept a view renders, named by its `this:` field.
+///
+/// `None` when the field is absent, is a variable, or names something
+/// that is not a concept — every case where there is no field list to
+/// check a template against.
+fn model_concept(assertion: &SyntaxApplication, scope: &Scope) -> Option<Model> {
+    let field = assertion.fields.iter().find(|f| f.name == "this")?;
+    let name = field_text(&field.value)?;
+    let concept = resolve_concept(&name, scope)?;
+    let fields: BTreeSet<String> = concept
+        .descriptor
+        .concept()
+        .with()
+        .iter()
+        .map(|(field, _)| field.to_string())
+        .collect();
+    Some(Model { name, fields })
+}
+
+/// A view's model: what it is called, and what it declares.
+struct Model {
+    /// The name as the view writes it, for a diagnostic to quote.
+    name: String,
+    /// Every field the concept declares, required and optional alike.
+    fields: BTreeSet<String>,
+}
+
+impl Model {
+    /// Whether a template may interpolate this reference.
+    ///
+    /// `{this}` and `{dom.host/*}` are ambient — the subject and the
+    /// outer host's attributes, which no concept declares. A
+    /// `{block/key}` is legal exactly when `block` is, because the
+    /// renderer puts the key into the same per-iteration scope as the
+    /// field it belongs to.
+    fn accepts(&self, reference: &FieldReference) -> bool {
+        reference.is_ambient() || self.fields.contains(reference.declared_name())
+    }
+
+    /// The declared fields, rendered for a diagnostic.
+    fn known(&self) -> String {
+        if self.fields.is_empty() {
+            return format!("`{}` declares no fields.", self.name);
+        }
+        let names: Vec<String> = self.fields.iter().map(|f| format!("`{f}`")).collect();
+        format!("`{}` declares {}.", self.name, names.join(", "))
+    }
+}
+
+/// Every `{field}` a template interpolates must be one the model
+/// declares.
+///
+/// The renderer resolves a reference against the row it is rendering
+/// and renders **nothing** when it misses — so a typo costs a value on
+/// the page and produces no other symptom. This is the same failure the
+/// `on:` checks catch, on the other half of the template.
+fn check_interpolations(
+    template: &str,
+    value_range: lsp_types::Range,
+    model: &Model,
+) -> Result<(), AnalyzeError> {
+    for reference in fields::scan(template) {
+        if model.accepts(&reference) {
+            continue;
+        }
+        return Err(AnalyzeError::at(
+            AnalyzeErrorKind::UnknownTemplateField {
+                field: reference.name.clone(),
+                model: model.name.clone(),
+                known: model.known(),
+            },
+            offset_range(value_range, template, reference.offset, reference.len()),
+        ));
+    }
+    Ok(())
+}
+
+/// A bound declaration's `{field}` sources are interpolations too, and
+/// resolve in the same scope a template's do.
+///
+/// Only a source filling a field the command actually declares is
+/// checked. One that fills nothing is inert whatever it interpolates —
+/// and is already what `E_EVENT_COMMAND_MISMATCH` reports — so adding a
+/// second diagnostic for it would report the same mistake twice.
+fn check_event_sources(
+    binding: &EventBinding,
+    descriptor: &EventDescriptor,
+    command: &ConceptDefinition,
+    model: &Model,
+    range: lsp_types::Range,
+) -> Result<(), AnalyzeError> {
+    let concept = command.descriptor.concept();
+    for (command_field, source) in &descriptor.sources {
+        let Source::Field(name) = source else {
+            continue;
+        };
+        if !concept.with().keys().any(|field| field == command_field) {
+            continue;
+        }
+        let reference = FieldReference {
+            name: name.clone(),
+            offset: 0,
+        };
+        if model.accepts(&reference) {
+            continue;
+        }
+        return Err(AnalyzeError::at(
+            AnalyzeErrorKind::UnknownEventSourceField {
+                attribute: binding.attribute.clone(),
+                field: name.clone(),
+                detail: format!("`{command_field}`, which `{}` does not declare", model.name),
+            },
+            range,
+        ));
+    }
+    Ok(())
 }
 
 /// The concept a binding's command half names — by bare name or by
@@ -265,17 +468,23 @@ fn resolve_command(
             range,
         )
     };
-    if let Some(concept) = scope.concept(&binding.command) {
-        return Ok(concept);
+    resolve_concept(&binding.command, scope).ok_or_else(unknown)
+}
+
+/// The concept a name refers to, by published name or by URI.
+///
+/// The two forms the notation writes for the same thing: a bare name
+/// goes through the name table, a URI names the concept's entity
+/// directly.
+fn resolve_concept(name: &str, scope: &Scope) -> Option<ConceptDefinition> {
+    if let Some(concept) = scope.concept(name) {
+        return Some(concept);
     }
-    // A URI-spelled command (`on:invite=tonk:invite`) names the
-    // concept's entity rather than its published name.
-    let entity = binding.command.parse().map_err(|_| unknown())?;
+    let entity = name.parse().ok()?;
     scope
         .resolved_concept(&entity)
         .flatten()
         .or_else(|| scope.concept_by_entity(&entity))
-        .ok_or_else(unknown)
 }
 
 /// The declaration must fill the command it is bound to.
@@ -451,6 +660,155 @@ view!:
         let source = document("on:demo=demo/act", "{this}").replace("subject: \"{", "topic: \"{");
         let error = lower(&source).expect_err("an unfillable command must not lower");
         assert_eq!(error.kind.code(), "E_EVENT_COMMAND_MISMATCH", "{error}");
+    }
+
+    /// A model concept, a command over it, and a view that renders
+    /// it. `$template` is the `show:` body and `$source` the
+    /// declaration's source for `subject`, so a test can break either
+    /// half against a model whose fields are known.
+    fn modelled(template: &str, source: &str) -> String {
+        format!(
+            r#"
+concept!: &counter/model
+  description: A counter.
+  with:
+    count:
+      description: How many.
+      the: xyz.tonk.counter/count
+      as: signed-integer
+      cardinality: one
+
+command!: &counter/increment
+  description: Add one.
+  with:
+    subject:
+      description: Which counter.
+      the: xyz.tonk.counter.increment/subject
+      as: entity
+
+event!: &on/bump
+  type: "click"
+  where:
+    subject: "{source}"
+
+view!:
+  this: counter/model
+  show:
+    ui: |
+{}
+"#,
+            template
+                .lines()
+                .map(|line| format!("      {line}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        )
+    }
+
+    /// The gap the `on:` checks left open, on the other half of the
+    /// template: `{counter}` is not a field of `counter/model`, and
+    /// before this it lowered clean and rendered as nothing at all.
+    #[dialog_common::test]
+    fn a_template_interpolating_an_undeclared_field_fails_the_lowering() {
+        let error = lower(&modelled("<p>{counter}</p>", "{this}"))
+            .expect_err("an undeclared interpolation must not lower");
+        assert_eq!(error.kind.code(), "E_UNKNOWN_TEMPLATE_FIELD", "{error}");
+        assert!(
+            error.to_string().contains("`count`"),
+            "the report names what the model does declare: {error}",
+        );
+    }
+
+    #[dialog_common::test]
+    fn a_template_interpolating_a_declared_field_lowers() {
+        lower(&modelled("<p>{count}</p>", "{this}")).expect("`count` is a field of the model");
+    }
+
+    /// `{this}` is the subject and `{dom.host/*}` is copied off the
+    /// outer host element. No concept declares either, and rejecting
+    /// them would reject most of the library.
+    #[dialog_common::test]
+    fn the_subject_and_host_attributes_are_not_model_fields() {
+        lower(&modelled(
+            "<a href=\"/c/{this}\" data-model=\"{dom.host/model}\">{count}</a>",
+            "{this}",
+        ))
+        .expect("ambient references are not checked against the model");
+    }
+
+    /// The exclusion the check lives or dies on. A stylesheet's rule
+    /// blocks are braces, not fields; so is a script's block syntax.
+    #[dialog_common::test]
+    fn css_and_script_braces_are_not_interpolations() {
+        lower(&modelled(
+            "<style>p { color: red; }</style>\n<script>if (x) { go(); }</script>\n<p>{count}</p>",
+            "{this}",
+        ))
+        .expect("a rule block is not a field reference");
+    }
+
+    /// The report points at the reference, not at the block scalar.
+    #[dialog_common::test]
+    fn an_undeclared_interpolation_is_reported_where_it_is_written() {
+        let source = modelled("<p>{counter}</p>", "{this}");
+        let error = lower(&source).expect_err("must not lower");
+        let range = error.range.expect("the report is placed");
+        let line = source
+            .lines()
+            .nth(range.start.line as usize)
+            .expect("the line is in the document");
+        assert_eq!(
+            &line[range.start.character as usize..range.end.character as usize],
+            "{counter}",
+        );
+    }
+
+    /// A declaration's `{field}` source is an interpolation too, in
+    /// the same scope, so the same miss applies — the command posts
+    /// with that field empty.
+    #[dialog_common::test]
+    fn an_event_sourcing_an_undeclared_field_fails_the_lowering() {
+        let error = lower(&modelled(
+            "<button on:bump=counter/increment>+</button>",
+            "{tally}",
+        ))
+        .expect_err("an undeclared source must not lower");
+        assert_eq!(error.kind.code(), "E_UNKNOWN_EVENT_SOURCE_FIELD", "{error}");
+    }
+
+    #[dialog_common::test]
+    fn an_event_sourcing_a_declared_field_lowers() {
+        lower(&modelled(
+            "<button on:bump=counter/increment>{count}</button>",
+            "{count}",
+        ))
+        .expect("`count` is a field of the model the view renders");
+    }
+
+    /// A source that fills a field the command does not declare is
+    /// inert whatever it interpolates, and is already what the
+    /// fill check reports. Reporting the interpolation too would name
+    /// the same mistake twice, and point at the less useful half.
+    #[dialog_common::test]
+    fn a_source_the_command_cannot_use_is_not_an_interpolation_error() {
+        let source = modelled("<button on:bump=counter/increment>+</button>", "{tally}")
+            .replace("    subject: \"{tally}\"", "    tally: \"{tally}\"");
+        let error = lower(&source).expect_err("the command still cannot be filled");
+        assert_eq!(
+            error.kind.code(),
+            "E_EVENT_COMMAND_MISMATCH",
+            "the fill check owns this, not the interpolation check: {error}",
+        );
+    }
+
+    /// A portal document is mounted verbatim, so its braces are not
+    /// interpolations and its `on:` attributes are not bindings. The
+    /// display decides this from the same `type` entry.
+    #[dialog_common::test]
+    fn a_portal_documents_braces_are_not_interpolations() {
+        let source = modelled("<p>{counter}</p>", "{this}")
+            .replace("  show:\n", "  show:\n    type: \"text/html\"\n");
+        lower(&source).expect("a portal document is not read as a template");
     }
 
     /// The report points at the attribute, not at the template.

--- a/rust/tonk-template/src/bindings.rs
+++ b/rust/tonk-template/src/bindings.rs
@@ -114,41 +114,39 @@ impl Bindings {
     }
 }
 
-/// Every `on:<name>=<command>` binding a template's raw HTML makes, in
-/// document order, deduplicated.
+/// Every `on:<name>=<command>` binding a template's raw HTML makes,
+/// deduplicated, ordered by what the binding says.
 ///
-/// A text scan rather than a DOM walk, because the analyzer has no DOM
-/// and the browser's `preprocess` walk is not available to it. It
-/// mirrors that walk on the two points that matter: only attribute
-/// positions inside a tag count, and an HTML comment carries none —
-/// the parser drops comment content, so a binding mentioned in prose
-/// inside `<!-- -->` must not become a dangling reference here.
+/// The walk is [`crate::scan::walk`], shared with the interpolation
+/// scan so the two cannot disagree about what a template contains —
+/// only attribute positions inside a tag count, and a comment carries
+/// none.
 pub fn scan(template: &str) -> Vec<EventBinding> {
-    let bytes = template.as_bytes();
     let mut out: Vec<EventBinding> = Vec::new();
-    let mut index = 0usize;
-
-    while index < bytes.len() {
-        if bytes[index] != b'<' {
-            index += 1;
-            continue;
+    crate::scan::walk(template, &mut |found| {
+        let crate::scan::Found::Attribute {
+            name,
+            name_offset,
+            value,
+            ..
+        } = found
+        else {
+            return;
+        };
+        let Some(event_name) = event_name_for_attribute(name) else {
+            return;
+        };
+        let command = value.trim();
+        if command.is_empty() {
+            return;
         }
-        if template[index..].starts_with("<!--") {
-            index = match template[index + 4..].find("-->") {
-                Some(offset) => index + 4 + offset + 3,
-                None => bytes.len(),
-            };
-            continue;
-        }
-        // `<` that opens no tag (a stray less-than in text) is not a
-        // tag start; only a name or a closing slash follows one.
-        let after = index + 1;
-        if after >= bytes.len() || !(bytes[after].is_ascii_alphabetic() || bytes[after] == b'/') {
-            index += 1;
-            continue;
-        }
-        index = scan_tag(template, after, &mut out);
-    }
+        out.push(EventBinding {
+            attribute: name.to_owned(),
+            event_name,
+            command: command.to_owned(),
+            offset: name_offset,
+        });
+    });
 
     // The derived order puts the offset last, so a repeated binding's
     // occurrences land next to each other and `dedup_by` — which keeps
@@ -159,93 +157,6 @@ pub fn scan(template: &str) -> Vec<EventBinding> {
             == (&right.attribute, &right.event_name, &right.command)
     });
     out
-}
-
-/// Read one tag's attributes starting just after its `<`. Returns the
-/// offset just past the tag's `>` (or the end of input).
-fn scan_tag(template: &str, mut index: usize, out: &mut Vec<EventBinding>) -> usize {
-    let bytes = template.as_bytes();
-    // Skip the tag name (and a closing tag's slash).
-    while index < bytes.len() && !bytes[index].is_ascii_whitespace() && bytes[index] != b'>' {
-        index += 1;
-    }
-
-    while index < bytes.len() {
-        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
-            index += 1;
-        }
-        if index >= bytes.len() || bytes[index] == b'>' {
-            return (index + 1).min(bytes.len());
-        }
-        // A self-closing `/` before `>` is not an attribute name.
-        if bytes[index] == b'/' {
-            index += 1;
-            continue;
-        }
-
-        let name_start = index;
-        while index < bytes.len()
-            && !bytes[index].is_ascii_whitespace()
-            && !matches!(bytes[index], b'=' | b'>' | b'/')
-        {
-            index += 1;
-        }
-        let name = &template[name_start..index];
-
-        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
-            index += 1;
-        }
-        if index >= bytes.len() || bytes[index] != b'=' {
-            // A valueless attribute — nothing to bind.
-            continue;
-        }
-        index += 1;
-        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
-            index += 1;
-        }
-        if index >= bytes.len() {
-            return bytes.len();
-        }
-
-        let value_start;
-        let value_end;
-        match bytes[index] {
-            quote @ (b'"' | b'\'') => {
-                index += 1;
-                value_start = index;
-                while index < bytes.len() && bytes[index] != quote {
-                    index += 1;
-                }
-                value_end = index;
-                index = (index + 1).min(bytes.len());
-            }
-            _ => {
-                value_start = index;
-                while index < bytes.len()
-                    && !bytes[index].is_ascii_whitespace()
-                    && bytes[index] != b'>'
-                {
-                    index += 1;
-                }
-                value_end = index;
-            }
-        }
-
-        let Some(event_name) = event_name_for_attribute(name) else {
-            continue;
-        };
-        let command = template[value_start..value_end].trim();
-        if command.is_empty() {
-            continue;
-        }
-        out.push(EventBinding {
-            attribute: name.to_owned(),
-            event_name,
-            command: command.to_owned(),
-            offset: name_start,
-        });
-    }
-    bytes.len()
 }
 
 #[cfg(test)]

--- a/rust/tonk-template/src/fields.rs
+++ b/rust/tonk-template/src/fields.rs
@@ -1,0 +1,193 @@
+//! The `{field}` references a template makes, found without a DOM.
+//!
+//! A template interpolates `{name}` and the renderer resolves it
+//! against the row it is rendering: `{this}` is the subject, a
+//! `{dom.host/attr}` is copied off the outer host element, and
+//! anything else is a field of the model's conclusion. A name that
+//! resolves to none of those renders as **nothing** — no error, no
+//! placeholder, just a gap where the value should be. That is the same
+//! failure an unresolvable `on:` binding used to have, on the other
+//! half of the template, and it is caught the same way: find the
+//! references here, check them against the model's declared fields in
+//! the analyzer.
+//!
+//! This module is only the finding. What counts as a legal name
+//! depends on the concept the view renders, which lives in the
+//! analyzer's scope, so the check itself does too.
+
+use crate::scan::{Found, walk};
+
+/// The namespace of host-element attributes copied into the
+/// conclusion (`{dom.host/model}`). These describe the *outer* host,
+/// not the subject, so no concept declares them and nothing here can
+/// check them.
+pub const HOST_NAMESPACE: &str = "dom.host/";
+
+/// The subject itself, legal in any template.
+pub const THIS: &str = "this";
+
+/// The suffix that names a keyed collection entry's key
+/// (`{block/key}` beside `{block}`). The renderer inserts it into the
+/// per-iteration shadow alongside the field, so it is legal wherever
+/// its field is.
+pub const KEY_SUFFIX: &str = "/key";
+
+/// One `{field}` reference, with where it is written.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FieldReference {
+    /// The name between the braces, verbatim.
+    pub name: String,
+    /// Byte offset of the `{` in the template. A repeated reference
+    /// keeps the earliest — the report has to point somewhere, and
+    /// that is the one an author reads first.
+    pub offset: usize,
+}
+
+impl FieldReference {
+    /// The name with a `/key` suffix removed, which is what a concept
+    /// would declare. `{block/key}` is legal exactly when `block` is.
+    pub fn declared_name(&self) -> &str {
+        self.name.strip_suffix(KEY_SUFFIX).unwrap_or(&self.name)
+    }
+
+    /// True for a reference no concept can account for: the subject,
+    /// or a host attribute.
+    pub fn is_ambient(&self) -> bool {
+        self.name == THIS || self.name.starts_with(HOST_NAMESPACE)
+    }
+
+    /// The `{name}` as written, for a diagnostic that quotes it.
+    pub fn written(&self) -> String {
+        format!("{{{}}}", self.name)
+    }
+
+    /// How many bytes the reference occupies, braces included.
+    pub fn len(&self) -> usize {
+        self.name.len() + 2
+    }
+
+    /// Never — a reference always spans at least `{}`. Present because
+    /// clippy asks for it beside [`FieldReference::len`].
+    pub fn is_empty(&self) -> bool {
+        false
+    }
+}
+
+/// Every `{field}` reference a template makes, deduplicated by name,
+/// each carrying the earliest offset it appears at.
+///
+/// Only text runs and attribute values are read, and `<style>` /
+/// `<script>` bodies are not — see [`crate::scan`]. Without that last
+/// exclusion every CSS rule block in the library reads as a wall of
+/// undefined fields, which is exactly what makes a naive version of
+/// this check unusable.
+pub fn scan(template: &str) -> Vec<FieldReference> {
+    let mut out: Vec<FieldReference> = Vec::new();
+    walk(template, &mut |found| {
+        let (text, base) = match found {
+            Found::Text { text, offset } => (text, offset),
+            Found::Attribute {
+                value,
+                value_offset,
+                ..
+            } => (value, value_offset),
+        };
+        collect(text, base, &mut out);
+    });
+
+    // Ordered by name so a report does not shift when a template
+    // moves; the offset only breaks ties, keeping the earliest.
+    out.sort();
+    out.dedup_by(|left, right| left.name == right.name);
+    out
+}
+
+/// Push every `{...}` in one run of text.
+///
+/// Mirrors `parse_segments`: the first `}` closes, and an unterminated
+/// `{` is literal text rather than a reference.
+fn collect(text: &str, base: usize, out: &mut Vec<FieldReference>) {
+    let mut rest = text;
+    let mut consumed = 0usize;
+    while let Some(open) = rest.find('{') {
+        let after = open + 1;
+        let Some(close) = rest[after..].find('}') else {
+            return;
+        };
+        out.push(FieldReference {
+            name: rest[after..after + close].to_owned(),
+            offset: base + consumed + open,
+        });
+        let next = after + close + 1;
+        consumed += next;
+        rest = &rest[next..];
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    fn names(template: &str) -> Vec<String> {
+        scan(template).into_iter().map(|f| f.name).collect()
+    }
+
+    #[dialog_common::test]
+    fn it_finds_references_in_text_and_attributes() {
+        assert_eq!(
+            names(r#"<a href="/x/{this}" title={name}>{title}</a>"#),
+            vec!["name", "this", "title"],
+        );
+    }
+
+    /// The exclusion the whole check depends on. A rule block is not
+    /// a field reference, and there are hundreds of them.
+    #[dialog_common::test]
+    fn it_ignores_css_and_script_braces() {
+        let template = concat!(
+            "<style>p { color: red; }</style>",
+            "<script>if (x) { go(); }</script>",
+            "<p>{title}</p>",
+        );
+        assert_eq!(names(template), vec!["title"]);
+    }
+
+    #[dialog_common::test]
+    fn it_ignores_a_reference_inside_a_comment() {
+        assert_eq!(names("<!-- {gone} --><p>{kept}</p>"), vec!["kept"]);
+    }
+
+    #[dialog_common::test]
+    fn it_keeps_the_earliest_offset_of_a_repeated_reference() {
+        let template = "<p>{title}</p><h1>{title}</h1>";
+        let found = scan(template);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].offset, template.find("{title}").expect("present"));
+        assert_eq!(
+            &template[found[0].offset..found[0].offset + found[0].len()],
+            "{title}",
+        );
+    }
+
+    #[dialog_common::test]
+    fn an_unterminated_brace_is_not_a_reference() {
+        assert!(names("<p>a {b</p>").is_empty());
+    }
+
+    #[dialog_common::test]
+    fn a_key_reference_is_declared_by_its_field() {
+        let found = scan("<p>{block/key}</p>");
+        assert_eq!(found[0].declared_name(), "block");
+        assert!(!found[0].is_ambient());
+    }
+
+    #[dialog_common::test]
+    fn the_subject_and_host_attributes_are_ambient() {
+        for template in ["<p>{this}</p>", "<p>{dom.host/model}</p>"] {
+            assert!(scan(template)[0].is_ambient(), "{template}");
+        }
+    }
+}

--- a/rust/tonk-template/src/lib.rs
+++ b/rust/tonk-template/src/lib.rs
@@ -33,8 +33,10 @@ use ipld_core::ipld::Ipld;
 
 pub mod bindings;
 pub mod event;
+pub mod fields;
 pub mod fold;
 pub mod resolve;
+pub mod scan;
 
 /// One chunk of an interpolated string.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/rust/tonk-template/src/scan.rs
+++ b/rust/tonk-template/src/scan.rs
@@ -1,0 +1,293 @@
+//! One template lexer, shared by everything that reads a `show:`
+//! template without a DOM.
+//!
+//! The analyzer has no DOM, so anything it wants to know about a
+//! template it has to read from the text. Two passes want to: the
+//! event-binding scan ([`crate::bindings::scan`]) reads `on:`
+//! attributes, and the interpolation scan ([`crate::fields::scan`])
+//! reads `{field}` references out of text and attribute values.
+//!
+//! They read the same template and must agree with the *browser* about
+//! what is in it, so they share one walk rather than each carrying
+//! their own. The two rules that matter are the two the renderer's DOM
+//! walk applies:
+//!
+//! * An HTML comment carries nothing — the parser drops its content,
+//!   so a binding or a `{field}` mentioned in prose inside `<!-- -->`
+//!   is not one.
+//! * `<style>` and `<script>` content is verbatim CSS/JS, where `{ … }`
+//!   are real braces. The renderer refuses to descend into them
+//!   (`is_raw_text_element` in `tonk-display`), so neither does this.
+//!   Their *attributes* still count: the renderer visits the element
+//!   before deciding not to descend.
+//!
+//! Getting either wrong is not a subtle difference. Without the first,
+//! a documented example fails the build; without the second, every
+//! stylesheet in the library becomes a wall of undefined fields.
+
+/// Something the walk found, with its byte offset in the template so a
+/// diagnostic can point at it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Found<'a> {
+    /// An attribute inside a tag. `value` is the unquoted value.
+    Attribute {
+        /// The attribute name as written (`on:click`, `href`).
+        name: &'a str,
+        /// Byte offset of the name.
+        name_offset: usize,
+        /// The value with any quotes stripped.
+        value: &'a str,
+        /// Byte offset of the value's first character.
+        value_offset: usize,
+    },
+    /// A run of character data between tags.
+    Text {
+        /// The run, verbatim.
+        text: &'a str,
+        /// Byte offset of the run.
+        offset: usize,
+    },
+}
+
+/// Walk a template, reporting every attribute and every text run.
+///
+/// A text scan rather than a parse: it does not build a tree, because
+/// no caller needs one. What it does reproduce is the renderer's view
+/// of which bytes are markup — see the module docs for the two
+/// exclusions that matter.
+pub fn walk(template: &str, visit: &mut impl FnMut(Found<'_>)) {
+    let bytes = template.as_bytes();
+    let mut index = 0usize;
+    let mut text_start = 0usize;
+
+    while index < bytes.len() {
+        if bytes[index] != b'<' {
+            index += 1;
+            continue;
+        }
+        if template[index..].starts_with("<!--") {
+            emit_text(template, text_start, index, visit);
+            index = match template[index + 4..].find("-->") {
+                Some(offset) => index + 4 + offset + 3,
+                None => bytes.len(),
+            };
+            text_start = index;
+            continue;
+        }
+        // A `<` that opens no tag (a stray less-than in prose) is not
+        // a tag start; only a name or a closing slash follows one.
+        let after = index + 1;
+        if after >= bytes.len() || !(bytes[after].is_ascii_alphabetic() || bytes[after] == b'/') {
+            index += 1;
+            continue;
+        }
+        emit_text(template, text_start, index, visit);
+        let (end, raw_text_name) = scan_tag(template, after, visit);
+        index = end;
+        // A `<style>` / `<script>` body is verbatim, so skip to the
+        // matching close tag without reporting the text between.
+        if let Some(name) = raw_text_name {
+            index = skip_raw_text(template, index, name);
+        }
+        text_start = index;
+    }
+    emit_text(template, text_start, bytes.len(), visit);
+}
+
+/// Report the text between two offsets, if there is any.
+fn emit_text(template: &str, start: usize, end: usize, visit: &mut impl FnMut(Found<'_>)) {
+    if start < end {
+        visit(Found::Text {
+            text: &template[start..end],
+            offset: start,
+        });
+    }
+}
+
+/// Read one tag's attributes starting just after its `<`.
+///
+/// Returns the offset just past the tag's `>` (or the end of input),
+/// and the lowercase name of a raw-text element whose body the caller
+/// must skip.
+fn scan_tag(
+    template: &str,
+    mut index: usize,
+    visit: &mut impl FnMut(Found<'_>),
+) -> (usize, Option<&'static str>) {
+    let bytes = template.as_bytes();
+    let closing = bytes[index] == b'/';
+    let name_start = index;
+    while index < bytes.len() && !bytes[index].is_ascii_whitespace() && bytes[index] != b'>' {
+        index += 1;
+    }
+    let tag_name = &template[name_start..index];
+    let raw_text = match tag_name.to_ascii_lowercase().as_str() {
+        "style" if !closing => Some("style"),
+        "script" if !closing => Some("script"),
+        _ => None,
+    };
+
+    loop {
+        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+            index += 1;
+        }
+        if index >= bytes.len() {
+            return (bytes.len(), raw_text);
+        }
+        if bytes[index] == b'>' {
+            return (index + 1, raw_text);
+        }
+        // A self-closing `/` before `>` is not an attribute name; nor
+        // is there a body to skip after one.
+        if bytes[index] == b'/' {
+            index += 1;
+            return (scan_to_tag_end(template, index), None);
+        }
+
+        let name_start = index;
+        while index < bytes.len()
+            && !bytes[index].is_ascii_whitespace()
+            && !matches!(bytes[index], b'=' | b'>' | b'/')
+        {
+            index += 1;
+        }
+        let name = &template[name_start..index];
+
+        let mut probe = index;
+        while probe < bytes.len() && bytes[probe].is_ascii_whitespace() {
+            probe += 1;
+        }
+        if probe >= bytes.len() || bytes[probe] != b'=' {
+            // A valueless attribute — nothing to interpolate or bind.
+            continue;
+        }
+        index = probe + 1;
+        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+            index += 1;
+        }
+        if index >= bytes.len() {
+            return (bytes.len(), raw_text);
+        }
+
+        let value_start;
+        let value_end;
+        match bytes[index] {
+            quote @ (b'"' | b'\'') => {
+                index += 1;
+                value_start = index;
+                while index < bytes.len() && bytes[index] != quote {
+                    index += 1;
+                }
+                value_end = index;
+                index = (index + 1).min(bytes.len());
+            }
+            _ => {
+                value_start = index;
+                while index < bytes.len()
+                    && !bytes[index].is_ascii_whitespace()
+                    && bytes[index] != b'>'
+                {
+                    index += 1;
+                }
+                value_end = index;
+            }
+        }
+
+        visit(Found::Attribute {
+            name,
+            name_offset: name_start,
+            value: &template[value_start..value_end],
+            value_offset: value_start,
+        });
+    }
+}
+
+/// The offset just past the next `>`, or the end of input.
+fn scan_to_tag_end(template: &str, index: usize) -> usize {
+    match template[index..].find('>') {
+        Some(offset) => index + offset + 1,
+        None => template.len(),
+    }
+}
+
+/// The offset just past `</name>`, or the end of input. Case-insensitive
+/// on the tag name, as HTML is.
+fn skip_raw_text(template: &str, index: usize, name: &str) -> usize {
+    let haystack = template[index..].to_ascii_lowercase();
+    let needle = format!("</{name}");
+    match haystack.find(&needle) {
+        Some(offset) => scan_to_tag_end(template, index + offset),
+        None => template.len(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    /// Every attribute and text run, as `(name_or_text, offset)`.
+    fn collect(template: &str) -> Vec<(String, usize)> {
+        let mut out = Vec::new();
+        walk(template, &mut |found| match found {
+            Found::Attribute {
+                name,
+                name_offset,
+                value,
+                ..
+            } => out.push((format!("@{name}={value}"), name_offset)),
+            Found::Text { text, offset } => out.push((format!("#{text}"), offset)),
+        });
+        out
+    }
+
+    #[dialog_common::test]
+    fn it_reports_text_and_attributes_with_their_offsets() {
+        let template = r#"<a href="/x/{this}">go</a>"#;
+        assert_eq!(
+            collect(template),
+            vec![("@href=/x/{this}".to_string(), 3), ("#go".to_string(), 20),],
+        );
+    }
+
+    /// A stylesheet's braces are CSS, not fields. The renderer refuses
+    /// to descend into `<style>`; so does this.
+    #[dialog_common::test]
+    fn it_does_not_read_a_style_body() {
+        let found = collect("<style>p { color: red; }</style><p>hi</p>");
+        assert_eq!(found, vec![("#hi".to_string(), 35)]);
+    }
+
+    #[dialog_common::test]
+    fn it_does_not_read_a_script_body() {
+        let found = collect("<script>if (x) { go({y}); }</script><b>hi</b>");
+        assert_eq!(found, vec![("#hi".to_string(), 39)]);
+    }
+
+    /// A raw-text element's own attributes still count: the renderer
+    /// visits the element before deciding not to walk into it.
+    #[dialog_common::test]
+    fn it_still_reads_a_raw_text_elements_attributes() {
+        let found = collect(r#"<script src="{module}"></script>"#);
+        assert_eq!(found, vec![("@src={module}".to_string(), 8)]);
+    }
+
+    #[dialog_common::test]
+    fn it_reports_nothing_inside_a_comment() {
+        assert_eq!(
+            collect("<!-- {gone} --><i>{kept}</i>"),
+            vec![("#{kept}".to_string(), 18)]
+        );
+    }
+
+    #[dialog_common::test]
+    fn it_reads_a_self_closing_tags_attributes() {
+        let found = collect(r#"<img src={a} /><p>x</p>"#);
+        assert_eq!(
+            found,
+            vec![("@src={a}".to_string(), 5), ("#x".to_string(), 18)],
+        );
+    }
+}


### PR DESCRIPTION
Stacked on #905 — review that first; this PR's diff is the commits on top of it.

## What changed

A `show:` template interpolates `{name}` and the renderer resolves it against the row it is rendering. A name that resolves to nothing renders as **nothing** — no gap, no placeholder, no warning, just a value missing from the page. That is the same failure an unresolvable `on:` binding used to have, on the other half of the template, and #905 fixed only the binding half.

The view names the concept it renders, so the analyzer already knows which names are legal. It now checks them.

| code | what it catches |
| --- | --- |
| `E_UNKNOWN_TEMPLATE_FIELD` | a `show:` template interpolates `{name}`, and the model does not declare `name` |
| `E_UNKNOWN_EVENT_SOURCE_FIELD` | a **bound** `event!:` sources a command field from `{name}`, and the model does not declare `name` |

Both report against the reference itself — the `{name}` as written — not the block scalar around it, using the coordinate mapping #905 added for the `on:` diagnostics.

What is legal, besides a declared field:

- `{this}` — the subject. Ambient; no concept declares it.
- `{dom.host/*}` — copied off the *outer* host element (`{dom.host/model}`). Describes the host, not the subject, so no concept declares these either and nothing here can check them.
- `{block/key}` — legal exactly when `block` is. The renderer inserts `<field>/key` into the same per-iteration shadow as the field it belongs to (`render.rs`'s `row_key_field`), so the key is in scope wherever its field is.

### The model has to be prefetched, and at first it was not

Worth reading before the rest, because it is the bug this PR shipped and the reason to distrust a green test run here.

The check resolves the view's `this:` through `Scope`, and `Scope` holds only what the graph's resolve phase was asked to prefetch. The view needs registered each binding's *command* and *declaration* — #905 added those — but never the *model*. So:

- model declared in the same document → in scope anyway → checked
- model already on the branch → `Scope` has nothing → `model_concept` returns `None` → **both checks silently skip**

The second is the ordinary case. A view written against a concept the space already carries went unchecked, which is how this was reported: a hand-written counter view interpolating `{counter}` where the model declares `count` lowered clean against this PR's own preview, and the renderer emitted `<!--tonk-iter:counter-->` — the unknown name became an iteration axis and the element was cloned zero times.

`collect_view_model_needs` now registers the `this:` concept as a need in both spellings a reference takes, exactly as the command half already did.

The reason it survived review-by-testing is worth stating plainly: **every self-contained fixture passes either way.** Six tests asserted the check fires, all of them on documents that declared their own concept, and all six would have gone on passing with the branch path dead. The test that pins it (`a_view_whose_model_is_on_the_branch_is_still_checked`) lowers a document containing *only* the view and its declaration against a stub resolver serving the concept and command as branch facts, and was verified failing with the need removed.

### The scope rule for event sources

`E_UNKNOWN_EVENT_SOURCE_FIELD` fires **only** for a source filling a field the command actually declares. A source that fills nothing is inert whatever it interpolates, and is already exactly what `E_EVENT_COMMAND_MISMATCH` reports; a second diagnostic would name one mistake twice and point at the less useful half. `a_source_the_command_cannot_use_is_not_an_interpolation_error` pins that: with the command field renamed away, the error that comes back is still the mismatch, not this one.

Only *bound* declarations are checked. An `event!:` on its own has no view, so no model, so no scope to resolve `{field}` in.

### Why this is a mirror of the renderer, not a heuristic

This check is one exclusion away from being unusable, and the first version of it was. The naive scan — every `{...}` in the template text — flags **~120 references** across the six shipped libraries, essentially all of them CSS rule blocks:

```
{ display: block; }
{ --edge-ink: #e2dfdd; --edge-soft: #c8c3bf; … }
```

The temptation is to filter by shape ("only plain identifiers count"). That is a guess, and it would silently stop catching a real typo the moment one contained a character the filter rejected.

The actual rule is not a guess — the renderer already has it. `walk()` in `tonk-display/src/template.rs` refuses to descend into `<style>` and `<script>`, because their content is verbatim CSS/JS where `{ … }` are real braces. Three exclusions, each taken from the renderer rather than invented here:

1. **`<style>` / `<script>` bodies** — `is_raw_text_element`. Their *attributes* still count, because the renderer visits the element before deciding not to walk into it.
2. **HTML comments** — the parser drops the content, so a reference in prose inside `<!-- -->` is not one. (`bindings::scan` already had this.)
3. **`type: text/html` portal documents** — the display checks that same `show:` entry and mounts the templates into a `<tonk-portal>` verbatim rather than interpolating them (`element.rs`, `handle_portal_view_frame`). Nothing interpolates them and nothing delegates their events, so a `{` in one is a brace and an `on:` in one is an attribute.

With those three, false positives across every shipped library go from ~120 to **zero**, with no shape filtering at all.

(3) also changes #905 slightly: `on:` bindings inside a portal document are no longer scanned. They were, and the delegate never looks inside a portal, so demanding they resolve was a diagnostic over markup the runtime does not read.

### One scan, not two

Two passes now read the same template for different things, and they must agree with the browser about what is in it. Rather than let a second scanner drift from the first — which is the exact failure mode this whole stack keeps finding — the walk moved into one lexer, `tonk-template::scan`, reporting attributes and text runs with their offsets. `bindings::scan` (`on:` attributes) and `fields::scan` (`{field}` references) are now two readings of one walk.

## Verification

```console
cargo fmt --all
cargo test -p tonk-analyzer -p tonk-template -p tonk-worker -p tonk-render -p tonk-display
# → analyzer 197, template 94, worker 111 + standard_library 31 + command_migration 12 + fab_drift 6,
#   render 32 + compat 8, display 73 — all passing
cargo clippy --no-deps -p tonk-template -p tonk-analyzer --all-targets --all-features -- -D warnings
cargo check -p tonk-template -p tonk-analyzer --target wasm32-unknown-unknown
```

CI is green on the current head, which is what exercises the browser jobs, the e2e shards and the workspace-wide Nix-pinned clippy — none of which run locally here.

`AnalyzeError` sits against clippy's 128-byte `result_large_err` ceiling, so `UnknownEventSourceField` renders its command field and model into one `detail` string rather than carrying them as separate `String`s — the same accommodation `EventCommandMismatch` already makes.

New tests:

- `tonk-template::scan` — text and attribute offsets; a `<style>` body and a `<script>` body are not read; a raw-text element's own attributes still are; comment content is not; a self-closing tag's attributes are.
- `tonk-template::fields` — references in text and attributes; CSS and script braces ignored; comment content ignored; a repeated reference keeps its earliest offset; an unterminated `{` is not a reference; `{block/key}` declares as `block`; `{this}` and `{dom.host/*}` are ambient.
- `tonk-analyzer::view` — an undeclared interpolation fails and a declared one lowers; ambient references are not checked against the model; CSS and script braces do not fail a view; the report covers `{counter}` alone rather than the block scalar; an undeclared event source fails and a declared one lowers; a source the command cannot use stays the fill check's to report; a portal document's braces are not interpolations.
- `tonk-analyzer::view::the_counter_document_that_prompted_this_check_fails_the_lowering` — the reported document verbatim, rather than a fixture written to suit the check. It also lowers the same document with `{counter}` → `{count}`, so it cannot pass by rejecting the shape wholesale.
- `tonk-analyzer::graph::a_view_whose_model_is_on_the_branch_is_still_checked` — the model resolved from a stub branch instead of the document. See **The model has to be prefetched** above; this is the only test in the set that distinguishes the two paths.
- `tonk-analyzer::library_analysis_tests::the_interpolation_checks_reach_the_shipped_libraries` — both checks are silent when they pass, so the existing library-analysis tests would go on passing if the pass resolved no model and skipped every view. This introduces the exact typo each check exists to catch into a real library (`{title}` → `{titel}` in `notebook.yaml`, `{provider}` → `{provideer}` in `profile.yaml`, and `subject: "{this}"` → `"{nope}"` in `prose.yaml`) and requires the lowering to fail with the specific code. The substitution is applied to the target file *before* it is concatenated with `core.yaml`, because `core.yaml` contains the same strings and comes first — mutating the joined text silently breaks the wrong file, which is how the first version of this gate passed for the wrong reason.

## Things a reviewer should look at sceptically

- **The check is only as good as what the resolve phase prefetches.** That is what the model bug was, and the class is not closed by fixing one instance: any value the check reads out of `Scope` is invisible unless a `Need` put it there, and the failure mode is a silent skip rather than an error. The other two things it reads — the bound command and the declaration name — are prefetched by #905, and `is_portal` reads the document directly. Worth confirming rather than taking from this list.
- **A view whose `this:` resolves to no concept at all is still skipped entirely** — a variable, or a name neither the document nor the branch supplies. That is the deliberate conservative default, but it means coverage is exactly as good as head resolution is, and a skip looks identical to a pass.
- **The event-source check has almost nothing to bite on today.** Of the 20 `on:` bindings in the shipped libraries, exactly one bound declaration (`prose.yaml`'s `on/prose-change`) sources a command field from a `{field}`; every other reads a DOM property path (`.detail.*`, `.currentTarget.*`), which this check does not look at. It is forward-looking, not a fix for existing breakage. The reach gate is pointed at that one live case, so if it disappears the assert says so rather than passing quietly.
- **No shipped library had a template-field miss either.** The audit found one candidate — `notebook.yaml`'s directory view appearing to interpolate `{label}` — which turned out to be inside an HTML comment. The corpus is clean; this catches the *next* one.
- **`{block/title}` is rejected, and that is intended.** Only `<field>` and `<field>/key` enter the renderer's per-iteration shadow, so a deeper path renders nothing. But it is worth confirming the reading of `render.rs` rather than taking it from this description.
- **This is a lowering-time check.** A view already seeded onto a branch is never re-lowered, so an interpolation that is already wrong stays silent until the document is pushed again. Nothing here retro-checks a space.
- **The portal exclusion widens what `is_portal` suppresses**, including the `on:` scan #905 added. That is a behavior change to the PR below this one, argued above rather than buried.

## Storybook impact

- [x] No user-visible contract changed because: this is a build-time check only. No renderer, display, or runtime path changed — a template that lowered and rendered correctly before does both identically now. What is new is that a template referencing a field that does not exist fails the build instead of rendering a silent gap, and no shipped library contains such a reference, so no screen or journey changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WyWgReUaivze37mfWSNA4D

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces new modules and updates error handling for template fields and event sources in the `tonk` project. It enhances the interpolation checks for templates, ensuring that undeclared fields and event source fields are properly reported.

### Detailed summary
- Added `fields` and `scan` modules in `rust/tonk-template/src/lib.rs`.
- Enhanced error handling for unknown template fields and event source fields in `rust/tonk-analyzer/src/analyzer/error.rs`.
- Implemented interpolation checks in `rust/tonk-analyzer/src/analyzer.rs`.
- Updated `scan` function to improve event binding detection in `rust/tonk-template/src/bindings.rs`.
- Introduced `FieldReference` struct to manage field references in `rust/tonk-template/src/fields.rs`.
- Enhanced checks for model fields in `rust/tonk-analyzer/src/analyzer/view.rs` and related tests.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->