### PR TITLE
fix(ui): align CLI account handoff dialogs

### DIFF
--- a/docs/plans/2026-09-09-cli-account-handoff-ui.md
+++ b/docs/plans/2026-09-09-cli-account-handoff-ui.md
@@ -1,0 +1,38 @@
+# CLI account handoff rows
+
+The link approval pane should use the Hub's separated row layout: heading,
+terminal name, account, device, explanation, actions, and status. Keep ordinary
+account settings on their existing sheet. Long identifiers must wrap on mobile.
+The callback page should use the same column width, with its result before its
+close action.
+
+The Hub is an opaque-origin guest. Passkeys must still run in the top document.
+Publish the reserved passkey seat through the existing page-effect registration
+relay with a distinct custody-anchor reason; resize and scroll update that seat.
+Only device authorization uses it; other custody prompts retain their placement.
+
+Validation: check both changed Rust crates for wasm, exercise the anchor relay
+with browser tests, and inspect the source-based layout at desktop/mobile sizes.
+Actual hosted CLI authorization and physical passkeys require separate evidence.
+
+Implemented the row styling, callback row order/width, and custody anchor relay.
+The anchored prompt waits for its seat if the worker arrives first, avoiding a
+flash in the floating position. The guest replaces the approval rows once the top-page prompt is ready. The
+account bar remains visible. A distinct custody lifecycle reply restores the
+approval rows on dismissal; it does not close the Hub registration menu.
+
+Validation completed: Wasm check for tonk-ui and tonk-workspace; the focused
+custody anchor browser test (including late anchor arrival, repositioning, and
+unrelated floating prompts); the callback shell unit test; formatting and diff
+checks. The browser pool initially timed out inside the sandbox and passed with
+browser access. Source-based browser previews cover desktop and 320px mobile;
+they do not exercise hosted authorization or a physical passkey.
+
+The final desktop preview shows only the account bar and passkey confirmation.
+Focused browser tests verify that approval and status rows are hidden during
+confirmation, that its position matches the old approval screen, and that
+dismissal restores the approval rows.
+
+The desktop passkey message now uses the same 36px row height as the account
+bar, heading, and action buttons. Text can still grow the message row if it
+wraps. Browser measurements confirmed all four desktop rows are 36px.

--- a/docs/plans/2026-09-09-cli-account-handoff-ui.md
+++ b/docs/plans/2026-09-09-cli-account-handoff-ui.md
@@ -36,3 +36,9 @@ dismissal restores the approval rows.
 The desktop passkey message now uses the same 36px row height as the account
 bar, heading, and action buttons. Text can still grow the message row if it
 wraps. Browser measurements confirmed all four desktop rows are 36px.
+
+CI regression: wrong-account handoff rejection timed out reading its status.
+A focused browser reproducer confirmed that `tonk:custody-closed` erased the
+worker's refusal after the passkey screen had hidden it. Closing now preserves
+refused, failed, and completed ceremony results, while clearing temporary
+waiting text. The new refusal regression and existing dismissal test pass.

--- a/rust/tonk-cli/src/callback.rs
+++ b/rust/tonk-cli/src/callback.rs
@@ -326,7 +326,7 @@ fn confirmation(message: &str) -> String {
   }}
 
   .account__ceremony {{
-    width: min(432px, 100%);
+    width: 100%;
     margin-inline: auto;
   }}
 
