### PR TITLE
fix(ui): explain passkey provider compatibility errors

### DIFF
--- a/rust/tonk-ui/src/user_error.rs
+++ b/rust/tonk-ui/src/user_error.rs
@@ -130,6 +130,23 @@ fn diagnostic_message(action: AccountAction, detail: &str) -> String {
             | AccountAction::FinishAccountBackup
     );
 
+    // Safari also reports this generic refusal when an older passkey provider
+    // cannot fulfill a PRF assertion. It is not proof of missing PRF support,
+    // so keep the update guidance conditional.
+    if passkey_action
+        && detail.contains("notallowederror")
+        && detail.contains(
+            "the request is not allowed by the user agent or the platform in the current context",
+        )
+    {
+        return if action == AccountAction::DeleteAccount {
+            "Nothing was deleted. Tonk uses technology that may require a newer password manager or browser. Update yours and try again."
+        } else {
+            "Tonk uses technology that may require a newer password manager or browser. Update yours and try again."
+        }
+        .to_owned();
+    }
+
     if passkey_action
         && (detail.contains("notallowederror")
             || detail.contains("aborterror")
@@ -427,6 +444,29 @@ mod tests {
         for (action, detail, expected) in cases {
             assert_eq!(diagnostic(action, detail), expected);
         }
+    }
+
+    #[test]
+    fn safari_context_refusal_suggests_provider_updates_without_diagnosing_prf() {
+        let detail = "NotAllowedError: custody assertion failed: NotAllowedError: The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.";
+        for action in [AccountAction::LogIn, AccountAction::AddPasskey] {
+            assert_eq!(
+                diagnostic(action, detail),
+                "Tonk uses technology that may require a newer password manager or browser. Update yours and try again."
+            );
+        }
+        assert_eq!(
+            diagnostic(AccountAction::DeleteAccount, detail),
+            "Nothing was deleted. Tonk uses technology that may require a newer password manager or browser. Update yours and try again."
+        );
+        assert_eq!(
+            diagnostic(
+                AccountAction::LogIn,
+                "AbortError: The operation was aborted"
+            ),
+            "The passkey prompt was cancelled or timed out. Try again and complete the prompt."
+        );
+        assert!(!diagnostic(AccountAction::SaveInitialDisplayName, detail).contains("PRF"));
     }
 
     #[test]


### PR DESCRIPTION
Safari can report a generic permission refusal when an older password manager cannot complete Tonk’s passkey request. Show “Tonk uses technology that may require a newer password manager or browser. Update yours and try again.” instead of saying the user cancelled. Keep the guidance conditional and preserve the deletion reassurance.

Stacked on #921.

Validation: all 8 `cargo test -p tonk-ui --lib user_error` tests pass, including the reported Safari diagnostic and cancellation coverage. `cargo fmt --all -- --check` and `git diff --check` pass. The new message has not been verified on a physical iOS device.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances error handling in the `user_error.rs` file for scenarios involving Safari and passkey actions. It provides user guidance when a request is not allowed due to browser or platform limitations, without incorrectly diagnosing missing PRF support.

### Detailed summary
- Added conditional guidance for users when a `NotAllowedError` occurs during passkey actions.
- Updated messages for `AccountAction::DeleteAccount` and other actions to inform users about potential updates needed for their password manager or browser.
- Introduced a new test, `safari_context_refusal_suggests_provider_updates_without_diagnosing_prf`, to verify the correct error messages and conditions.
- Confirmed that diagnostic messages do not mention PRF when related to the new error handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->