### PR TITLE
chore: release 0.6.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "dialog-reactor"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4631,7 +4631,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-access-service"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4686,7 +4686,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-account"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "blake3",
@@ -4714,7 +4714,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-analytics"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "dialog-common",
  "hex",
@@ -4732,7 +4732,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-analyzer"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4758,7 +4758,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-board"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "custom-elements",
  "js-sys",
@@ -4773,7 +4773,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-cli"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-code"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4848,7 +4848,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-common"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "dialog-common",
  "futures-util",
@@ -4861,7 +4861,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-core"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "base58",
  "dialog-artifacts",
@@ -4880,7 +4880,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-display"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4905,7 +4905,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-email"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "serde",
  "serde_json",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-evaluator"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "dialog-artifacts",
@@ -4937,7 +4937,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-fab"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4958,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-guest"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "console_error_panic_hook",
  "custom-elements",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-host"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "bytes",
  "custom-elements",
@@ -5004,7 +5004,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-identity"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -5044,7 +5044,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-inspector"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "bs58",
  "custom-elements",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-invite"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "bs58",
@@ -5082,7 +5082,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-language-server"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -5102,7 +5102,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-macros"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-notation"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "dialog-common",
  "lsp-types",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-portal"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "bs58",
@@ -5158,7 +5158,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-prose"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-render"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "async-trait",
  "dialog-common",
@@ -5184,7 +5184,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-router"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "dialog-common",
  "tokio",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-schema"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-sigil"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "blake3",
  "bs58",
@@ -5242,7 +5242,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-table"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-template"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "dialog-common",
  "indexmap",
@@ -5268,7 +5268,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-tree"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "custom-elements",
  "js-sys",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-ui"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-worker"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5405,7 +5405,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-worker-api"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "dialog-artifacts",
  "dialog-capability",
@@ -5423,7 +5423,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-workspace"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "bs58",
  "custom-elements",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.13"
+version = "0.6.14"
 authors = ["Tonk Labs"]
 edition = "2024"
 license = "MIT"


### PR DESCRIPTION
Bumps the shared workspace version from 0.6.13 to 0.6.14 and refreshes the 35 inherited package versions in Cargo.lock. No dependency or application code changes.

Validation passed:
- `cargo check -p tonk-cli --offline`
- `cargo fmt --all -- --check`
- `cargo pkgid -p tonk-cli` resolves to 0.6.14
- `git diff --check`
- Verified Cargo.lock changes only workspace package versions.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of multiple packages in the `Cargo.toml` and `Cargo.lock` files from `0.6.13` to `0.6.14`, indicating a new release of the project and its dependencies.

### Detailed summary
- Updated version of the workspace package from `0.6.13` to `0.6.14`.
- Updated version of the following packages from `0.6.13` to `0.6.14`:
  - `dialog-reactor`
  - `tonk-access-service`
  - `tonk-account`
  - `tonk-analytics`
  - `tonk-analyzer`
  - `tonk-board`
  - `tonk-cli`
  - `tonk-code`
  - `tonk-common`
  - `tonk-core`
  - `tonk-display`
  - `tonk-email`
  - `tonk-evaluator`
  - `tonk-fab`
  - `tonk-guest`
  - `tonk-host`
  - `tonk-identity`
  - `tonk-inspector`
  - `tonk-invite`
  - `tonk-language-server`
  - `tonk-macros`
  - `tonk-notation`
  - `tonk-portal`
  - `tonk-prose`
  - `tonk-render`
  - `tonk-router`
  - `tonk-schema`
  - `tonk-sigil`
  - `tonk-table`
  - `tonk-template`
  - `tonk-tree`
  - `tonk-ui`
  - `tonk-worker`
  - `tonk-worker-api`
  - `tonk-workspace`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->