@@ -387,8 +387,8 @@ fn confirmation(message: &str) -> String {
   }}
 
   .account__narrator {{
-    width: min(432px, 100%);
-    margin: 7px auto 0;
+    width: 100%;
+    margin: 0;
     padding: 10px 16px 11px;
     background: var(--frost-solid);
     box-shadow: 0 0 0 1px var(--ring);
@@ -436,10 +436,10 @@ fn confirmation(message: &str) -> String {
   <section class="account__ceremony" aria-labelledby="confirmation-title">
     <div class="account__stack">
       <h1 id="confirmation-title" class="account__ceremony-head">command-line access</h1>
+      <div class="account__narrator" role="status">
+        <p>{message}</p>
+      </div>
       <button class="account__run" type="button" onclick="window.close()">close this window</button>
-    </div>
-    <div class="account__narrator" role="status">
-      <p>{message}</p>
     </div>
   </section>
 </main>
@@ -560,7 +560,8 @@ mod tests {
         assert!(page.contains("Authorized. You can return to your terminal."));
         assert!(page.contains("--page: #e8e6e4"));
         assert!(page.contains("--page: #161313"));
-        assert!(page.contains("width: min(432px, 100%)"));
+        assert!(page.contains("width: min(576px, calc(100vw - 32px))"));
+        assert!(page.find(r#"role="status""#).unwrap() < page.find("close this window").unwrap());
         assert!(page.contains("min-height: 44px"));
         assert!(page.contains("@media (max-width: 463px)"));
         assert!(page.contains("@media (prefers-reduced-motion: reduce)"));

--- a/rust/tonk-portal/src/bridge.rs
+++ b/rust/tonk-portal/src/bridge.rs
@@ -281,7 +281,8 @@ const BOOTSTRAP_JS: &str = r#"(function(){
     // the host can word the prompt. Fire-and-forget (no response).
     register:function(reason){
       var opener=document.activeElement;
-      var token=(opener&&opener!==document.body)?mint():"";
+      // Even an unfocused opener needs the ceremony's terminal event.
+      var token=mint();
       if(token){ registerFocus.set(token,opener); }
       ready.then(function(){port.postMessage({v:1,type:"register",reason:reason,focusToken:token});});
     },
@@ -333,6 +334,10 @@ const BOOTSTRAP_JS: &str = r#"(function(){
         var h=pending.get(env.id); if(!h) return; pending.delete(env.id);
         h.resolve(env.delegation); return;
       }
+      case "custody-open": {
+        window.dispatchEvent(new Event("tonk:custody-opened")); return;
+      }
+      case "custody-focus":
       case "register-focus": {
         var opener=registerFocus.get(env.focusToken);
         registerFocus.delete(env.focusToken);
@@ -341,7 +346,7 @@ const BOOTSTRAP_JS: &str = r#"(function(){
         // so signal the guest window even when that old node can no longer
         // take focus. Hub chrome uses this terminal event to clear its durable
         // linking marker and restore the spaces page in one step.
-        window.dispatchEvent(new Event("tonk:registration-closed"));
+        window.dispatchEvent(new Event(env.type==="custody-focus" ? "tonk:custody-closed" : "tonk:registration-closed"));
         if(opener&&opener.isConnected&&!opener.matches(":disabled")){
           window.focus();
           opener.focus({preventScroll:true});
@@ -2010,6 +2015,17 @@ impl RegisterFocusReturn {
             let _ = frame.focus();
         }
         self.post("register-focus");
+        self.handled = true;
+    }
+
+    /// Replace the guest approval rows once the top-page prompt is ready.
+    pub fn show_custody(&self) {
+        self.post("custody-open");
+    }
+
+    /// Finish an account custody screen without closing Hub registration.
+    pub fn restore_custody(mut self) {
+        self.post("custody-focus");
         self.handled = true;
     }
 
@@ -4320,6 +4336,24 @@ mod tests {
 
         let returned = listener.wait_for("register-focus").await;
         assert_eq!(get_str(&returned, "focusToken").as_deref(), Some("focus-2"));
+    }
+
+    #[dialog_common::test]
+    async fn it_replaces_and_restores_custody_through_the_request_port() {
+        let channel = MessageChannel::new().expect("message channel");
+        let listener = PortListener::attach(&channel.port2());
+        let reply = RegisterFocusReturn {
+            port: channel.port1(),
+            frame: None,
+            token: "custody-1".into(),
+            handled: false,
+        };
+        reply.show_custody();
+        let opened = listener.wait_for("custody-open").await;
+        assert_eq!(get_str(&opened, "focusToken").as_deref(), Some("custody-1"));
+        reply.restore_custody();
+        let closed = listener.wait_for("custody-focus").await;
+        assert_eq!(get_str(&closed, "focusToken").as_deref(), Some("custody-1"));
     }
 
     /// `open_href` accepts only a well-formed `{type:"open", href}`. The

--- a/rust/tonk-ui/src/bin/ui.rs
+++ b/rust/tonk-ui/src/bin/ui.rs
@@ -62,6 +62,13 @@ async fn main() {
         // dismiss remains the true teardown.
         let request = tonk_ui::register_dialog::parse_request(reason);
         match request.reason.as_str() {
+            "custody-anchor" => {
+                tonk_ui::custody_relay::return_to_approval(return_focus);
+                if let Some(anchor) = request.anchor {
+                    tonk_ui::custody_relay::reanchor(anchor);
+                }
+                return;
+            }
             "profile-transition" => {
                 // Add Account already promoted the empty landing profile.
                 // Preserve the anchored ceremony request, then reload so

--- a/rust/tonk-ui/src/custody_relay.rs
+++ b/rust/tonk-ui/src/custody_relay.rs
@@ -12,7 +12,7 @@
 //! key with the root (`POST /api/identity/root`, what the worker is
 //! waiting on), and stays up to say what happened.
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 
 use tonk_worker_api::{
     LINK_ACCOUNT, LinkAccountRequest, RootStatus, WEBAUTHN, WebAuthnKind, WebAuthnRequest,
@@ -24,6 +24,8 @@ use web_sys::{Element, MessageEvent};
 use crate::user_error::{self, AccountAction};
 
 thread_local! {
+    static RETURN_FOCUS: RefCell<Option<tonk_portal::RegisterFocusReturn>> = const { RefCell::new(None) };
+    static ANCHOR: RefCell<Option<crate::register_dialog::Anchor>> = const { RefCell::new(None) };
     static INSTALLED: Cell<bool> = const { Cell::new(false) };
     /// One card at a time: a second request arriving while the card is
     /// up is already answered by the save the first one performs.
@@ -42,7 +44,8 @@ const CARD_HTML: &str = r#"
               box-shadow:0 0 0 1px var(--ring, rgb(56 24 42 / 85%));
               font:600 13px/1 var(--cond, 'IBM Plex Sans Condensed', system-ui, sans-serif);
               letter-spacing:.02em;text-transform:lowercase">passkey needed</div>
-  <p id="tonk-custody-text" style="margin:0;padding:14px 16px;background:var(--card, #fcfbfb);
+  <p id="tonk-custody-text" style="box-sizing:border-box;min-height:36px;display:flex;align-items:center;
+            margin:0;padding:var(--custody-message-padding, 14px) 16px;background:var(--card, #fcfbfb);
             box-shadow:0 0 0 1px var(--ring, rgb(56 24 42 / 85%));font-weight:600">
     Tonk is securing something to your account and needs your passkey to
     unlock the account&rsquo;s custody key on this device.
@@ -103,10 +106,19 @@ pub(crate) async fn publish_encryption_key() -> Result<bool, String> {
 }
 
 fn remove_card() {
-    if let Some(card) = card() {
+    let anchored = card().is_some_and(|card| {
+        let anchored = card.has_attribute("data-anchored");
         card.remove();
-    }
+        anchored
+    });
     BUSY.with(|busy| busy.set(false));
+    if anchored {
+        RETURN_FOCUS.with(|focus| {
+            if let Some(focus) = focus.borrow_mut().take() {
+                focus.restore_custody();
+            }
+        });
+    }
 }
 
 fn card() -> Option<Element> {
@@ -151,13 +163,76 @@ fn on_click(card: &Element, selector: &str, callback: impl FnMut() + 'static) {
     closure.forget();
 }
 
-fn mount_card() -> Option<Element> {
+/// Retain the guest lifecycle reply while its approval screen is replaced.
+pub fn return_to_approval(focus: Option<tonk_portal::RegisterFocusReturn>) {
+    if let Some(focus) = focus {
+        if card().is_some_and(|card| card.has_attribute("data-anchored")) {
+            focus.show_custody();
+        }
+        RETURN_FOCUS.with(|current| *current.borrow_mut() = Some(focus));
+    }
+}
+
+/// Keep the top-document passkey rows seated in the guest's dialog column.
+pub fn reanchor(anchor: crate::register_dialog::Anchor) {
+    if !anchor.left.is_finite()
+        || !anchor.bottom.is_finite()
+        || !anchor.width.is_finite()
+        || anchor.width <= 0.0
+    {
+        return;
+    }
+    ANCHOR.with(|seat| *seat.borrow_mut() = Some(anchor));
+    position_card();
+}
+
+fn position_card() {
+    let Some(rows) = card()
+        .filter(|host| host.has_attribute("data-anchored"))
+        .and_then(|host| host.first_element_child())
+    else {
+        return;
+    };
+    let Some(rows) = rows.dyn_ref::<web_sys::HtmlElement>() else {
+        return;
+    };
+    ANCHOR.with(|seat| {
+        if let Some(anchor) = seat.borrow().as_ref() {
+            let style = rows.style();
+            let _ = style.set_property("left", &format!("{}px", anchor.left));
+            let _ = style.set_property("top", &format!("{}px", anchor.bottom + 7.0));
+            let _ = style.set_property("width", &format!("{}px", anchor.width));
+            let _ = style.set_property("right", "auto");
+            let _ = style.set_property("bottom", "auto");
+            let _ = style.remove_property("visibility");
+        } else {
+            // The worker and guest relay arrive independently. Wait for the
+            // seat instead of flashing this prompt in the floating fallback.
+            let _ = rows.style().set_property("visibility", "hidden");
+        }
+    });
+}
+
+fn mount_card(anchored: bool) -> Option<Element> {
     let document = web_sys::window().and_then(|window| window.document())?;
     let body = document.body()?;
     let host = document.create_element("div").ok()?;
     host.set_id(CARD_ID);
+    if anchored {
+        host.set_attribute("data-anchored", "").ok()?;
+        host.set_attribute("style", "--custody-message-padding:7px")
+            .ok()?;
+    }
     host.set_inner_html(CARD_HTML);
     body.append_child(&host).ok()?;
+    position_card();
+    if anchored {
+        RETURN_FOCUS.with(|focus| {
+            if let Some(focus) = focus.borrow().as_ref() {
+                focus.show_custody();
+            }
+        });
+    }
     Some(host)
 }
 
@@ -165,7 +240,7 @@ fn mount_card() -> Option<Element> {
 /// the click and reports the outcome on the card; dismissing leaves the
 /// worker's wait to time out, failing the operation that asked.
 fn show_consent() {
-    let Some(host) = mount_card() else {
+    let Some(host) = mount_card(false) else {
         BUSY.with(|busy| busy.set(false));
         return;
     };
@@ -253,7 +328,10 @@ fn run_command_ceremony(intent: tonk_worker_api::CustodyIntent, credential_id: O
     if BUSY.with(|busy| busy.replace(true)) {
         return;
     }
-    let Some(host) = mount_card() else {
+    let Some(host) = mount_card(matches!(
+        &intent,
+        tonk_worker_api::CustodyIntent::AuthorizeDevice(_)
+    )) else {
         BUSY.with(|busy| busy.set(false));
         return;
     };
@@ -598,5 +676,47 @@ fn describe(error: &wasm_bindgen::JsValue) -> String {
     match name {
         Some(name) => format!("{name}: {message}"),
         None => message,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    #[wasm_bindgen_test]
+    fn device_consent_tracks_its_guest_seat() {
+        remove_card();
+        ANCHOR.with(|seat| seat.borrow_mut().take());
+        let host = mount_card(true).unwrap();
+        let rows: web_sys::HtmlElement = host.first_element_child().unwrap().dyn_into().unwrap();
+        assert_eq!(
+            rows.style().get_property_value("visibility").unwrap(),
+            "hidden"
+        );
+        reanchor(crate::register_dialog::Anchor {
+            left: 24.0,
+            bottom: 320.0,
+            width: 288.0,
+        });
+        let rows = host.first_element_child().unwrap();
+        let rect = rows.get_bounding_client_rect();
+        assert_eq!(rect.left(), 24.0);
+        assert_eq!(rect.top(), 327.0);
+        assert_eq!(rect.width(), 288.0);
+        reanchor(crate::register_dialog::Anchor {
+            left: 32.0,
+            bottom: 160.0,
+            width: 576.0,
+        });
+        assert_eq!(rows.get_bounding_client_rect().top(), 167.0);
+        assert_eq!(rows.get_bounding_client_rect().width(), 576.0);
+        remove_card();
+        // A subsequent unrelated custody request keeps its floating placement.
+        let host = mount_card(false).unwrap();
+        let rows: web_sys::HtmlElement = host.first_element_child().unwrap().dyn_into().unwrap();
+        assert_eq!(rows.style().get_property_value("bottom").unwrap(), "16px");
+        remove_card();
+        ANCHOR.with(|seat| seat.borrow_mut().take());
     }
 }

--- a/rust/tonk-ui/styles.css
+++ b/rust/tonk-ui/styles.css
@@ -2276,6 +2276,41 @@ ui-account-settings .link-foot .m-cancel { box-shadow: 0 0 0 1px var(--ring); }
 ui-account-settings [data-ceremony-status] { color: var(--ink); }
 ui-account-settings [data-ceremony-status][hidden] { display: none; }
 
+/* CLI approval follows the Hub's row stack rather than the settings sheet. */
+ui-account-settings .s-body:has([data-link-approval]:not([hidden])) {
+    min-height: 0; max-height: none; overflow: visible; padding: 0;
+    background: none; border: 0; position: relative;
+}
+ui-account-settings [data-link-approval]:not([hidden]) {
+    display: flex; flex-direction: column; gap: 7px;
+}
+ui-account-settings [data-link-approval] > :is(.sect, .srowd, .expl),
+ui-account-settings .s-body:has([data-link-approval]:not([hidden])) > [data-ceremony-status]:not([hidden]) {
+    box-sizing: border-box; margin: 0; padding: 10px 16px;
+    min-height: 36px; max-width: none; background: var(--card);
+    border: 0; box-shadow: 0 0 0 1px var(--ring);
+}
+ui-account-settings [data-link-approval] .srowd b {
+    min-width: 0; white-space: normal; overflow-wrap: anywhere; text-align: right;
+}
+ui-account-settings [data-link-approval] .link-foot { margin: 0; }
+ui-account-settings [data-link-approval] .link-foot button {
+    font: 600 13px/1 var(--cond); letter-spacing: 0.02em;
+}
+ui-account-settings .s-body:has([data-link-approval]:not([hidden])) > [data-ceremony-status]:not([hidden]) {
+    margin-top: 7px;
+}
+ui-account-settings [data-custody-seat] { display: none; }
+ui-account-settings[data-passkey-screen] [data-link-approval],
+ui-account-settings[data-passkey-screen] .s-body:has([data-link-approval]:not([hidden])) > [data-ceremony-status]:not([hidden]) { display: none; }
+ui-account-settings[data-passkey-requested] [data-custody-seat] {
+    display: block; position: absolute; top: 0; left: 0; width: 100%; height: 180px;
+    pointer-events: none;
+}
+ui-account-settings[data-passkey-screen] [data-custody-seat] {
+    display: block; position: static; height: 180px;
+}
+
 /* Map our Web Awesome theme into the `<tonk-code>` element's
    public CSS variables. The element ships GitHub-flavored defaults
    that work standalone in light/dark; this block plugs it into our

--- a/rust/tonk-workspace/src/ui_account_settings.html
+++ b/rust/tonk-workspace/src/ui_account_settings.html
@@ -50,6 +50,7 @@
     </div>
   </div>
   <p class="expl" data-ceremony-status role="status" aria-live="polite" hidden></p>
+  <div data-custody-seat aria-hidden="true"></div>
 </div>
 <tonk-dialog data-delete-account-dialog heading="confirm account deletion">
   <div class="confirm-body">

--- a/rust/tonk-workspace/src/ui_account_settings.rs
+++ b/rust/tonk-workspace/src/ui_account_settings.rs
@@ -241,7 +241,14 @@ impl CustomElement for UiAccountSettings {
         let closed: EventClosure = Closure::wrap(Box::new(move |_: Event| {
             let _ = host.remove_attribute("data-passkey-screen");
             let _ = host.remove_attribute("data-passkey-requested");
-            show_status(&host, "");
+            // Closing the passkey UI is not a new command result. The worker
+            // may already have published its refusal while this screen hid it.
+            if !matches!(
+                host.get_attribute("data-ceremony-state").as_deref(),
+                Some(ceremony_state::REFUSED | ceremony_state::FAILED | ceremony_state::DONE)
+            ) {
+                show_status(&host, "");
+            }
         }));
         if let Some(window) = window() {
             let _ = window.add_event_listener_with_callback(
@@ -1251,6 +1258,49 @@ mod tests {
         );
         host.remove();
         style.remove();
+    }
+
+    #[wasm_bindgen_test]
+    fn custody_close_preserves_the_handoff_refusal() {
+        let host = mount();
+        super::set_pane(&host, "link");
+        host.set_attribute("data-passkey-screen", "").unwrap();
+        let row = js_sys::JSON::parse(
+            &serde_json::json!({
+                "fields": {
+                    "ceremony": tonk_schema::ceremony::AUTHORIZE_DEVICE,
+                    "state": tonk_schema::ceremony_state::REFUSED,
+                    "detail": "this handoff requires account did:key:expected"
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+        super::render_ceremony(&host, &row);
+        let status = host
+            .query_selector("[data-ceremony-status]")
+            .unwrap()
+            .unwrap();
+        assert!(
+            status
+                .text_content()
+                .unwrap()
+                .contains("this handoff requires account")
+        );
+        window()
+            .unwrap()
+            .dispatch_event(&web_sys::Event::new("tonk:custody-closed").unwrap())
+            .unwrap();
+        assert!(
+            status
+                .text_content()
+                .unwrap()
+                .contains("this handoff requires account"),
+            "closing the passkey screen must retain the worker's refusal"
+        );
+        assert!(!status.has_attribute("hidden"));
+        assert!(!host.has_attribute("data-passkey-screen"));
+        host.remove();
     }
 
     fn mount() -> HtmlElement {

--- a/rust/tonk-workspace/src/ui_account_settings.rs
+++ b/rust/tonk-workspace/src/ui_account_settings.rs
@@ -43,6 +43,11 @@ fn set_text(this: &HtmlElement, selector: &str, value: &str) {
 
 #[derive(Default)]
 struct UiAccountSettings {
+    custody_opened: Option<EventClosure>,
+    custody_closed: Option<EventClosure>,
+    position_change: Option<EventClosure>,
+    position_observer: Option<web_sys::ResizeObserver>,
+    position_callback: Option<FrameClosure>,
     click: Option<EventClosure>,
     change: Option<EventClosure>,
     keydown: Option<EventClosure>,
@@ -217,9 +222,91 @@ impl CustomElement for UiAccountSettings {
         subscribe_ceremony(this, self.subscription.clone());
 
         refresh(this);
+        let host = this.clone();
+        let opened: EventClosure = Closure::wrap(Box::new(move |_: Event| {
+            if host.has_attribute("data-passkey-screen") {
+                return;
+            }
+            let _ = host.set_attribute("data-passkey-screen", "");
+            publish_custody_seat(&host);
+        }));
+        if let Some(window) = window() {
+            let _ = window.add_event_listener_with_callback(
+                "tonk:custody-opened",
+                opened.as_ref().unchecked_ref(),
+            );
+        }
+        self.custody_opened = Some(opened);
+        let host = this.clone();
+        let closed: EventClosure = Closure::wrap(Box::new(move |_: Event| {
+            let _ = host.remove_attribute("data-passkey-screen");
+            let _ = host.remove_attribute("data-passkey-requested");
+            show_status(&host, "");
+        }));
+        if let Some(window) = window() {
+            let _ = window.add_event_listener_with_callback(
+                "tonk:custody-closed",
+                closed.as_ref().unchecked_ref(),
+            );
+        }
+        self.custody_closed = Some(closed);
+        let host = this.clone();
+        let position: EventClosure = Closure::wrap(Box::new(move |_: Event| {
+            publish_custody_seat(&host);
+        }));
+        if let Some(window) = window() {
+            for event in ["scroll", "resize"] {
+                let _ = window.add_event_listener_with_callback_and_bool(
+                    event,
+                    position.as_ref().unchecked_ref(),
+                    true,
+                );
+            }
+        }
+        self.position_change = Some(position);
+        let host = this.clone();
+        let callback: FrameClosure = Closure::wrap(Box::new(move |_, _| {
+            publish_custody_seat(&host);
+        }));
+        if let Ok(observer) = web_sys::ResizeObserver::new(callback.as_ref().unchecked_ref()) {
+            observer.observe(this);
+            self.position_observer = Some(observer);
+            self.position_callback = Some(callback);
+        }
     }
 
     fn disconnected_callback(&mut self, this: &HtmlElement) {
+        if let Some(opened) = self.custody_opened.take()
+            && let Some(window) = window()
+        {
+            let _ = window.remove_event_listener_with_callback(
+                "tonk:custody-opened",
+                opened.as_ref().unchecked_ref(),
+            );
+        }
+        if let Some(closed) = self.custody_closed.take()
+            && let Some(window) = window()
+        {
+            let _ = window.remove_event_listener_with_callback(
+                "tonk:custody-closed",
+                closed.as_ref().unchecked_ref(),
+            );
+        }
+        if let Some(observer) = self.position_observer.take() {
+            observer.disconnect();
+        }
+        self.position_callback.take();
+        if let Some(position) = self.position_change.take()
+            && let Some(window) = window()
+        {
+            for event in ["scroll", "resize"] {
+                let _ = window.remove_event_listener_with_callback_and_bool(
+                    event,
+                    position.as_ref().unchecked_ref(),
+                    true,
+                );
+            }
+        }
         self.subscription.borrow_mut().take();
         self.frames.clear();
         if let Some(click) = self.click.take() {
@@ -694,11 +781,31 @@ fn add_passkey(this: &HtmlElement) {
     );
 }
 
+/// The passkey runs in the top document; reserve and publish its seat in
+/// this sealed guest using the same page-effect relay as Hub registration.
+fn publish_custody_seat(this: &HtmlElement) {
+    let Some(seat) = this.query_selector("[data-custody-seat]").ok().flatten() else {
+        return;
+    };
+    let rect = seat.get_bounding_client_rect();
+    if rect.width() <= 0.0 || rect.height() <= 0.0 {
+        return;
+    }
+    tonk_host::request_registration(
+        &serde_json::json!({
+            "reason": "custody-anchor",
+            "anchor": { "left": rect.left(), "bottom": rect.top() - 7.0, "width": rect.width() }
+        })
+        .to_string(),
+    );
+}
+
 /// Assert `tonk:authorize-device` for the terminal named in the URL.
 fn approve_link(this: &HtmlElement) {
     let Some(request) = link_request() else {
         return;
     };
+    let _ = this.set_attribute("data-passkey-requested", "");
     show_status(this, "Waiting for your passkey\u{2026}");
     let mut fields = serde_json::json!({
         "audience": request.audience,
@@ -742,6 +849,7 @@ fn decline_link(this: &HtmlElement) {
 fn show_status(this: &HtmlElement, text: &str) {
     set_text(this, "[data-ceremony-status]", text);
     set_hidden(this, "[data-ceremony-status]", text.is_empty());
+    publish_custody_seat(this);
 }
 
 /// A transient claim for `window.tonk.transact`: the concept inline,
@@ -898,6 +1006,13 @@ fn render_ceremony(this: &HtmlElement, row: &JsValue) {
         }
         _ => return,
     };
+    if which == ceremony::AUTHORIZE_DEVICE {
+        if state == ceremony_state::PENDING_CEREMONY || state == ceremony_state::WORKING {
+            let _ = this.set_attribute("data-passkey-requested", "");
+        } else {
+            let _ = this.remove_attribute("data-passkey-requested");
+        }
+    }
     let _ = this.set_attribute("data-ceremony", &which);
     let _ = this.set_attribute("data-ceremony-state", &state);
     show_status(this, &text);
@@ -1078,6 +1193,64 @@ mod tests {
         );
 
         host.remove();
+    }
+
+    #[wasm_bindgen_test]
+    fn custody_screen_replaces_approval_and_restores_on_dismiss() {
+        let document = window().unwrap().document().unwrap();
+        let style = document.create_element("style").unwrap();
+        style.set_text_content(Some(include_str!("../../tonk-ui/styles.css")));
+        document.body().unwrap().append_child(&style).unwrap();
+        let host = mount();
+        super::set_pane(&host, "link");
+        host.set_attribute("data-passkey-requested", "").unwrap();
+        super::show_status(&host, "Waiting for your passkey…");
+        let approval = pane(&host, "link");
+        let top = approval.get_bounding_client_rect().top();
+        let window = window().unwrap();
+        window
+            .dispatch_event(&web_sys::Event::new("tonk:custody-opened").unwrap())
+            .unwrap();
+        assert_eq!(
+            window
+                .get_computed_style(&approval)
+                .unwrap()
+                .unwrap()
+                .get_property_value("display")
+                .unwrap(),
+            "none"
+        );
+        let status = host
+            .query_selector("[data-ceremony-status]")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            window
+                .get_computed_style(&status)
+                .unwrap()
+                .unwrap()
+                .get_property_value("display")
+                .unwrap(),
+            "none"
+        );
+        let seat = host.query_selector("[data-custody-seat]").unwrap().unwrap();
+        assert_eq!(seat.get_bounding_client_rect().top(), top);
+        window
+            .dispatch_event(&web_sys::Event::new("tonk:custody-closed").unwrap())
+            .unwrap();
+        assert!(!host.has_attribute("data-passkey-screen"));
+        assert!(!host.has_attribute("data-passkey-requested"));
+        assert_eq!(
+            window
+                .get_computed_style(&approval)
+                .unwrap()
+                .unwrap()
+                .get_property_value("display")
+                .unwrap(),
+            "flex"
+        );
+        host.remove();
+        style.remove();
     }
 
     fn mount() -> HtmlElement {


### PR DESCRIPTION
CLI account approval used a large settings sheet, and approving opened a detached passkey prompt in the corner. This change uses separate rows for terminal details, explanatory copy, and actions, then replaces the approval screen with an aligned passkey confirmation while keeping the account bar visible. Dismissing the prompt restores approval; scroll and resize keep the top-page passkey controls aligned with the sandboxed guest.

The desktop confirmation rows share a 36px height, with room to expand for wrapped text. The callback page matches the column width and shows its result before the close action.

Stacked on #920; base branch is `feat/doctor`.

Validation:
- Wasm check for `tonk-ui` and `tonk-workspace`.
- Focused browser tests for replacement/dismissal, anchor positioning, and custody lifecycle messages.
- Callback shell unit test; formatting and diff checks.
- Source-based desktop/mobile previews, including measured 36px desktop rows with repository fonts.

Hosted CLI authorization and physical passkeys have not been exercised.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR implements a custody anchor feature in the UI, enhancing the handling of passkeys and approval screens. It introduces new event listeners and modifies styles for improved user experience during account custody operations.

### Detailed summary
- Added a `data-custody-seat` element in `ui_account_settings.html`.
- Implemented custody handling in `ui.rs`, including `return_to_approval` and `reanchor` functions.
- Updated CSS styles for account ceremony elements in `styles.css`.
- Enhanced `callback.rs` to manage custody events.
- Modified `UiAccountSettings` to handle custody events and publish custody seats.
- Added tests for custody screen behavior and state preservation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->