### PR TITLE
fix(worker): use disposable bounded in-memory sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,7 +986,7 @@ dependencies = [
 [[package]]
 name = "dialog-artifacts"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-09-02#805151c678c516edc03c2825171ed4b54adf37ab"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=314e49926eb5bca58bacdcf9f2123ccb4422ea35#314e49926eb5bca58bacdcf9f2123ccb4422ea35"
 dependencies = [
  "arrayref",
  "async-stream",
@@ -1025,7 +1025,7 @@ dependencies = [
 [[package]]
 name = "dialog-capability"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-09-02#805151c678c516edc03c2825171ed4b54adf37ab"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=314e49926eb5bca58bacdcf9f2123ccb4422ea35#314e49926eb5bca58bacdcf9f2123ccb4422ea35"
 dependencies = [
  "async-trait",
  "base58",
@@ -1048,7 +1048,7 @@ dependencies = [
 [[package]]
 name = "dialog-common"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-09-02#805151c678c516edc03c2825171ed4b54adf37ab"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=314e49926eb5bca58bacdcf9f2123ccb4422ea35#314e49926eb5bca58bacdcf9f2123ccb4422ea35"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1076,7 +1076,7 @@ dependencies = [
 [[package]]
 name = "dialog-credentials"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-09-02#805151c678c516edc03c2825171ed4b54adf37ab"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=314e49926eb5bca58bacdcf9f2123ccb4422ea35#314e49926eb5bca58bacdcf9f2123ccb4422ea35"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -1102,7 +1102,7 @@ dependencies = [
 [[package]]
 name = "dialog-csv"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-09-02#805151c678c516edc03c2825171ed4b54adf37ab"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=314e49926eb5bca58bacdcf9f2123ccb4422ea35#314e49926eb5bca58bacdcf9f2123ccb4422ea35"
 dependencies = [
  "async-trait",
  "base58",
@@ -1117,7 +1117,7 @@ dependencies = [
 [[package]]
 name = "dialog-did-web"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-09-02#805151c678c516edc03c2825171ed4b54adf37ab"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=314e49926eb5bca58bacdcf9f2123ccb4422ea35#314e49926eb5bca58bacdcf9f2123ccb4422ea35"
 dependencies = [
  "async-trait",
  "base58",
@@ -1140,7 +1140,7 @@ dependencies = [
 [[package]]
 name = "dialog-effects"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-09-02#805151c678c516edc03c2825171ed4b54adf37ab"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=314e49926eb5bca58bacdcf9f2123ccb4422ea35#314e49926eb5bca58bacdcf9f2123ccb4422ea35"
 dependencies = [
  "async-trait",
  "base58",
@@ -1155,7 +1155,7 @@ dependencies = [
 [[package]]
 name = "dialog-identity"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-09-02#805151c678c516edc03c2825171ed4b54adf37ab"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=314e49926eb5bca58bacdcf9f2123ccb4422ea35#314e49926eb5bca58bacdcf9f2123ccb4422ea35"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1173,7 +1173,7 @@ dependencies = [
 [[package]]
 name = "dialog-macros"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-09-02#805151c678c516edc03c2825171ed4b54adf37ab"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=314e49926eb5bca58bacdcf9f2123ccb4422ea35#314e49926eb5bca58bacdcf9f2123ccb4422ea35"
 dependencies = [
  "blake3",
  "convert_case",
@@ -1185,7 +1185,7 @@ dependencies = [
 [[package]]
 name = "dialog-network"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-09-02#805151c678c516edc03c2825171ed4b54adf37ab"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=314e49926eb5bca58bacdcf9f2123ccb4422ea35#314e49926eb5bca58bacdcf9f2123ccb4422ea35"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1200,7 +1200,7 @@ dependencies = [
 [[package]]
 name = "dialog-operator"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-09-02#805151c678c516edc03c2825171ed4b54adf37ab"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=314e49926eb5bca58bacdcf9f2123ccb4422ea35#314e49926eb5bca58bacdcf9f2123ccb4422ea35"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1238,7 +1238,7 @@ dependencies = [
 [[package]]
 name = "dialog-query"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-09-02#805151c678c516edc03c2825171ed4b54adf37ab"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=314e49926eb5bca58bacdcf9f2123ccb4422ea35#314e49926eb5bca58bacdcf9f2123ccb4422ea35"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1298,7 +1298,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-fs"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-09-02#805151c678c516edc03c2825171ed4b54adf37ab"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=314e49926eb5bca58bacdcf9f2123ccb4422ea35#314e49926eb5bca58bacdcf9f2123ccb4422ea35"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -1315,7 +1315,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-09-02#805151c678c516edc03c2825171ed4b54adf37ab"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=314e49926eb5bca58bacdcf9f2123ccb4422ea35#314e49926eb5bca58bacdcf9f2123ccb4422ea35"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "dialog-remote-ucan-s3"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-09-02#805151c678c516edc03c2825171ed4b54adf37ab"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=314e49926eb5bca58bacdcf9f2123ccb4422ea35#314e49926eb5bca58bacdcf9f2123ccb4422ea35"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1391,7 +1391,7 @@ dependencies = [
 [[package]]
 name = "dialog-repository"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-09-02#805151c678c516edc03c2825171ed4b54adf37ab"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=314e49926eb5bca58bacdcf9f2123ccb4422ea35#314e49926eb5bca58bacdcf9f2123ccb4422ea35"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1430,7 +1430,7 @@ dependencies = [
 [[package]]
 name = "dialog-search-tree"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-09-02#805151c678c516edc03c2825171ed4b54adf37ab"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=314e49926eb5bca58bacdcf9f2123ccb4422ea35#314e49926eb5bca58bacdcf9f2123ccb4422ea35"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1460,7 +1460,7 @@ dependencies = [
 [[package]]
 name = "dialog-storage"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-09-02#805151c678c516edc03c2825171ed4b54adf37ab"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=314e49926eb5bca58bacdcf9f2123ccb4422ea35#314e49926eb5bca58bacdcf9f2123ccb4422ea35"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1507,7 +1507,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-09-02#805151c678c516edc03c2825171ed4b54adf37ab"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=314e49926eb5bca58bacdcf9f2123ccb4422ea35#314e49926eb5bca58bacdcf9f2123ccb4422ea35"
 dependencies = [
  "async-trait",
  "base58",
@@ -1528,7 +1528,7 @@ dependencies = [
 [[package]]
 name = "dialog-ucan-core"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-09-02#805151c678c516edc03c2825171ed4b54adf37ab"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=314e49926eb5bca58bacdcf9f2123ccb4422ea35#314e49926eb5bca58bacdcf9f2123ccb4422ea35"
 dependencies = [
  "dialog-varsig",
  "futures",
@@ -1554,7 +1554,7 @@ dependencies = [
 [[package]]
 name = "dialog-varsig"
 version = "0.1.0"
-source = "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-09-02#805151c678c516edc03c2825171ed4b54adf37ab"
+source = "git+https://github.com/dialog-db/dialog-db.git?rev=314e49926eb5bca58bacdcf9f2123ccb4422ea35#314e49926eb5bca58bacdcf9f2123ccb4422ea35"
 dependencies = [
  "dialog-common",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,22 +191,22 @@ wasm-bindgen-test = "0.3"
 web-sys = { version = "0.3" }
 
 # Dialog DB
-dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-09-02" }
-dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-09-02" }
-dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-09-02" }
-dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-09-02" }
-dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-09-02" }
-dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-09-02" }
-dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-09-02" }
-dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-09-02" }
-dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-09-02" }
-dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-09-02" }
-dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-09-02" }
-dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-09-02" }
-dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-09-02" }
-dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-09-02" }
-dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-09-02" }
-dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", tag = "tonk-2026-09-02" }
+dialog-artifacts = { git = "https://github.com/dialog-db/dialog-db.git", rev = "314e49926eb5bca58bacdcf9f2123ccb4422ea35" }
+dialog-capability = { git = "https://github.com/dialog-db/dialog-db.git", rev = "314e49926eb5bca58bacdcf9f2123ccb4422ea35" }
+dialog-common = { git = "https://github.com/dialog-db/dialog-db.git", rev = "314e49926eb5bca58bacdcf9f2123ccb4422ea35" }
+dialog-credentials = { git = "https://github.com/dialog-db/dialog-db.git", rev = "314e49926eb5bca58bacdcf9f2123ccb4422ea35" }
+dialog-csv = { git = "https://github.com/dialog-db/dialog-db.git", rev = "314e49926eb5bca58bacdcf9f2123ccb4422ea35" }
+dialog-effects = { git = "https://github.com/dialog-db/dialog-db.git", rev = "314e49926eb5bca58bacdcf9f2123ccb4422ea35" }
+dialog-operator = { git = "https://github.com/dialog-db/dialog-db.git", rev = "314e49926eb5bca58bacdcf9f2123ccb4422ea35" }
+dialog-query = { git = "https://github.com/dialog-db/dialog-db.git", rev = "314e49926eb5bca58bacdcf9f2123ccb4422ea35" }
+dialog-remote-s3 = { git = "https://github.com/dialog-db/dialog-db.git", rev = "314e49926eb5bca58bacdcf9f2123ccb4422ea35" }
+dialog-remote-ucan-s3 = { git = "https://github.com/dialog-db/dialog-db.git", rev = "314e49926eb5bca58bacdcf9f2123ccb4422ea35" }
+dialog-repository = { git = "https://github.com/dialog-db/dialog-db.git", rev = "314e49926eb5bca58bacdcf9f2123ccb4422ea35" }
+dialog-search-tree = { git = "https://github.com/dialog-db/dialog-db.git", rev = "314e49926eb5bca58bacdcf9f2123ccb4422ea35" }
+dialog-storage = { git = "https://github.com/dialog-db/dialog-db.git", rev = "314e49926eb5bca58bacdcf9f2123ccb4422ea35" }
+dialog-ucan = { git = "https://github.com/dialog-db/dialog-db.git", rev = "314e49926eb5bca58bacdcf9f2123ccb4422ea35" }
+dialog-ucan-core = { git = "https://github.com/dialog-db/dialog-db.git", rev = "314e49926eb5bca58bacdcf9f2123ccb4422ea35" }
+dialog-varsig = { git = "https://github.com/dialog-db/dialog-db.git", rev = "314e49926eb5bca58bacdcf9f2123ccb4422ea35" }
 
 [profile.dev]
 opt-level = 1

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -18,8 +18,8 @@ let
   # that the same dependencies can be used across all derivations that
   # need them. Crane expects the full git URL as the key.
   cargoGitDependencies = {
-    "git+https://github.com/dialog-db/dialog-db.git?tag=tonk-2026-05-19#9c49c9956028119d7d9293b93e329dc1b84e4999" =
-      "sha256-jwKq75n7oPjfNglx+mArc79+Y/v3yRZj4teeNs9iZCw=";
+    "git+https://github.com/dialog-db/dialog-db.git?rev=314e49926eb5bca58bacdcf9f2123ccb4422ea35#314e49926eb5bca58bacdcf9f2123ccb4422ea35" =
+      "sha256-V3ZKANhlwG2MLTW6A4c/GS76k1bVB0OusFLGrNj4t9Q=";
   };
 
   # Filter source to only Rust-relevant files

--- a/plan/in-memory-worker-sessions.md
+++ b/plan/in-memory-worker-sessions.md
@@ -1,0 +1,129 @@
+# Disposable worker operators with bounded in-memory grants
+
+Every worker boot should create an operator with a matching, expiring profile-to-operator grant held in memory. Membership and invitation authority remain attached to accounts and profiles. Replacing a worker therefore changes only the final session hop and requires no invitation replay. This fixes Safari sync after worker replacement while avoiding a durable delegation commit on every boot. The tradeoff is one fresh session-grant signature per boot; Safari latency must be measured rather than assumed negligible.
+
+The evidence and reproduction are in [mobile-sync-diagnosis.md](mobile-sync-diagnosis.md). Safari returned different Ed25519 signatures for identical inputs. Dialog's non-extractable-key derivation hashes such a signature, so reconstruction changed the operator DID while `session::open` reused a persisted grant addressed to the previous operator. The phone's delegation metadata confirmed that mismatch. Current `prepare_join` claims invitations for `current_account`, including onboarding accounts. `Invite::visit` has only test callers in this repository; the session module's guest-replay commentary describes an obsolete flow.
+
+Scope is the browser worker and the narrow Dialog API it needs. Keep the existing 12-hour session TTL, one-hour renewal margin, device/profile and account identities, invitation proofs, revocation behavior, non-extractable browser keys, and local/offline space contents. CLI session persistence is a separate follow-up. No pruning system or stable operator identity across boots is required. Expiration bounds authorization; dropping a worker releases its operator and in-memory grant without a cleanup transaction.
+
+## 1. Dialog can build a bounded in-memory session
+
+- [x] A bounded operator proves a retained space grant with the correct expiry, without writing session facts or changing the access-branch revision.
+
+This prerequisite belongs in Dialog, currently pinned by Tonk's `Cargo.toml` and `Cargo.lock` to `tonk-2026-09-02`, commit `805151c678c516edc03c2825171ed4b54adf37ab`. Work in an isolated Dialog checkout and read its repository instructions. Do not edit Cargo's dependency cache. The relevant files are `rust/dialog-operator/src/operator/builder.rs` and `rust/dialog-operator/src/operator/access.rs`.
+
+Add `OperatorBuilder::allow_until<T, C>(self, capability: C, expiration: Timestamp) -> Self`, with the same capability bounds as `allow`. Internally retain each allowed scope with its optional expiration. Preserve `allow`'s existing unbounded behavior for existing callers. During `build`, apply the expiration to the `DelegationBuilder` before signing the profile-to-operator certificate. Install that certificate in the existing in-memory session collection before installing `WalkReach`; its recursion-bounding operator clone must carry the same grant. No `Retain` operation is needed for session authority.
+
+Start with behavioral tests beside the existing session-composition and no-session-residue tests. Retain a space-to-profile grant, snapshot the access-branch revision, construct a bounded operator, and prove a concrete storage capability as that operator. Check the final audience, chain continuity, and effective expiration (the earlier of the upstream grant and session bounds). Check that the branch revision and stored delegation count remain unchanged. Exercise proof-cache hits as well as a fresh walk, and requests with explicit time ranges within and beyond the session window. A request for a current invocation must not gain an unbounded or already-expired session proof. Use explicit timestamps/windows rather than sleeps; distinguish proof construction for a historical window from authorization of a current invocation. With the existing builder the bounded API is absent and `allow` yields an unbounded proof, which is the initial failing boundary.
+
+Run `cargo test -p dialog-operator --locked` in the Dialog checkout, plus its focused WASM session tests using its configured runner. Keep the change additive and independently reviewable. Pin Tonk's Dialog dependency family to the resulting immutable revision, updating only associated lock entries and required dependency hashes in `nix/rust.nix`. `flake.nix` also has a separate Dialog source input used by `nix/wbg-pool.nix`; do not conflate a test-runner update with the Rust-library pin. Any temporary local dependency override must be removed before handoff.
+
+## 2. Worker boot and renewal create matching disposable sessions
+
+- [x] Opening or renewing a worker session changes its operator identity, preserves joined-space access, and leaves profile session storage unchanged.
+
+In `rust/tonk-worker/src/session.rs`, make `open` create a fresh session on every call. Use a new random 32-byte derivation context, propagate entropy failures, calculate the existing TTL expiration once, and build with `allow_until(Subject::any(), expiration)`. A random context makes disposability explicit on native and Chromium too; the code no longer relies on reconstructing signature-derived identities. Keep building over the caller's cloned storage pool so existing repository handles retain their storage configuration. `Session` still returns the operator and the exact expiration used for its grant.
+
+Remove the persisted-session reuse path, `PersistedSession`, `SESSION_SITE`, load/save helpers, and the explicit durable `.access().save(...)` session grant. `rotate` can own the common fresh-session construction and `open` call it. Leave old `tonk-session-v1` credential data and historical session delegations untouched: new code does not consult them, and fresh random contexts avoid deliberately reusing their audiences. This is also recovery for affected Safari installations—next boot uses the existing profile and invitation authority to authorize its newly created operator. No storage clearing or rejoin is part of migration.
+
+Update `ensure_session_authority` in `rust/tonk-worker/src/router/sync.rs` to describe the actual lifecycle. Preserve construction outside the state write lock, the post-construction comparison against the observed `session_expires_at`, and atomic replacement of operator plus expiry. Concurrent callers may construct candidates; only a candidate for the still-current expired generation is installed. Losing candidates have no durable session side effects. A construction error retains the current state and surfaces through the existing error path. Requests already holding the state read lock finish before replacement. Keep renewal timing and revocation policy unchanged.
+
+Replace stale stable-DID/guest-replay comments in both files. Inspect `worker::boot_state`'s session-open error recovery under the new path and retain any recovery still needed for opening profile storage; do not turn an unrelated read failure into a reason to discard profile data.
+
+First extend `session` tests to open twice and assert distinct operators, unchanged profile identity, valid bounded proofs through both, and unchanged profile-main revision after each session construction. These assertions fail against current code: native operators reuse the fixed-context identity and fresh session creation persists a grant. Add an upgrade fixture containing a fresh legacy session record and a grant to a different operator; opening must ignore that record and prove through the new in-memory grant without writing replacement session metadata. Add a storage-close/reopen fixture, releasing handles before reopening, rather than testing only a second operator over the same live pool.
+
+Replace `renewal_tests::it_keeps_the_operator_did_across_renewal`, which currently does not force renewal, with a test that actually marks the session due. Assert a changed DID, a fresh bounded proof, no profile-main commit, and no further replacement when another renewal check runs before the margin. Exercise concurrent due checks and failed candidate construction with focused test hooks if needed. Do not weaken grant expiry or add production timing knobs for tests.
+
+Run `cargo test -p tonk-worker --lib --locked session::tests` while iterating. At this checkpoint also run `cargo test -p tonk-worker --lib --locked router::join::tests` and the WASM renewal tests. Keep the dependency integration and worker adaptation reviewable as one working Tonk increment after the Dialog prerequisite.
+
+## 3. Prove joined-space recovery across actual worker lifetimes
+
+- [ ] A durable onboarding member syncs after worker replacement on macOS Safari and iOS Safari, without rejoining or accumulating session grants.
+
+Add regression coverage alongside `rust/tonk-worker/src/router/join.rs` tests: join a disposable fixture space through an onboarding account, prove a real storage capability with the resulting operator, rebuild the worker from the same durable profile/storage, then prove and sync again. Assert the account/member/profile identities and membership count survive while the operator changes. Compare session delegation records and profile-main revisions around session construction only; joining and genuine content work legitimately create commits. Include a profile with existing invitation grants and no completed email setup, matching the reported case.
+
+Use the repository's WASM runner for automated browser coverage. Focused commands are:
+
+```sh
+cargo test -p tonk-worker --lib --locked --target wasm32-unknown-unknown session::tests
+cargo test -p tonk-worker --lib --locked --target wasm32-unknown-unknown router::sync::renewal_tests
+cargo test -p tonk-worker --lib --locked --target wasm32-unknown-unknown router::join::tests
+```
+
+The configured runner is `wbg-pool`; ordinary Chromium coverage does not establish Safari coverage. On the corrected build, use a disposable invite in macOS Safari: join and sync, enter Settings without submitting email, return through Spaces, then explicitly unregister only that origin's service worker and reload. Preserve IndexedDB and all space data. Confirm the profile remains the same, the new operator differs, and a remote change made by another member is pulled; also push a small change back. Repeat worker replacement several times and confirm no new profile-to-operator delegation rows accumulate. Repeat on iOS Safari using worker replacement where available and the original navigation sequence. Neither metadata HTTP 200 nor a changed indicator alone proves synchronization.
+
+Check an offline worker restart can open already-local space content without an account-service request. Restore connectivity and confirm sync resumes with the fresh session. This tests offline session construction, not complete offline replication of untouched space content.
+
+Measure repeated session construction on macOS Safari and Chromium, recording operator-build and bounded-grant signing time separately from total worker boot and first successful pull. Use a disposable profile; report sample count and median/tail measurements. Confirm no durable session-retention work occurs. The measurement answers the remaining performance question; there is no invented millisecond acceptance threshold.
+
+After the final implementation, run `cargo fmt --all -- --check`, the native worker library suite (`cargo test -p tonk-worker --lib --locked`), and `git diff --check`. Run the relevant repository Nix dependency/build check after the Dialog pin; format any changed Nix file with the repository formatter. Remove temporary instrumentation and dependency overrides. Report native, Chromium, macOS Safari, iOS Safari, and deployed-build evidence separately, including any unavailable checks.
+
+## Planning evidence
+
+This document describes work to implement, not completed validation. The earlier temporary native proof-reopen test passed over a shared storage pool; it did not cover disposable in-memory grants or Safari worker replacement. The Safari signature nondeterminism and mismatched saved/current operator identities were observed on the affected device. At that planning checkpoint, only planning/diagnosis Markdown files had been added in this worktree.
+
+## Implementation progress (2026-09-09)
+
+The implementation is built and tested against the isolated Dialog prerequisite.
+The Dialog prerequisite is published, and native, Chromium, and Nix validation
+against the published immutable pin passed. Device acceptance remains pending.
+
+Dialog commit `314e49926eb5bca58bacdcf9f2123ccb4422ea35` is preserved in
+`/Users/jackdouglas/tonk/dialog-db/.wt/fix/bounded-worker-sessions` on branch
+`fix/bounded-worker-sessions`. It starts at Tonk's exact previous pin and leaves
+the supplied checkout's unrelated work untouched. `allow_until` applies an
+optional expiration before signing the in-memory grant. Session selection also
+checks the requested time window so a lapsed overlapping grant cannot mask a
+valid one. The new bounded-session test first failed at the missing API.
+
+Worker boot and renewal use random 32-byte contexts and bounded in-memory grants.
+Legacy session metadata and grants remain untouched. Tests cover distinct opens,
+proofs through both operators, access-branch revision stability, storage close
+and reopen with a mismatched legacy grant, forced renewal, failed construction,
+and a deliberately losing concurrent candidate. An onboarding membership test
+boots both lifetimes through `boot_state`, releases the old state/storage, and
+checks profile/account/member identity, local content, and storage proof expiry.
+Its fixture has no remote and cannot establish network replication.
+
+Boot's old hydration fallback was removed: the new builder resolves reference
+cells without walking or retaining content. Hydration cannot repair its entropy,
+signing, or local reference failure modes; these now surface without touching
+profile contents.
+
+Validation:
+
+- Dialog native: 33 passed with `cargo test -p dialog-operator --locked`.
+- Dialog Chromium: four focused session tests passed with the configured
+  `wbg-pool` runner.
+- Worker native: 121 passed both with the initial local Dialog override and
+  against the published immutable pin using `--locked`. The
+  sandboxed run initially had 21 filesystem/loopback permission failures; the
+  unchanged suite passed with fixture access.
+- Worker Chromium: 11 tests matched `session::tests` (eight signing-session tests
+  plus three router-session tests); three renewal tests and 26 join tests passed.
+  All 40 tests passed again against the published pin without overrides.
+- The join restart test initially compared a minimal unbootstrapped fixture with
+  a real boot; fixing both lifetimes to run real boot eliminated that fixture
+  mismatch without changing product behavior.
+- `nix build .#checks.aarch64-darwin.sharedWorkspaceDeps --no-link` passed,
+  including the published Dialog source/vendor and workspace dependency build.
+- Rust/Nix formatting, Nix source-reference, and diff whitespace checks passed.
+- macOS Safari, iOS Safari, actual remote pull/push after worker replacement,
+  network-offline restart, and signing/boot/pull latency measurements are unrun.
+  Chromium unit tests are not evidence of those device or hosted behaviors.
+
+The user approved publication on 2026-09-09. Dialog commit
+`314e49926eb5bca58bacdcf9f2123ccb4422ea35` was pushed to
+`https://github.com/dialog-db/dialog-db.git`, branch `fix/bounded-worker-sessions`.
+A fresh `git ls-remote` verified the exact remote SHA. No PR was merged.
+
+The prepared dependency update changes all 16 workspace Dialog declarations and
+21 lockfile source entries to that immutable revision, without changing the
+separate `flake.nix` runner input. The source archive's locally computed NAR hash
+is `sha256-V3ZKANhlwG2MLTW6A4c/GS76k1bVB0OusFLGrNj4t9Q=`. The manifest, lockfile,
+and Nix hash edits are applied locally. Cargo fetched the published pin, and locked native and Chromium tests passed
+without local overrides. The Nix `sharedWorkspaceDeps` check also passed. The dependency integration,
+worker adaptation, and task records form one local Tonk increment.
+
+The temporary Cargo path override was removed after initial validation. Ordinary
+locked builds now resolve the published immutable Dialog commit.

--- a/plan/mobile-sync-diagnosis.md
+++ b/plan/mobile-sync-diagnosis.md
@@ -1,0 +1,113 @@
+# iOS Safari joined-space sync diagnosis
+
+Reported 2026-09-09 on staging, product-wip. Join and sync succeeded, then
+FABB settings opened the email setup prompt. No email was submitted and no
+account switch was reported. Within a couple of minutes the user returned
+via Spaces and selected the space; the page reloaded and sync failed.
+
+The pull fails at FetchRemoteBranch -> Resolve -> Authorization ->
+UnprovenSubject. HTTP 502 is the worker fallback wrapper, not independent
+proof of an upstream server outage. Device metadata confirms the claimed
+principal is the operator (DID ending RXjA8c), the profile ends 2FoKYPw,
+and the target space ends 6ti3cr. Repository GET returns 200 and main tracks
+origin/main. No invitation credentials are recorded here.
+
+Source inspection: session::open restores a fresh persisted session without
+minting. session::rotate durably retains the bounded profile-to-operator
+grant. perform_join retains both the account-to-device grant and claimed
+invite chain before its first pull. Dialog's proof walk can also report
+UnprovenSubject when candidate envelopes are unavailable or unverifiable.
+Settings opens the registration UI for a provider-free profile; that alone
+has not been shown to change authority.
+
+Experiment: temporarily extended
+session::tests::it_authorizes_a_presign_chain_bounded_by_the_session to call
+session::open again and prove the same space through the rebuilt operator.
+`cargo test -p tonk-worker session::tests::it_authorizes_a_presign_chain_bounded_by_the_session --lib --locked --offline`
+passed (1 test). Temporary change removed. This checks a native operator
+rebuild over the same storage pool and a simple space-to-profile chain;
+it does not reproduce an iOS worker restart or the full claimed invite.
+
+Next: query only issuer/audience/subject metadata in profile main on the
+failing device. Establish whether the session grant and every account/invite
+hop exist before investigating envelope reads, validity bounds, or storage
+recovery. Root cause remains unconfirmed. No product fix applied.
+
+## Device metadata and likely mechanism
+
+The device query returned nine delegation records. Their issuer/audience
+links connect the space to profile 2FoKYPw, but the profile-to-operator grant
+(blob 6SLMMLoCayCxY2i6oPo1yf3DPvfLCeb2DMFZb9gGzq5Y) names audience
+CeHJs86p, not the current operator t2RXjA8c. No returned grant names the
+current operator. Presence of metadata does not verify envelope validity.
+
+Pinned Dialog 805151c, dialog-operator/src/operator/builder.rs:214-249:
+extractable keys derive from seed plus context; non-extractable browser
+keys derive from a signature over a fixed context. Browser signing calls
+WebCrypto Ed25519. Apple documents randomized CryptoKit Ed25519 signatures:
+https://developer.apple.com/documentation/cryptokit/curve25519/signing/privatekey/signature(for:)
+WebCrypto working-group issue specifically records WebKit's behavior:
+https://github.com/WICG/webcrypto-secure-curves/issues/28
+
+Likely mechanism: fresh signature changes derived operator on rebuild;
+session::open trusts saved expiry and does not grant the new audience.
+Native proof-reopen test uses seed derivation and cannot catch this.
+Next smallest confirmation: sign the same message twice with one throwaway
+non-extractable Ed25519 key on the affected Safari and compare bytes.
+Likely correction must give browser operators stable persisted identity
+without relying on signature determinism, including recovery for existing
+session records. No implementation authorized or applied.
+
+## Confirmation on affected Safari
+
+The user ran the throwaway non-extractable Ed25519 test on the affected
+Safari: signing identical message bytes twice with the same key returned
+`identical signatures: false`. Together with the missing current-operator
+grant and pinned derivation source, this confirms the signature-derived
+operator identity defect as the explanation for this session mismatch.
+The exact full UI sequence has not been reproduced locally.
+
+Failure chain: randomized browser signature -> different derived operator
+on reconstruction -> persisted fresh session reused without minting a grant
+for that operator -> no proof from current operator to profile/space ->
+UnprovenSubject -> worker 502 wrapper and failed sync indication.
+Settings navigation exposes reconstruction; submitting email or completing
+account setup is not required for this defect. The evidence does not
+establish why that particular navigation caused the page reload.
+
+Correction requirements: stable browser operator identity independent of
+signature bytes; durable recovery of older session records so the restored
+operator and its bounded grant agree; preserve non-extractable key handling,
+local joined-space data, and membership; verify identity plus actual proof
+resolution across storage reopen and worker restart on Safari. Root cause
+is diagnosed; no product fix has been implemented or deployed.
+
+## Disposable operator audit
+
+Current worker join resolves `current_account` and claims the invite to that
+account (router/join.rs:623-630). `current_account` uses the passkey root or
+an onboarding account with an account-to-profile grant (router/account.rs:
+150-169). Repository-wide `Invite::visit`/`.visit(` search finds only the
+invite library tests as visit callers; no worker guest-join mode remains.
+Session/renewal guest-replay commentary is stale. Production worker
+operator-DID references found are session-grant creation and repository
+metadata; no durable membership/invite audience depends on that DID.
+Operators are replaceable in the current browser flow, provided their
+bounded profile grants match their actual key. Stable identity across boots
+is not a requirement; earlier correction wording was too restrictive.
+
+Boot overhead from invoking current session::rotate each boot: operator
+construction (also incurred by session reuse), bounded grant signing, grant
+retention in profile main (blob/fact/history commit with refresh and possible
+CAS retry), plus session credential metadata write. No account-service
+round trip or passkey interaction is inherently required to mint the grant.
+The retention path may need branch data; do not promise entirely read-free
+or network-free startup in partially hydrated states. No Safari timings
+measured. No automatic expired-session delegation pruning was found in the
+worker; expiry rejects authority but does not itself remove stored records.
+
+A candidate design is a disposable operator with an in-memory bounded
+profile-to-operator grant, avoiding per-boot durable session churn. Dialog
+already composes in-memory session grants, but its current .allow builder
+mints unbounded grants, so it cannot be used unchanged for Tonk's TTL model.
+This is design guidance, not an implemented or tested correction.

--- a/rust/tonk-worker/src/router/join.rs
+++ b/rust/tonk-worker/src/router/join.rs
@@ -3048,6 +3048,85 @@ pub(crate) mod tests {
         );
     }
 
+    /// Rebuild all worker state from durable storage after an onboarding
+    /// join. This fixture has no remote: it verifies local content and the
+    /// real storage proof, while network replication needs a served fixture.
+    #[dialog_common::test]
+    async fn it_reopens_an_onboarding_membership_with_a_disposable_session() {
+        let (name, registry, profile_did, operator_did, account, key, before, revision) = {
+            let fixture = test_state_without_root().await;
+            let initial = crate::worker::boot_state(
+                fixture.storage.clone(),
+                fixture.profile_name.clone(),
+                fixture.profile.clone(),
+                fixture.registry.clone(),
+            )
+            .await
+            .unwrap();
+            drop(fixture);
+            let (app, state, _lsp) = api_router_with_state(initial);
+            let (url, key) = handcrafted_invite_url(86, 87).await;
+            assert_eq!(post_join(&app, &url).await, StatusCode::CREATED);
+            let before = snapshot(&state, &key).await;
+            let subject = key.parse().unwrap();
+            assert_eq!(
+                proof_window(&state, &subject).await,
+                Some(state.read().await.session_expires_at)
+            );
+            let tonk = state.read().await;
+            let account = crate::onboarding::did(&tonk).await.unwrap().unwrap();
+            let branch = dialog_repository::Repository::from(tonk.profile.signer().clone())
+                .branch(dialog_repository::ACCESS_BRANCH)
+                .open()
+                .perform(&tonk.operator)
+                .await
+                .unwrap();
+            (
+                tonk.profile_name.clone(),
+                tonk.registry.clone(),
+                tonk.profile.did(),
+                tonk.operator.did(),
+                account,
+                key,
+                before,
+                branch.revision(),
+            )
+        };
+        let storage =
+            dialog_storage::provider::storage::Storage::<crate::worker::DefaultSpace>::default();
+        let profile = dialog_operator::Profile::open(&name)
+            .perform(&storage)
+            .await
+            .unwrap();
+        assert_eq!(profile.did(), profile_did);
+        // Isolate session construction from boot's legitimate meta work.
+        let session = crate::session::open(&profile, &storage).await.unwrap();
+        let branch = dialog_repository::Repository::from(profile.signer().clone())
+            .branch(dialog_repository::ACCESS_BRANCH)
+            .open()
+            .perform(&session.operator)
+            .await
+            .unwrap();
+        assert_eq!(branch.revision(), revision);
+        drop(branch);
+        drop(session);
+        let rebuilt = crate::worker::boot_state(storage, name, profile, registry)
+            .await
+            .unwrap();
+        assert_ne!(rebuilt.operator.did(), operator_did);
+        assert_eq!(
+            crate::onboarding::did(&rebuilt).await.unwrap(),
+            Some(account)
+        );
+        let (_app, state, _lsp) = api_router_with_state(rebuilt);
+        assert_eq!(snapshot(&state, &key).await, before);
+        assert_eq!(content_memberships(&state, &key).await.len(), 1);
+        assert_eq!(
+            proof_window(&state, &key.parse().unwrap()).await,
+            Some(state.read().await.session_expires_at)
+        );
+    }
+
     /// A local-only invite has no remote to prove, so it commits on
     /// cryptographic verification alone — and still lands its roster.
     #[dialog_common::test]

--- a/rust/tonk-worker/src/router/sync.rs
+++ b/rust/tonk-worker/src/router/sync.rs
@@ -1387,34 +1387,26 @@ pub async fn drain_sync(state: &AppState) {
     }
 }
 
-/// Make sure every credential this worker is about to sign with is still
-/// good, rotating the operator and replaying every guest invite onto it
-/// when anything is due.
-///
-/// Rotation replaces the operator key, not just its delegation: the
-/// certificate store is content-addressed with no delete, and its chain
-/// walk never consults the clock, so a re-minted delegation filed under
-/// the same audience would sit beside the lapsed one and be chosen about
-/// half the time. A new key means a new audience and no ambiguity.
-///
-/// That is also why one guest coming due rotates for all of them. The
-/// operator is shared by every mounted repository, so a new audience
-/// orphans every guest chain at once, and the only safe rotation is the
-/// one that re-mints the whole set. Durable spaces need no replay: they
-/// reach the operator through `space -> root -> device -> operator`,
-/// whose last hop `session::open` re-mints anyway.
-///
-/// The replacement is built over the state's existing storage pool, so
-/// every repository and branch handle the reactor has cached stays
-/// valid — the operator changes, the spaces underneath do not.
-///
-/// Order matters at the end: every replacement chain is retained first,
-/// every record is written second, and only then does the state adopt
-/// the new operator. A failure anywhere leaves the current operator and
-/// the current records exactly as they were — the chains retained for an
-/// audience nothing points at are inert, and a record still naming the
-/// previous operator reads as due on the next attempt.
+/// Replace a due session with a disposable operator and bounded in-memory
+/// grant. Account and profile authority survives without invitation replay.
+/// Build over the existing storage pool outside the state write lock, then
+/// install only if the observed generation is still current. Losing
+/// candidates and construction failures have no durable session effects.
 pub(crate) async fn ensure_session_authority(state: &AppState) -> Result<(), TonkWorkerError> {
+    renew_session_with(state, |profile, storage| async move {
+        crate::session::rotate(&profile, &storage).await
+    })
+    .await
+}
+
+async fn renew_session_with<F, Fut>(state: &AppState, build: F) -> Result<(), TonkWorkerError>
+where
+    F: FnOnce(
+        dialog_operator::Profile,
+        dialog_storage::provider::storage::Storage<crate::worker::DefaultSpace>,
+    ) -> Fut,
+    Fut: std::future::Future<Output = Result<crate::session::Session, TonkWorkerError>>,
+{
     let now = crate::session::now();
     let (profile, storage, expires_at) = {
         let tonk = state.read().await;
@@ -1429,10 +1421,9 @@ pub(crate) async fn ensure_session_authority(state: &AppState) -> Result<(), Ton
         return Ok(());
     }
 
-    // Mint outside the lock — nothing else may proceed while a write
-    // lock is held, and this signs. The operator KEY is stable, so this
-    // replaces the delegation authorizing it, not the audience.
-    let session = crate::session::rotate(&profile, &storage).await?;
+    // Signing happens outside the write lock; existing readers finish
+    // before the new operator and expiry are installed together.
+    let session = build(profile, storage).await?;
 
     let mut tonk = state.write().await;
     // A concurrent drain may have rotated while this one was minting.
@@ -1442,10 +1433,6 @@ pub(crate) async fn ensure_session_authority(state: &AppState) -> Result<(), Ton
         return Ok(());
     }
 
-    // No guest replay: a guest's chain is addressed to the operator, and
-    // the operator's DID no longer moves, so a renewed delegation leaves
-    // every guest chain exactly as valid as it was. Replaying invites
-    // here was the only consumer of a guest's retained invite URL.
     tonk.operator = session.operator;
     tonk.session_expires_at = session.expires_at;
     Ok(())
@@ -1739,14 +1726,13 @@ mod overlay_tests {
     }
 }
 
-/// Session renewal tests — wasm-only, because they need a real
-/// certificate store to mint against.
+/// Session renewal tests exercise the worker's state replacement boundary.
 #[cfg(all(test, target_arch = "wasm32", target_os = "unknown"))]
 mod renewal_tests {
     use wasm_bindgen_test::wasm_bindgen_test_configure;
     wasm_bindgen_test_configure!(run_in_service_worker);
 
-    use super::ensure_session_authority;
+    use super::{ensure_session_authority, renew_session_with};
     use crate::router::tests::test_state;
     use crate::router::{AppState, api_router_with_state};
 
@@ -1754,25 +1740,99 @@ mod renewal_tests {
         state.read().await.operator.did().to_string()
     }
 
-    /// The operator key derives from a CONSTANT context, so renewal
-    /// replaces the delegation authorizing it and never the key itself.
-    ///
-    /// This is what lets a chain addressed to the operator, such as a
-    /// guest's invite hop, survive renewal. Deriving a fresh key each
-    /// time invalidated those chains twice a day, which made a retained
-    /// bearer secret the only way to mint replacements.
+    async fn revision(state: &AppState) -> Option<dialog_repository::Revision> {
+        let tonk = state.read().await;
+        dialog_repository::Repository::from(tonk.profile.signer().clone())
+            .branch(dialog_repository::ACCESS_BRANCH)
+            .open()
+            .perform(&tonk.operator)
+            .await
+            .unwrap()
+            .revision()
+    }
+
     #[dialog_common::test]
-    async fn it_keeps_the_operator_did_across_renewal() {
+    async fn it_replaces_a_due_session_once_without_committing() {
         let (_app, state, _lsp) = api_router_with_state(test_state().await);
         let before = operator_did(&state).await;
-
+        let head = revision(&state).await;
+        state.write().await.session_expires_at = crate::session::now();
         ensure_session_authority(&state).await.unwrap();
+        let renewed = operator_did(&state).await;
+        assert_ne!(before, renewed);
+        assert_eq!(revision(&state).await, head);
+        {
+            let tonk = state.read().await;
+            let proof = tonk
+                .profile
+                .access()
+                .prove(
+                    dialog_capability::Subject::from(tonk.profile.did())
+                        .attenuate(dialog_effects::Use),
+                )
+                .audience(&tonk.operator)
+                .perform(&tonk.operator)
+                .await
+                .unwrap();
+            assert_eq!(proof.duration.expiration, Some(tonk.session_expires_at));
+            assert_eq!(
+                proof.proofs.last().unwrap().0.audience(),
+                &tonk.operator.did()
+            );
+        }
         ensure_session_authority(&state).await.unwrap();
+        assert_eq!(operator_did(&state).await, renewed);
+    }
 
-        assert_eq!(
-            before,
-            operator_did(&state).await,
-            "renewal re-mints the delegation, not the operator key",
-        );
+    #[dialog_common::test]
+    async fn it_keeps_the_current_session_when_construction_fails() {
+        let (_app, state, _lsp) = api_router_with_state(test_state().await);
+        let before = operator_did(&state).await;
+        let head = revision(&state).await;
+        let due = crate::session::now();
+        state.write().await.session_expires_at = due;
+        let result = renew_session_with(&state, |_, _| async {
+            Err(crate::TonkWorkerError::Internal(
+                "injected session construction failure".into(),
+            ))
+        })
+        .await;
+        assert!(result.is_err());
+        assert_eq!(operator_did(&state).await, before);
+        assert_eq!(state.read().await.session_expires_at, due);
+        assert_eq!(revision(&state).await, head);
+    }
+
+    #[dialog_common::test]
+    async fn it_installs_only_one_concurrent_candidate() {
+        let (_app, state, _lsp) = api_router_with_state(test_state().await);
+        let head = revision(&state).await;
+        state.write().await.session_expires_at = crate::session::now();
+        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+        let (installed_tx, installed_rx) = tokio::sync::oneshot::channel();
+        let winner = async {
+            renew_session_with(&state, |profile, storage| async move {
+                ready_rx.await.unwrap();
+                crate::session::rotate(&profile, &storage).await
+            })
+            .await
+            .unwrap();
+            let installed = operator_did(&state).await;
+            installed_tx.send(installed.clone()).unwrap();
+            installed
+        };
+        let loser = renew_session_with(&state, |profile, storage| async move {
+            let candidate = crate::session::rotate(&profile, &storage).await.unwrap();
+            ready_tx.send(()).unwrap();
+            let installed = installed_rx.await.unwrap();
+            assert_ne!(candidate.operator.did().to_string(), installed);
+            Ok(candidate)
+        });
+        let (installed, result) = futures_util::join!(winner, loser);
+        result.unwrap();
+        assert_eq!(operator_did(&state).await, installed);
+        assert_eq!(revision(&state).await, head);
+        ensure_session_authority(&state).await.unwrap();
+        assert_eq!(operator_did(&state).await, installed);
     }
 }

--- a/rust/tonk-worker/src/session.rs
+++ b/rust/tonk-worker/src/session.rs
@@ -12,11 +12,10 @@
 //! stolen device at most one session lifetime even if the registry is
 //! unreachable.
 //!
-//! Renewal re-mints the delegation under a STABLE audience: the
-//! operator key is derived from a constant context, so it does not move.
-//! Revocation withholds authority by refusing to renew the delegation,
-//! and a chain is revoked by CID, so nothing needs the audience to
-//! change. See [`rotate`] for what moving it used to cost.
+//! Each boot and renewal creates a disposable operator and a matching
+//! bounded grant held only in memory. Membership and invitation authority
+//! belong to accounts and profiles, so replacing this final hop needs no
+//! invitation replay or durable session write.
 //!
 //! Renewal rides the sync drain — the regular beat this worker has —
 //! rather than chasing every presign path. The gap that leaves: a
@@ -25,34 +24,15 @@
 //! drain's rotation heals. Service-worker lifetimes make that window
 //! rare; revisit only if it is ever observed.
 
-use dialog_capability::access::{Prove, Retain};
 use dialog_capability::{Provider, Subject};
 use dialog_operator::{DeriveOperator, Operator, Profile};
 use dialog_storage::provider::space::SpaceProvider;
 use dialog_storage::provider::storage::Storage;
-use dialog_ucan::Ucan;
 use dialog_ucan_core::time::Timestamp;
 use dialog_ucan_core::time::timestamp::{Duration, SystemTime};
-use serde::{Deserialize, Serialize};
-use tonk_common::log;
 
 use crate::TonkWorkerError;
 use crate::worker::DefaultSpace;
-
-/// Credential site on the profile holding the current session's
-/// derivation context and expiry, as JSON. Device-local — credential
-/// sites never ride a branch — so persisting a session shares nothing.
-const SESSION_SITE: &str = "tonk-session-v1";
-
-/// The persisted shape of a session: enough to re-derive the operator
-/// (derivation is a deterministic KDF over the profile seed and the
-/// context) and to know when reuse must stop.
-#[derive(Serialize, Deserialize)]
-struct PersistedSession {
-    version: u8,
-    context: Vec<u8>,
-    expires_at: u64,
-}
 
 /// How long a session delegation is good for.
 ///
@@ -60,15 +40,6 @@ struct PersistedSession {
 /// and a closed laptop, or renewal failure becomes the common path
 /// instead of the exceptional one.
 pub use tonk_identity::session::SESSION_TTL_SECONDS;
-
-/// Derivation context for the device's operator key.
-///
-/// Constant, so the operator DID is stable for the life of the profile:
-/// `derive` is a KDF over (profile seed, context), and renewal re-mints
-/// the delegation rather than the key. Anything addressed to the
-/// operator — notably a guest's invite chain — therefore stays valid
-/// across a renewal.
-const OPERATOR_CONTEXT: &[u8] = b"worker";
 
 /// How long before expiry a session is rotated.
 ///
@@ -99,57 +70,12 @@ where
     S: Provider<dialog_effects::blob::Read>
         + Provider<dialog_effects::blob::Write>
         + Provider<dialog_effects::blob::Import>,
-    S: Provider<Prove<Ucan>> + Provider<Retain<Ucan>>,
 {
-    // Reuse the persisted session while it is still fresh: derivation
-    // is deterministic over (seed, context), so the operator
-    // reconstitutes without minting, and the delegation saved when the
-    // session was first opened still proves. A reused session makes
-    // boot READ-ONLY on the access branch — no commit, no
-    // authorization walk — so a worker restart cannot churn the
-    // shared account root and a partial access branch cannot brick a
-    // boot (offline included). Minting resumes only near expiry, on
-    // the renewal beat that already owns it.
-    let now = Timestamp::now().to_unix();
-    if let Some(persisted) = load_persisted(profile, storage).await
-        && !needs_renewal(persisted.expires_at, now)
-    {
-        match profile
-            .derive(persisted.context.clone())
-            .build(storage.clone())
-            .await
-        {
-            Ok(operator) => {
-                return Ok(Session {
-                    operator,
-                    expires_at: persisted.expires_at,
-                });
-            }
-            Err(error) => {
-                log!("persisted session unusable, minting a fresh one: {error}");
-            }
-        }
-    }
-
     rotate(profile, storage).await
 }
 
-/// Mint a fresh `profile → operator` delegation for the device's
-/// operator key.
-///
-/// The KEY is stable — [`OPERATOR_CONTEXT`] is constant, and derivation
-/// is deterministic over (seed, context) — so renewal replaces the
-/// delegation, not the audience.
-///
-/// It used to derive a new key from a random context every time. That
-/// bought nothing the expiry did not already buy: revocation withholds
-/// authority by refusing to renew the DELEGATION, and a chain is revoked
-/// by CID, so nothing needs the audience to move. What it cost was
-/// substantial — a guest's chain is addressed to the operator, so every
-/// rotation invalidated it, and the only way to re-mint one was to
-/// replay the invite. That is the sole reason a guest's invite URL, a
-/// bearer secret, had to be kept on disk at all, and why a guest nearing
-/// expiry could force a rotation that was not otherwise due.
+/// Create a fresh operator and bounded in-memory profile grant.
+/// Existing session credentials and delegations are left untouched.
 pub async fn rotate<S>(
     profile: &Profile,
     storage: &Storage<S>,
@@ -159,112 +85,28 @@ where
     S: Provider<dialog_effects::blob::Read>
         + Provider<dialog_effects::blob::Write>
         + Provider<dialog_effects::blob::Import>,
-    S: Provider<Prove<Ucan>> + Provider<Retain<Ucan>>,
 {
-    // No `.allow(...)`: that mints an *unexpiring* profile → operator
-    // delegation, which is the thing this module exists to replace. The
-    // bounded equivalent is minted below.
-    let operator = profile
-        .derive(OPERATOR_CONTEXT.to_vec())
-        .build(storage.clone())
-        .await
-        .map_err(|error| {
-            TonkWorkerError::Internal(format!("failed to derive a session operator: {error}"))
-        })?;
-
+    let mut context = [0u8; 32];
+    getrandom::fill(&mut context).map_err(|error| {
+        TonkWorkerError::Internal(format!("failed to generate session entropy: {error}"))
+    })?;
     let expiration = Timestamp::new(SystemTime::now() + Duration::from_secs(SESSION_TTL_SECONDS))
         .map_err(|error| {
         TonkWorkerError::Internal(format!("session expiration out of range: {error}"))
     })?;
-
-    let delegation = profile
-        .access()
-        .claim(Subject::any())
-        .expires(expiration)
-        .delegate(operator.did())
-        .perform(&operator)
+    let operator = profile
+        .derive(context)
+        .allow_until(Subject::any(), expiration)
+        .build(storage.clone())
         .await
         .map_err(|error| {
-            TonkWorkerError::Internal(format!("failed to mint the session delegation: {error}"))
+            TonkWorkerError::Internal(format!("failed to build a session operator: {error}"))
         })?;
-
-    profile
-        .access()
-        .save(delegation)
-        .perform(&operator)
-        .await
-        .map_err(|error| {
-            TonkWorkerError::Internal(format!("failed to save the session delegation: {error}"))
-        })?;
-
-    // Persist AFTER the delegation is durably saved, so a stored
-    // context always has a provable delegation behind it. Best-effort:
-    // a failed persist only costs the next boot a fresh mint.
-    persist_session(
-        profile,
-        storage,
-        &PersistedSession {
-            version: 1,
-            context: OPERATOR_CONTEXT.to_vec(),
-            expires_at: expiration.to_unix(),
-        },
-    )
-    .await;
 
     Ok(Session {
         operator,
         expires_at: expiration.to_unix(),
     })
-}
-
-/// Read the persisted session, if any. Absence and decode failure both
-/// read as "no persisted session".
-async fn load_persisted<S>(profile: &Profile, storage: &Storage<S>) -> Option<PersistedSession>
-where
-    S: SpaceProvider + Clone + 'static,
-{
-    let bytes = match profile
-        .credential()
-        .site(SESSION_SITE)
-        .load::<Vec<u8>>()
-        .perform(storage)
-        .await
-    {
-        Ok(bytes) => bytes,
-        Err(error) => {
-            if !crate::credential::is_missing(&error) {
-                log!("persisted session unreadable: {error}");
-            }
-            return None;
-        }
-    };
-    match serde_json::from_slice::<PersistedSession>(&bytes) {
-        Ok(persisted) if persisted.version == 1 => Some(persisted),
-        Ok(_) => None,
-        Err(error) => {
-            log!("persisted session malformed: {error}");
-            None
-        }
-    }
-}
-
-/// Store the session for reuse by later boots. Best-effort.
-async fn persist_session<S>(profile: &Profile, storage: &Storage<S>, session: &PersistedSession)
-where
-    S: SpaceProvider + Clone + 'static,
-{
-    let Ok(encoded) = serde_json::to_vec(session) else {
-        return;
-    };
-    if let Err(error) = profile
-        .credential()
-        .site(SESSION_SITE)
-        .save(encoded)
-        .perform(storage)
-        .await
-    {
-        log!("failed to persist the session (next boot mints fresh): {error}");
-    }
 }
 
 /// Whether a session expiring at `expires_at` is close enough to lapsing
@@ -326,32 +168,34 @@ mod tests {
     }
 
     #[dialog_common::test]
-    async fn it_reuses_a_fresh_session_across_opens() {
+    async fn it_creates_distinct_sessions_across_opens() {
         let (storage, profile) = scratch().await;
 
         let first = open(&profile, &storage).await.unwrap();
         let second = open(&profile, &storage).await.unwrap();
 
-        assert_eq!(
-            first.operator.did(),
-            second.operator.did(),
-            "a still-fresh session reconstitutes: reuse is what keeps a \
-             boot read-only on the access branch"
-        );
-        assert_eq!(first.expires_at, second.expires_at);
+        assert_ne!(first.operator.did(), second.operator.did());
+        assert_eq!(first.operator.profile_did(), profile.did());
+        assert_eq!(second.operator.profile_did(), profile.did());
     }
 
-    /// The one that matters: swapping `.allow(Subject::any())` for a
-    /// bounded claim must still authorize a presign. This walks the same
-    /// BFS the presign path does — operator toward a space subject,
-    /// composing the session hop with a `space -> profile` grant — and
-    /// checks both that it resolves and that the session's expiry is
-    /// what bounds the result.
-    #[dialog_common::test]
-    async fn it_authorizes_a_presign_chain_bounded_by_the_session() {
-        let (storage, profile) = scratch().await;
-        let session = open(&profile, &storage).await.unwrap();
+    async fn access_revision(
+        profile: &Profile,
+        operator: &Operator<DefaultSpace>,
+    ) -> Option<dialog_repository::Revision> {
+        dialog_repository::Repository::from(profile.signer().clone())
+            .branch(dialog_repository::ACCESS_BRANCH)
+            .open()
+            .perform(operator)
+            .await
+            .unwrap()
+            .revision()
+    }
 
+    async fn retain_space(
+        profile: &Profile,
+        operator: &Operator<DefaultSpace>,
+    ) -> dialog_varsig::Did {
         let space = Ed25519Signer::generate().await.unwrap();
         let grant = DelegationBuilder::new()
             .issuer(dialog_credentials::Signer::from(space.clone()))
@@ -364,28 +208,116 @@ mod tests {
         profile
             .access()
             .save(UcanDelegation(DelegationChain::new(grant)))
-            .perform(&session.operator)
+            .perform(operator)
             .await
             .unwrap();
+        space.did()
+    }
 
+    async fn assert_proof(profile: &Profile, session: &Session, space: &dialog_varsig::Did) {
         let proof = profile
             .access()
-            .prove(Subject::from(space.did()))
+            .prove(Subject::from(space.clone()).attenuate(dialog_effects::Use))
             .audience(&session.operator)
             .perform(&session.operator)
             .await
-            .expect("the session operator must still reach the space");
+            .unwrap();
+        assert_eq!(proof.proofs.len(), 2);
+        assert_eq!(proof.proofs[0].0.audience(), proof.proofs[1].0.issuer());
+        assert_eq!(proof.proofs[1].0.audience(), &session.operator.did());
+        assert_eq!(proof.duration.expiration, Some(session.expires_at));
+    }
 
+    #[dialog_common::test]
+    async fn it_authorizes_replacement_sessions_without_committing() {
+        let (storage, profile) = scratch().await;
+        let setup = open(&profile, &storage).await.unwrap();
+        let space = retain_space(&profile, &setup.operator).await;
+        let revision = access_revision(&profile, &setup.operator).await;
+        let first = open(&profile, &storage).await.unwrap();
+        assert_eq!(access_revision(&profile, &first.operator).await, revision);
+        let second = open(&profile, &storage).await.unwrap();
+        assert_eq!(access_revision(&profile, &second.operator).await, revision);
+        assert_ne!(first.operator.did(), second.operator.did());
+        assert_eq!(second.operator.profile_did(), profile.did());
+        for session in [&first, &second] {
+            assert_proof(&profile, session, &space).await;
+            assert_proof(&profile, session, &space).await;
+        }
+    }
+
+    #[dialog_common::test]
+    async fn it_ignores_legacy_sessions_and_reopens_durable_storage() {
+        let name = dialog_operator::helpers::unique_name("session-reopen");
+        let (profile_did, old_operator, space, revision, legacy) = {
+            let storage = Storage::<DefaultSpace>::default();
+            let profile = Profile::open(&name)
+                .at(Directory::Temp)
+                .perform(&storage)
+                .await
+                .unwrap();
+            // Simulate Safari's saved grant naming an audience unrelated
+            // to the operator reconstructed from the legacy context.
+            let old = profile
+                .derive(b"legacy-other-operator")
+                .build(storage.clone())
+                .await
+                .unwrap();
+            let expiration =
+                Timestamp::new(SystemTime::now() + Duration::from_secs(SESSION_TTL_SECONDS))
+                    .unwrap();
+            let grant = profile
+                .access()
+                .claim(Subject::any())
+                .expires(expiration)
+                .delegate(old.did())
+                .perform(&old)
+                .await
+                .unwrap();
+            profile.access().save(grant).perform(&old).await.unwrap();
+            let space = retain_space(&profile, &old).await;
+            let legacy = serde_json::to_vec(&serde_json::json!({
+                "version": 1, "context": b"worker".to_vec(), "expires_at": expiration.to_unix()
+            }))
+            .unwrap();
+            profile
+                .credential()
+                .site("tonk-session-v1")
+                .save(legacy.clone())
+                .perform(&storage)
+                .await
+                .unwrap();
+            (
+                profile.did(),
+                old.did(),
+                space,
+                access_revision(&profile, &old).await,
+                legacy,
+            )
+        };
+        // All prior operators, profiles, branches and the storage pool have
+        // been released. Reopen the same durable profile with a new pool.
+        let storage = Storage::<DefaultSpace>::default();
+        let profile = Profile::open(&name)
+            .at(Directory::Temp)
+            .perform(&storage)
+            .await
+            .unwrap();
+        let session = open(&profile, &storage).await.unwrap();
+        assert_eq!(profile.did(), profile_did);
+        assert_ne!(session.operator.did(), old_operator);
+        assert_eq!(access_revision(&profile, &session.operator).await, revision);
+        assert_proof(&profile, &session, &space).await;
+        let after = profile
+            .credential()
+            .site("tonk-session-v1")
+            .load::<Vec<u8>>()
+            .perform(&storage)
+            .await
+            .unwrap();
         assert_eq!(
-            proof.proofs.len(),
-            2,
-            "the chain is space -> profile -> operator"
-        );
-        assert_eq!(
-            proof.duration.expiration,
-            Some(session.expires_at),
-            "an unexpiring space grant composed with a bounded session \
-             must come out bounded by the session"
+            after, legacy,
+            "legacy session metadata is neither consulted nor replaced"
         );
     }
 

--- a/rust/tonk-worker/src/worker.rs
+++ b/rust/tonk-worker/src/worker.rs
@@ -1710,60 +1710,11 @@ pub(crate) async fn boot_state(
     registry: crate::device::Registry,
 ) -> Result<TonkState, crate::TonkWorkerError> {
     let reactor = crate::Reactor::new(profile.clone());
-    let session = match crate::session::open(&profile, &storage).await {
-        Ok(session) => session,
-        Err(error) => {
-            // A partial access branch bricks session open: a remote
-            // profile update adopted by reference leaves the head ahead
-            // of the local blocks, and the authorization walk reads
-            // entirely locally by design (its recursion-bounding env has
-            // no network reach — hydration inside it would be circular).
-            // Hydrate the access branch with a network-capable operator
-            // and retry once; offline or truly broken states surface the
-            // original error.
-            tonk_common::log!(
-                "session open failed ({error}); hydrating the access branch and retrying"
-            );
-            use dialog_operator::DeriveOperator as _;
-            let context: [u8; 16] = rand::random();
-            let operator = profile
-                .derive(context.to_vec())
-                .build(storage.clone())
-                .await
-                .map_err(|e| {
-                    crate::TonkWorkerError::Internal(format!(
-                        "failed to derive a hydration operator: {e} (after session open failed: {error})"
-                    ))
-                })?;
-            let access = reactor
-                .profile_repository()
-                .branch(tonk_account::MAIN_BRANCH)
-                .acquire(&operator)
-                .await
-                .map_err(|e| {
-                    crate::TonkWorkerError::Internal(format!(
-                        "failed to open the access branch for hydration: {e} (after session open failed: {error})"
-                    ))
-                })?;
-            access
-                .handle()
-                .download()
-                .perform(&operator)
-                .await
-                .map_err(|e| {
-                    crate::TonkWorkerError::Internal(format!(
-                        "failed to hydrate the access branch: {e} (after session open failed: {error})"
-                    ))
-                })?;
-            crate::session::open(&profile, &storage)
-                .await
-                .map_err(|e| {
-                    crate::TonkWorkerError::Internal(format!(
-                        "failed to open a signing session after hydrating the access branch: {e}"
-                    ))
-                })?
-        }
-    };
+    // Session construction reads branch reference cells, but no longer
+    // walks or retains delegation content. Hydrating after a construction
+    // failure cannot repair entropy, signing, or local reference errors;
+    // surface them without touching the profile's durable contents.
+    let session = crate::session::open(&profile, &storage).await?;
 
     let state = TonkState {
         profile,


### PR DESCRIPTION
## What changed

Fix worker-session authorization after browser worker replacement. Safari can produce different signatures for identical inputs, which changed the reconstructed operator DID while the worker reused a persisted grant addressed to its previous operator. Each boot and renewal now creates a fresh random operator with a matching 12-hour grant held in memory.

The change preserves account/profile membership, invitation authority, local contents, the one-hour renewal margin, and existing legacy session records. Renewal installs operator and expiry atomically; failed or losing concurrent candidates create no durable session writes. Session construction no longer needs the old delegation-hydration fallback.

Depends on https://github.com/dialog-db/dialog-db/pull/489. The Dialog family is pinned to tested commit `314e49926eb5bca58bacdcf9f2123ccb4422ea35`, with the corresponding Nix hash; the separate runner input is unchanged.

## Verification

All checks below used the published immutable Dialog pin without local overrides:

- `cargo test -p tonk-worker --lib --locked`: 121 passed.
- Chromium `wbg-pool`: 11 tests matching `session::tests`, three `router::sync::renewal_tests`, and 26 `router::join::tests` passed.
- `nix build .#checks.aarch64-darwin.sharedWorkspaceDeps --no-link`: passed.
- Rust/Nix formatting, Nix source-reference, and diff whitespace checks passed.

Regression coverage includes distinct operators across opens, bounded proofs without profile commits, storage close/reopen with mismatched legacy authority, forced renewal, construction failure, concurrent candidates, and preserved onboarding membership after rebuilding worker state.

macOS Safari/iOS Safari, actual remote pull/push after worker replacement, network-offline restart, and signing/boot/pull latency measurements remain unverified. The onboarding fixture has no remote; its passing proof/content assertions do not establish network replication. This change has not been deployed.

## Storybook impact

User-visible sync reliability fix with backend regression coverage in `session::tests`, `router::sync::renewal_tests`, and `it_reopens_an_onboarding_membership_with_a_disposable_session`. No rendered UI or CLI output changed. Storybook was not updated and no shared Storybook regression ID was added; device acceptance remains recorded in `plan/in-memory-worker-sessions.md`.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on creating disposable worker operators with bounded in-memory grants, improving session management in the `tonk-worker` by ensuring that sessions are created fresh on each boot without relying on persisted data, thus enhancing reliability and performance.

### Detailed summary
- Updated `cargoGitDependencies` to use `rev` instead of `tag` for consistency.
- Refactored session handling in `rust/tonk-worker/src/worker.rs` to avoid reliance on persisted sessions.
- Introduced a new test in `rust/tonk-worker/src/router/join.rs` for onboarding membership with disposable sessions.
- Enhanced session renewal logic in `rust/tonk-worker/src/router/sync.rs` to create disposable operators.
- Removed old session persistence code and related structures in `rust/tonk-worker/src/session.rs`.
- Added tests for distinct session creation and proof validation in `rust/tonk-worker/src/session.rs`. 
- Documented the new session management strategy in `plan/in-memory-worker-sessions.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->