### PR TITLE
chore: release 0.6.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "dialog-reactor"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4634,7 +4634,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-access-service"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4689,7 +4689,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-account"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "anyhow",
  "blake3",
@@ -4717,7 +4717,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-analytics"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "dialog-common",
  "hex",
@@ -4735,7 +4735,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-analyzer"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4761,7 +4761,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-board"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "custom-elements",
  "js-sys",
@@ -4776,7 +4776,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-cli"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4842,7 +4842,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-code"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4851,7 +4851,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-common"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "dialog-common",
  "futures-util",
@@ -4864,7 +4864,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-core"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "base58",
  "dialog-artifacts",
@@ -4883,7 +4883,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-display"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4908,7 +4908,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-email"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "serde",
  "serde_json",
@@ -4917,7 +4917,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-evaluator"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "anyhow",
  "dialog-artifacts",
@@ -4940,7 +4940,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-fab"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "custom-elements",
  "dialog-common",
@@ -4961,7 +4961,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-guest"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "console_error_panic_hook",
  "custom-elements",
@@ -4984,7 +4984,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-host"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "bytes",
  "custom-elements",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-identity"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -5047,7 +5047,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-inspector"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "bs58",
  "custom-elements",
@@ -5067,7 +5067,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-invite"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "anyhow",
  "blake3",
@@ -5086,7 +5086,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-language-server"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "async-trait",
  "dialog-capability",
@@ -5106,7 +5106,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-macros"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5119,7 +5119,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-notation"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "dialog-common",
  "lsp-types",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-perf"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "anyhow",
  "axum",
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-portal"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "anyhow",
  "bs58",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-prose"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5187,7 +5187,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-render"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "async-trait",
  "dialog-common",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-router"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "dialog-common",
  "tokio",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-schema"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5250,7 +5250,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-sigil"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "blake3",
  "bs58",
@@ -5262,7 +5262,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-table"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5271,7 +5271,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-template"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "dialog-common",
  "indexmap",
@@ -5288,7 +5288,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-tree"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "custom-elements",
  "js-sys",
@@ -5302,7 +5302,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-ui"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5350,7 +5350,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-worker"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5426,7 +5426,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-worker-api"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "dialog-artifacts",
  "dialog-capability",
@@ -5444,7 +5444,7 @@ dependencies = [
 
 [[package]]
 name = "tonk-workspace"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "bs58",
  "custom-elements",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.14"
+version = "0.6.15"
 authors = ["Tonk Labs"]
 edition = "2024"
 license = "MIT"


### PR DESCRIPTION
## What changed

Bumps the shared workspace version from 0.6.14 to 0.6.15 and refreshes the 36 inherited package versions in `Cargo.lock`. No dependency or application code changes.

## Verification

- `cargo check -p tonk-cli`
- `cargo test -p tonk-cli`
- `cargo fmt --all -- --check`
- `cargo pkgid -p tonk-cli` resolves to 0.6.15
- `git diff --check`
- Verified `Cargo.lock` changes only inherited workspace package versions

## Storybook impact

- [ ] User-visible browser or CLI behavior changed. I updated these screen, journey, verification, or triage IDs:
- [ ] This fixes a user-visible bug. The regression test and Storybook now share this ID:
- [x] No user-visible contract changed because: this PR changes release metadata only.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of multiple packages in the `Cargo.toml` and `Cargo.lock` files from `0.6.14` to `0.6.15`, indicating a new release for each package.

### Detailed summary
- Updated version of `workspace.package` from `0.6.14` to `0.6.15`.
- Updated version of the following packages from `0.6.14` to `0.6.15`:
  - `dialog-reactor`
  - `tonk-access-service`
  - `tonk-account`
  - `tonk-analytics`
  - `tonk-analyzer`
  - `tonk-board`
  - `tonk-cli`
  - `tonk-code`
  - `tonk-common`
  - `tonk-core`
  - `tonk-display`
  - `tonk-email`
  - `tonk-evaluator`
  - `tonk-fab`
  - `tonk-guest`
  - `tonk-host`
  - `tonk-identity`
  - `tonk-inspector`
  - `tonk-invite`
  - `tonk-language-server`
  - `tonk-macros`
  - `tonk-notation`
  - `tonk-perf`
  - `tonk-portal`
  - `tonk-prose`
  - `tonk-render`
  - `tonk-router`
  - `tonk-schema`
  - `tonk-sigil`
  - `tonk-table`
  - `tonk-template`
  - `tonk-tree`
  - `tonk-ui`
  - `tonk-worker`
  - `tonk-worker-api`
  - `tonk-workspace`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->